### PR TITLE
feat: add ck doctor command for setup overview (buu → dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,41 @@ ck diagnose --kit engineer
 ck diagnose --verbose
 ```
 
+### Doctor Command
+
+Check your current ClaudeKit setup and available components:
+
+```bash
+# Show ClaudeKit setup overview
+ck doctor
+```
+
+**What the doctor command shows:**
+- **Global Setup**: Installation status, version, and component counts
+- **Project Setup**: Current project information and available components
+- **Summary**: Overall setup status and total available components
+- **Helpful Tips**: Next steps and related commands
+
+**Example output:**
+```
+CK Global Setup
+Location: /Users/user/.claude
+Version: 1.0.0
+Components: 0 agents, 0 commands, 0 workflows, 0 skills
+
+CK Project Setup
+Location: ./my-project/.claude
+Version: 1.10.4
+Name: claudekit-engineer
+Components: 15 agents, 11 commands, 4 workflows, 31 skills
+
+Total Available Components:
+🤖 Agents: 15
+⚡ Commands: 11
+🔄 Workflows: 4
+🛠️ Skills: 31
+```
+
 **What it checks:**
 - ✅ GitHub CLI installation and authentication status
 - ✅ Environment variables (GITHUB_TOKEN, GH_TOKEN)
@@ -741,8 +776,9 @@ claudekit-cli/
 
 ### 1. Commands
 - **`ck new`**: Create new project from release
-- **`ck update`**: Update existing project
+- **`ck update`**: Update existing project or install globally with `--global` flag
 - **`ck versions`**: List available versions of ClaudeKit repositories
+- **`ck doctor`**: Show current ClaudeKit setup and component overview
 - **`ck diagnose`**: Run diagnostics to troubleshoot authentication and access issues
 - **`ck --version`**: Show CLI version
 - **`ck --help`**: Show help

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,111 @@
+import * as clack from "@clack/prompts";
+import { getClaudeKitSetup } from "../utils/claudekit-scanner.js";
+import { logger } from "../utils/logger.js";
+
+export async function doctorCommand(): Promise<void> {
+	clack.intro("🩺 ClaudeKit Setup Overview");
+
+	try {
+		const setup = await getClaudeKitSetup();
+
+		// Display Global Setup
+		logger.info("");
+		logger.info("CK Global Setup");
+		if (setup.global.path) {
+			logger.info(`Location: ${setup.global.path}`);
+
+			if (setup.global.metadata) {
+				logger.info(`Version: ${setup.global.metadata.version}`);
+				logger.info(`Name: ${setup.global.metadata.name}`);
+			} else {
+				logger.info("Version: Not installed globally");
+			}
+
+			// Display component counts
+			const { agents, commands, workflows, skills } = setup.global.components;
+			logger.info(
+				`Components: ${agents} agents, ${commands} commands, ${workflows} workflows, ${skills} skills`,
+			);
+		} else {
+			logger.info("Status: No global installation found");
+			logger.info("Install globally with: ck update --global");
+		}
+
+		// Display Project Setup
+		logger.info("");
+		logger.info("CK Project Setup");
+		if (setup.project.path) {
+			logger.info(`Location: ${setup.project.path}`);
+
+			if (setup.project.metadata) {
+				logger.info(`Version: ${setup.project.metadata.version}`);
+				logger.info(`Name: ${setup.project.metadata.name}`);
+			} else {
+				logger.info("Version: Unknown (no metadata.json found)");
+			}
+
+			// Display component counts
+			const { agents, commands, workflows, skills } = setup.project.components;
+			logger.info(
+				`Components: ${agents} agents, ${commands} commands, ${workflows} workflows, ${skills} skills`,
+			);
+		} else {
+			logger.info("Status: Not in a ClaudeKit project");
+			logger.info("Create a project with: ck new");
+		}
+
+		// Display Summary
+		logger.info("");
+		logger.info("Summary:");
+
+		if (setup.global.path && setup.project.path) {
+			logger.info("✅ Both global and project setups available");
+		} else if (setup.global.path) {
+			logger.info("✅ Global setup available (no project detected)");
+		} else if (setup.project.path) {
+			logger.info("✅ Project setup available (no global installation)");
+		} else {
+			logger.info("❌ No ClaudeKit setup found");
+			logger.info("Get started with: ck new --kit engineer --global");
+		}
+
+		// Display component summary
+		const totalAgents = setup.global.components.agents + setup.project.components.agents;
+		const totalCommands = setup.global.components.commands + setup.project.components.commands;
+		const totalWorkflows = setup.global.components.workflows + setup.project.components.workflows;
+		const totalSkills = setup.global.components.skills + setup.project.components.skills;
+
+		if (totalAgents > 0 || totalCommands > 0 || totalWorkflows > 0 || totalSkills > 0) {
+			logger.info("");
+			logger.info("Total Available Components:");
+			logger.info(`🤖 Agents: ${totalAgents}`);
+			logger.info(`⚡ Commands: ${totalCommands}`);
+			logger.info(`🔄 Workflows: ${totalWorkflows}`);
+			logger.info(`🛠️  Skills: ${totalSkills}`);
+		}
+
+		// Display helpful tips
+		logger.info("");
+		logger.info("Helpful Commands:");
+		if (setup.global.path) {
+			logger.info("• Update global installation: ck update --global");
+		} else {
+			logger.info("• Install globally: ck update --global");
+		}
+
+		if (setup.project.path) {
+			logger.info("• Update project: ck update");
+		} else {
+			logger.info("• Create new project: ck new");
+		}
+
+		logger.info("• Troubleshoot issues: ck diagnose");
+		logger.info("• Check versions: ck versions");
+	} catch (error) {
+		logger.error("Failed to analyze ClaudeKit setup");
+		if (error instanceof Error) {
+			logger.error(error.message);
+		}
+		process.exit(1);
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { cac } from "cac";
 import packageInfo from "../package.json" assert { type: "json" };
 import { diagnoseCommand } from "./commands/diagnose.js";
+import { doctorCommand } from "./commands/doctor.js";
 import { newCommand } from "./commands/new.js";
 import { updateCommand } from "./commands/update.js";
 import { versionCommand } from "./commands/version.js";
@@ -72,6 +73,11 @@ cli
 	.action(async (options) => {
 		await diagnoseCommand(options);
 	});
+
+// Doctor command
+cli.command("doctor", "Show current ClaudeKit setup and component overview").action(async () => {
+	await doctorCommand();
+});
 
 // Version
 cli.version(packageVersion);

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,41 @@ export interface DownloadProgress {
 // Authentication method
 export type AuthMethod = "gh-cli" | "env-var" | "keychain" | "prompt";
 
+// ClaudeKit setup types
+export interface ComponentCounts {
+	agents: number;
+	commands: number;
+	workflows: number;
+	skills: number;
+}
+
+export interface ClaudeKitMetadata {
+	version: string;
+	name: string;
+	description: string;
+	buildDate?: string;
+	repository?: {
+		type: string;
+		url: string;
+	};
+	download?: {
+		lastDownloadedAt: string | null;
+		downloadedBy: string | null;
+		installCount: number;
+	};
+}
+
+export interface ClaudeKitSetupInfo {
+	path: string;
+	metadata: ClaudeKitMetadata | null;
+	components: ComponentCounts;
+}
+
+export interface ClaudeKitSetup {
+	global: ClaudeKitSetupInfo;
+	project: ClaudeKitSetupInfo;
+}
+
 // Error types
 export class ClaudeKitError extends Error {
 	constructor(

--- a/src/utils/claudekit-scanner.ts
+++ b/src/utils/claudekit-scanner.ts
@@ -1,0 +1,160 @@
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { pathExists, readFile, readdir } from "fs-extra";
+import type { ClaudeKitSetup, ComponentCounts } from "../types.js";
+
+export interface ClaudeKitMetadata {
+	version: string;
+	name: string;
+	description: string;
+	buildDate?: string;
+	repository?: {
+		type: string;
+		url: string;
+	};
+	download?: {
+		lastDownloadedAt: string | null;
+		downloadedBy: string | null;
+		installCount: number;
+	};
+}
+
+export async function scanClaudeKitDirectory(directoryPath: string): Promise<ComponentCounts> {
+	const counts: ComponentCounts = {
+		agents: 0,
+		commands: 0,
+		workflows: 0,
+		skills: 0,
+	};
+
+	try {
+		// Check if directory exists
+		if (!(await pathExists(directoryPath))) {
+			return counts;
+		}
+
+		const items = await readdir(directoryPath);
+
+		// Count agents
+		if (items.includes("agents")) {
+			const agentsPath = join(directoryPath, "agents");
+			const agentFiles = await readdir(agentsPath);
+			counts.agents = agentFiles.filter((file) => file.endsWith(".md")).length;
+		}
+
+		// Count commands
+		if (items.includes("commands")) {
+			const commandsPath = join(directoryPath, "commands");
+			const commandFiles = await readdir(commandsPath);
+			counts.commands = commandFiles.filter((file) => file.endsWith(".md")).length;
+		}
+
+		// Count workflows (in .claude/workflows directory)
+		if (items.includes("workflows")) {
+			const workflowsPath = join(directoryPath, "workflows");
+			const workflowFiles = await readdir(workflowsPath);
+			counts.workflows = workflowFiles.filter((file) => file.endsWith(".md")).length;
+		}
+
+		// Count skills
+		if (items.includes("skills")) {
+			const skillsPath = join(directoryPath, "skills");
+			// Count skill directories (each skill is a directory with SKILL.md)
+			const skillItems = await readdir(skillsPath);
+			let skillCount = 0;
+
+			for (const item of skillItems) {
+				const itemPath = join(skillsPath, item);
+				const stat = await readdir(itemPath).catch(() => null);
+				if (stat?.includes("SKILL.md")) {
+					skillCount++;
+				}
+			}
+			counts.skills = skillCount;
+		}
+	} catch (error) {
+		// If directory doesn't exist or can't be read, return zero counts
+	}
+
+	return counts;
+}
+
+export async function readClaudeKitMetadata(
+	metadataPath: string,
+): Promise<ClaudeKitMetadata | null> {
+	try {
+		if (!(await pathExists(metadataPath))) {
+			return null;
+		}
+
+		const content = await readFile(metadataPath, "utf8");
+		const metadata = JSON.parse(content) as ClaudeKitMetadata;
+
+		return metadata;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Get the global ClaudeKit installation directory for the current platform
+ */
+function getGlobalInstallDir(): string {
+	const userHome = homedir();
+	const currentPlatform = platform();
+
+	switch (currentPlatform) {
+		case "darwin":
+			// macOS: ~/.claude/
+			return join(userHome, ".claude");
+
+		case "win32": {
+			// Windows: %APPDATA%/ClaudeKit/
+			const appData = process.env.APPDATA;
+			if (appData) {
+				return join(appData, "ClaudeKit");
+			}
+			// Fallback to user home
+			return join(userHome, "AppData", "Roaming", "ClaudeKit");
+		}
+		default:
+			// Linux and other platforms: ~/.claude/
+			return join(userHome, ".claude");
+	}
+}
+
+export async function getClaudeKitSetup(
+	projectDir: string = process.cwd(),
+): Promise<ClaudeKitSetup> {
+	const setup: ClaudeKitSetup = {
+		global: {
+			path: "",
+			metadata: null,
+			components: { agents: 0, commands: 0, workflows: 0, skills: 0 },
+		},
+		project: {
+			path: "",
+			metadata: null,
+			components: { agents: 0, commands: 0, workflows: 0, skills: 0 },
+		},
+	};
+
+	// Check global setup
+	const globalDir = getGlobalInstallDir();
+
+	if (await pathExists(globalDir)) {
+		setup.global.path = globalDir;
+		setup.global.metadata = await readClaudeKitMetadata(join(globalDir, "metadata.json"));
+		setup.global.components = await scanClaudeKitDirectory(globalDir);
+	}
+
+	// Check project setup
+	const projectClaudeDir = join(projectDir, ".claude");
+	if (await pathExists(projectClaudeDir)) {
+		setup.project.path = projectClaudeDir;
+		setup.project.metadata = await readClaudeKitMetadata(join(projectClaudeDir, "metadata.json"));
+		setup.project.components = await scanClaudeKitDirectory(projectClaudeDir);
+	}
+
+	return setup;
+}

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { doctorCommand } from "../../src/commands/doctor.js";
+import { getClaudeKitSetup } from "../../src/utils/claudekit-scanner.js";
+
+describe("Doctor Command", () => {
+	let testDir: string;
+	let mockClaudeDir: string;
+
+	beforeEach(async () => {
+		// Create test directory
+		testDir = join(process.cwd(), "test-temp", `doctor-test-${Date.now()}`);
+		await mkdir(testDir, { recursive: true });
+
+		// Create mock .claude directory
+		mockClaudeDir = join(testDir, ".claude");
+		await mkdir(mockClaudeDir, { recursive: true });
+
+		// Create subdirectories
+		await mkdir(join(mockClaudeDir, "agents"), { recursive: true });
+		await mkdir(join(mockClaudeDir, "commands"), { recursive: true });
+		await mkdir(join(mockClaudeDir, "workflows"), { recursive: true });
+		await mkdir(join(mockClaudeDir, "skills"), { recursive: true });
+
+		// Create mock metadata
+		const mockMetadata = {
+			version: "1.0.0",
+			name: "test-claudekit",
+			description: "Test ClaudeKit for unit testing",
+		};
+		await writeFile(
+			join(mockClaudeDir, "metadata.json"),
+			JSON.stringify(mockMetadata, null, 2),
+			"utf8",
+		);
+
+		// Create mock agent files
+		await writeFile(join(mockClaudeDir, "agents", "agent1.md"), "# Agent 1", "utf8");
+		await writeFile(join(mockClaudeDir, "agents", "agent2.md"), "# Agent 2", "utf8");
+
+		// Create mock command files
+		await writeFile(join(mockClaudeDir, "commands", "command1.md"), "# Command 1", "utf8");
+		await writeFile(join(mockClaudeDir, "commands", "command2.md"), "# Command 2", "utf8");
+		await writeFile(join(mockClaudeDir, "commands", "command3.md"), "# Command 3", "utf8");
+
+		// Create mock workflow files
+		await writeFile(join(mockClaudeDir, "workflows", "workflow1.md"), "# Workflow 1", "utf8");
+
+		// Create mock skill directories
+		const skill1Dir = join(mockClaudeDir, "skills", "skill1");
+		await mkdir(skill1Dir, { recursive: true });
+		await writeFile(join(skill1Dir, "SKILL.md"), "# Skill 1", "utf8");
+
+		const skill2Dir = join(mockClaudeDir, "skills", "skill2");
+		await mkdir(skill2Dir, { recursive: true });
+		await writeFile(join(skill2Dir, "SKILL.md"), "# Skill 2", "utf8");
+	});
+
+	afterEach(async () => {
+		// Cleanup test directory
+		if (testDir) {
+			await rm(testDir, { recursive: true, force: true });
+		}
+	});
+
+	describe("getClaudeKitSetup", () => {
+		test("should detect project setup correctly", async () => {
+			const setup = await getClaudeKitSetup(testDir);
+
+			expect(setup.project.path).toBe(mockClaudeDir);
+			expect(setup.project.metadata).not.toBeNull();
+			expect(setup.project.metadata?.version).toBe("1.0.0");
+			expect(setup.project.metadata?.name).toBe("test-claudekit");
+
+			// Check component counts
+			expect(setup.project.components.agents).toBe(2);
+			expect(setup.project.components.commands).toBe(3);
+			expect(setup.project.components.workflows).toBe(1);
+			expect(setup.project.components.skills).toBe(2);
+		});
+
+		test("should return empty setup when no .claude directory exists", async () => {
+			const emptyDir = join(process.cwd(), "test-temp", `empty-test-${Date.now()}`);
+			await mkdir(emptyDir, { recursive: true });
+
+			try {
+				const setup = await getClaudeKitSetup(emptyDir);
+
+				expect(setup.project.path).toBe("");
+				expect(setup.project.metadata).toBeNull();
+				expect(setup.project.components.agents).toBe(0);
+				expect(setup.project.components.commands).toBe(0);
+				expect(setup.project.components.workflows).toBe(0);
+				expect(setup.project.components.skills).toBe(0);
+			} finally {
+				await rm(emptyDir, { recursive: true, force: true });
+			}
+		});
+
+		test("should handle corrupted metadata.json gracefully", async () => {
+			// Write corrupted metadata
+			await writeFile(join(mockClaudeDir, "metadata.json"), "{ invalid json", "utf8");
+
+			const setup = await getClaudeKitSetup(testDir);
+
+			expect(setup.project.path).toBe(mockClaudeDir);
+			expect(setup.project.metadata).toBeNull();
+			// Components should still be counted
+			expect(setup.project.components.agents).toBe(2);
+		});
+	});
+
+	describe("doctorCommand", () => {
+		test("should run without errors in project directory", async () => {
+			// Test that the command doesn't throw an error
+			// We can't easily test the output without mocking console methods
+			expect(async () => {
+				await doctorCommand();
+			}).not.toThrow();
+		});
+
+		test("should run without errors outside project directory", async () => {
+			const nonProjectDir = join(process.cwd(), "test-temp", `non-project-${Date.now()}`);
+			await mkdir(nonProjectDir, { recursive: true });
+
+			try {
+				// Change to non-project directory temporarily
+				const originalCwd = process.cwd();
+				process.chdir(nonProjectDir);
+
+				expect(async () => {
+					await doctorCommand();
+				}).not.toThrow();
+
+				// Restore original directory
+				process.chdir(originalCwd);
+			} finally {
+				await rm(nonProjectDir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	describe("Component counting logic", () => {
+		test("should count only .md files in agents directory", async () => {
+			// Add a non-md file
+			await writeFile(join(mockClaudeDir, "agents", "readme.txt"), "Readme", "utf8");
+
+			const setup = await getClaudeKitSetup(testDir);
+			// Should still only count .md files
+			expect(setup.project.components.agents).toBe(2);
+		});
+
+		test("should count skills only if SKILL.md exists", async () => {
+			// Create a skill directory without SKILL.md
+			const skill3Dir = join(mockClaudeDir, "skills", "skill3");
+			await mkdir(skill3Dir, { recursive: true });
+			await writeFile(join(skill3Dir, "README.md"), "# Readme", "utf8");
+
+			const setup = await getClaudeKitSetup(testDir);
+			// Should only count skills with SKILL.md
+			expect(setup.project.components.skills).toBe(2);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

This PR implements the `ck doctor` command as requested in GitHub issue #24, providing users with a comprehensive overview of their ClaudeKit setup.

## Features Implemented

### ✅ Doctor Command
- **Global Setup Analysis**: Detects and displays global ClaudeKit installation status
- **Project Setup Analysis**: Scans and displays current project configuration
- **Component Counting**: Counts agents, commands, workflows, and skills in both setups
- **Version Information**: Reads metadata.json files for version tracking
- **Cross-Platform Support**: Works on macOS, Windows, and Linux

### ✅ Component Scanning
- **Smart Detection**: Intelligently scans for ClaudeKit components
- **Type-Specific Counting**: 
  - Agents: `.md` files in `agents/` directory
  - Commands: `.md` files in `commands/` directory
  - Workflows: `.md` files in `workflows/` directory
  - Skills: Directories containing `SKILL.md` files
- **Error Handling**: Graceful handling of missing or corrupted files

### ✅ Rich Output Format
- **Setup Status**: Clear indicators for global and project installations
- **Component Summary**: Total counts across all setups
- **Helpful Tips**: Contextual suggestions based on current setup
- **Visual Indicators**: Uses emojis for better readability

## Technical Implementation

### New Files Created
- `src/commands/doctor.ts` - Main doctor command implementation
- `src/utils/claudekit-scanner.ts` - Component scanning utilities
- `tests/commands/doctor.test.ts` - Comprehensive test suite

### Modified Files
- `src/types.ts` - Added ClaudeKit setup type definitions
- `src/index.ts` - Added doctor command to CLI interface
- `README.md` - Added doctor command documentation

## Example Output

```bash
$ ck doctor
🩺 ClaudeKit Setup Overview

CK Global Setup
Location: /Users/user/.claude
Version: v1.0.0
Name: claudekit-engineer
Components: 0 agents, 0 commands, 0 workflows, 0 skills

CK Project Setup
Location: ./my-project/.claude
Version: 1.10.4
Name: claudekit-engineer
Components: 15 agents, 11 commands, 4 workflows, 31 skills

Summary:
✅ Both global and project setups available

Total Available Components:
🤖 Agents: 15
⚡ Commands: 11
🔄 Workflows: 4
🛠️ Skills: 31

Helpful Commands:
• Update global installation: ck update --global
• Update project: ck update
• Troubleshoot issues: ck diagnose
• Check versions: ck versions
```

## Testing

- ✅ 7 unit tests passing
- ✅ Component counting logic verified
- ✅ Metadata handling tested (corrupted/missing files)
- ✅ Error handling scenarios covered
- ✅ TypeScript compilation successful
- ✅ Code formatting follows project standards

## Workflow Integration

This PR is part of the development workflow:
- **buu** → **dev** → **test** → **main**
- Each step will involve code review and testing
- Features are progressively integrated and validated

## Issue Resolution

Resolves #24 - "feat: options to check current CK setup"

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the code completed
- [x] Unit tests added for new functionality
- [x] Documentation updated
- [x] Build and lint pass
- [x] TypeScript compilation successful
- [x] No breaking changes
- [x] Integration with existing features verified