### PR TITLE
feat: multi-select kit prompt for dual-kit purchasers

### DIFF
--- a/src/commands/init/types.ts
+++ b/src/commands/init/types.ts
@@ -100,6 +100,12 @@ export interface InitContext {
 
 	/** Whether cancelled by user */
 	cancelled: boolean;
+
+	/** Additional kits to install after current one (multi-kit mode) */
+	pendingKits?: KitType[];
+
+	/** All kits accessible to the user (from access check) */
+	accessibleKits?: KitType[];
 }
 
 /**

--- a/src/domains/ui/prompts.ts
+++ b/src/domains/ui/prompts.ts
@@ -15,7 +15,7 @@ import { confirm, intro, isCancel, log, note, outro } from "@/shared/safe-prompt
 import type { KitConfig, KitType } from "@/types";
 
 // Re-export all prompts from submodules
-export { selectKit, getDirectory } from "./prompts/kit-prompts.js";
+export { selectKit, selectKits, getDirectory } from "./prompts/kit-prompts.js";
 export {
 	selectVersion,
 	selectVersionEnhanced,
@@ -43,7 +43,7 @@ import {
 	promptUpdateMode,
 } from "./prompts/installation-prompts.js";
 // Import for class methods
-import { getDirectory, selectKit } from "./prompts/kit-prompts.js";
+import { getDirectory, selectKit, selectKits } from "./prompts/kit-prompts.js";
 import {
 	getLatestVersion,
 	selectVersion,
@@ -53,6 +53,10 @@ import {
 export class PromptsManager {
 	async selectKit(defaultKit?: KitType, accessibleKits?: KitType[]): Promise<KitType> {
 		return selectKit(defaultKit, accessibleKits);
+	}
+
+	async selectKits(accessibleKits: KitType[]): Promise<KitType[]> {
+		return selectKits(accessibleKits);
 	}
 
 	async selectVersion(versions: string[], defaultVersion?: string): Promise<string> {

--- a/src/domains/ui/prompts/kit-prompts.ts
+++ b/src/domains/ui/prompts/kit-prompts.ts
@@ -4,8 +4,11 @@
  * Prompts for kit selection and directory input
  */
 
-import { isCancel, select, text } from "@/shared/safe-prompts.js";
+import { isCancel, multiselect, select, text } from "@/shared/safe-prompts.js";
 import { AVAILABLE_KITS, type KitType } from "@/types";
+
+/** Minimum number of kits required for multi-select prompt */
+const MIN_KITS_FOR_MULTISELECT = 2;
 
 /**
  * Prompt user to select a kit
@@ -33,6 +36,37 @@ export async function selectKit(
 	}
 
 	return kit as KitType;
+}
+
+/**
+ * Prompt user to select multiple kits (for dual-kit purchasers)
+ * @param accessibleKits - Kits the user has access to (required, must have >= MIN_KITS_FOR_MULTISELECT)
+ * @returns Array of selected kit types (guaranteed non-empty due to `required: true`)
+ * @throws {Error} If called with fewer than MIN_KITS_FOR_MULTISELECT kits or user cancels
+ */
+export async function selectKits(accessibleKits: KitType[]): Promise<KitType[]> {
+	if (accessibleKits.length < MIN_KITS_FOR_MULTISELECT) {
+		throw new Error(`selectKits requires at least ${MIN_KITS_FOR_MULTISELECT} accessible kits`);
+	}
+
+	// Note: `required: true` prevents empty selection at the prompt level.
+	// The clack/prompts multiselect will show an error and prevent submission
+	// if user tries to submit without selecting any options.
+	const selected = await multiselect({
+		message: "Select ClaudeKit(s) to install:",
+		options: accessibleKits.map((key) => ({
+			value: key,
+			label: AVAILABLE_KITS[key].name,
+			hint: AVAILABLE_KITS[key].description,
+		})),
+		required: true,
+	});
+
+	if (isCancel(selected)) {
+		throw new Error("Kit selection cancelled");
+	}
+
+	return selected as KitType[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Add multi-select prompt when user has access to multiple kits, allowing installation of both kits in a single command.

## Changes

- Add `selectKits()` multi-select function with `MIN_KITS_FOR_MULTISELECT` constant
- Update selection-handler to use multi-select when >1 kit accessible
- Add `installAdditionalKit()` for sequential installation with version matching
- Add `pendingKits`/`accessibleKits` to InitContext for multi-kit tracking
- Error handling with partial success reporting
- Tests for multi-kit selection logic

## Test Plan

- [x] Multi-select prompt shown when >1 kit accessible
- [x] Single-select behavior preserved for single-kit users
- [x] Version matching for additional kits
- [x] Error handling with partial success reporting
- [x] Quality gate passes