### PR TITLE
fix: saveProjectConfig uses selective merge to preserve user settings

### DIFF
--- a/src/domains/config/config-manager.ts
+++ b/src/domains/config/config-manager.ts
@@ -165,6 +165,7 @@ export class ConfigManager {
 
 	/**
 	 * Save project-level config to .claude/.ck.json (local) or .ck.json (global).
+	 * Uses selective merge to preserve existing user settings while updating paths.
 	 *
 	 * @param projectDir - The project directory. In global mode, this should be ~/.claude.
 	 *                     In local mode, this is the project root directory.
@@ -184,8 +185,39 @@ export class ConfigManager {
 			if (!existsSync(configDir)) {
 				await mkdir(configDir, { recursive: true });
 			}
+
+			// Load existing config to preserve user settings
+			let existingConfig: Record<string, unknown> = {};
+			if (existsSync(configPath)) {
+				try {
+					const content = await readFile(configPath, "utf-8");
+					existingConfig = JSON.parse(content);
+				} catch (error) {
+					// If parsing fails, start fresh
+					logger.debug(
+						`Could not parse existing config, starting fresh: ${error instanceof Error ? error.message : "Unknown error"}`,
+					);
+				}
+			}
+
 			const validFolders = FoldersConfigSchema.parse(folders);
-			await writeFile(configPath, JSON.stringify({ paths: validFolders }, null, 2), "utf-8");
+
+			// Ensure existingConfig.paths is an object before spreading
+			const existingPaths =
+				existingConfig.paths && typeof existingConfig.paths === "object"
+					? (existingConfig.paths as Record<string, unknown>)
+					: {};
+
+			// Selective merge: only update paths, preserve all other settings
+			const mergedConfig = {
+				...existingConfig,
+				paths: {
+					...existingPaths,
+					...validFolders,
+				},
+			};
+
+			await writeFile(configPath, JSON.stringify(mergedConfig, null, 2), "utf-8");
 			logger.debug(`Project config saved to ${configPath}`);
 		} catch (error) {
 			throw new Error(

--- a/tests/config-folders.test.ts
+++ b/tests/config-folders.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ConfigManager } from "@/domains/config/config-manager.js";
@@ -85,6 +85,95 @@ describe("ConfigManager Folders Support", () => {
 			const result = await ConfigManager.loadProjectConfig(testDir);
 			expect(result?.docs).toBe("only-docs");
 			expect(result?.plans).toBeUndefined();
+		});
+
+		test("should preserve existing user settings when updating paths (selective merge)", async () => {
+			// Create existing config with user customizations
+			await mkdir(join(testDir, ".claude"), { recursive: true });
+			const existingConfig = {
+				codingLevel: -1,
+				privacyBlock: true,
+				plan: {
+					namingFormat: "{date}-{issue}-{slug}",
+					validation: { mode: "prompt", minQuestions: 3 },
+				},
+				paths: { docs: "docs", plans: "plans" },
+				locale: { thinkingLanguage: "vi" },
+			};
+			await writeFile(join(testDir, ".claude", ".ck.json"), JSON.stringify(existingConfig));
+
+			// Update only docs path
+			await ConfigManager.saveProjectConfig(testDir, { docs: "my-docs" });
+
+			// Read raw file to verify all settings preserved
+			const content = await readFile(join(testDir, ".claude", ".ck.json"), "utf-8");
+			const savedConfig = JSON.parse(content);
+
+			// Verify user settings are preserved
+			expect(savedConfig.codingLevel).toBe(-1);
+			expect(savedConfig.privacyBlock).toBe(true);
+			expect(savedConfig.plan.namingFormat).toBe("{date}-{issue}-{slug}");
+			expect(savedConfig.plan.validation.mode).toBe("prompt");
+			expect(savedConfig.locale.thinkingLanguage).toBe("vi");
+
+			// Verify paths are correctly updated
+			expect(savedConfig.paths.docs).toBe("my-docs");
+			expect(savedConfig.paths.plans).toBe("plans"); // preserved from existing
+		});
+
+		test("should merge paths while preserving other path fields", async () => {
+			// Create existing config with extra path fields
+			await mkdir(join(testDir, ".claude"), { recursive: true });
+			const existingConfig = {
+				paths: { docs: "old-docs", plans: "old-plans", custom: "custom-path" },
+			};
+			await writeFile(join(testDir, ".claude", ".ck.json"), JSON.stringify(existingConfig));
+
+			// Update only docs
+			await ConfigManager.saveProjectConfig(testDir, { docs: "new-docs" });
+
+			const content = await readFile(join(testDir, ".claude", ".ck.json"), "utf-8");
+			const savedConfig = JSON.parse(content);
+
+			// Verify merge behavior
+			expect(savedConfig.paths.docs).toBe("new-docs"); // updated
+			expect(savedConfig.paths.plans).toBe("old-plans"); // preserved
+			expect(savedConfig.paths.custom).toBe("custom-path"); // preserved
+		});
+
+		test("should handle corrupted JSON gracefully and start fresh", async () => {
+			// Create corrupted config file
+			await mkdir(join(testDir, ".claude"), { recursive: true });
+			await writeFile(join(testDir, ".claude", ".ck.json"), "{ invalid json }");
+
+			// Should not throw, should create new config
+			await ConfigManager.saveProjectConfig(testDir, { docs: "new-docs" });
+
+			const content = await readFile(join(testDir, ".claude", ".ck.json"), "utf-8");
+			const savedConfig = JSON.parse(content);
+
+			expect(savedConfig.paths.docs).toBe("new-docs");
+		});
+
+		test("should handle malformed paths (non-object) gracefully", async () => {
+			// Create config with paths as a string instead of object
+			await mkdir(join(testDir, ".claude"), { recursive: true });
+			const malformedConfig = {
+				codingLevel: 2,
+				paths: "invalid-string-instead-of-object",
+			};
+			await writeFile(join(testDir, ".claude", ".ck.json"), JSON.stringify(malformedConfig));
+
+			// Should not throw, should replace malformed paths with valid object
+			await ConfigManager.saveProjectConfig(testDir, { docs: "new-docs" });
+
+			const content = await readFile(join(testDir, ".claude", ".ck.json"), "utf-8");
+			const savedConfig = JSON.parse(content);
+
+			// Other settings should be preserved
+			expect(savedConfig.codingLevel).toBe(2);
+			// Paths should be a valid object now
+			expect(savedConfig.paths.docs).toBe("new-docs");
 		});
 	});
 


### PR DESCRIPTION
## Summary

Fixes `ConfigManager.saveProjectConfig()` to use selective merge instead of overwriting the entire `.ck.json` file. This preserves user customizations like `codingLevel`, `privacyBlock`, `plan`, `locale`, `trust`, `project`, and `assertions` when the CLI updates folder paths.

## Changes

- **config-manager.ts**: Load existing config before writing, deep merge `paths` object with type safety
- **config-folders.test.ts**: Add 4 test cases for selective merge behavior

## Test Results

✅ All 25 config tests pass

Closes #246