### PR TITLE
feat: add --kit all and comma-separated multi-kit support

### DIFF
--- a/src/__tests__/commands/init/phases/selection-handler-multikit.test.ts
+++ b/src/__tests__/commands/init/phases/selection-handler-multikit.test.ts
@@ -305,4 +305,83 @@ describe("selection-handler multi-kit flow", () => {
 			expect(shouldCheckExisting).toBe(true);
 		});
 	});
+
+	describe("--kit option parsing", () => {
+		const allKitTypes: KitType[] = ["engineer", "marketing"];
+
+		describe("--kit all", () => {
+			it("expands 'all' to all kit types", () => {
+				const kitOption = "all";
+				const accessibleKits: KitType[] = ["engineer", "marketing"];
+
+				const kitsToInstall = kitOption === "all" ? accessibleKits : [kitOption as KitType];
+
+				expect(kitsToInstall).toEqual(["engineer", "marketing"]);
+				expect(kitsToInstall[0]).toBe("engineer");
+				expect(kitsToInstall.slice(1)).toEqual(["marketing"]);
+			});
+
+			it("respects accessible kits when using 'all'", () => {
+				const kitOption = "all";
+				const accessibleKits: KitType[] = ["engineer"]; // Only has access to engineer
+
+				const kitsToInstall = kitOption === "all" ? accessibleKits : [kitOption as KitType];
+
+				expect(kitsToInstall).toEqual(["engineer"]);
+				expect(kitsToInstall.length).toBe(1);
+			});
+		});
+
+		describe("comma-separated kits", () => {
+			it("parses comma-separated kit names", () => {
+				const kitOption = "engineer,marketing";
+				const requestedKits = kitOption.split(",").map((k) => k.trim()) as KitType[];
+
+				expect(requestedKits).toEqual(["engineer", "marketing"]);
+			});
+
+			it("handles whitespace around commas", () => {
+				const kitOption = "engineer , marketing";
+				const requestedKits = kitOption.split(",").map((k) => k.trim()) as KitType[];
+
+				expect(requestedKits).toEqual(["engineer", "marketing"]);
+			});
+
+			it("detects invalid kit names", () => {
+				const kitOption = "engineer,invalid";
+				const requestedKits = kitOption.split(",").map((k) => k.trim());
+				const invalidKits = requestedKits.filter((k) => !allKitTypes.includes(k as KitType));
+
+				expect(invalidKits).toEqual(["invalid"]);
+			});
+
+			it("validates access for all requested kits", () => {
+				const kitOption = "engineer,marketing";
+				const requestedKits = kitOption.split(",").map((k) => k.trim()) as KitType[];
+				const accessibleKits: KitType[] = ["engineer"]; // Only has access to engineer
+
+				const noAccessKits = requestedKits.filter((k) => !accessibleKits.includes(k));
+
+				expect(noAccessKits).toEqual(["marketing"]);
+			});
+
+			it("sets first kit as primary and rest as pending", () => {
+				const kitOption = "engineer,marketing";
+				const requestedKits = kitOption.split(",").map((k) => k.trim()) as KitType[];
+
+				const kitType = requestedKits[0];
+				const pendingKits = requestedKits.length > 1 ? requestedKits.slice(1) : undefined;
+
+				expect(kitType).toBe("engineer");
+				expect(pendingKits).toEqual(["marketing"]);
+			});
+
+			it("handles single kit without comma", () => {
+				const kitOption = "engineer";
+				const hasComma = kitOption.includes(",");
+
+				expect(hasComma).toBe(false);
+			});
+		});
+	});
 });

--- a/src/cli/command-registry.ts
+++ b/src/cli/command-registry.ts
@@ -22,7 +22,7 @@ export function registerCommands(cli: ReturnType<typeof cac>): void {
 	cli
 		.command("new", "Bootstrap a new ClaudeKit project (with interactive version selection)")
 		.option("--dir <dir>", "Target directory (default: .)")
-		.option("--kit <kit>", "Kit to use (engineer, marketing)")
+		.option("--kit <kit>", "Kit to use: engineer, marketing, all, or comma-separated")
 		.option(
 			"-r, --release <version>",
 			"Skip version selection, use specific version (e.g., latest, v1.0.0)",
@@ -58,7 +58,7 @@ export function registerCommands(cli: ReturnType<typeof cac>): void {
 	cli
 		.command("init", "Initialize or update ClaudeKit project (with interactive version selection)")
 		.option("--dir <dir>", "Target directory (default: .)")
-		.option("--kit <kit>", "Kit to use (engineer, marketing)")
+		.option("--kit <kit>", "Kit to use: engineer, marketing, all, or comma-separated")
 		.option(
 			"-r, --release <version>",
 			"Skip version selection, use specific version (e.g., latest, v1.0.0)",


### PR DESCRIPTION
## Summary
- Support `--kit all` to install all accessible kits in non-interactive mode
- Support `--kit engineer,marketing` comma-separated syntax for explicit multi-kit install
- Validate kit names and access for all requested kits before installation
- First kit becomes primary, rest queued as pendingKits for sequential install

## Usage
```bash
# Install all accessible kits
ck init -g --beta --yes --install-skills --kit all

# Install specific kits
ck init -g --beta --yes --install-skills --kit engineer,marketing
```

## Changes
- `selection-handler.ts`: Parse `--kit` option for `all`, comma-separated, and single values
- `command-registry.ts`: Updated help text for `--kit` option
- Added 8 unit tests for new parsing logic

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint:fix` passes
- [x] Unit tests for new feature pass (23/23)
- [x] `bun run build` succeeds