### PR TITLE
fix: npm publish payload too large and semantic-release plugin ordering

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,35 @@
+# Exclude tarballs to prevent nested packaging
+*.tgz
+*.tar.gz
+
+# Development files
+src/
+tests/
+scripts/
+docs/
+plans/
+.claude/
+.github/
+.githooks/
+
+# Config files
+*.config.js
+*.config.ts
+.releaserc.json
+tsconfig.json
+biome.json
+.editorconfig
+.gitignore
+
+# Test artifacts
+coverage/
+*.test.ts
+*.spec.ts
+
+# Build artifacts that shouldn't be published
+node_modules/
+
+# Misc
+*.log
+*.md
+!README.md

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,17 +5,17 @@
 		"@semantic-release/release-notes-generator",
 		"@semantic-release/changelog",
 		[
+			"./scripts/build-binaries-after-version-bump.js",
+			{
+				"rebuildBinaries": true
+			}
+		],
+		[
 			"@semantic-release/npm",
 			{
 				"npmPublish": true,
 				"tarballDir": "dist",
 				"pkgRoot": "."
-			}
-		],
-		[
-			"./scripts/build-binaries-after-version-bump.js",
-			{
-				"rebuildBinaries": true
 			}
 		],
 		[

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [2.5.1](https://github.com/mrgoonie/claudekit-cli/compare/v2.5.0...v2.5.1) (2025-12-01)
+
+
+### Bug Fixes
+
+* **cli:** add Node.js fallback for Alpine/musl compatibility ([699cd75](https://github.com/mrgoonie/claudekit-cli/commit/699cd755a395d71365e4ea6e680b939183047b0c))
+* **cli:** address code review recommendations ([fb38063](https://github.com/mrgoonie/claudekit-cli/commit/fb3806357b3b5f63efb117cc0c07aa9635329acc))
+* **cli:** address PR review concerns for Alpine fallback ([17279e3](https://github.com/mrgoonie/claudekit-cli/commit/17279e335f3cc649ca9628c296421680eca3e212))
+* **cli:** address second round of PR review concerns ([e850170](https://github.com/mrgoonie/claudekit-cli/commit/e8501709393751dfe1d874933416dd3ef697187e))
+* **test:** skip dist check in CI environment ([ee002a6](https://github.com/mrgoonie/claudekit-cli/commit/ee002a668ee7f5898a8f642efb05dd1c3f610346))
+
 # [2.5.0](https://github.com/mrgoonie/claudekit-cli/compare/v2.4.0...v2.5.0) (2025-12-01)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "claudekit-cli",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"description": "CLI tool for bootstrapping and updating ClaudeKit projects",
 	"type": "module",
 	"repository": {
@@ -25,7 +25,6 @@
 		"compile:binary": "bun build src/index.ts --compile --outfile bin/ck",
 		"compile:binaries": "node scripts/build-all-binaries.js",
 		"check-version-sync": "node scripts/check-binary-version-sync.js",
-		"prepublishOnly": "npm run build && npm run compile && npm run build:platform-binaries",
 		"build:platform-binaries": "bun run scripts/build-platform-binaries.js",
 		"test": "bun test",
 		"test:watch": "bun test --watch",


### PR DESCRIPTION
## Summary

This PR merges the fixes from dev to main to trigger a new release that resolves the npm publish failure.

### Changes

- **Remove `prepublishOnly` hook** - Eliminates redundant build during npm publish that caused duplicate artifacts
- **Add `.npmignore`** - Explicitly excludes tarballs and dev files from published package
- **Fix semantic-release plugin order** - Moves binary build BEFORE npm publish to ensure fresh binaries
- **Add essential file verification** - Verifies `dist/index.js` and `bin/ck.js` exist before publish
- **Add documentation** - Clarifies why only Linux binary is verified in CI

### Root Cause

The `prepublishOnly` hook was causing duplicate artifact creation during npm publish:
1. Semantic-release built binaries correctly (~131MB tarball)
2. `npm publish` triggered `prepublishOnly` hook
3. Hook re-ran build, creating nested tarball
4. Package ballooned to ~490MB unpacked
5. NPM rejected with `413 Payload Too Large`

### Results

- **Package size reduced from ~264MB to ~230KB (packed)**
- **Plugin order fixed** - Binaries built before npm publish
- **Safety checks added** - Verification before publish

### Test Plan

- [x] Typecheck passes
- [x] Lint passes
- [x] Build passes
- [x] `npm pack --dry-run` shows correct package size

### Related

- Fixes #130 (Alpine/musl compatibility can now be released)
- Closes #132 (original PR)
- Closes #133 (fix PR)