### PR TITLE
fix: preserve .ck.json user config on updates

### DIFF
--- a/src/types/kit.ts
+++ b/src/types/kit.ts
@@ -56,6 +56,7 @@ export const USER_CONFIG_PATTERNS = [
 	".repomixignore",
 	".mcp.json",
 	".ckignore",
+	".ck.json",
 	"CLAUDE.md",
 ];
 

--- a/tests/utils/manifest-writer.test.ts
+++ b/tests/utils/manifest-writer.test.ts
@@ -169,10 +169,12 @@ describe("ManifestWriter", () => {
 			const content = await Bun.file(metadataPath).text();
 			const metadata: Metadata = JSON.parse(content);
 
-			// USER_CONFIG_PATTERNS = [".gitignore", ".repomixignore", ".mcp.json", "CLAUDE.md"]
+			// USER_CONFIG_PATTERNS includes user config files that should be preserved on updates
 			expect(metadata.userConfigFiles).toContain(".gitignore");
 			expect(metadata.userConfigFiles).toContain(".repomixignore");
 			expect(metadata.userConfigFiles).toContain(".mcp.json");
+			expect(metadata.userConfigFiles).toContain(".ckignore");
+			expect(metadata.userConfigFiles).toContain(".ck.json");
 			expect(metadata.userConfigFiles).toContain("CLAUDE.md");
 		});
 


### PR DESCRIPTION
## Summary
- Add `.ck.json` to `USER_CONFIG_PATTERNS` to prevent overwriting during updates
- Fixes locale settings (e.g., `thinkingLanguage: "vi"`) being lost on `ck init`

## Root Cause
The v3.13.2 fix for `saveProjectConfig` only handled cases where `--docs-dir`/`--plans-dir` flags were passed. But when `ck init` copies files from the kit template, `.ck.json` wasn't in the protected list, so it was overwritten.

## Changes
- `src/types/kit.ts`: Add `.ck.json` to `USER_CONFIG_PATTERNS`
- `tests/lib/merge.test.ts`: Add tests for `.ck.json` preservation
- `tests/utils/manifest-writer.test.ts`: Update existing test to include `.ck.json`

## Test plan
- [x] All unit tests pass (156 tests)
- [x] `.ck.json` is now preserved when user already has custom settings
- [x] First install still copies `.ck.json` from template

Closes #246