### PR TITLE
fix: skip local detection when cwd is global kit directory

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -62,8 +62,15 @@ export async function initCommand(options: UpdateCommandOptions): Promise<void> 
 
 		// Detect local installation conflict (only in global mode)
 		if (validOptions.global) {
+			// Skip local detection if cwd is the global kit directory itself
+			// (e.g., when running `ck init -g` from home directory)
+			const globalKitDir = PathResolver.getGlobalKitDir();
+			const cwdResolved = resolve(process.cwd());
+			const isInGlobalDir =
+				cwdResolved === globalKitDir || cwdResolved === resolve(globalKitDir, "..");
+
 			const localSettingsPath = join(process.cwd(), ".claude", "settings.json");
-			if (await pathExists(localSettingsPath)) {
+			if (!isInGlobalDir && (await pathExists(localSettingsPath))) {
 				if (isNonInteractive) {
 					// CI mode: warn and proceed
 					logger.warning(


### PR DESCRIPTION
## Summary

Fix false positive local installation detection when running `ck init -g` from home directory.

## Issue

Closes #178 - `ck init -g` from home directory incorrectly detects global ~/.claude as local installation

## Root Cause

When running `ck init -g` from `~`, the code checked for `~/.claude/settings.json` and treated it as a "local" installation, prompting the user to remove it. But `~/.claude/` IS the global installation directory.

## Solution

Added check to skip local detection when:
- `cwd` equals the global kit directory (`~/.claude/`)
- `cwd` equals the parent of global kit directory (`~` home dir)

## Code Changes

| File | Changes |
|------|---------|
| `src/commands/init.ts` | Added `isInGlobalDir` check before local detection |
| `tests/commands/init-local-detection.test.ts` | Added tests for issue #178 edge cases |

## Test Plan

- [x] Added 2 test cases for global directory detection
- [x] All existing init-local-detection tests pass (7 tests)
- [x] Quality gate passed (typecheck, lint, build)
