### PR TITLE
fix: remove duplicate 'v' prefix in kit version display

### DIFF
--- a/src/commands/update-cli.ts
+++ b/src/commands/update-cli.ts
@@ -83,11 +83,11 @@ async function displayKitUpdateReminder(): Promise<void> {
 		lines.push("To update your ClaudeKit content (skills, commands, workflows):");
 
 		if (hasLocal && localVersion) {
-			lines.push(`  ${picocolors.cyan(pad(cmdLocal))}  Update local project (v${localVersion})`);
+			lines.push(`  ${picocolors.cyan(pad(cmdLocal))}  Update local project (${localVersion})`);
 			const localCheck = versionCheckResults.get(localVersion);
 			if (localCheck?.updateAvailable) {
 				const indent = " ".repeat(maxCmdLen + 4);
-				lines.push(`${indent}${picocolors.green(`→ v${localCheck.latestVersion} available!`)}`);
+				lines.push(`${indent}${picocolors.green(`→ ${localCheck.latestVersion} available!`)}`);
 			}
 		} else {
 			lines.push(`  ${picocolors.cyan(pad(cmdLocal))}  Initialize in current project`);
@@ -95,12 +95,12 @@ async function displayKitUpdateReminder(): Promise<void> {
 
 		if (hasGlobal && globalVersion) {
 			lines.push(
-				`  ${picocolors.cyan(pad(cmdGlobal))}  Update global ~/.claude (v${globalVersion})`,
+				`  ${picocolors.cyan(pad(cmdGlobal))}  Update global ~/.claude (${globalVersion})`,
 			);
 			const globalCheck = versionCheckResults.get(globalVersion);
 			if (globalCheck?.updateAvailable) {
 				const indent = " ".repeat(maxCmdLen + 4);
-				lines.push(`${indent}${picocolors.green(`→ v${globalCheck.latestVersion} available!`)}`);
+				lines.push(`${indent}${picocolors.green(`→ ${globalCheck.latestVersion} available!`)}`);
 			}
 		} else {
 			lines.push(`  ${picocolors.cyan(pad(cmdGlobal))}  Initialize global ~/.claude`);


### PR DESCRIPTION
## Summary
- Fixed double `v` prefix bug in `ck update` command output
- Version strings from metadata already include `v` prefix (e.g., `v2.1.0-beta.1`)
- Removed redundant `v` interpolation that caused display like `vv2.1.0-beta.1`

## Changes
- `src/commands/update-cli.ts`: Removed 4 instances of redundant `v` prefix in version display

## Before
```
ck init     Update local project (vv2.1.0-beta.1)
ck init -g  Update global ~/.claude (vv2.1.0-beta.1)
```

## After
```
ck init     Update local project (v2.1.0-beta.1)
ck init -g  Update global ~/.claude (v2.1.0-beta.1)
```

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] Unit tests pass (82/82)