### PR TITLE
fix(update): preserve --beta flag in init command suggestions

### DIFF
--- a/src/__tests__/commands/update-cli.test.ts
+++ b/src/__tests__/commands/update-cli.test.ts
@@ -56,5 +56,25 @@ describe("update-cli", () => {
 				expect(cmd).toContain("--install-skills");
 			}
 		});
+
+		it("includes --beta flag when beta is true", () => {
+			const result = buildInitCommand(false, undefined, true);
+			expect(result).toBe("ck init --yes --install-skills --beta");
+		});
+
+		it("includes --beta flag with kit and global", () => {
+			const result = buildInitCommand(true, "engineer", true);
+			expect(result).toBe("ck init -g --kit engineer --yes --install-skills --beta");
+		});
+
+		it("does not include --beta flag when beta is false", () => {
+			const result = buildInitCommand(false, "engineer", false);
+			expect(result).toBe("ck init --kit engineer --yes --install-skills");
+		});
+
+		it("does not include --beta flag when beta is undefined", () => {
+			const result = buildInitCommand(false, "engineer");
+			expect(result).toBe("ck init --kit engineer --yes --install-skills");
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- When running `ck update --beta`, the suggested `ck init` commands in the update reminder now properly include the `--beta` flag
- Previously, the beta flag was not propagated to the init command suggestions, causing inconsistent behavior

## Changes
- Added `beta` parameter to `buildInitCommand()` function
- Updated `displayKitUpdateReminder()` to accept and propagate beta flag
- All 4 call sites now pass `opts.beta` through

## Test Plan
- [x] Added 4 unit tests for beta flag propagation
- [x] All existing tests pass
- [x] Quality gate passed (typecheck, lint, test, build)