### PR TITLE
fix(config): prevent duplicate hook matchers during selective merge

### DIFF
--- a/src/domains/config/settings-merger.ts
+++ b/src/domains/config/settings-merger.ts
@@ -118,15 +118,17 @@ export class SettingsMerger {
 
 	/**
 	 * Merge hook entries for a specific event
-	 * Deduplicates by command string to avoid duplicate hooks
+	 * Deduplicates by command string and merges hooks with matching matchers
 	 *
 	 * Execution order: User hooks execute FIRST, then ClaudeKit hooks.
 	 * This is intentional - user customizations take priority and can
 	 * modify behavior before CK hooks run (e.g., environment setup).
 	 *
+	 * Matcher-aware merging: When source and dest have entries with the same
+	 * matcher value, merge their hooks arrays instead of creating duplicates.
+	 *
 	 * Partial duplicate handling: If a CK entry contains both duplicate
-	 * and unique commands, the ENTIRE entry is added (entries are atomic).
-	 * Only fully-duplicated entries are skipped.
+	 * and unique commands, only unique commands are added to existing matchers.
 	 */
 	private static mergeHookEntries(
 		sourceEntries: HookConfig[] | HookEntry[],
@@ -134,48 +136,112 @@ export class SettingsMerger {
 		eventName: string,
 		result: MergeResult,
 	): HookConfig[] | HookEntry[] {
-		// Extract all existing commands from destination for deduplication
-		const existingCommands = new Set<string>();
-		SettingsMerger.extractCommands(destEntries, existingCommands);
-
 		// Track preserved user hook entries only if destination has hooks for this event
 		if (destEntries.length > 0) {
 			result.hooksPreserved += destEntries.length;
 		}
 
-		// Start with destination entries (user hooks first for priority)
-		const merged: (HookConfig | HookEntry)[] = [...destEntries];
+		// Deep copy destination entries to avoid mutating original
+		const merged: (HookConfig | HookEntry)[] = destEntries.map((entry) =>
+			SettingsMerger.deepCopyEntry(entry),
+		);
 
-		// Add source entries that aren't fully duplicated
+		// Build index of existing matchers for efficient lookup
+		const matcherIndex = new Map<string, number>();
+		for (let i = 0; i < merged.length; i++) {
+			const entry = merged[i];
+			if ("matcher" in entry && entry.matcher) {
+				matcherIndex.set(entry.matcher, i);
+			}
+		}
+
+		// Extract all existing commands from destination for deduplication
+		const existingCommands = new Set<string>();
+		SettingsMerger.extractCommands(destEntries, existingCommands);
+
+		// Process each source entry
 		for (const entry of sourceEntries) {
+			const sourceMatcher = "matcher" in entry ? entry.matcher : undefined;
 			const commands = SettingsMerger.getEntryCommands(entry);
 
-			// Check if ALL commands in entry already exist (fully duplicated)
-			const isFullyDuplicated =
-				commands.length > 0 && commands.every((cmd) => existingCommands.has(cmd));
+			// Check if a matcher entry with same value already exists
+			if (sourceMatcher && matcherIndex.has(sourceMatcher)) {
+				// Merge hooks into existing matcher entry
+				const existingIdx = matcherIndex.get(sourceMatcher);
+				if (existingIdx === undefined) continue;
+				const existingEntry = merged[existingIdx] as HookConfig;
 
-			// Track duplicate commands for logging (partial or full)
-			const duplicateCommands = commands.filter((cmd) => existingCommands.has(cmd));
-			if (duplicateCommands.length > 0) {
-				const summary =
-					duplicateCommands.length === 1
-						? `"${SettingsMerger.truncateCommand(duplicateCommands[0])}"`
-						: `${duplicateCommands.length} commands`;
-				result.conflictsDetected.push(`${eventName}: duplicate ${summary}`);
-			}
+				// Get new commands not already in existing entry
+				const newCommands = commands.filter((cmd) => !existingCommands.has(cmd));
+				const duplicateCommands = commands.filter((cmd) => existingCommands.has(cmd));
 
-			// Add entry if not fully duplicated (entries are atomic - can't split)
-			if (!isFullyDuplicated) {
-				merged.push(entry);
-				result.hooksAdded++;
-				// Register new commands to prevent future duplicates
-				for (const cmd of commands) {
-					existingCommands.add(cmd);
+				// Log duplicates
+				if (duplicateCommands.length > 0) {
+					const summary =
+						duplicateCommands.length === 1
+							? `"${SettingsMerger.truncateCommand(duplicateCommands[0])}"`
+							: `${duplicateCommands.length} commands`;
+					result.conflictsDetected.push(`${eventName}: duplicate ${summary}`);
+				}
+
+				// Add unique hooks to existing matcher
+				if (newCommands.length > 0 && "hooks" in entry && entry.hooks) {
+					if (!existingEntry.hooks) {
+						existingEntry.hooks = [];
+					}
+					for (const hook of entry.hooks) {
+						if (hook.command && !existingCommands.has(hook.command)) {
+							existingEntry.hooks.push(hook);
+							existingCommands.add(hook.command);
+						}
+					}
+					result.hooksAdded++;
+				}
+			} else {
+				// No matching matcher - check for full command duplication
+				const isFullyDuplicated =
+					commands.length > 0 && commands.every((cmd) => existingCommands.has(cmd));
+
+				// Track duplicate commands for logging (partial or full)
+				const duplicateCommands = commands.filter((cmd) => existingCommands.has(cmd));
+				if (duplicateCommands.length > 0) {
+					const summary =
+						duplicateCommands.length === 1
+							? `"${SettingsMerger.truncateCommand(duplicateCommands[0])}"`
+							: `${duplicateCommands.length} commands`;
+					result.conflictsDetected.push(`${eventName}: duplicate ${summary}`);
+				}
+
+				// Add entry if not fully duplicated
+				if (!isFullyDuplicated) {
+					merged.push(entry);
+					result.hooksAdded++;
+					// Register matcher if present
+					if (sourceMatcher) {
+						matcherIndex.set(sourceMatcher, merged.length - 1);
+					}
+					// Register new commands
+					for (const cmd of commands) {
+						existingCommands.add(cmd);
+					}
 				}
 			}
 		}
 
 		return merged;
+	}
+
+	/**
+	 * Deep copy a hook entry to avoid mutating originals
+	 */
+	private static deepCopyEntry(entry: HookConfig | HookEntry): HookConfig | HookEntry {
+		if ("hooks" in entry) {
+			return {
+				...entry,
+				hooks: entry.hooks ? [...entry.hooks.map((h) => ({ ...h }))] : undefined,
+			};
+		}
+		return { ...entry };
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Fixes #219 - Selective merge creates duplicate hook matchers during `ck init -g`.

When merging hook settings with identical matcher values, entries are now properly deduplicated and merged into a single entry instead of creating duplicates.

## Changes
1. Modified `mergeHookEntries()` in `src/domains/config/settings-merger.ts` to perform matcher-aware merging
2. When source and dest have entries with same `matcher` value, hooks are merged into existing entry
3. Added `deepCopyEntry()` helper to avoid mutating original entries
4. Added 2 new test cases for issue #219 scenario
5. Updated "real-world settings merge" test to reflect correct behavior

## Before (Bug)
```json
"PreToolUse": [
  { "matcher": "Bash|...", "hooks": [{ "command": "scout-block.cjs" }] },
  { "matcher": "Bash|...", "hooks": [{ "command": "scout-block.cjs" }, { "command": "privacy-block.cjs" }] }
]
```

## After (Fixed)
```json
"PreToolUse": [
  { "matcher": "Bash|...", "hooks": [{ "command": "scout-block.cjs" }, { "command": "privacy-block.cjs" }] }
]
```

## Testing
- Existing tests updated and passing
- New test cases verify duplicate matcher prevention