### PR TITLE
test: add tests for telemetry directory skip and JSON formatting

### DIFF
--- a/tests/utils/file-scanner.test.ts
+++ b/tests/utils/file-scanner.test.ts
@@ -158,6 +158,7 @@ describe("FileScanner", () => {
 			await mkdir(join(destDir, "session-env"), { recursive: true });
 			await mkdir(join(destDir, "statsig"), { recursive: true });
 			await mkdir(join(destDir, ".anthropic"), { recursive: true });
+			await mkdir(join(destDir, "telemetry"), { recursive: true });
 			await mkdir(join(destDir, "claudekit-files"), { recursive: true });
 
 			// Create files in each directory
@@ -169,6 +170,7 @@ describe("FileScanner", () => {
 			await writeFile(join(destDir, "session-env", "env.json"), "session data");
 			await writeFile(join(destDir, "statsig", "analytics.json"), "analytics");
 			await writeFile(join(destDir, ".anthropic", "config.json"), "claude config");
+			await writeFile(join(destDir, "telemetry", "data.json"), "telemetry data");
 			await writeFile(join(destDir, "claudekit-files", "my-file.txt"), "claudekit file");
 
 			const files = await FileScanner.getFiles(destDir);


### PR DESCRIPTION
## Summary
Addresses code review feedback from PR #207.

## Changes
- Added `telemetry/` directory to the Claude Code internal directories skip test
- Added test verifying `settings.json` is formatted with consistent 2-space indentation

## Test plan
- [x] All 98 tests pass for `file-scanner.test.ts` and `merge.test.ts`
- [x] Typecheck passes