### PR TITLE
feat(init): add selective merge to skip unchanged files during init

### DIFF
--- a/src/__tests__/domains/installation/selective-merger.test.ts
+++ b/src/__tests__/domains/installation/selective-merger.test.ts
@@ -1,0 +1,748 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SelectiveMerger } from "@/domains/installation/selective-merger.js";
+import type { ReleaseManifest } from "@/domains/migration/release-manifest.js";
+import { OwnershipChecker } from "@/services/file-operations/ownership-checker.js";
+
+describe("SelectiveMerger", () => {
+	let tempDir: string;
+	let sourceDir: string;
+	let destDir: string;
+
+	beforeEach(async () => {
+		tempDir = join(
+			tmpdir(),
+			`selective-merger-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		sourceDir = join(tempDir, "source");
+		destDir = join(tempDir, "dest");
+		await mkdir(sourceDir, { recursive: true });
+		await mkdir(destDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	describe("shouldCopyFile", () => {
+		describe("new files (dest doesn't exist)", () => {
+			test("returns changed=true for new file", async () => {
+				const sourcePath = join(sourceDir, "new-file.txt");
+				await writeFile(sourcePath, "content");
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "new-file.txt", checksum, size: 7 }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const destPath = join(destDir, "new-file.txt");
+
+				const result = await merger.shouldCopyFile(destPath, "new-file.txt");
+
+				expect(result.changed).toBe(true);
+				expect(result.reason).toBe("new");
+			});
+
+			test("returns changed=true for new file in nested directory", async () => {
+				const nestedDir = join(sourceDir, "hooks", "scripts");
+				await mkdir(nestedDir, { recursive: true });
+				const sourcePath = join(nestedDir, "hook.cjs");
+				await writeFile(sourcePath, "module.exports = {}");
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "hooks/scripts/hook.cjs", checksum, size: 19 }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const destPath = join(destDir, "hooks", "scripts", "hook.cjs");
+
+				const result = await merger.shouldCopyFile(destPath, "hooks/scripts/hook.cjs");
+
+				expect(result.changed).toBe(true);
+				expect(result.reason).toBe("new");
+			});
+		});
+
+		describe("unchanged files (same size, same checksum)", () => {
+			test("returns changed=false for identical text file", async () => {
+				const content = "unchanged content";
+				const sourcePath = join(sourceDir, "unchanged.txt");
+				const destPath = join(destDir, "unchanged.txt");
+				await writeFile(sourcePath, content);
+				await writeFile(destPath, content);
+
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "unchanged.txt", checksum, size: content.length }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "unchanged.txt");
+
+				expect(result.changed).toBe(false);
+				expect(result.reason).toBe("unchanged");
+				expect(result.sourceChecksum).toBe(checksum);
+				expect(result.destChecksum).toBe(checksum);
+			});
+
+			test("returns changed=false for identical empty file", async () => {
+				const sourcePath = join(sourceDir, "empty.txt");
+				const destPath = join(destDir, "empty.txt");
+				await writeFile(sourcePath, "");
+				await writeFile(destPath, "");
+
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "empty.txt", checksum, size: 0 }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "empty.txt");
+
+				expect(result.changed).toBe(false);
+				expect(result.reason).toBe("unchanged");
+			});
+
+			test("returns changed=false for identical JSON file", async () => {
+				const content = JSON.stringify({ key: "value", nested: { arr: [1, 2, 3] } }, null, 2);
+				const sourcePath = join(sourceDir, "config.json");
+				const destPath = join(destDir, "config.json");
+				await writeFile(sourcePath, content);
+				await writeFile(destPath, content);
+
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "config.json", checksum, size: content.length }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "config.json");
+
+				expect(result.changed).toBe(false);
+				expect(result.reason).toBe("unchanged");
+			});
+
+			test("returns changed=false for identical file in nested path", async () => {
+				const content = "nested file content";
+				const nestedSrc = join(sourceDir, "commands", "ck");
+				const nestedDest = join(destDir, "commands", "ck");
+				await mkdir(nestedSrc, { recursive: true });
+				await mkdir(nestedDest, { recursive: true });
+
+				const sourcePath = join(nestedSrc, "help.md");
+				const destPath = join(nestedDest, "help.md");
+				await writeFile(sourcePath, content);
+				await writeFile(destPath, content);
+
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "commands/ck/help.md", checksum, size: content.length }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "commands/ck/help.md");
+
+				expect(result.changed).toBe(false);
+				expect(result.reason).toBe("unchanged");
+			});
+
+			test("returns changed=false for file with special characters content", async () => {
+				const content = "Special: émojis 🎉, tabs\t, newlines\n, unicode: 你好";
+				const sourcePath = join(sourceDir, "special.txt");
+				const destPath = join(destDir, "special.txt");
+				await writeFile(sourcePath, content);
+				await writeFile(destPath, content);
+
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "special.txt", checksum, size: Buffer.byteLength(content) }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "special.txt");
+
+				expect(result.changed).toBe(false);
+				expect(result.reason).toBe("unchanged");
+			});
+		});
+
+		describe("size differs (fast path)", () => {
+			test("returns changed=true when dest is larger", async () => {
+				const sourcePath = join(sourceDir, "size-diff.txt");
+				const destPath = join(destDir, "size-diff.txt");
+				await writeFile(sourcePath, "short");
+				await writeFile(destPath, "much longer content here");
+
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "size-diff.txt", checksum, size: 5 }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "size-diff.txt");
+
+				expect(result.changed).toBe(true);
+				expect(result.reason).toBe("size-differ");
+				expect(result.sourceChecksum).toBe(checksum);
+				expect(result.destChecksum).toBeUndefined(); // Checksum not calculated for size diff
+			});
+
+			test("returns changed=true when dest is smaller", async () => {
+				const sourcePath = join(sourceDir, "size-diff2.txt");
+				const destPath = join(destDir, "size-diff2.txt");
+				await writeFile(sourcePath, "longer content");
+				await writeFile(destPath, "short");
+
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "size-diff2.txt", checksum, size: 14 }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "size-diff2.txt");
+
+				expect(result.changed).toBe(true);
+				expect(result.reason).toBe("size-differ");
+			});
+
+			test("returns changed=true when dest is empty but source is not", async () => {
+				const sourcePath = join(sourceDir, "was-empty.txt");
+				const destPath = join(destDir, "was-empty.txt");
+				await writeFile(sourcePath, "now has content");
+				await writeFile(destPath, "");
+
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "was-empty.txt", checksum, size: 15 }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "was-empty.txt");
+
+				expect(result.changed).toBe(true);
+				expect(result.reason).toBe("size-differ");
+			});
+
+			test("returns changed=true when source is empty but dest is not", async () => {
+				const sourcePath = join(sourceDir, "now-empty.txt");
+				const destPath = join(destDir, "now-empty.txt");
+				await writeFile(sourcePath, "");
+				await writeFile(destPath, "had content");
+
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "now-empty.txt", checksum, size: 0 }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "now-empty.txt");
+
+				expect(result.changed).toBe(true);
+				expect(result.reason).toBe("size-differ");
+			});
+		});
+
+		describe("checksum differs (slow path - same size)", () => {
+			test("returns changed=true for same size, different content", async () => {
+				const sourcePath = join(sourceDir, "checksum-diff.txt");
+				const destPath = join(destDir, "checksum-diff.txt");
+				await writeFile(sourcePath, "content-a");
+				await writeFile(destPath, "content-b");
+
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "checksum-diff.txt", checksum, size: 9 }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "checksum-diff.txt");
+
+				expect(result.changed).toBe(true);
+				expect(result.reason).toBe("checksum-differ");
+				expect(result.sourceChecksum).toBe(checksum);
+				expect(result.destChecksum).toBeDefined();
+				expect(result.destChecksum).not.toBe(checksum);
+			});
+
+			test("returns changed=true for same length strings with different chars", async () => {
+				const sourcePath = join(sourceDir, "abc.txt");
+				const destPath = join(destDir, "abc.txt");
+				await writeFile(sourcePath, "abc");
+				await writeFile(destPath, "xyz");
+
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "abc.txt", checksum, size: 3 }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "abc.txt");
+
+				expect(result.changed).toBe(true);
+				expect(result.reason).toBe("checksum-differ");
+			});
+
+			test("returns changed=true for JSON with same size but different values", async () => {
+				const sourceContent = '{"a":1}';
+				const destContent = '{"b":2}';
+				const sourcePath = join(sourceDir, "config.json");
+				const destPath = join(destDir, "config.json");
+				await writeFile(sourcePath, sourceContent);
+				await writeFile(destPath, destContent);
+
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "config.json", checksum, size: sourceContent.length }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "config.json");
+
+				expect(result.changed).toBe(true);
+				expect(result.reason).toBe("checksum-differ");
+			});
+		});
+
+		describe("manifest entry missing", () => {
+			test("returns changed=true when file not in manifest", async () => {
+				const sourcePath = join(sourceDir, "unlisted.txt");
+				const destPath = join(destDir, "unlisted.txt");
+				await writeFile(sourcePath, "content");
+				await writeFile(destPath, "content");
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "other-file.txt", checksum: "a".repeat(64), size: 10 }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "unlisted.txt");
+
+				expect(result.changed).toBe(true);
+				expect(result.reason).toBe("new");
+			});
+
+			test("returns changed=true with empty manifest files array", async () => {
+				const destPath = join(destDir, "any.txt");
+				await writeFile(destPath, "content");
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "any.txt");
+
+				expect(result.changed).toBe(true);
+				expect(result.reason).toBe("new");
+			});
+		});
+
+		describe("path matching", () => {
+			test("matches exact path with forward slashes", async () => {
+				const content = "nested content";
+				const nestedDest = join(destDir, "dir1", "dir2");
+				await mkdir(nestedDest, { recursive: true });
+				const destPath = join(nestedDest, "file.txt");
+				await writeFile(destPath, content);
+
+				const checksum = await OwnershipChecker.calculateChecksum(destPath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "dir1/dir2/file.txt", checksum, size: content.length }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "dir1/dir2/file.txt");
+
+				expect(result.changed).toBe(false);
+				expect(result.reason).toBe("unchanged");
+			});
+
+			test("handles deeply nested paths", async () => {
+				const content = "deep content";
+				const deepPath = join(destDir, "a", "b", "c", "d", "e");
+				await mkdir(deepPath, { recursive: true });
+				const destPath = join(deepPath, "deep.txt");
+				await writeFile(destPath, content);
+
+				const checksum = await OwnershipChecker.calculateChecksum(destPath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "a/b/c/d/e/deep.txt", checksum, size: content.length }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "a/b/c/d/e/deep.txt");
+
+				expect(result.changed).toBe(false);
+				expect(result.reason).toBe("unchanged");
+			});
+		});
+
+		describe("binary content handling", () => {
+			test("handles binary content correctly", async () => {
+				const binaryContent = Buffer.from([0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd]);
+				const sourcePath = join(sourceDir, "binary.bin");
+				const destPath = join(destDir, "binary.bin");
+				await writeFile(sourcePath, binaryContent);
+				await writeFile(destPath, binaryContent);
+
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "binary.bin", checksum, size: binaryContent.length }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "binary.bin");
+
+				expect(result.changed).toBe(false);
+				expect(result.reason).toBe("unchanged");
+			});
+
+			test("detects changes in binary content", async () => {
+				const sourceContent = Buffer.from([0x00, 0x01, 0x02]);
+				const destContent = Buffer.from([0x00, 0x01, 0x03]);
+				const sourcePath = join(sourceDir, "binary-diff.bin");
+				const destPath = join(destDir, "binary-diff.bin");
+				await writeFile(sourcePath, sourceContent);
+				await writeFile(destPath, destContent);
+
+				const checksum = await OwnershipChecker.calculateChecksum(sourcePath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [{ path: "binary-diff.bin", checksum, size: sourceContent.length }],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "binary-diff.bin");
+
+				expect(result.changed).toBe(true);
+				expect(result.reason).toBe("checksum-differ");
+			});
+		});
+
+		describe("multiple files in manifest", () => {
+			test("correctly identifies file among many", async () => {
+				const content = "target file";
+				const destPath = join(destDir, "target.txt");
+				await writeFile(destPath, content);
+
+				const checksum = await OwnershipChecker.calculateChecksum(destPath);
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [
+						{ path: "file1.txt", checksum: "1".repeat(64), size: 100 },
+						{ path: "file2.txt", checksum: "2".repeat(64), size: 200 },
+						{ path: "target.txt", checksum, size: content.length },
+						{ path: "file4.txt", checksum: "4".repeat(64), size: 400 },
+						{ path: "dir/file5.txt", checksum: "5".repeat(64), size: 500 },
+					],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "target.txt");
+
+				expect(result.changed).toBe(false);
+				expect(result.reason).toBe("unchanged");
+			});
+
+			test("correctly identifies changed file among unchanged", async () => {
+				const destPath = join(destDir, "changed.txt");
+				await writeFile(destPath, "modified content");
+
+				const manifest: ReleaseManifest = {
+					version: "v1.0.0",
+					generatedAt: new Date().toISOString(),
+					files: [
+						{ path: "file1.txt", checksum: "1".repeat(64), size: 100 },
+						{ path: "changed.txt", checksum: "original".padEnd(64, "0"), size: 16 },
+						{ path: "file3.txt", checksum: "3".repeat(64), size: 300 },
+					],
+				};
+
+				const merger = new SelectiveMerger(manifest);
+				const result = await merger.shouldCopyFile(destPath, "changed.txt");
+
+				expect(result.changed).toBe(true);
+				// Could be size-differ or checksum-differ depending on content
+				expect(["size-differ", "checksum-differ"]).toContain(result.reason);
+			});
+		});
+	});
+
+	describe("hasManifest", () => {
+		test("returns true when manifest has files", () => {
+			const manifest: ReleaseManifest = {
+				version: "v1.0.0",
+				generatedAt: new Date().toISOString(),
+				files: [{ path: "file.txt", checksum: "a".repeat(64), size: 10 }],
+			};
+
+			const merger = new SelectiveMerger(manifest);
+			expect(merger.hasManifest()).toBe(true);
+		});
+
+		test("returns false when manifest is null", () => {
+			const merger = new SelectiveMerger(null);
+			expect(merger.hasManifest()).toBe(false);
+		});
+
+		test("returns false when manifest has no files", () => {
+			const manifest: ReleaseManifest = {
+				version: "v1.0.0",
+				generatedAt: new Date().toISOString(),
+				files: [],
+			};
+
+			const merger = new SelectiveMerger(manifest);
+			expect(merger.hasManifest()).toBe(false);
+		});
+
+		test("returns true for manifest with single file", () => {
+			const manifest: ReleaseManifest = {
+				version: "v1.0.0",
+				generatedAt: new Date().toISOString(),
+				files: [{ path: "single.txt", checksum: "x".repeat(64), size: 1 }],
+			};
+
+			const merger = new SelectiveMerger(manifest);
+			expect(merger.hasManifest()).toBe(true);
+		});
+
+		test("returns true for manifest with many files", () => {
+			const files = Array.from({ length: 100 }, (_, i) => ({
+				path: `file${i}.txt`,
+				checksum: `${i}`.repeat(64).slice(0, 64),
+				size: i * 10,
+			}));
+
+			const manifest: ReleaseManifest = {
+				version: "v1.0.0",
+				generatedAt: new Date().toISOString(),
+				files,
+			};
+
+			const merger = new SelectiveMerger(manifest);
+			expect(merger.hasManifest()).toBe(true);
+		});
+	});
+
+	describe("getManifestFileCount", () => {
+		test("returns correct file count", () => {
+			const manifest: ReleaseManifest = {
+				version: "v1.0.0",
+				generatedAt: new Date().toISOString(),
+				files: [
+					{ path: "file1.txt", checksum: "a".repeat(64), size: 10 },
+					{ path: "file2.txt", checksum: "b".repeat(64), size: 20 },
+					{ path: "dir/file3.txt", checksum: "c".repeat(64), size: 30 },
+				],
+			};
+
+			const merger = new SelectiveMerger(manifest);
+			expect(merger.getManifestFileCount()).toBe(3);
+		});
+
+		test("returns 0 for null manifest", () => {
+			const merger = new SelectiveMerger(null);
+			expect(merger.getManifestFileCount()).toBe(0);
+		});
+
+		test("returns 0 for empty files array", () => {
+			const manifest: ReleaseManifest = {
+				version: "v1.0.0",
+				generatedAt: new Date().toISOString(),
+				files: [],
+			};
+
+			const merger = new SelectiveMerger(manifest);
+			expect(merger.getManifestFileCount()).toBe(0);
+		});
+
+		test("returns 1 for single file", () => {
+			const manifest: ReleaseManifest = {
+				version: "v1.0.0",
+				generatedAt: new Date().toISOString(),
+				files: [{ path: "single.txt", checksum: "a".repeat(64), size: 10 }],
+			};
+
+			const merger = new SelectiveMerger(manifest);
+			expect(merger.getManifestFileCount()).toBe(1);
+		});
+
+		test("returns correct count for large manifest", () => {
+			const files = Array.from({ length: 800 }, (_, i) => ({
+				path: `file${i}.txt`,
+				checksum: `${i}`.repeat(64).slice(0, 64),
+				size: i,
+			}));
+
+			const manifest: ReleaseManifest = {
+				version: "v1.0.0",
+				generatedAt: new Date().toISOString(),
+				files,
+			};
+
+			const merger = new SelectiveMerger(manifest);
+			expect(merger.getManifestFileCount()).toBe(800);
+		});
+	});
+
+	describe("manifest map lookup efficiency", () => {
+		test("O(1) lookup with Map instead of array find", async () => {
+			// Create large manifest to test lookup efficiency
+			const files = Array.from({ length: 1000 }, (_, i) => ({
+				path: `dir${Math.floor(i / 100)}/subdir${Math.floor(i / 10) % 10}/file${i}.txt`,
+				checksum: `${i}`.padStart(64, "0"),
+				size: i * 10,
+			}));
+
+			// Add target file at the end
+			const targetContent = "target content";
+			const destPath = join(destDir, "target.txt");
+			await writeFile(destPath, targetContent);
+			const targetChecksum = await OwnershipChecker.calculateChecksum(destPath);
+			files.push({ path: "target.txt", checksum: targetChecksum, size: targetContent.length });
+
+			const manifest: ReleaseManifest = {
+				version: "v1.0.0",
+				generatedAt: new Date().toISOString(),
+				files,
+			};
+
+			const merger = new SelectiveMerger(manifest);
+
+			// Should find the file efficiently
+			const startTime = performance.now();
+			const result = await merger.shouldCopyFile(destPath, "target.txt");
+			const endTime = performance.now();
+
+			expect(result.changed).toBe(false);
+			expect(result.reason).toBe("unchanged");
+			// Should complete in reasonable time (< 100ms for 1000 files)
+			expect(endTime - startTime).toBeLessThan(100);
+		});
+	});
+
+	describe("edge cases", () => {
+		test("handles file with only whitespace", async () => {
+			const content = "   \t\n  ";
+			const destPath = join(destDir, "whitespace.txt");
+			await writeFile(destPath, content);
+
+			const checksum = await OwnershipChecker.calculateChecksum(destPath);
+
+			const manifest: ReleaseManifest = {
+				version: "v1.0.0",
+				generatedAt: new Date().toISOString(),
+				files: [{ path: "whitespace.txt", checksum, size: content.length }],
+			};
+
+			const merger = new SelectiveMerger(manifest);
+			const result = await merger.shouldCopyFile(destPath, "whitespace.txt");
+
+			expect(result.changed).toBe(false);
+			expect(result.reason).toBe("unchanged");
+		});
+
+		test("handles file with null bytes", async () => {
+			const content = "before\x00after";
+			const destPath = join(destDir, "nullbyte.txt");
+			await writeFile(destPath, content);
+
+			const checksum = await OwnershipChecker.calculateChecksum(destPath);
+
+			const manifest: ReleaseManifest = {
+				version: "v1.0.0",
+				generatedAt: new Date().toISOString(),
+				files: [{ path: "nullbyte.txt", checksum, size: content.length }],
+			};
+
+			const merger = new SelectiveMerger(manifest);
+			const result = await merger.shouldCopyFile(destPath, "nullbyte.txt");
+
+			expect(result.changed).toBe(false);
+			expect(result.reason).toBe("unchanged");
+		});
+
+		test("handles large file simulation (content)", async () => {
+			// Simulate larger file with repeated content
+			const content = "x".repeat(10000);
+			const destPath = join(destDir, "large.txt");
+			await writeFile(destPath, content);
+
+			const checksum = await OwnershipChecker.calculateChecksum(destPath);
+
+			const manifest: ReleaseManifest = {
+				version: "v1.0.0",
+				generatedAt: new Date().toISOString(),
+				files: [{ path: "large.txt", checksum, size: content.length }],
+			};
+
+			const merger = new SelectiveMerger(manifest);
+			const result = await merger.shouldCopyFile(destPath, "large.txt");
+
+			expect(result.changed).toBe(false);
+			expect(result.reason).toBe("unchanged");
+		});
+	});
+});

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -522,6 +522,12 @@ export async function initCommand(options: UpdateCommandOptions): Promise<void> 
 		const claudeDir = validOptions.global ? resolvedDir : join(resolvedDir, ".claude");
 		const releaseManifest = await ReleaseManifestLoader.load(extractDir);
 
+		// Enable selective merge optimization if manifest available
+		// This skips copying unchanged files based on checksum comparison
+		if (releaseManifest) {
+			merger.setManifest(releaseManifest);
+		}
+
 		if (!validOptions.fresh && (await pathExists(claudeDir))) {
 			const legacyDetection = await LegacyMigration.detectLegacy(claudeDir);
 

--- a/src/domains/installation/selective-merger.ts
+++ b/src/domains/installation/selective-merger.ts
@@ -1,0 +1,113 @@
+import { stat } from "node:fs/promises";
+import type { ReleaseManifest, ReleaseManifestFile } from "@/domains/migration/release-manifest.js";
+import { OwnershipChecker } from "@/services/file-operations/ownership-checker.js";
+import { logger } from "@/shared/logger.js";
+
+/**
+ * Result of comparing source and destination files
+ */
+export interface CompareResult {
+	changed: boolean;
+	reason: "new" | "size-differ" | "checksum-differ" | "unchanged";
+	sourceChecksum?: string;
+	destChecksum?: string;
+}
+
+/**
+ * SelectiveMerger - Determines which files need to be copied during init/update
+ *
+ * Uses hybrid size+checksum comparison for efficiency:
+ * 1. Fast path: If dest doesn't exist → new file, must copy
+ * 2. Fast path: If sizes differ → file changed, must copy
+ * 3. Slow path: If sizes match → calculate dest checksum, compare with manifest
+ *
+ * This significantly reduces I/O for update operations where most files are unchanged.
+ * Fresh installs are unaffected (all files are new).
+ */
+export class SelectiveMerger {
+	private manifest: ReleaseManifest | null;
+	private manifestMap: Map<string, ReleaseManifestFile>;
+
+	constructor(manifest: ReleaseManifest | null) {
+		this.manifest = manifest;
+		this.manifestMap = new Map();
+		if (manifest) {
+			for (const file of manifest.files) {
+				this.manifestMap.set(file.path, file);
+			}
+		}
+	}
+
+	/**
+	 * Compare source and destination file to determine if copy is needed
+	 * Uses hybrid size+checksum comparison for efficiency
+	 *
+	 * @param destPath Absolute path to destination file
+	 * @param relativePath Relative path for manifest lookup (forward slashes)
+	 * @returns CompareResult indicating whether file should be copied
+	 */
+	async shouldCopyFile(destPath: string, relativePath: string): Promise<CompareResult> {
+		// Check if destination exists
+		let destStat;
+		try {
+			destStat = await stat(destPath);
+		} catch {
+			// Destination doesn't exist → new file, must copy
+			return { changed: true, reason: "new" };
+		}
+
+		// Get source info from manifest
+		const manifestEntry = this.manifestMap.get(relativePath);
+		if (!manifestEntry) {
+			// No manifest entry → can't compare, must copy
+			logger.debug(`No manifest entry for ${relativePath}, will copy`);
+			return { changed: true, reason: "new" };
+		}
+
+		// Fast path: compare sizes first (O(1) stat)
+		if (destStat.size !== manifestEntry.size) {
+			logger.debug(`Size differs for ${relativePath}: ${destStat.size} vs ${manifestEntry.size}`);
+			return {
+				changed: true,
+				reason: "size-differ",
+				sourceChecksum: manifestEntry.checksum,
+			};
+		}
+
+		// Slow path: sizes match, compare checksums
+		const destChecksum = await OwnershipChecker.calculateChecksum(destPath);
+
+		if (destChecksum !== manifestEntry.checksum) {
+			logger.debug(`Checksum differs for ${relativePath}`);
+			return {
+				changed: true,
+				reason: "checksum-differ",
+				sourceChecksum: manifestEntry.checksum,
+				destChecksum,
+			};
+		}
+
+		// Checksums match → file unchanged
+		logger.debug(`Unchanged: ${relativePath}`);
+		return {
+			changed: false,
+			reason: "unchanged",
+			sourceChecksum: manifestEntry.checksum,
+			destChecksum,
+		};
+	}
+
+	/**
+	 * Check if manifest is available for selective merge
+	 */
+	hasManifest(): boolean {
+		return this.manifest !== null && this.manifestMap.size > 0;
+	}
+
+	/**
+	 * Get number of files tracked in manifest
+	 */
+	getManifestFileCount(): number {
+		return this.manifestMap.size;
+	}
+}


### PR DESCRIPTION
## Summary

Implement hybrid size+checksum comparison to optimize `ck init` / `ck init -g`:

- Add `SelectiveMerger` class with O(1) manifest lookup via Map
- Size check first (fast path O(1) stat), checksum only when sizes match
- Integrate via `FileMerger.setManifest()` method
- Track and log skipped unchanged files count

## Performance Impact

| Scenario | Before | After |
|----------|--------|-------|
| Fresh install | 800 writes | 800 writes (same) |
| Minor update (5 files) | 800 writes | 5 writes + 795 stats |
| No changes | 800 writes | 0 writes + 800 stats |

Expected: ~30s → <2s for unchanged installations

## Test Plan

- [x] 36 unit tests covering all scenarios (new files, unchanged, size diff, checksum diff, edge cases)
- [x] typecheck passes
- [x] lint passes
- [x] build passes

## Changes

| File | Change |
|------|--------|
| `src/domains/installation/selective-merger.ts` | NEW - SelectiveMerger class |
| `src/domains/installation/file-merger.ts` | Add `setManifest()` + selective skip logic |
| `src/commands/init.ts` | Pass manifest to FileMerger |
| `src/__tests__/domains/installation/selective-merger.test.ts` | 36 comprehensive tests |

Closes #225