### PR TITLE
fix(ci): prevent committing large binaries to git

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -21,7 +21,7 @@
 		[
 			"@semantic-release/git",
 			{
-				"assets": ["package.json", "CHANGELOG.md", "bin/"],
+				"assets": ["package.json", "CHANGELOG.md"],
 				"message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
 			}
 		],


### PR DESCRIPTION
Remove bin/ directory from @semantic-release/git assets to prevent pushing large compiled binaries (100+ MB) to the git repository.

The binaries will still be:
- Built during CI by the custom semantic-release plugin
- Uploaded to GitHub Releases via @semantic-release/github

This fixes the git push failure caused by files exceeding GitHub's 100 MB size limit.