### PR TITLE
fix(init): respect -y flag for merge confirmation prompt

### DIFF
--- a/src/commands/init/phases/merge-handler.ts
+++ b/src/commands/init/phases/merge-handler.ts
@@ -134,7 +134,7 @@ export async function handleMerge(ctx: InitContext): Promise<InitContext> {
 
 	// Merge files
 	const sourceDir = ctx.options.global ? join(ctx.extractDir, ".claude") : ctx.extractDir;
-	await merger.merge(sourceDir, ctx.resolvedDir, false);
+	await merger.merge(sourceDir, ctx.resolvedDir, ctx.isNonInteractive);
 
 	// Build file tracking list and track with progress
 	const installedFiles = merger.getAllInstalledFiles();


### PR DESCRIPTION
## Summary
Fix merge confirmation prompt not respecting `-y` flag during `ck init`.

## Changes
- Pass `ctx.isNonInteractive` to `merger.merge()` instead of hardcoded `false`

## Before
```bash
ck init -g -y --install-skills
# Still prompted: "Do you want to continue?"
```

## After
```bash
ck init -g -y --install-skills  
# Skips all confirmations as expected
```

## Files Changed
- `src/commands/init/phases/merge-handler.ts` (1 line fix)