### PR TITLE
fix: standardize settings.json formatting to 2-space indentation

### DIFF
--- a/src/domains/config/settings-merger.ts
+++ b/src/domains/config/settings-merger.ts
@@ -300,7 +300,7 @@ export class SettingsMerger {
 	 * This avoids creating .backup files while ensuring data integrity.
 	 */
 	static async writeSettingsFile(filePath: string, settings: SettingsJson): Promise<void> {
-		const content = JSON.stringify(settings, null, "\t");
+		const content = JSON.stringify(settings, null, 2);
 		await SettingsMerger.atomicWriteFile(filePath, content);
 	}
 


### PR DESCRIPTION
## Summary
- Standardizes all settings.json write paths to use consistent 2-space indentation
- Fixes inconsistent formatting when `ck init -g` writes merged settings

## Changes
- `settings-merger.ts`: Changed `writeSettingsFile()` from tabs (`\t`) to 2-space
- `file-merger.ts`: Added `formatJsonContent()` helper for fallback code paths
- Updated `selectiveMergeSettings()` to use `SettingsMerger.writeSettingsFile()` for consistency

## Test plan
- [x] All 105 existing tests pass
- [x] Manual test: `ck init -g --yes` produces properly formatted settings.json