### PR TITLE
fix(ci): add bash shell for Windows mkdir command

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Create bin directory
         run: mkdir -p bin
+        shell: bash
 
       - name: Compile binary (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
The 'mkdir -p bin' command failed on Windows runners because PowerShell doesn't recognize the -p flag. Adding 'shell: bash' ensures Git Bash is used, which supports Unix-style mkdir across all platforms.

Fixes: https://github.com/mrgoonie/claudekit-cli/actions/runs/18682960054