### PR TITLE
feat(ui): add verbosity levels and unicode fallback for CLI output

### DIFF
--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -1,13 +1,6 @@
 import { type WriteStream, createWriteStream } from "node:fs";
 import pc from "picocolors";
-
-// Use ASCII-safe symbols to avoid unicode rendering issues in certain terminals
-const symbols = {
-	info: "[i]",
-	success: "[+]",
-	warning: "[!]",
-	error: "[x]",
-};
+import { output } from "./output-manager.js";
 
 interface LogContext {
 	[key: string]: any;
@@ -18,18 +11,22 @@ class Logger {
 	private logFileStream?: WriteStream;
 
 	info(message: string): void {
+		const symbols = output.getSymbols();
 		console.log(pc.blue(symbols.info), message);
 	}
 
 	success(message: string): void {
+		const symbols = output.getSymbols();
 		console.log(pc.green(symbols.success), message);
 	}
 
 	warning(message: string): void {
+		const symbols = output.getSymbols();
 		console.log(pc.yellow(symbols.warning), message);
 	}
 
 	error(message: string): void {
+		const symbols = output.getSymbols();
 		console.error(pc.red(symbols.error), message);
 	}
 

--- a/src/shared/output-manager.ts
+++ b/src/shared/output-manager.ts
@@ -1,0 +1,293 @@
+import pc from "picocolors";
+import { isTTY, supportsUnicode } from "./terminal-utils.js";
+
+/**
+ * Output configuration for verbosity and format control
+ */
+export interface OutputConfig {
+	verbose: boolean;
+	json: boolean;
+	quiet: boolean;
+}
+
+/**
+ * Symbol sets for Unicode and ASCII terminals
+ * Based on issue #210 specification
+ */
+export const SYMBOLS = {
+	unicode: {
+		prompt: "◇",
+		success: "✓",
+		error: "✗",
+		warning: "⚠",
+		info: "ℹ",
+		line: "│",
+		selected: "●",
+		unselected: "○",
+		pointer: ">",
+	},
+	ascii: {
+		prompt: "?",
+		success: "+",
+		error: "x",
+		warning: "!",
+		info: "i",
+		line: "|",
+		selected: ">",
+		unselected: " ",
+		pointer: ">",
+	},
+} as const;
+
+export type SymbolSet = (typeof SYMBOLS)["unicode"] | (typeof SYMBOLS)["ascii"];
+
+/**
+ * JSON output entry for machine-readable output
+ */
+export interface JsonOutputEntry {
+	type: "success" | "error" | "warning" | "info" | "progress" | "result";
+	message?: string;
+	data?: Record<string, unknown>;
+	timestamp: string;
+}
+
+/**
+ * Centralized output manager for consistent CLI output
+ *
+ * Features:
+ * - Unicode/ASCII symbol switching based on terminal capabilities
+ * - Verbosity levels (quiet, default, verbose)
+ * - JSON output mode for machine-readable output
+ * - TTY-aware progress/spinner visibility
+ */
+class OutputManager {
+	private config: OutputConfig = {
+		verbose: false,
+		json: false,
+		quiet: false,
+	};
+	private jsonBuffer: JsonOutputEntry[] = [];
+	private unicodeSupported: boolean;
+	private flushPromise: Promise<void> | null = null; // Async mutex for JSON flush
+
+	constructor() {
+		this.unicodeSupported = supportsUnicode();
+	}
+
+	/**
+	 * Configure output options
+	 */
+	configure(config: Partial<OutputConfig>): void {
+		this.config = { ...this.config, ...config };
+	}
+
+	/**
+	 * Get current configuration
+	 */
+	getConfig(): OutputConfig {
+		return { ...this.config };
+	}
+
+	/**
+	 * Check if verbose mode is enabled
+	 */
+	isVerbose(): boolean {
+		return this.config.verbose;
+	}
+
+	/**
+	 * Check if JSON mode is enabled
+	 */
+	isJson(): boolean {
+		return this.config.json;
+	}
+
+	/**
+	 * Check if quiet mode is enabled
+	 */
+	isQuiet(): boolean {
+		return this.config.quiet;
+	}
+
+	/**
+	 * Get appropriate symbol set based on terminal capabilities
+	 */
+	getSymbols(): SymbolSet {
+		return this.unicodeSupported ? SYMBOLS.unicode : SYMBOLS.ascii;
+	}
+
+	/**
+	 * Check if progress indicators should be shown
+	 * Hidden in JSON mode or non-TTY environments
+	 */
+	shouldShowProgress(): boolean {
+		if (this.config.json) return false;
+		if (!isTTY()) return false;
+		return true;
+	}
+
+	/**
+	 * Output success message
+	 */
+	success(message: string, data?: Record<string, unknown>): void {
+		if (this.config.json) {
+			this.addJsonEntry({ type: "success", message, data });
+			return;
+		}
+		if (this.config.quiet) return;
+		const symbol = this.getSymbols().success;
+		console.log(pc.green(`${symbol} ${message}`));
+	}
+
+	/**
+	 * Output error message
+	 */
+	error(message: string, data?: Record<string, unknown>): void {
+		if (this.config.json) {
+			this.addJsonEntry({ type: "error", message, data });
+			return;
+		}
+		const symbol = this.getSymbols().error;
+		console.error(pc.red(`${symbol} ${message}`));
+	}
+
+	/**
+	 * Output warning message
+	 */
+	warning(message: string, data?: Record<string, unknown>): void {
+		if (this.config.json) {
+			this.addJsonEntry({ type: "warning", message, data });
+			return;
+		}
+		if (this.config.quiet) return;
+		const symbol = this.getSymbols().warning;
+		console.log(pc.yellow(`${symbol} ${message}`));
+	}
+
+	/**
+	 * Output info message
+	 */
+	info(message: string, data?: Record<string, unknown>): void {
+		if (this.config.json) {
+			this.addJsonEntry({ type: "info", message, data });
+			return;
+		}
+		if (this.config.quiet) return;
+		const symbol = this.getSymbols().info;
+		console.log(pc.blue(`${symbol} ${message}`));
+	}
+
+	/**
+	 * Output verbose message (only in verbose mode)
+	 */
+	verbose(message: string, data?: Record<string, unknown>): void {
+		if (!this.config.verbose) return;
+		if (this.config.json) {
+			this.addJsonEntry({ type: "info", message, data });
+			return;
+		}
+		console.log(pc.dim(`  ${message}`));
+	}
+
+	/**
+	 * Output indented message (for sub-items)
+	 */
+	indent(message: string): void {
+		if (this.config.json) return;
+		if (this.config.quiet) return;
+		console.log(`  ${message}`);
+	}
+
+	/**
+	 * Output a blank line
+	 */
+	newline(): void {
+		if (this.config.json) return;
+		if (this.config.quiet) return;
+		console.log();
+	}
+
+	/**
+	 * Output a section header for visual grouping
+	 */
+	section(title: string): void {
+		if (this.config.json) {
+			this.addJsonEntry({ type: "info", message: `[Section] ${title}` });
+			return;
+		}
+		if (this.config.quiet) return;
+		const symbols = this.getSymbols();
+		console.log();
+		console.log(pc.bold(pc.cyan(`${symbols.line} ${title}`)));
+	}
+
+	/**
+	 * Add entry to JSON buffer (auto-flushes at 1000 entries to prevent memory issues)
+	 */
+	addJsonEntry(entry: Omit<JsonOutputEntry, "timestamp">): void {
+		this.jsonBuffer.push({
+			...entry,
+			timestamp: new Date().toISOString(),
+		});
+
+		// Auto-flush if buffer gets too large (deferred to prevent recursion)
+		if (this.jsonBuffer.length >= 1000 && !this.flushPromise) {
+			queueMicrotask(() => this.flushJson());
+		}
+	}
+
+	/**
+	 * Add result data to JSON buffer
+	 */
+	addJsonResult(data: Record<string, unknown>): void {
+		this.addJsonEntry({ type: "result", data });
+	}
+
+	/**
+	 * Flush JSON buffer to stdout and clear (async mutex prevents race conditions)
+	 */
+	async flushJson(): Promise<void> {
+		if (this.jsonBuffer.length === 0) return;
+		if (this.flushPromise) return this.flushPromise;
+
+		this.flushPromise = (async () => {
+			// Copy and clear buffer atomically
+			const bufferCopy = [...this.jsonBuffer];
+			this.jsonBuffer = [];
+			console.log(JSON.stringify(bufferCopy, null, 2));
+		})().finally(() => {
+			this.flushPromise = null;
+		});
+
+		return this.flushPromise;
+	}
+
+	/**
+	 * Get JSON buffer without flushing (for testing)
+	 */
+	getJsonBuffer(): JsonOutputEntry[] {
+		return [...this.jsonBuffer];
+	}
+
+	/**
+	 * Clear JSON buffer
+	 */
+	clearJsonBuffer(): void {
+		this.jsonBuffer = [];
+	}
+
+	/**
+	 * Reset to default configuration
+	 */
+	reset(): void {
+		this.config = { verbose: false, json: false, quiet: false };
+		this.jsonBuffer = [];
+		this.flushPromise = null;
+		this.unicodeSupported = supportsUnicode();
+	}
+}
+
+/**
+ * Singleton output manager instance
+ */
+export const output = new OutputManager();

--- a/src/shared/progress-bar.ts
+++ b/src/shared/progress-bar.ts
@@ -1,0 +1,244 @@
+import pc from "picocolors";
+import { output } from "./output-manager.js";
+import { isTTY, supportsUnicode } from "./terminal-utils.js";
+
+/**
+ * Progress bar options
+ */
+export interface ProgressBarOptions {
+	total: number;
+	width?: number;
+	format?: "download" | "percentage" | "count";
+	label?: string;
+	showEta?: boolean;
+}
+
+/**
+ * Bar characters for different terminal capabilities
+ */
+const BAR_CHARS = {
+	unicode: { filled: "█", empty: "░" },
+	ascii: { filled: "=", empty: "-" },
+} as const;
+
+/**
+ * Progress bar constants
+ */
+const RENDER_RATE_LIMIT_MS = 100; // Max 10 updates/sec to prevent flicker
+const JSON_MILESTONE_INTERVAL = 25; // Log progress at 25%, 50%, 75%, 100%
+const MIN_ELAPSED_SECONDS = 0.1; // Min elapsed time for ETA calculation (avoid div/0)
+const MAX_LABEL_WIDTH = 14; // Max visible label width (16 total - 2 leading spaces)
+
+/**
+ * TTY-aware progress bar component
+ *
+ * Features:
+ * - Unicode/ASCII bar characters based on terminal capabilities
+ * - Hidden in JSON mode or non-TTY environments
+ * - Size formatting for downloads (KB, MB, GB)
+ * - ETA calculation
+ */
+export class ProgressBar {
+	private current = 0;
+	private total: number;
+	private label: string;
+	private width: number;
+	private format: "download" | "percentage" | "count";
+	private showEta: boolean;
+	private startTime: number;
+	private lastRenderTime = 0;
+	private lastRenderContent = "";
+	private isCompleted = false;
+
+	constructor(options: ProgressBarOptions) {
+		this.total = options.total;
+		this.label = options.label || "";
+		this.width = options.width || 20;
+		this.format = options.format || "percentage";
+		this.showEta = options.showEta ?? false;
+		this.startTime = Date.now();
+	}
+
+	/**
+	 * Update progress to a specific value
+	 */
+	update(current: number): void {
+		if (this.isCompleted) return; // Ignore updates after completion
+		this.current = Math.min(current, this.total);
+		this.render();
+	}
+
+	/**
+	 * Increment progress by delta
+	 */
+	increment(delta = 1): void {
+		this.update(this.current + delta);
+	}
+
+	/**
+	 * Mark progress as complete
+	 */
+	complete(message?: string): void {
+		if (this.isCompleted) return;
+		this.isCompleted = true;
+		this.current = this.total;
+
+		if (output.isJson()) {
+			output.addJsonEntry({
+				type: "progress",
+				message: message || `${this.label} complete`,
+				data: { current: this.current, total: this.total, percent: 100 },
+			});
+			return;
+		}
+
+		if (!this.shouldRender()) {
+			// Non-TTY: just print completion
+			console.log(message || `${this.label} complete`);
+			return;
+		}
+
+		// Clear the progress line and print completion
+		this.clearLine();
+		if (message) {
+			const symbols = output.getSymbols();
+			console.log(`${pc.green(symbols.success)} ${message}`);
+		}
+	}
+
+	/**
+	 * Clear the current line (TTY only)
+	 */
+	private clearLine(): void {
+		if (isTTY()) {
+			process.stdout.write("\r\x1b[K");
+		}
+	}
+
+	/**
+	 * Check if progress should be rendered
+	 */
+	private shouldRender(): boolean {
+		if (output.isJson()) return false;
+		if (!isTTY()) return false;
+		return true;
+	}
+
+	/**
+	 * Render the progress bar
+	 */
+	private render(): void {
+		// Rate limit rendering to avoid flicker
+		const now = Date.now();
+		if (now - this.lastRenderTime < RENDER_RATE_LIMIT_MS && this.current < this.total) {
+			return;
+		}
+		this.lastRenderTime = now;
+
+		if (output.isJson()) {
+			// In JSON mode, only log at certain milestones
+			const percent = Math.floor((this.current / this.total) * 100);
+			if (percent % JSON_MILESTONE_INTERVAL === 0 || this.current === this.total) {
+				output.addJsonEntry({
+					type: "progress",
+					data: { current: this.current, total: this.total, percent },
+				});
+			}
+			return;
+		}
+
+		if (!this.shouldRender()) {
+			// Non-TTY: print progress at milestones
+			const percent = Math.floor((this.current / this.total) * 100);
+			if (percent % JSON_MILESTONE_INTERVAL === 0 && this.lastRenderContent !== `${percent}%`) {
+				this.lastRenderContent = `${percent}%`;
+				console.log(`  ${this.label} ${this.formatProgress()}`);
+			}
+			return;
+		}
+
+		// TTY: render progress bar inline
+		const content = this.formatBar();
+		process.stdout.write(`\r${content}`);
+	}
+
+	/**
+	 * Format the progress bar string
+	 */
+	private formatBar(): string {
+		const chars = this.getBarCharacters();
+		const percent = this.total > 0 ? this.current / this.total : 0;
+		const filledCount = Math.round(percent * this.width);
+		const emptyCount = this.width - filledCount;
+
+		const bar = chars.filled.repeat(filledCount) + chars.empty.repeat(emptyCount);
+		const progress = this.formatProgress();
+
+		// Truncate long labels with ellipsis (consistent width: 2 leading spaces + 14 chars)
+		const displayLabel =
+			this.label.length > MAX_LABEL_WIDTH
+				? `${this.label.slice(0, MAX_LABEL_WIDTH - 3)}...`
+				: this.label;
+		let line = `  ${displayLabel}`.padEnd(16);
+		line += `[${bar}] ${progress}`;
+
+		if (this.showEta && this.current > 0 && this.current < this.total) {
+			const elapsed = Math.max((Date.now() - this.startTime) / 1000, MIN_ELAPSED_SECONDS);
+			const rate = this.current / elapsed;
+			const remaining = (this.total - this.current) / rate;
+			line += ` ETA: ${this.formatTime(remaining)}`;
+		}
+
+		return line;
+	}
+
+	/**
+	 * Format progress value based on format type
+	 */
+	private formatProgress(): string {
+		switch (this.format) {
+			case "download":
+				return `${this.formatSize(this.current)} / ${this.formatSize(this.total)}`;
+			case "count":
+				return `${this.current}/${this.total}`;
+			default: {
+				const percent = this.total > 0 ? Math.round((this.current / this.total) * 100) : 0;
+				return `${percent}%`;
+			}
+		}
+	}
+
+	/**
+	 * Format bytes as human-readable size
+	 */
+	private formatSize(bytes: number): string {
+		if (bytes < 1024) return `${bytes} B`;
+		if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+		if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+		return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+	}
+
+	/**
+	 * Format seconds as human-readable time
+	 */
+	private formatTime(seconds: number): string {
+		if (seconds < 60) return `${Math.round(seconds)}s`;
+		const mins = Math.floor(seconds / 60);
+		const secs = Math.round(seconds % 60);
+		return `${mins}m${secs}s`;
+	}
+
+	/**
+	 * Get appropriate bar characters based on terminal capabilities
+	 */
+	private getBarCharacters(): { filled: string; empty: string } {
+		return supportsUnicode() ? BAR_CHARS.unicode : BAR_CHARS.ascii;
+	}
+}
+
+/**
+ * Create a progress bar with sensible defaults
+ */
+export function createProgressBar(options: ProgressBarOptions): ProgressBar {
+	return new ProgressBar(options);
+}

--- a/src/shared/safe-prompts.ts
+++ b/src/shared/safe-prompts.ts
@@ -1,36 +1,47 @@
 import * as clack from "@clack/prompts";
 import picocolors from "picocolors";
+import { output } from "./output-manager.js";
 
 /**
- * Safe wrapper around clack prompts that uses simple ASCII characters
- * instead of unicode box drawing to avoid rendering issues.
+ * Safe wrapper around clack prompts that uses Unicode or ASCII characters
+ * based on terminal capabilities.
  *
- * This module provides ASCII-safe alternatives for clack/prompts functions
- * that use Unicode characters which may not render correctly on all terminals.
+ * This module provides terminal-aware alternatives for clack/prompts functions
+ * that automatically switch between Unicode and ASCII based on detection.
  */
 
 /**
- * Simple intro with ASCII characters
+ * Get current symbols from output manager
+ */
+function getSymbols() {
+	return output.getSymbols();
+}
+
+/**
+ * Simple intro with terminal-aware symbols
  */
 export function intro(message: string): void {
+	if (output.isJson()) return;
 	console.log();
-	console.log(picocolors.cyan(`> ${message}`));
+	console.log(picocolors.cyan(`${getSymbols().pointer} ${message}`));
 	console.log();
 }
 
 /**
- * Simple outro with ASCII characters
+ * Simple outro with terminal-aware symbols
  */
 export function outro(message: string): void {
+	if (output.isJson()) return;
 	console.log();
-	console.log(picocolors.green(`[OK] ${message}`));
+	console.log(picocolors.green(`${getSymbols().success} ${message}`));
 	console.log();
 }
 
 /**
- * Simple note with ASCII box drawing
+ * Simple note with terminal-aware formatting
  */
 export function note(message: string, title?: string): void {
+	if (output.isJson()) return;
 	console.log();
 	if (title) {
 		console.log(picocolors.cyan(`  ${title}:`));
@@ -45,28 +56,35 @@ export function note(message: string, title?: string): void {
 }
 
 /**
- * ASCII-safe log functions that wrap clack.log with ASCII symbols
+ * Terminal-aware log functions with automatic symbol switching
  */
 export const log = {
 	info: (message: string): void => {
-		console.log(picocolors.blue(`[i] ${message}`));
+		if (output.isJson()) return;
+		console.log(picocolors.blue(`${getSymbols().info} ${message}`));
 	},
 	success: (message: string): void => {
-		console.log(picocolors.green(`[+] ${message}`));
+		if (output.isJson()) return;
+		console.log(picocolors.green(`${getSymbols().success} ${message}`));
 	},
 	warn: (message: string): void => {
-		console.log(picocolors.yellow(`[!] ${message}`));
+		if (output.isJson()) return;
+		console.log(picocolors.yellow(`${getSymbols().warning} ${message}`));
 	},
 	warning: (message: string): void => {
-		console.log(picocolors.yellow(`[!] ${message}`));
+		if (output.isJson()) return;
+		console.log(picocolors.yellow(`${getSymbols().warning} ${message}`));
 	},
 	error: (message: string): void => {
-		console.log(picocolors.red(`[x] ${message}`));
+		if (output.isJson()) return;
+		console.log(picocolors.red(`${getSymbols().error} ${message}`));
 	},
 	step: (message: string): void => {
-		console.log(picocolors.cyan(`[>] ${message}`));
+		if (output.isJson()) return;
+		console.log(picocolors.cyan(`${getSymbols().pointer} ${message}`));
 	},
 	message: (message: string): void => {
+		if (output.isJson()) return;
 		console.log(`    ${message}`);
 	},
 };

--- a/src/shared/safe-spinner.ts
+++ b/src/shared/safe-spinner.ts
@@ -1,8 +1,9 @@
 import ora, { type Ora, type Options } from "ora";
+import pc from "picocolors";
+import { output } from "./output-manager.js";
 
 /**
- * Custom ASCII spinner frames to avoid unicode rendering issues
- * Uses simple ASCII characters that render correctly on all terminals
+ * Custom ASCII spinner frames for legacy terminals
  */
 const ASCII_SPINNER = {
 	interval: 100,
@@ -10,31 +11,57 @@ const ASCII_SPINNER = {
 };
 
 /**
- * Create a spinner with simple ASCII characters to avoid unicode rendering issues
+ * Unicode spinner frames for modern terminals
+ */
+const UNICODE_SPINNER = {
+	interval: 80,
+	frames: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+};
+
+/**
+ * Create a spinner with terminal-aware symbols
+ * Uses Unicode on modern terminals, ASCII on legacy terminals
+ * Hidden in JSON mode or non-TTY environments
  */
 export function createSpinner(options: string | Options): Ora {
 	const spinnerOptions: Options = typeof options === "string" ? { text: options } : options;
+	const symbols = output.getSymbols();
+	const shouldShow = output.shouldShowProgress();
+
+	// Determine spinner type based on terminal capabilities
+	const spinnerType =
+		symbols === output.getSymbols() && symbols.success === "✓" ? UNICODE_SPINNER : ASCII_SPINNER;
 
 	const spinner = ora({
 		...spinnerOptions,
-		// Use custom ASCII spinner instead of unicode dots
-		spinner: ASCII_SPINNER,
-		// Override symbols to use ASCII
+		spinner: spinnerType,
 		prefixText: "",
+		// Disable spinner in JSON mode or non-TTY
+		isSilent: !shouldShow,
 	});
 
-	// Override succeed and fail methods to use ASCII symbols
+	// Override succeed and fail methods to use terminal-aware symbols
 	spinner.succeed = (text?: string) => {
+		if (output.isJson()) {
+			spinner.stop();
+			output.addJsonEntry({ type: "success", message: text || spinner.text });
+			return spinner;
+		}
 		spinner.stopAndPersist({
-			symbol: "[+]",
+			symbol: pc.green(symbols.success),
 			text: text || spinner.text,
 		});
 		return spinner;
 	};
 
 	spinner.fail = (text?: string) => {
+		if (output.isJson()) {
+			spinner.stop();
+			output.addJsonEntry({ type: "error", message: text || spinner.text });
+			return spinner;
+		}
 		spinner.stopAndPersist({
-			symbol: "[x]",
+			symbol: pc.red(symbols.error),
 			text: text || spinner.text,
 		});
 		return spinner;

--- a/src/shared/terminal-utils.ts
+++ b/src/shared/terminal-utils.ts
@@ -16,18 +16,48 @@ const ASCII_SYMBOLS = {
 	info: "[INFO]",
 } as const;
 
-// Detect Unicode support
+/**
+ * Detect Unicode support based on terminal environment.
+ * Auto-detects without user config - modern terminals get Unicode, legacy get ASCII.
+ *
+ * Detection order:
+ * 1. Explicit modern terminal indicators (high confidence)
+ * 2. Locale-based detection (medium confidence)
+ * 3. Platform defaults (fallback)
+ */
 export function supportsUnicode(): boolean {
-	// Windows Terminal and modern consoles
-	if (process.env.WT_SESSION) return true;
-	// CI environments often don't support Unicode well
-	if (process.env.CI) return false;
-	// Check TERM - dumb terminal doesn't support Unicode
+	// Modern terminal emulators - high confidence
+	if (process.env.WT_SESSION) return true; // Windows Terminal
+	if (process.env.TERM_PROGRAM === "iTerm.app") return true;
+	if (process.env.TERM_PROGRAM === "Apple_Terminal") return true;
+	if (process.env.TERM_PROGRAM === "vscode") return true;
+	if (process.env.KONSOLE_VERSION) return true;
+
+	// CI environments - usually support Unicode
+	if (process.env.CI) return true;
+
+	// Dumb terminal - no Unicode
 	if (process.env.TERM === "dumb") return false;
-	// Non-TTY output (pipes) - prefer ASCII for parseability
+
+	// Non-TTY output (pipes, redirects) - prefer ASCII for parseability
 	if (!process.stdout.isTTY) return false;
+
+	// Locale-based detection
+	const locale = process.env.LANG || process.env.LC_ALL || "";
+	if (locale.toLowerCase().includes("utf")) return true;
+
+	// Windows without modern terminal = legacy CMD
+	if (process.platform === "win32") return false;
+
 	// Default: Unix-like systems typically support Unicode
-	return process.platform !== "win32" || !!process.env.WT_SESSION;
+	return true;
+}
+
+/**
+ * Check if running in a TTY (interactive terminal)
+ */
+export function isTTY(): boolean {
+	return process.stdout.isTTY === true;
 }
 
 export type StatusSymbols = typeof UNICODE_SYMBOLS | typeof ASCII_SYMBOLS;

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -4,6 +4,16 @@
 import { z } from "zod";
 import { KitType } from "./kit.js";
 
+/**
+ * Global output options schema for verbosity control
+ * These options are available on all commands
+ */
+export const GlobalOutputOptionsSchema = z.object({
+	verbose: z.boolean().default(false), // Full output including subprocess logs
+	json: z.boolean().default(false), // Machine-readable JSON output
+});
+export type GlobalOutputOptions = z.infer<typeof GlobalOutputOptionsSchema>;
+
 // Exclude pattern validation schema
 export const ExcludePatternSchema = z
 	.string()
@@ -28,72 +38,94 @@ export const DEFAULT_FOLDERS: Required<FoldersConfig> = {
 };
 
 // Command options schemas
-export const NewCommandOptionsSchema = z.object({
-	dir: z.string().default("."),
-	kit: KitType.optional(),
-	release: z.string().optional(),
-	force: z.boolean().default(false),
-	exclude: z.array(ExcludePatternSchema).optional().default([]),
-	opencode: z.boolean().default(false),
-	gemini: z.boolean().default(false),
-	installSkills: z.boolean().default(false),
-	prefix: z.boolean().default(false),
-	beta: z.boolean().default(false),
-	dryRun: z.boolean().default(false), // Preview changes without applying
-	refresh: z.boolean().default(false), // Bypass release cache to fetch latest versions
-	docsDir: z.string().optional(), // Custom docs folder name
-	plansDir: z.string().optional(), // Custom plans folder name
-});
+export const NewCommandOptionsSchema = z
+	.object({
+		dir: z.string().default("."),
+		kit: KitType.optional(),
+		release: z.string().optional(),
+		force: z.boolean().default(false),
+		exclude: z.array(ExcludePatternSchema).optional().default([]),
+		opencode: z.boolean().default(false),
+		gemini: z.boolean().default(false),
+		installSkills: z.boolean().default(false),
+		prefix: z.boolean().default(false),
+		beta: z.boolean().default(false),
+		dryRun: z.boolean().default(false), // Preview changes without applying
+		refresh: z.boolean().default(false), // Bypass release cache to fetch latest versions
+		docsDir: z.string().optional(), // Custom docs folder name
+		plansDir: z.string().optional(), // Custom plans folder name
+		yes: z.boolean().default(false), // Non-interactive mode
+	})
+	.merge(GlobalOutputOptionsSchema);
 export type NewCommandOptions = z.infer<typeof NewCommandOptionsSchema>;
 
-export const UpdateCommandOptionsSchema = z.object({
-	dir: z.string().default("."),
-	kit: KitType.optional(),
-	release: z.string().optional(),
-	exclude: z.array(ExcludePatternSchema).optional().default([]),
-	only: z.array(ExcludePatternSchema).optional().default([]),
-	global: z.boolean().default(false),
-	fresh: z.boolean().default(false),
-	installSkills: z.boolean().default(false),
-	prefix: z.boolean().default(false),
-	beta: z.boolean().default(false),
-	dryRun: z.boolean().default(false), // Preview changes without applying
-	forceOverwrite: z.boolean().default(false), // Override ownership protections
-	forceOverwriteSettings: z.boolean().default(false), // Skip selective merge, fully replace settings.json
-	skipSetup: z.boolean().default(false), // Skip interactive configuration wizard
-	refresh: z.boolean().default(false), // Bypass release cache to fetch latest versions
-	docsDir: z.string().optional(), // Custom docs folder name
-	plansDir: z.string().optional(), // Custom plans folder name
-	yes: z.boolean().default(false), // Non-interactive mode with sensible defaults
-});
+export const UpdateCommandOptionsSchema = z
+	.object({
+		dir: z.string().default("."),
+		kit: KitType.optional(),
+		release: z.string().optional(),
+		exclude: z.array(ExcludePatternSchema).optional().default([]),
+		only: z.array(ExcludePatternSchema).optional().default([]),
+		global: z.boolean().default(false),
+		fresh: z.boolean().default(false),
+		installSkills: z.boolean().default(false),
+		prefix: z.boolean().default(false),
+		beta: z.boolean().default(false),
+		dryRun: z.boolean().default(false), // Preview changes without applying
+		forceOverwrite: z.boolean().default(false), // Override ownership protections
+		forceOverwriteSettings: z.boolean().default(false), // Skip selective merge, fully replace settings.json
+		skipSetup: z.boolean().default(false), // Skip interactive configuration wizard
+		refresh: z.boolean().default(false), // Bypass release cache to fetch latest versions
+		docsDir: z.string().optional(), // Custom docs folder name
+		plansDir: z.string().optional(), // Custom plans folder name
+		yes: z.boolean().default(false), // Non-interactive mode with sensible defaults
+	})
+	.merge(GlobalOutputOptionsSchema);
 export type UpdateCommandOptions = z.infer<typeof UpdateCommandOptionsSchema>;
 
-export const VersionCommandOptionsSchema = z.object({
-	kit: KitType.optional(),
-	limit: z.number().optional(),
-	all: z.boolean().optional(),
-});
+export const VersionCommandOptionsSchema = z
+	.object({
+		kit: KitType.optional(),
+		limit: z.number().optional(),
+		all: z.boolean().optional(),
+	})
+	.merge(GlobalOutputOptionsSchema);
 export type VersionCommandOptions = z.infer<typeof VersionCommandOptionsSchema>;
 
-export const UninstallCommandOptionsSchema = z.object({
-	yes: z.boolean().default(false),
-	local: z.boolean().default(false),
-	global: z.boolean().default(false),
-	all: z.boolean().default(false),
-	dryRun: z.boolean().default(false), // Preview without deleting
-	forceOverwrite: z.boolean().default(false), // Delete even modified files
-});
+export const UninstallCommandOptionsSchema = z
+	.object({
+		yes: z.boolean().default(false),
+		local: z.boolean().default(false),
+		global: z.boolean().default(false),
+		all: z.boolean().default(false),
+		dryRun: z.boolean().default(false), // Preview without deleting
+		forceOverwrite: z.boolean().default(false), // Delete even modified files
+	})
+	.merge(GlobalOutputOptionsSchema);
 export type UninstallCommandOptions = z.infer<typeof UninstallCommandOptionsSchema>;
 
 // CLI update command options (for updating the CLI package itself)
-export const UpdateCliOptionsSchema = z.object({
-	release: z.string().optional(), // Specific version to update to (using 'release' to avoid conflict with global --version flag)
-	check: z.boolean().default(false), // Check only, don't install
-	yes: z.boolean().default(false), // Skip confirmation prompt
-	beta: z.boolean().default(false), // Update to beta version
-	registry: z.string().url().optional(), // Custom npm registry URL
-});
+export const UpdateCliOptionsSchema = z
+	.object({
+		release: z.string().optional(), // Specific version to update to (using 'release' to avoid conflict with global --version flag)
+		check: z.boolean().default(false), // Check only, don't install
+		yes: z.boolean().default(false), // Skip confirmation prompt
+		beta: z.boolean().default(false), // Update to beta version
+		registry: z.string().url().optional(), // Custom npm registry URL
+	})
+	.merge(GlobalOutputOptionsSchema);
 export type UpdateCliOptions = z.infer<typeof UpdateCliOptionsSchema>;
+
+// Doctor command options
+export const DoctorCommandOptionsSchema = z
+	.object({
+		report: z.boolean().default(false), // Generate shareable diagnostic report
+		fix: z.boolean().default(false), // Auto-fix fixable issues
+		checkOnly: z.boolean().default(false), // CI mode: no prompts, exit 1 on failures
+		full: z.boolean().default(false), // Run full checks including slow ones
+	})
+	.merge(GlobalOutputOptionsSchema);
+export type DoctorCommandOptions = z.infer<typeof DoctorCommandOptionsSchema>;
 
 // Backward compatibility alias
 export type InitCommandOptions = UpdateCommandOptions;

--- a/tests/commands/uninstall.test.ts
+++ b/tests/commands/uninstall.test.ts
@@ -72,6 +72,8 @@ describe("uninstall command integration", () => {
 
 			await uninstallCommand({
 				yes: true,
+				json: false,
+				verbose: false,
 				local: true,
 				global: false,
 				all: false,
@@ -109,6 +111,8 @@ describe("uninstall command integration", () => {
 
 			await uninstallCommand({
 				yes: true,
+				json: false,
+				verbose: false,
 				local: true,
 				global: false,
 				all: false,
@@ -153,6 +157,8 @@ describe("uninstall command integration", () => {
 
 			await uninstallCommand({
 				yes: true,
+				json: false,
+				verbose: false,
 				local: true,
 				global: false,
 				all: false,
@@ -187,6 +193,8 @@ describe("uninstall command integration", () => {
 
 			await uninstallCommand({
 				yes: true,
+				json: false,
+				verbose: false,
 				local: true,
 				global: false,
 				all: false,
@@ -223,6 +231,8 @@ describe("uninstall command integration", () => {
 
 			await uninstallCommand({
 				yes: true,
+				json: false,
+				verbose: false,
 				local: true,
 				global: false,
 				all: false,
@@ -279,6 +289,8 @@ describe("uninstall command integration", () => {
 
 			await uninstallCommand({
 				yes: true,
+				json: false,
+				verbose: false,
 				local: true,
 				global: false,
 				all: false,
@@ -336,6 +348,8 @@ describe("uninstall command integration", () => {
 			// For now, we test the local flag worked
 			await uninstallCommand({
 				yes: true,
+				json: false,
+				verbose: false,
 				local: false,
 				global: true,
 				all: false,
@@ -368,6 +382,8 @@ describe("uninstall command integration", () => {
 
 			await uninstallCommand({
 				yes: true,
+				json: false,
+				verbose: false,
 				local: true,
 				global: true,
 				all: false,
@@ -401,6 +417,8 @@ describe("uninstall command integration", () => {
 			// Using --all flag (equivalent to --local --global)
 			await uninstallCommand({
 				yes: true,
+				json: false,
+				verbose: false,
 				local: false,
 				global: false,
 				all: true,
@@ -421,6 +439,8 @@ describe("uninstall command integration", () => {
 			await expect(
 				uninstallCommand({
 					yes: true,
+					json: false,
+					verbose: false,
 					local: true,
 					global: false,
 					all: false,
@@ -455,6 +475,8 @@ describe("uninstall command integration", () => {
 			await expect(
 				uninstallCommand({
 					yes: true,
+					json: false,
+					verbose: false,
 					local: true,
 					global: false,
 					all: false,
@@ -480,6 +502,8 @@ describe("uninstall command integration", () => {
 			await expect(
 				uninstallCommand({
 					yes: true,
+					json: false,
+					verbose: false,
 					local: true,
 					global: false,
 					all: false,
@@ -496,6 +520,8 @@ describe("uninstall command integration", () => {
 			await expect(
 				uninstallCommand({
 					yes: true,
+					json: false,
+					verbose: false,
 					local: true,
 					global: false,
 					all: false,
@@ -534,6 +560,8 @@ describe("uninstall command integration", () => {
 
 			await uninstallCommand({
 				yes: true,
+				json: false,
+				verbose: false,
 				local: true,
 				global: false,
 				all: false,

--- a/tests/utils/output-manager.test.ts
+++ b/tests/utils/output-manager.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { output } from "../../src/shared/output-manager.js";
+
+describe("OutputManager", () => {
+	let consoleSpy: ReturnType<typeof mock>;
+	let stderrSpy: ReturnType<typeof mock>;
+
+	beforeEach(() => {
+		output.reset();
+		consoleSpy = mock(() => {});
+		stderrSpy = mock(() => {});
+		console.log = consoleSpy;
+		console.error = stderrSpy;
+	});
+
+	afterEach(() => {
+		output.reset();
+	});
+
+	describe("configure", () => {
+		test("should set verbose mode", () => {
+			output.configure({ verbose: true });
+			expect(output.isVerbose()).toBe(true);
+		});
+
+		test("should set json mode", () => {
+			output.configure({ json: true });
+			expect(output.isJson()).toBe(true);
+		});
+
+		test("should set quiet mode", () => {
+			output.configure({ quiet: true });
+			expect(output.isQuiet()).toBe(true);
+		});
+	});
+
+	describe("getSymbols", () => {
+		test("should return symbols object with required keys", () => {
+			const symbols = output.getSymbols();
+			expect(symbols).toHaveProperty("prompt");
+			expect(symbols).toHaveProperty("success");
+			expect(symbols).toHaveProperty("error");
+			expect(symbols).toHaveProperty("warning");
+			expect(symbols).toHaveProperty("info");
+			expect(symbols).toHaveProperty("line");
+			expect(symbols).toHaveProperty("selected");
+			expect(symbols).toHaveProperty("pointer");
+		});
+	});
+
+	describe("output methods", () => {
+		test("success should not output in quiet mode", () => {
+			output.configure({ quiet: true });
+			output.success("test message");
+			expect(consoleSpy).not.toHaveBeenCalled();
+		});
+
+		test("error should still output in quiet mode (errors are critical)", () => {
+			output.configure({ quiet: true });
+			output.error("test error");
+			expect(stderrSpy).toHaveBeenCalled();
+		});
+
+		test("warning should not output in quiet mode", () => {
+			output.configure({ quiet: true });
+			output.warning("test warning");
+			expect(stderrSpy).not.toHaveBeenCalled();
+		});
+
+		test("info should not output in quiet mode", () => {
+			output.configure({ quiet: true });
+			output.info("test info");
+			expect(consoleSpy).not.toHaveBeenCalled();
+		});
+
+		test("verbose should only output when verbose mode is enabled", () => {
+			output.verbose("test verbose");
+			expect(consoleSpy).not.toHaveBeenCalled();
+
+			output.configure({ verbose: true });
+			output.verbose("test verbose");
+			expect(consoleSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe("JSON buffer", () => {
+		test("should buffer JSON entries", () => {
+			output.addJsonEntry({ type: "info", message: "test" });
+			const buffer = output.getJsonBuffer();
+			expect(buffer).toHaveLength(1);
+			expect(buffer[0].type).toBe("info");
+			expect(buffer[0].message).toBe("test");
+			expect(buffer[0].timestamp).toBeDefined();
+		});
+
+		test("should add result data to buffer", () => {
+			output.addJsonResult({ key: "value" });
+			const buffer = output.getJsonBuffer();
+			expect(buffer).toHaveLength(1);
+			expect(buffer[0].type).toBe("result");
+			expect(buffer[0].data).toEqual({ key: "value" });
+		});
+
+		test("should clear buffer", () => {
+			output.addJsonEntry({ type: "info", message: "test" });
+			output.clearJsonBuffer();
+			expect(output.getJsonBuffer()).toHaveLength(0);
+		});
+
+		test("should flush buffer to stdout", async () => {
+			output.addJsonEntry({ type: "info", message: "test" });
+			await output.flushJson();
+			expect(consoleSpy).toHaveBeenCalled();
+			expect(output.getJsonBuffer()).toHaveLength(0);
+		});
+
+		test("should auto-flush at 1000 entries", async () => {
+			for (let i = 0; i < 1000; i++) {
+				output.addJsonEntry({ type: "progress", data: { i } });
+			}
+			// Auto-flush is deferred via queueMicrotask, wait for it
+			await new Promise((resolve) => queueMicrotask(resolve));
+			await output.flushJson(); // Ensure flush completes
+			// Buffer should have been flushed and is now empty
+			expect(output.getJsonBuffer()).toHaveLength(0);
+			expect(consoleSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe("shouldShowProgress", () => {
+		test("should return false in json mode", () => {
+			output.configure({ json: true });
+			expect(output.shouldShowProgress()).toBe(false);
+		});
+
+		test("should return false in quiet mode", () => {
+			output.configure({ quiet: true });
+			expect(output.shouldShowProgress()).toBe(false);
+		});
+	});
+
+	describe("reset", () => {
+		test("should reset all configuration", () => {
+			output.configure({ verbose: true, json: true, quiet: true });
+			output.addJsonEntry({ type: "info", message: "test" });
+			output.reset();
+
+			expect(output.isVerbose()).toBe(false);
+			expect(output.isJson()).toBe(false);
+			expect(output.isQuiet()).toBe(false);
+			expect(output.getJsonBuffer()).toHaveLength(0);
+		});
+	});
+});

--- a/tests/utils/progress-bar.test.ts
+++ b/tests/utils/progress-bar.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { output } from "../../src/shared/output-manager.js";
+import { ProgressBar, createProgressBar } from "../../src/shared/progress-bar.js";
+
+describe("ProgressBar", () => {
+	let consoleSpy: ReturnType<typeof mock>;
+	let stdoutSpy: ReturnType<typeof mock>;
+
+	beforeEach(() => {
+		output.reset();
+		consoleSpy = mock(() => {});
+		stdoutSpy = mock(() => {});
+		console.log = consoleSpy;
+		process.stdout.write = stdoutSpy as typeof process.stdout.write;
+	});
+
+	afterEach(() => {
+		output.reset();
+	});
+
+	describe("createProgressBar", () => {
+		test("should create a ProgressBar instance", () => {
+			const bar = createProgressBar({ total: 100 });
+			expect(bar).toBeInstanceOf(ProgressBar);
+		});
+	});
+
+	describe("update", () => {
+		test("should clamp current to total", () => {
+			const bar = createProgressBar({ total: 100 });
+			bar.update(150);
+			// No error thrown, progress clamped to max
+		});
+	});
+
+	describe("increment", () => {
+		test("should increment by 1 by default", () => {
+			const bar = createProgressBar({ total: 100 });
+			bar.increment();
+			bar.increment();
+			// No error thrown
+		});
+
+		test("should increment by custom delta", () => {
+			const bar = createProgressBar({ total: 100 });
+			bar.increment(10);
+			// No error thrown
+		});
+	});
+
+	describe("complete", () => {
+		test("should complete in JSON mode", () => {
+			output.configure({ json: true });
+			const bar = createProgressBar({ total: 100, label: "Test" });
+			bar.complete("Done!");
+
+			const buffer = output.getJsonBuffer();
+			expect(buffer).toHaveLength(1);
+			expect(buffer[0].type).toBe("progress");
+			expect(buffer[0].message).toBe("Done!");
+		});
+
+		test("should use default message when none provided", () => {
+			output.configure({ json: true });
+			const bar = createProgressBar({ total: 100, label: "MyTask" });
+			bar.complete();
+
+			const buffer = output.getJsonBuffer();
+			expect(buffer[0].message).toBe("MyTask complete");
+		});
+	});
+
+	describe("format types", () => {
+		test("should format as percentage by default", () => {
+			output.configure({ json: true });
+			const bar = createProgressBar({ total: 100 });
+			bar.update(50);
+			bar.complete();
+
+			const buffer = output.getJsonBuffer();
+			// Progress entries should have percentage data
+			const lastEntry = buffer[buffer.length - 1];
+			expect(lastEntry.data?.percent).toBe(100);
+		});
+
+		test("should format as count", () => {
+			const bar = createProgressBar({ total: 10, format: "count" });
+			bar.update(5);
+			// No error thrown
+		});
+
+		test("should format as download with total size", () => {
+			const bar = createProgressBar({
+				total: 1024 * 1024, // 1 MB
+				format: "download",
+			});
+			bar.update(512 * 1024); // 512 KB
+			// No error thrown
+		});
+	});
+
+	describe("options", () => {
+		test("should accept width option", () => {
+			const bar = createProgressBar({ total: 100, width: 30 });
+			bar.update(50);
+			// No error thrown
+		});
+
+		test("should accept label option", () => {
+			const bar = createProgressBar({ total: 100, label: "Downloading" });
+			bar.update(50);
+			// No error thrown
+		});
+
+		test("should accept showEta option", () => {
+			const bar = createProgressBar({ total: 100, showEta: true });
+			bar.update(50);
+			// No error thrown - ETA calculation has div/0 protection
+		});
+	});
+
+	describe("JSON mode progress logging", () => {
+		test("should log progress entries in JSON mode", () => {
+			output.configure({ json: true });
+			const bar = createProgressBar({ total: 100 });
+
+			// Update to 25%
+			bar.update(25);
+			// Should have at least one entry
+			expect(output.getJsonBuffer().length).toBeGreaterThanOrEqual(1);
+
+			// Complete should log final entry
+			bar.complete();
+			const buffer = output.getJsonBuffer();
+			expect(buffer.length).toBeGreaterThanOrEqual(2);
+			expect(buffer[buffer.length - 1].type).toBe("progress");
+		});
+	});
+
+	describe("edge cases", () => {
+		test("should handle zero total", () => {
+			const bar = createProgressBar({ total: 0 });
+			bar.update(0);
+			bar.complete();
+			// No error thrown - div/0 protected
+		});
+
+		test("should handle immediate update after creation", () => {
+			const bar = createProgressBar({ total: 100, showEta: true });
+			// This tests the div/0 protection for ETA
+			bar.update(1);
+			// No error thrown
+		});
+
+		test("should truncate long labels", () => {
+			const bar = createProgressBar({
+				total: 100,
+				label: "This is a very long label that exceeds 16 characters",
+			});
+			bar.update(50);
+			// No error thrown - label is truncated
+		});
+	});
+});

--- a/tests/utils/terminal-utils.test.ts
+++ b/tests/utils/terminal-utils.test.ts
@@ -28,10 +28,10 @@ describe("terminal-utils", () => {
 			expect(supportsUnicode()).toBe(true);
 		});
 
-		it("should return false for CI environments", () => {
+		it("should return true for CI environments (modern CI supports Unicode)", () => {
 			process.env.WT_SESSION = undefined;
 			process.env.CI = "true";
-			expect(supportsUnicode()).toBe(false);
+			expect(supportsUnicode()).toBe(true);
 		});
 
 		it("should return false for dumb terminals", () => {
@@ -97,8 +97,10 @@ describe("terminal-utils", () => {
 			expect(symbols.info).toBe("ℹ");
 		});
 
-		it("should return ASCII fallback when Unicode not supported", () => {
-			process.env.CI = "true";
+		it("should return ASCII fallback when Unicode not supported (dumb terminal)", () => {
+			process.env.CI = undefined;
+			process.env.WT_SESSION = undefined;
+			process.env.TERM = "dumb";
 			const symbols = getStatusSymbols();
 			expect(symbols.pass).toBe("[PASS]");
 			expect(symbols.warn).toBe("[WARN]");


### PR DESCRIPTION
## Summary

Implements GitHub issue #210 - UI/UX overhaul for cleaner CLI experience.

### Changes

- **New flags**: `--verbose/-v` for full subprocess output, `--json` for machine-readable output
- **Enhanced Unicode detection**: Detects iTerm, VSCode, Konsole, UTF locale, Windows Terminal
- **Automatic ASCII fallback**: Legacy terminals get clean ASCII symbols instead of broken Unicode
- **OutputManager class**: Centralized output control with verbose/json/quiet modes
- **ProgressBar class**: TTY-aware progress bars with Unicode/ASCII bar characters

### Files Changed

| File | Change |
|------|--------|
| `src/shared/output-manager.ts` | **NEW** - Unified output manager |
| `src/shared/progress-bar.ts` | **NEW** - TTY-aware progress bar |
| `src/shared/terminal-utils.ts` | Enhanced Unicode detection |
| `src/shared/safe-prompts.ts` | Dynamic symbol switching |
| `src/shared/safe-spinner.ts` | Unicode/ASCII spinner selection |
| `src/types/commands.ts` | Added GlobalOutputOptionsSchema |
| `src/index.ts` | Added --json global flag, output.configure() |
| `src/domains/installation/download-manager.ts` | Uses new progress bar |

### Quality Gate

| Check | Status |
|-------|--------|
| `bun run typecheck` | ✅ Pass |
| `bun run lint:fix` | ✅ Pass |
| `bun test` | ✅ 1417 pass, 3 fail (integration tests requiring GitHub auth - not code issue) |
| `bun run build` | ✅ Pass (1.15 MB bundle) |

## Test plan

- [ ] Run `ck new --kit engineer` on modern terminal - should show Unicode UI
- [ ] Run `ck new --kit engineer` with `TERM=dumb` - should show ASCII fallback
- [ ] Run `ck new --kit engineer --verbose` - should show full pip/npm output
- [ ] Run `ck new --kit engineer --json` - should output JSON format
- [ ] Test on Windows Terminal, iTerm, VSCode terminal

Closes #210