### PR TITLE
fix: saveProjectConfig uses selective merge to preserve user settings

### DIFF
--- a/src/domains/config/config-manager.ts
+++ b/src/domains/config/config-manager.ts
@@ -192,19 +192,27 @@ export class ConfigManager {
 				try {
 					const content = await readFile(configPath, "utf-8");
 					existingConfig = JSON.parse(content);
-				} catch {
+				} catch (error) {
 					// If parsing fails, start fresh
-					logger.debug("Could not parse existing config, starting fresh");
+					logger.debug(
+						`Could not parse existing config, starting fresh: ${error instanceof Error ? error.message : "Unknown error"}`,
+					);
 				}
 			}
 
 			const validFolders = FoldersConfigSchema.parse(folders);
 
+			// Ensure existingConfig.paths is an object before spreading
+			const existingPaths =
+				existingConfig.paths && typeof existingConfig.paths === "object"
+					? (existingConfig.paths as Record<string, unknown>)
+					: {};
+
 			// Selective merge: only update paths, preserve all other settings
 			const mergedConfig = {
 				...existingConfig,
 				paths: {
-					...((existingConfig.paths as Record<string, unknown>) || {}),
+					...existingPaths,
 					...validFolders,
 				},
 			};

--- a/tests/config-folders.test.ts
+++ b/tests/config-folders.test.ts
@@ -154,6 +154,27 @@ describe("ConfigManager Folders Support", () => {
 
 			expect(savedConfig.paths.docs).toBe("new-docs");
 		});
+
+		test("should handle malformed paths (non-object) gracefully", async () => {
+			// Create config with paths as a string instead of object
+			await mkdir(join(testDir, ".claude"), { recursive: true });
+			const malformedConfig = {
+				codingLevel: 2,
+				paths: "invalid-string-instead-of-object",
+			};
+			await writeFile(join(testDir, ".claude", ".ck.json"), JSON.stringify(malformedConfig));
+
+			// Should not throw, should replace malformed paths with valid object
+			await ConfigManager.saveProjectConfig(testDir, { docs: "new-docs" });
+
+			const content = await readFile(join(testDir, ".claude", ".ck.json"), "utf-8");
+			const savedConfig = JSON.parse(content);
+
+			// Other settings should be preserved
+			expect(savedConfig.codingLevel).toBe(2);
+			// Paths should be a valid object now
+			expect(savedConfig.paths.docs).toBe("new-docs");
+		});
 	});
 
 	describe("resolveFoldersConfig", () => {


### PR DESCRIPTION
## Summary

Fixes `ConfigManager.saveProjectConfig()` to use selective merge instead of overwriting the entire `.ck.json` file. This preserves user customizations like `codingLevel`, `privacyBlock`, `plan`, `locale`, `trust`, `project`, and `assertions` when the CLI updates folder paths.

## Changes

- **config-manager.ts**: Load existing config before writing, deep merge `paths` object
- **config-folders.test.ts**: Add 3 test cases for selective merge behavior

## Test Plan

- [x] Existing config settings preserved when updating paths
- [x] Paths object properly merged (existing path fields preserved)
- [x] Corrupted JSON handled gracefully (starts fresh)
- [x] All 24 config tests pass

Closes #246