### PR TITLE
fix(encoding): resolve Unicode mojibake in progress bar and spinner

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,4 +1,3 @@
-import * as clack from "@clack/prompts";
 import {
 	AuthChecker,
 	AutoHealer,
@@ -13,6 +12,7 @@ import {
 } from "../lib/health-checks/index.js";
 import { isNonInteractive } from "../utils/environment.js";
 import { logger } from "../utils/logger.js";
+import { confirm, intro, isCancel, outro } from "../utils/safe-prompts.js";
 
 interface DoctorOptions {
 	report?: boolean;
@@ -35,7 +35,7 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<void> 
 
 	// Don't show intro in JSON/report mode
 	if (!json && !report) {
-		clack.intro("ClaudeKit Health Check");
+		intro("ClaudeKit Health Check");
 	}
 
 	// Create and configure runner
@@ -84,7 +84,7 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<void> 
 		renderer.renderHealingSummary(healSummary);
 
 		if (healSummary.failed === 0 && healSummary.succeeded > 0) {
-			clack.outro("All fixable issues resolved!");
+			outro("All fixable issues resolved!");
 			return;
 		}
 	}
@@ -99,12 +99,12 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<void> 
 		const fixable = summary.checks.filter((c) => c.autoFixable && c.status !== "pass" && c.fix);
 
 		if (fixable.length > 0 && !isNonInteractive()) {
-			const shouldFix = await clack.confirm({
+			const shouldFix = await confirm({
 				message: `${fixable.length} issue(s) can be fixed automatically. Fix now?`,
 				initialValue: true,
 			});
 
-			if (!clack.isCancel(shouldFix) && shouldFix) {
+			if (!isCancel(shouldFix) && shouldFix) {
 				const healer = new AutoHealer();
 				const healSummary = await healer.healAll(summary.checks);
 				renderer.renderHealingSummary(healSummary);
@@ -114,8 +114,8 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<void> 
 
 	// Outro
 	if (summary.failed === 0) {
-		clack.outro("All checks passed!");
+		outro("All checks passed!");
 	} else {
-		clack.outro(`${summary.failed} issue(s) found`);
+		outro(`${summary.failed} issue(s) found`);
 	}
 }

--- a/src/utils/safe-prompts.ts
+++ b/src/utils/safe-prompts.ts
@@ -1,8 +1,12 @@
+import * as clack from "@clack/prompts";
 import picocolors from "picocolors";
 
 /**
  * Safe wrapper around clack prompts that uses simple ASCII characters
  * instead of unicode box drawing to avoid rendering issues.
+ *
+ * This module provides ASCII-safe alternatives for clack/prompts functions
+ * that use Unicode characters which may not render correctly on all terminals.
  */
 
 /**
@@ -40,5 +44,45 @@ export function note(message: string, title?: string): void {
 	console.log();
 }
 
-// Re-export other clack functions unchanged
-export { select, confirm, text, isCancel } from "@clack/prompts";
+/**
+ * ASCII-safe log functions that wrap clack.log with ASCII symbols
+ */
+export const log = {
+	info: (message: string): void => {
+		console.log(picocolors.blue(`[i] ${message}`));
+	},
+	success: (message: string): void => {
+		console.log(picocolors.green(`[+] ${message}`));
+	},
+	warn: (message: string): void => {
+		console.log(picocolors.yellow(`[!] ${message}`));
+	},
+	warning: (message: string): void => {
+		console.log(picocolors.yellow(`[!] ${message}`));
+	},
+	error: (message: string): void => {
+		console.log(picocolors.red(`[x] ${message}`));
+	},
+	step: (message: string): void => {
+		console.log(picocolors.cyan(`[>] ${message}`));
+	},
+	message: (message: string): void => {
+		console.log(`    ${message}`);
+	},
+};
+
+// Re-export clack functions that don't have Unicode issues or work correctly
+// Note: select, confirm, text use Unicode but the core functionality works
+// The Unicode issues are mainly in the decorative elements
+export {
+	select,
+	confirm,
+	text,
+	isCancel,
+	spinner,
+	multiselect,
+	groupMultiselect,
+} from "@clack/prompts";
+
+// Re-export the entire clack module for cases where full access is needed
+export { clack };

--- a/src/utils/safe-spinner.ts
+++ b/src/utils/safe-spinner.ts
@@ -1,6 +1,15 @@
 import ora, { type Ora, type Options } from "ora";
 
 /**
+ * Custom ASCII spinner frames to avoid unicode rendering issues
+ * Uses simple ASCII characters that render correctly on all terminals
+ */
+const ASCII_SPINNER = {
+	interval: 100,
+	frames: ["-", "\\", "|", "/"],
+};
+
+/**
  * Create a spinner with simple ASCII characters to avoid unicode rendering issues
  */
 export function createSpinner(options: string | Options): Ora {
@@ -8,8 +17,8 @@ export function createSpinner(options: string | Options): Ora {
 
 	const spinner = ora({
 		...spinnerOptions,
-		// Use simple ASCII spinner instead of unicode
-		spinner: "dots",
+		// Use custom ASCII spinner instead of unicode dots
+		spinner: ASCII_SPINNER,
 		// Override symbols to use ASCII
 		prefixText: "",
 	});


### PR DESCRIPTION
## Summary
Resolves #190: Progress bars and spinners now display correctly on terminals with encoding issues by replacing Unicode characters with ASCII alternatives.

**Root Cause**: Unicode Braille characters from ora spinner and box-drawing characters from @clack/prompts don't render correctly on some terminals, resulting in garbled output (mojibake).

**Changes**:
- `src/utils/safe-spinner.ts`: Replaced Unicode dots spinner with ASCII spinner (`- \ | /`)
- `src/utils/safe-prompts.ts`: Added ASCII-safe log functions (`[i]`, `[+]`, `[!]`, `[x]`, `[>]`)
- Updated command and prompt modules to use safe-prompts functions

## Test Plan
- [x] Manual testing on terminal with encoding issues
- [x] Verify spinner animation displays correctly
- [x] Verify log messages display with proper prefixes
- [x] Test across multiple commands (doctor, uninstall, update-cli)
- [x] No breaking changes to existing prompts