### PR TITLE
refactor: replace settings.json.backup with atomic writes

### DIFF
--- a/src/domains/installation/file-merger.ts
+++ b/src/domains/installation/file-merger.ts
@@ -245,13 +245,7 @@ export class FileMerger {
 			return;
 		}
 
-		// Create backup before merge
-		const backupPath = await SettingsMerger.createBackup(destFile);
-		if (backupPath) {
-			logger.debug(`Created settings backup: ${backupPath}`);
-		}
-
-		// Perform selective merge
+		// Perform selective merge (atomic write ensures data integrity without backup files)
 		const mergeResult = SettingsMerger.merge(sourceSettings, destSettings);
 
 		// Log merge results


### PR DESCRIPTION
## Summary

Replace backup file strategy with atomic writes using temp file + rename pattern.

## Changes

- Add `atomicWriteFile()` using write-to-temp-then-rename
- Remove `createBackup()` method
- No more `settings.json.backup` files created

Closes #201
