### PR TITLE
fix: use ExecutionPolicy Bypass for Windows PowerShell scripts (#213)

### DIFF
--- a/src/services/package-installer/package-installer.ts
+++ b/src/services/package-installer/package-installer.ts
@@ -668,18 +668,19 @@ export async function installSkillsDependencies(skillsDir: string): Promise<Pack
 		};
 
 		if (platform === "win32") {
-			// Windows: Check if ExecutionPolicy bypass is needed
-			logger.warning("⚠️  Windows: Respecting system PowerShell execution policy");
-			logger.info("   If the script fails, you may need to set execution policy:");
-			logger.info("   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser");
-			logger.info("");
-
 			// Use executeInteractiveScript for real-time output streaming
-			await executeInteractiveScript("powershell", ["-File", scriptPath, "-Y"], {
-				timeout: 600000, // 10 minute timeout for skills installation
-				cwd: skillsDir,
-				env: scriptEnv,
-			});
+			// -NoLogo: Skip PowerShell banner
+			// -ExecutionPolicy Bypass: Allow running scripts (scoped to this process only)
+			// -File: Execute the script file
+			await executeInteractiveScript(
+				"powershell.exe",
+				["-NoLogo", "-ExecutionPolicy", "Bypass", "-File", scriptPath, "-Y"],
+				{
+					timeout: 600000, // 10 minute timeout for skills installation
+					cwd: skillsDir,
+					env: scriptEnv,
+				},
+			);
 		} else {
 			// Linux/macOS: Run bash script with real-time output
 			await executeInteractiveScript("bash", [scriptPath, ...scriptArgs], {


### PR DESCRIPTION
## Summary

Follow-up fix for #213 - Windows PowerShell installation still wasn't showing output because the script was blocked by execution policy before running.

## Changes

- Use `powershell.exe` with `-ExecutionPolicy Bypass` flag (scoped to child process only)
- Add `-NoLogo` to skip unnecessary PowerShell banner
- Remove confusing warning message since it's now handled automatically

## Before

```
ℹ Running: C:\Users\kaidu\.claude\skills\install.ps1
ℹ Resuming previous installation...
⚠ ⚠️  Windows: Respecting system PowerShell execution policy
ℹ    If the script fails, you may need to set execution policy:
...
ℹ ━━━ How to Fix ━━━
✗ Skills installation failed. See above for details.
```

## After

Full script output is now visible:
```
===================================================
Claude Code Skills Installation (Windows)
===================================================

[INFO] Script directory: C:\Users\kaidu\.claude\skills
[OK] Detected package manager: winget
[INFO] Mode: without admin (system packages may be skipped)
...
```

## Test Plan

- [x] Tested directly on Windows via `ssh kaidu@i9-bootcamp`
- [x] PowerShell script output now visible with `-ExecutionPolicy Bypass`
- [x] Build passes
- [x] Type check passes

Closes #213
