### PR TITLE
feat: support exclude patterns when scaffolding kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ ck new --dir my-project --kit engineer
 
 # Specific version
 ck new --kit engineer --version v1.0.0
+
+# With exclude patterns
+ck new --kit engineer --exclude "*.log" --exclude "temp/**"
+
+# Multiple patterns
+ck new --exclude "*.log" --exclude "*.tmp" --exclude "cache/**"
 ```
 
 ### Update Existing Project
@@ -94,6 +100,9 @@ ck update --kit engineer
 
 # Specific version
 ck update --kit engineer --version v1.0.0
+
+# With exclude patterns
+ck update --exclude "local-config/**" --exclude "*.local"
 ```
 
 ### List Available Versions
@@ -203,6 +212,95 @@ The following file patterns are protected and will not be overwritten during upd
 - `*.key`, `*.pem`, `*.p12`
 - `node_modules/**`, `.git/**`
 - `dist/**`, `build/**`
+
+## Excluding Files
+
+Use the `--exclude` flag to skip specific files or directories during download and extraction. This is useful for:
+
+- Excluding temporary or cache directories
+- Skipping log files or debug output
+- Omitting files you want to manage manually
+- Avoiding unnecessary large files
+
+### Basic Usage
+
+```bash
+# Exclude log files
+ck new --exclude "*.log"
+
+# Exclude multiple patterns
+ck new --exclude "*.log" --exclude "temp/**" --exclude "cache/**"
+
+# Common exclude patterns for updates
+ck update --exclude "node_modules/**" --exclude "dist/**" --exclude ".env.*"
+```
+
+### Supported Glob Patterns
+
+The `--exclude` flag accepts standard glob patterns:
+
+- `*` - Match any characters except `/` (e.g., `*.log` matches all log files)
+- `**` - Match any characters including `/` (e.g., `temp/**` matches all files in temp directory)
+- `?` - Match single character (e.g., `file?.txt` matches `file1.txt`, `file2.txt`)
+- `[abc]` - Match characters in brackets (e.g., `[Tt]emp` matches `Temp` or `temp`)
+- `{a,b}` - Match alternatives (e.g., `*.{log,tmp}` matches `*.log` and `*.tmp`)
+
+### Common Exclude Patterns
+
+```bash
+# Exclude all log files
+--exclude "*.log" --exclude "**/*.log"
+
+# Exclude temporary directories
+--exclude "tmp/**" --exclude "temp/**" --exclude ".tmp/**"
+
+# Exclude cache directories
+--exclude "cache/**" --exclude ".cache/**" --exclude "**/.cache/**"
+
+# Exclude build artifacts
+--exclude "dist/**" --exclude "build/**" --exclude "out/**"
+
+# Exclude local configuration
+--exclude "*.local" --exclude "local/**" --exclude ".env.local"
+
+# Exclude IDE/editor files
+--exclude ".vscode/**" --exclude ".idea/**" --exclude "*.swp"
+```
+
+### Important Notes
+
+**Additive Behavior:**
+- User exclude patterns are ADDED to the default protected patterns
+- They do not replace the built-in protections
+- All patterns work together to determine which files to skip
+
+**Security Restrictions:**
+- Absolute paths (starting with `/`) are not allowed
+- Path traversal patterns (containing `..`) are not allowed
+- Patterns must be between 1-500 characters
+- These restrictions prevent accidental or malicious file system access
+
+**Pattern Matching:**
+- Patterns are case-sensitive on Linux/macOS
+- Patterns are case-insensitive on Windows
+- Patterns are applied during both extraction and merge phases
+- Excluded files are never written to disk, saving time and space
+
+**Examples of Invalid Patterns:**
+
+```bash
+# ❌ Absolute paths not allowed
+ck new --exclude "/etc/passwd"
+
+# ❌ Path traversal not allowed
+ck new --exclude "../../secret"
+
+# ❌ Empty patterns not allowed
+ck new --exclude ""
+
+# ✅ Correct way to exclude root-level files
+ck new --exclude "secret.txt" --exclude "config.local.json"
+```
 
 ### Custom .claude Files
 

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -110,6 +110,12 @@ export async function newCommand(options: NewCommandOptions): Promise<void> {
 
 		// Download asset
 		const downloadManager = new DownloadManager();
+
+		// Apply user exclude patterns if provided
+		if (validOptions.exclude && validOptions.exclude.length > 0) {
+			downloadManager.setExcludePatterns(validOptions.exclude);
+		}
+
 		const tempDir = await downloadManager.createTempDir();
 
 		// Get authentication token for API requests
@@ -157,6 +163,12 @@ export async function newCommand(options: NewCommandOptions): Promise<void> {
 
 		// Copy files to target directory
 		const merger = new FileMerger();
+
+		// Apply user exclude patterns if provided
+		if (validOptions.exclude && validOptions.exclude.length > 0) {
+			merger.addIgnorePatterns(validOptions.exclude);
+		}
+
 		await merger.merge(extractDir, resolvedDir, true); // Skip confirmation for new projects
 
 		prompts.outro(`✨ Project created successfully at ${resolvedDir}`);

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -83,6 +83,12 @@ export async function updateCommand(options: UpdateCommandOptions): Promise<void
 
 		// Download asset
 		const downloadManager = new DownloadManager();
+
+		// Apply user exclude patterns if provided
+		if (validOptions.exclude && validOptions.exclude.length > 0) {
+			downloadManager.setExcludePatterns(validOptions.exclude);
+		}
+
 		const tempDir = await downloadManager.createTempDir();
 
 		// Get authentication token for API requests
@@ -139,6 +145,11 @@ export async function updateCommand(options: UpdateCommandOptions): Promise<void
 		if (customClaudeFiles.length > 0) {
 			merger.addIgnorePatterns(customClaudeFiles);
 			logger.success(`Protected ${customClaudeFiles.length} custom .claude file(s)`);
+		}
+
+		// Apply user exclude patterns if provided
+		if (validOptions.exclude && validOptions.exclude.length > 0) {
+			merger.addIgnorePatterns(validOptions.exclude);
 		}
 
 		await merger.merge(extractDir, resolvedDir, false); // Show confirmation for updates

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env bun
 
 import { cac } from "cac";
+import packageInfo from "../package.json" assert { type: "json" };
 import { newCommand } from "./commands/new.js";
 import { updateCommand } from "./commands/update.js";
 import { versionCommand } from "./commands/version.js";
 import { logger } from "./utils/logger.js";
-import versionInfo from "./version.json" assert { type: "json" };
 
 // Set proper output encoding to prevent unicode rendering issues
 if (process.stdout.setEncoding) {
@@ -15,7 +15,7 @@ if (process.stderr.setEncoding) {
 	process.stderr.setEncoding("utf8");
 }
 
-const packageVersion = versionInfo.version;
+const packageVersion = packageInfo.version;
 
 const cli = cac("ck");
 
@@ -30,7 +30,12 @@ cli
 	.option("--kit <kit>", "Kit to use (engineer, marketing)")
 	.option("--version <version>", "Specific version to download (default: latest)")
 	.option("--force", "Overwrite existing files without confirmation")
+	.option("--exclude <pattern>", "Exclude files matching glob pattern (can be used multiple times)")
 	.action(async (options) => {
+		// Normalize exclude to always be an array (CAC may pass string for single value)
+		if (options.exclude && !Array.isArray(options.exclude)) {
+			options.exclude = [options.exclude];
+		}
 		await newCommand(options);
 	});
 
@@ -40,7 +45,12 @@ cli
 	.option("--dir <dir>", "Target directory (default: .)")
 	.option("--kit <kit>", "Kit to use (engineer, marketing)")
 	.option("--version <version>", "Specific version to download (default: latest)")
+	.option("--exclude <pattern>", "Exclude files matching glob pattern (can be used multiple times)")
 	.action(async (options) => {
+		// Normalize exclude to always be an array (CAC may pass string for single value)
+		if (options.exclude && !Array.isArray(options.exclude)) {
+			options.exclude = [options.exclude];
+		}
 		await updateCommand(options);
 	});
 

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -42,11 +42,44 @@ export class DownloadManager {
 	private totalExtractedSize = 0;
 
 	/**
+	 * Instance-level ignore object with combined default and user patterns
+	 */
+	private ig: ReturnType<typeof ignore>;
+
+	/**
+	 * Store user-defined exclude patterns
+	 */
+	private userExcludePatterns: string[] = [];
+
+	/**
+	 * Initialize DownloadManager with default exclude patterns
+	 */
+	constructor() {
+		// Initialize ignore with default patterns
+		this.ig = ignore().add(DownloadManager.EXCLUDE_PATTERNS);
+	}
+
+	/**
+	 * Set additional user-defined exclude patterns
+	 * These are added to (not replace) the default EXCLUDE_PATTERNS
+	 */
+	setExcludePatterns(patterns: string[]): void {
+		this.userExcludePatterns = patterns;
+		// Reinitialize ignore with both default and user patterns
+		this.ig = ignore().add([...DownloadManager.EXCLUDE_PATTERNS, ...this.userExcludePatterns]);
+
+		if (patterns.length > 0) {
+			logger.info(`Added ${patterns.length} custom exclude pattern(s)`);
+			patterns.forEach((p) => logger.debug(`  - ${p}`));
+		}
+	}
+
+	/**
 	 * Check if file path should be excluded
+	 * Uses instance-level ignore with both default and user patterns
 	 */
 	private shouldExclude(filePath: string): boolean {
-		const ig = ignore().add(DownloadManager.EXCLUDE_PATTERNS);
-		return ig.ignores(filePath);
+		return this.ig.ignores(filePath);
 	}
 
 	/**

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,12 +4,22 @@ import { z } from "zod";
 export const KitType = z.enum(["engineer", "marketing"]);
 export type KitType = z.infer<typeof KitType>;
 
+// Exclude pattern validation schema
+export const ExcludePatternSchema = z
+	.string()
+	.trim()
+	.min(1, "Exclude pattern cannot be empty")
+	.max(500, "Exclude pattern too long")
+	.refine((val) => !val.startsWith("/"), "Absolute paths not allowed in exclude patterns")
+	.refine((val) => !val.includes(".."), "Path traversal not allowed in exclude patterns");
+
 // Command options schemas
 export const NewCommandOptionsSchema = z.object({
 	dir: z.string().default("."),
 	kit: KitType.optional(),
 	version: z.string().optional(),
 	force: z.boolean().default(false),
+	exclude: z.array(ExcludePatternSchema).optional().default([]),
 });
 export type NewCommandOptions = z.infer<typeof NewCommandOptionsSchema>;
 
@@ -17,6 +27,7 @@ export const UpdateCommandOptionsSchema = z.object({
 	dir: z.string().default("."),
 	kit: KitType.optional(),
 	version: z.string().optional(),
+	exclude: z.array(ExcludePatternSchema).optional().default([]),
 });
 export type UpdateCommandOptions = z.infer<typeof UpdateCommandOptionsSchema>;
 


### PR DESCRIPTION
## Summary
- add a  flag to \
> 🚀 ClaudeKit - Create New Project and \
> 🔄 ClaudeKit - Update Project

[?25lâ
â  Select a ClaudeKit:
â  â ClaudeKit Engineer (Engineering toolkit for building with Claude)
â  â ClaudeKit Marketing
â to filter downloaded assets with glob patterns
- validate user-defined exclude values with  and combine them with default protections in 
- document advanced usage and extend tests covering schema enforcement

## Testing
- bun test
