### PR TITLE
refactor: replace settings.json.backup with atomic writes

### DIFF
--- a/src/domains/installation/file-merger.ts
+++ b/src/domains/installation/file-merger.ts
@@ -245,13 +245,7 @@ export class FileMerger {
 			return;
 		}
 
-		// Create backup before merge
-		const backupPath = await SettingsMerger.createBackup(destFile);
-		if (backupPath) {
-			logger.debug(`Created settings backup: ${backupPath}`);
-		}
-
-		// Perform selective merge
+		// Perform selective merge (atomic write ensures data integrity without backup files)
 		const mergeResult = SettingsMerger.merge(sourceSettings, destSettings);
 
 		// Log merge results


### PR DESCRIPTION
## Summary

Replaces the backup file strategy with atomic writes using the temp file + rename pattern. This avoids creating `settings.json.backup` files while ensuring data integrity during settings updates.

## Changes

- Add `atomicWriteFile()` method using write-to-temp-then-rename pattern
- Remove `createBackup()` method from SettingsMerger  
- Remove backup logic from `file-merger.ts`
- Update tests to verify atomic write behavior (no leftover temp files, no backup files created)

## How it works

1. Write content to a temp file in the same directory (`.settings-{uuid}.tmp`)
2. Rename temp file to target (atomic on POSIX, near-atomic on Windows)
3. Clean up temp file on failure

This is the standard safe-write pattern used by many tools and avoids the clutter of `.backup` files.

## Test plan

- [x] All 26 settings-merger tests pass
- [x] Verified no temp files left behind after write
- [x] Verified no `.backup` files created during merge operations

Closes #201
