### PR TITLE
refactor: consolidate duplicate SKIP_DIRS arrays into shared module

### DIFF
--- a/src/services/file-operations/claudekit-scanner.ts
+++ b/src/services/file-operations/claudekit-scanner.ts
@@ -1,22 +1,8 @@
 import { join } from "node:path";
 import { PathResolver } from "@/shared/path-resolver.js";
+import { SKIP_DIRS_CLAUDE_INTERNAL } from "@/shared/skip-directories.js";
 import type { ClaudeKitSetup, ComponentCounts } from "@/types";
 import { pathExists, readFile, readdir } from "fs-extra";
-
-/**
- * Directories to skip during scanning to avoid Claude Code internal directories
- */
-const SKIP_DIRS = [
-	// Claude Code internal directories (not ClaudeKit files)
-	"debug",
-	"projects",
-	"shell-snapshots",
-	"file-history",
-	"todos",
-	"session-env",
-	"statsig",
-	".anthropic",
-];
 
 export interface ClaudeKitMetadata {
 	version: string;
@@ -80,7 +66,7 @@ export async function scanClaudeKitDirectory(directoryPath: string): Promise<Com
 
 			for (const item of skillItems) {
 				// Skip Claude Code internal directories
-				if (SKIP_DIRS.includes(item)) {
+				if (SKIP_DIRS_CLAUDE_INTERNAL.includes(item)) {
 					continue;
 				}
 

--- a/src/services/file-operations/file-scanner.ts
+++ b/src/services/file-operations/file-scanner.ts
@@ -1,33 +1,7 @@
 import { join, relative, resolve } from "node:path";
 import { logger } from "@/shared/logger.js";
+import { SKIP_DIRS_ALL } from "@/shared/skip-directories.js";
 import { lstat, pathExists, readdir } from "fs-extra";
-
-/**
- * Directories to skip during scanning to avoid:
- * - Permission issues (venvs, node_modules)
- * - Unnecessary scans (build artifacts, version control)
- */
-const SKIP_DIRS = [
-	// Build/package artifacts
-	"node_modules",
-	".venv",
-	"venv",
-	".test-venv",
-	"__pycache__",
-	".git",
-	".svn",
-	"dist",
-	"build",
-	// Claude Code internal directories (not ClaudeKit files)
-	"debug",
-	"projects",
-	"shell-snapshots",
-	"file-history",
-	"todos",
-	"session-env",
-	"statsig",
-	".anthropic",
-];
 
 /**
  * Utility class for scanning directories and comparing file structures
@@ -60,7 +34,7 @@ export class FileScanner {
 
 			for (const entry of entries) {
 				// Skip known problematic directories early
-				if (SKIP_DIRS.includes(entry)) {
+				if (SKIP_DIRS_ALL.includes(entry)) {
 					logger.debug(`Skipping directory: ${entry}`);
 					continue;
 				}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -14,3 +14,9 @@ export {
 export { PathResolver } from "./path-resolver.js";
 export { createSpinner } from "./safe-spinner.js";
 export { intro, outro, note, log, clack } from "./safe-prompts.js";
+export {
+	BUILD_ARTIFACT_DIRS,
+	CLAUDE_CODE_INTERNAL_DIRS,
+	SKIP_DIRS_ALL,
+	SKIP_DIRS_CLAUDE_INTERNAL,
+} from "./skip-directories.js";

--- a/src/shared/skip-directories.ts
+++ b/src/shared/skip-directories.ts
@@ -1,0 +1,54 @@
+/**
+ * Directories to skip during file scanning operations.
+ *
+ * These directories are excluded to avoid:
+ * - Permission issues (venvs, node_modules)
+ * - Unnecessary scans (build artifacts, version control)
+ * - Claude Code internal directories (not ClaudeKit files)
+ */
+
+/**
+ * Build artifacts and package directories to skip
+ */
+export const BUILD_ARTIFACT_DIRS: readonly string[] = [
+	"node_modules",
+	".venv",
+	"venv",
+	".test-venv",
+	"__pycache__",
+	".git",
+	".svn",
+	"dist",
+	"build",
+];
+
+/**
+ * Claude Code internal directories to skip
+ * These are managed by Claude Code itself, not ClaudeKit
+ */
+export const CLAUDE_CODE_INTERNAL_DIRS: readonly string[] = [
+	"debug",
+	"projects",
+	"shell-snapshots",
+	"file-history",
+	"todos",
+	"session-env",
+	"statsig",
+	"telemetry",
+	".anthropic",
+];
+
+/**
+ * All directories to skip during file scanning (full list)
+ * Use this for general file operations that scan entire directories
+ */
+export const SKIP_DIRS_ALL: readonly string[] = [
+	...BUILD_ARTIFACT_DIRS,
+	...CLAUDE_CODE_INTERNAL_DIRS,
+];
+
+/**
+ * Only Claude Code internal directories to skip
+ * Use this for ClaudeKit-specific scanning (e.g., counting components)
+ */
+export const SKIP_DIRS_CLAUDE_INTERNAL = CLAUDE_CODE_INTERNAL_DIRS;


### PR DESCRIPTION
## Summary
- Create `src/shared/skip-directories.ts` as single source of truth for skip directories
- Add missing `telemetry/` folder to Claude Code internal directories
- Eliminate DRY violation between `file-scanner.ts` and `claudekit-scanner.ts`

## Changes
- **New:** `src/shared/skip-directories.ts` - Exports categorized directory constants
- **Updated:** `file-scanner.ts` - Uses `SKIP_DIRS_ALL`
- **Updated:** `claudekit-scanner.ts` - Uses `SKIP_DIRS_CLAUDE_INTERNAL`
- **Updated:** `src/shared/index.ts` - Re-exports new constants

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint:fix` passes
- [x] `bun test file-scanner` passes (18 tests)
- [x] `bun run build` succeeds

Closes #205