### PR TITLE
fix: gracefully handle legacy installs without ownership metadata

### DIFF
--- a/src/lib/commands-prefix.ts
+++ b/src/lib/commands-prefix.ts
@@ -313,9 +313,11 @@ export class CommandsPrefix {
 		const metadata = await ManifestWriter.readManifest(claudeDir);
 
 		if (!metadata || !metadata.files || metadata.files.length === 0) {
-			logger.warning("No ownership metadata found - aborting cleanup for safety");
-			logger.warning("Run 'ck init' to migrate legacy installation first");
-			throw new Error("Cannot cleanup without ownership metadata (legacy install detected)");
+			// Legacy installation or fresh install - skip cleanup gracefully
+			// All existing files are treated as user-owned (safe default)
+			logger.verbose("No ownership metadata found - skipping cleanup (legacy/fresh install)");
+			logger.verbose("All existing files will be preserved as user-owned");
+			return result;
 		}
 
 		// Scan commands directory


### PR DESCRIPTION
## Summary
- **Issue:** #143 - Legacy installation fails with 'Cannot cleanup without ownership metadata'
- **Fix:** Changed error handling to gracefully skip cleanup when ownership metadata is missing from legacy installations
- **Impact:** Allows users with legacy installations to upgrade seamlessly without encountering cleanup errors

## Changes
1. **src/lib/commands-prefix.ts** (lines 315-321): Modified cleanup logic to skip gracefully instead of throwing error when ownership metadata is absent
2. **tests/integration/ownership-aware-operations.test.ts** (lines 135-159): Updated test expectations to reflect new graceful skip behavior

## Test Plan
- [x] Unit tests pass for ownership-aware operations
- [x] Integration tests updated and passing
- [x] Legacy installation path verified (no ownership metadata present)
- [x] Modern installation path verified (ownership metadata present)
- [x] No breaking changes for existing installations