### PR TITLE
fix: use ES module export syntax in semantic-release plugin

### DIFF
--- a/scripts/build-binaries-after-version-bump.js
+++ b/scripts/build-binaries-after-version-bump.js
@@ -107,4 +107,4 @@ async function prepare(pluginConfig, context) {
 	}
 }
 
-module.exports = { prepare };
+export { prepare };


### PR DESCRIPTION
The build-binaries-after-version-bump.js file was using CommonJS module.exports while package.json has "type": "module", causing semantic-release to fail.

Changed module.exports to export statement to match ES module syntax.