### PR TITLE
fix: skip GitHub API checks when --kit-path or --archive provided

### DIFF
--- a/src/commands/new/phases/directory-setup.ts
+++ b/src/commands/new/phases/directory-setup.ts
@@ -28,9 +28,9 @@ export async function directorySetup(
 	// Load config for defaults
 	const config = await ConfigManager.get();
 
-	// Detect accessible kits upfront (skip for --use-git mode which uses git credentials)
+	// Detect accessible kits upfront (skip for offline modes that bypass GitHub API)
 	let accessibleKits: KitType[] | undefined;
-	if (!validOptions.useGit) {
+	if (!validOptions.useGit && !validOptions.kitPath && !validOptions.archive) {
 		accessibleKits = await detectAccessibleKits();
 
 		if (accessibleKits.length === 0) {

--- a/src/commands/new/phases/version-selection.ts
+++ b/src/commands/new/phases/version-selection.ts
@@ -23,6 +23,25 @@ export async function selectVersion(
 	prompts: PromptsManager,
 	github: GitHubClient,
 ): Promise<VersionSelectionResult | null> {
+	// Skip version selection for offline modes (--kit-path, --archive)
+	// These don't require GitHub API access
+	if (options.kitPath || options.archive) {
+		const localVersion = options.release || "local";
+		return {
+			release: {
+				id: 0,
+				tag_name: localVersion,
+				name: localVersion,
+				draft: false,
+				prerelease: false,
+				tarball_url: "",
+				zipball_url: "",
+				assets: [],
+			},
+			selectedVersion: localVersion,
+		};
+	}
+
 	let selectedVersion: string | undefined = options.release;
 
 	// Validate non-interactive mode requires explicit version


### PR DESCRIPTION
## Summary
- Skip kit access detection for `--kit-path` and `--archive` modes (no GitHub API needed)
- Return synthetic release object for local installations in version selection

Closes #298

## Test plan
- [ ] `ck new --kit-path /path/to/local/kit` should work without git/GitHub credentials
- [ ] `ck new --archive /path/to/archive.zip` should work without git/GitHub credentials
- [ ] Normal `ck new` flow unchanged (still detects kit access via API)