### PR TITLE
fix: preserve --beta flag from existing installation in ck update

### DIFF
--- a/src/commands/update-cli.ts
+++ b/src/commands/update-cli.ts
@@ -177,7 +177,14 @@ export async function promptKitUpdate(beta?: boolean): Promise<void> {
 			return;
 		}
 
-		const initCmd = buildInitCommand(selection.isGlobal, selection.kit, beta);
+		// Detect if existing installation is beta (from version string)
+		const kitKey = selection.kit ?? "engineer";
+		const kitVersion = selection.isGlobal
+			? globalMetadata?.kits?.[kitKey]?.version
+			: localMetadata?.kits?.[kitKey]?.version;
+		const isBetaInstalled = kitVersion?.includes("-beta") ?? false;
+
+		const initCmd = buildInitCommand(selection.isGlobal, selection.kit, beta || isBetaInstalled);
 		const promptMessage = selection.promptMessage;
 
 		// Prompt user


### PR DESCRIPTION
## Summary
- Detect beta from installed version string in metadata (e.g., `v2.3.0-beta.17`)
- Pass `beta || isBetaInstalled` to `buildInitCommand()`

## Problem
When running `ck update`, the init command didn't include `--beta` even if the user originally installed with `--beta`.

## Solution
Read kit version from metadata and check for `-beta` substring.

Closes #307