### PR TITLE
fix: use semver sorting for beta version selection

### DIFF
--- a/src/domains/versioning/release-filter.ts
+++ b/src/domains/versioning/release-filter.ts
@@ -233,4 +233,36 @@ export class ReleaseFilter {
 			return releaseDate >= cutoffDate;
 		});
 	}
+
+	/**
+	 * Get the latest stable release by semantic version.
+	 * Returns the highest semver non-prerelease, non-draft release.
+	 *
+	 * IMPORTANT: Do NOT trust GitHub API order - it uses lexicographic sorting
+	 * for same-day releases (e.g., "beta.10" < "beta.4"). Always sort by semver.
+	 *
+	 * @see https://github.com/mrgoonie/claudekit-cli/issues/256
+	 */
+	static getLatestStable(releases: GitHubRelease[]): GitHubRelease | null {
+		const stableReleases = releases
+			.filter((r) => !r.prerelease && !r.draft)
+			.sort((a, b) => -VersionFormatter.compare(a.tag_name, b.tag_name));
+		return stableReleases.length > 0 ? stableReleases[0] : null;
+	}
+
+	/**
+	 * Get the latest prerelease by semantic version.
+	 * Returns the highest semver prerelease (beta/alpha/rc) release.
+	 *
+	 * IMPORTANT: Do NOT trust GitHub API order - it uses lexicographic sorting
+	 * for same-day releases (e.g., "beta.10" < "beta.4"). Always sort by semver.
+	 *
+	 * @see https://github.com/mrgoonie/claudekit-cli/issues/256
+	 */
+	static getLatestPrerelease(releases: GitHubRelease[]): GitHubRelease | null {
+		const prereleases = releases
+			.filter((r) => r.prerelease && !r.draft)
+			.sort((a, b) => -VersionFormatter.compare(a.tag_name, b.tag_name));
+		return prereleases.length > 0 ? prereleases[0] : null;
+	}
 }


### PR DESCRIPTION
## Summary

Fixes `ck init --beta --yes` installing wrong beta version (e.g., beta.9 instead of beta.10).

**Root cause:** GitHub API returns same-day releases in lexicographic order, where `"beta.10" < "beta.4"` because `'1' < '4'` in ASCII.

## Changes

- Add `getLatestStable()` and `getLatestPrerelease()` to `ReleaseFilter` with proper semver sorting
- Refactor `ReleasesApi.getLatestRelease()` to use semver-sorted methods instead of trusting API order
- Add regression tests simulating GitHub API's quirky ordering

## Test plan

- [x] Unit tests pass (29 new tests for version selection)
- [x] Regression test for issue #256 scenario
- [x] Quality gate passes (typecheck, lint, build)

Fixes #256