### PR TITLE
fix: add gh CLI version check to warn users with outdated versions

### DIFF
--- a/tests/lib/health-checks/system-checker.test.ts
+++ b/tests/lib/health-checks/system-checker.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Unit tests for the compareVersions function logic used in SystemChecker
+ * We test the version comparison algorithm directly rather than mocking exec
+ */
+describe("SystemChecker - Version Comparison Logic", () => {
+	// Replicate the compareVersions function for testing
+	function compareVersions(a: string, b: string): number {
+		const partsA = a.split(".").map(Number);
+		const partsB = b.split(".").map(Number);
+		const maxLen = Math.max(partsA.length, partsB.length);
+
+		for (let i = 0; i < maxLen; i++) {
+			const numA = partsA[i] ?? 0;
+			const numB = partsB[i] ?? 0;
+			if (numA < numB) return -1;
+			if (numA > numB) return 1;
+		}
+		return 0;
+	}
+
+	const MIN_GH_CLI_VERSION = "2.20.0";
+
+	describe("compareVersions", () => {
+		test("returns -1 when first version is lower (2.4.0 < 2.20.0)", () => {
+			expect(compareVersions("2.4.0", "2.20.0")).toBe(-1);
+		});
+
+		test("returns -1 when first version is lower (2.19.9 < 2.20.0)", () => {
+			expect(compareVersions("2.19.9", "2.20.0")).toBe(-1);
+		});
+
+		test("returns 0 when versions are equal", () => {
+			expect(compareVersions("2.20.0", "2.20.0")).toBe(0);
+		});
+
+		test("returns 1 when first version is higher (2.63.0 > 2.20.0)", () => {
+			expect(compareVersions("2.63.0", "2.20.0")).toBe(1);
+		});
+
+		test("returns 1 when first version is higher (2.20.1 > 2.20.0)", () => {
+			expect(compareVersions("2.20.1", "2.20.0")).toBe(1);
+		});
+
+		test("handles different version lengths (2.4 vs 2.4.0)", () => {
+			expect(compareVersions("2.4", "2.4.0")).toBe(0);
+		});
+
+		test("handles major version differences (3.0.0 > 2.99.99)", () => {
+			expect(compareVersions("3.0.0", "2.99.99")).toBe(1);
+		});
+	});
+
+	describe("version check logic", () => {
+		test("v2.4.0 is below minimum and should trigger warning", () => {
+			const version = "2.4.0";
+			const isBelowMinimum = compareVersions(version, MIN_GH_CLI_VERSION) < 0;
+			expect(isBelowMinimum).toBe(true);
+		});
+
+		test("v2.19.9 is below minimum and should trigger warning", () => {
+			const version = "2.19.9";
+			const isBelowMinimum = compareVersions(version, MIN_GH_CLI_VERSION) < 0;
+			expect(isBelowMinimum).toBe(true);
+		});
+
+		test("v2.20.0 meets minimum and should pass", () => {
+			const version = "2.20.0";
+			const isBelowMinimum = compareVersions(version, MIN_GH_CLI_VERSION) < 0;
+			expect(isBelowMinimum).toBe(false);
+		});
+
+		test("v2.63.0 exceeds minimum and should pass", () => {
+			const version = "2.63.0";
+			const isBelowMinimum = compareVersions(version, MIN_GH_CLI_VERSION) < 0;
+			expect(isBelowMinimum).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Add minimum gh CLI version check (v2.20.0) to `ck doctor`
- Show warning with platform-specific upgrade instructions when gh version is too old
- Add unit tests for version comparison logic

## Problem

Users with ancient gh CLI versions (e.g., v2.4.0) experience authentication failures even when `gh auth status` shows authenticated. The `gh auth token -h github.com` flag behavior differs in older versions, causing silent token retrieval failures.

## Solution

- Added `MIN_GH_CLI_VERSION = "2.20.0"` constant
- Added `compareVersions()` function for semantic version comparison
- Updated `checkGitHubCli()` to warn when version is below minimum
- Added `getGhUpgradeInstructions()` with platform-specific commands

## What Users See Now

When user has gh CLI < v2.20.0:

```
SYSTEM
──────────────────────────────────────────────────
⚠ GitHub CLI  v2.4.0 (outdated)    Minimum required: v2.20.0
              → Upgrade GitHub CLI to v2.20.0+:
                macOS:   brew upgrade gh
                Windows: winget upgrade GitHub.cli
                Linux:   sudo apt update && sudo apt upgrade gh
                Or visit: https://cli.github.com
```

## Test Plan

- [x] `bun run typecheck` passes
- [x] `bun run lint:fix` passes
- [x] `bun test tests/lib/health-checks` passes (88 tests, including 11 new version comparison tests)

Fixes #171
