### PR TITLE
fix: setup wizard skipped when .env exists but required keys missing

### DIFF
--- a/docs/ck-command-flow-guide.md
+++ b/docs/ck-command-flow-guide.md
@@ -116,6 +116,7 @@ flowchart TD
 - Optional: Install skills
 - Optional: Install Gemini MCP
 - Optional: Open in code editor
+- Setup wizard: Prompts for required env keys (e.g., `GEMINI_API_KEY`) if missing
 
 ---
 
@@ -160,6 +161,7 @@ flowchart TD
 - Fresh install option (`--fresh`) removes `.claude` dir
 - Settings merge preserves customizations
 - Dry-run mode shows changes without applying
+- Setup wizard: Checks required env keys exist (not just `.env` file), prompts if missing
 
 ---
 
@@ -224,6 +226,7 @@ flowchart TD
 - Skill components and dependencies
 - Slash command hooks present
 - Active CLAUDE.md file
+- Required environment keys (e.g., `GEMINI_API_KEY`) in `.env`
 
 ---
 

--- a/src/commands/new/phases/post-setup.ts
+++ b/src/commands/new/phases/post-setup.ts
@@ -1,9 +1,11 @@
 /**
  * Post Setup Phase
  *
- * Handles optional package installations and final success message.
+ * Handles optional package installations, skills, and setup wizard.
  */
 
+import { join } from "node:path";
+import { checkRequiredKeysExist, runSetupWizard } from "@/domains/installation/setup-wizard.js";
 import type { PromptsManager } from "@/domains/ui/prompts.js";
 import { processPackageInstallations } from "@/services/package-installer/package-installer.js";
 import { logger } from "@/shared/logger.js";
@@ -65,6 +67,34 @@ export async function postSetup(
 			skipConfirm: isNonInteractive,
 			withSudo: validOptions.withSudo,
 		});
+	}
+
+	// Run setup wizard if required keys are missing from .env
+	if (!isNonInteractive) {
+		const claudeDir = join(resolvedDir, ".claude");
+		const envPath = join(claudeDir, ".env");
+		const { allPresent, missing, envExists } = await checkRequiredKeysExist(envPath);
+
+		if (!allPresent) {
+			// Different prompt message based on whether .env exists
+			const missingKeys = missing.map((m) => m.label).join(", ");
+			const promptMessage = envExists
+				? `Missing required: ${missingKeys}. Set up now?`
+				: "Set up API keys now? (Gemini API key for ai-multimodal skill, optional webhooks)";
+
+			const shouldSetup = await prompts.confirm(promptMessage);
+			if (shouldSetup) {
+				await runSetupWizard({
+					targetDir: claudeDir,
+					isGlobal: false, // new command is never global
+				});
+			} else {
+				prompts.note(
+					`Create ${envPath} manually or run 'ck init' again.\nRequired: GEMINI_API_KEY\nOptional: DISCORD_WEBHOOK_URL, TELEGRAM_BOT_TOKEN`,
+					"Configuration skipped",
+				);
+			}
+		}
 	}
 }
 

--- a/src/domains/health-checks/checkers/env-keys-checker.ts
+++ b/src/domains/health-checks/checkers/env-keys-checker.ts
@@ -1,0 +1,83 @@
+/**
+ * Environment keys checker for ck doctor
+ * Checks if required environment keys are present in .env files
+ */
+
+import { join } from "node:path";
+import { REQUIRED_ENV_KEYS, checkRequiredKeysExist } from "@/domains/installation/setup-wizard.js";
+import type { ClaudeKitSetup } from "@/types";
+import type { CheckResult } from "../types.js";
+
+/**
+ * Check required environment keys in .env files
+ * Returns warnings for missing required keys
+ */
+export async function checkEnvKeys(setup: ClaudeKitSetup): Promise<CheckResult[]> {
+	const results: CheckResult[] = [];
+
+	// Check global .env
+	if (setup.global.path) {
+		const globalEnvPath = join(setup.global.path, ".env");
+		const globalCheck = await checkRequiredKeysExist(globalEnvPath);
+
+		if (!globalCheck.allPresent) {
+			const missingKeys = globalCheck.missing.map((m) => m.label).join(", ");
+			results.push({
+				id: "ck-global-env-keys",
+				name: "Global Environment Keys",
+				group: "claudekit",
+				priority: "standard",
+				status: "warn",
+				message: globalCheck.envExists ? `Missing: ${missingKeys}` : ".env file not found",
+				details: globalEnvPath,
+				suggestion: "Run: ck init --global",
+				autoFixable: false,
+			});
+		} else {
+			results.push({
+				id: "ck-global-env-keys",
+				name: "Global Environment Keys",
+				group: "claudekit",
+				priority: "standard",
+				status: "pass",
+				message: `${REQUIRED_ENV_KEYS.length} required key(s) configured`,
+				details: globalEnvPath,
+				autoFixable: false,
+			});
+		}
+	}
+
+	// Check project .env - only if it's a real ClaudeKit project (has metadata)
+	if (setup.project.metadata) {
+		const projectEnvPath = join(setup.project.path, ".env");
+		const projectCheck = await checkRequiredKeysExist(projectEnvPath);
+
+		if (!projectCheck.allPresent) {
+			const missingKeys = projectCheck.missing.map((m) => m.label).join(", ");
+			results.push({
+				id: "ck-project-env-keys",
+				name: "Project Environment Keys",
+				group: "claudekit",
+				priority: "standard",
+				status: "warn",
+				message: projectCheck.envExists ? `Missing: ${missingKeys}` : ".env file not found",
+				details: projectEnvPath,
+				suggestion: "Run: ck init",
+				autoFixable: false,
+			});
+		} else {
+			results.push({
+				id: "ck-project-env-keys",
+				name: "Project Environment Keys",
+				group: "claudekit",
+				priority: "standard",
+				status: "pass",
+				message: `${REQUIRED_ENV_KEYS.length} required key(s) configured`,
+				details: projectEnvPath,
+				autoFixable: false,
+			});
+		}
+	}
+
+	return results;
+}

--- a/src/domains/health-checks/checkers/index.ts
+++ b/src/domains/health-checks/checkers/index.ts
@@ -9,6 +9,7 @@ export { checkHooksExist } from "./hooks-checker.js";
 export { checkSettingsValid } from "./settings-checker.js";
 export { checkPathRefsValid } from "./path-refs-checker.js";
 export { checkProjectConfigCompleteness } from "./config-completeness-checker.js";
+export { checkEnvKeys } from "./env-keys-checker.js";
 
 // Re-export shared utilities
 export { shouldSkipExpensiveOperations, HOOK_EXTENSIONS } from "./shared.js";

--- a/src/domains/health-checks/claudekit-checker.ts
+++ b/src/domains/health-checks/claudekit-checker.ts
@@ -5,6 +5,7 @@ import {
 	checkClaudeMd,
 	checkCliInstallMethod,
 	checkComponentCounts,
+	checkEnvKeys,
 	checkGlobalDirReadable,
 	checkGlobalDirWritable,
 	checkGlobalInstall,
@@ -60,6 +61,10 @@ export class ClaudekitChecker implements Checker {
 		results.push(...checkSkillsScripts(setup));
 		logger.verbose("ClaudekitChecker: Checking component counts");
 		results.push(checkComponentCounts(setup));
+
+		// Environment keys check
+		logger.verbose("ClaudekitChecker: Checking required environment keys");
+		results.push(...(await checkEnvKeys(setup)));
 
 		// Permission checks
 		logger.verbose("ClaudekitChecker: Checking global dir readability");

--- a/src/domains/installation/index.ts
+++ b/src/domains/installation/index.ts
@@ -6,7 +6,13 @@ export { DownloadManager } from "./download-manager.js";
 export { FileMerger } from "./file-merger.js";
 export { PackageManagerDetector } from "./package-manager-detector.js";
 export { handleFreshInstallation } from "./fresh-installer.js";
-export { runSetupWizard } from "./setup-wizard.js";
+export {
+	runSetupWizard,
+	checkRequiredKeysExist,
+	REQUIRED_ENV_KEYS,
+	type RequiredEnvKey,
+	type RequiredKeysCheckResult,
+} from "./setup-wizard.js";
 export {
 	downloadAndExtract,
 	type DownloadExtractOptions,

--- a/src/domains/installation/setup-wizard.ts
+++ b/src/domains/installation/setup-wizard.ts
@@ -11,6 +11,54 @@ export interface SetupWizardOptions {
 	isGlobal: boolean;
 }
 
+/**
+ * Required environment keys that must be present for ClaudeKit to function
+ * Easy to extend with additional keys in the future
+ */
+export interface RequiredEnvKey {
+	key: string;
+	label: string;
+}
+
+export const REQUIRED_ENV_KEYS: RequiredEnvKey[] = [
+	{ key: "GEMINI_API_KEY", label: "Gemini API Key" },
+];
+
+export interface RequiredKeysCheckResult {
+	allPresent: boolean;
+	missing: RequiredEnvKey[];
+	envExists: boolean;
+}
+
+/**
+ * Check if required environment keys exist in .env file
+ * Returns which keys are missing (if any)
+ */
+export async function checkRequiredKeysExist(envPath: string): Promise<RequiredKeysCheckResult> {
+	const envExists = await pathExists(envPath);
+
+	if (!envExists) {
+		return { allPresent: false, missing: REQUIRED_ENV_KEYS, envExists: false };
+	}
+
+	const env = await parseEnvFile(envPath);
+	const missing: RequiredEnvKey[] = [];
+
+	for (const required of REQUIRED_ENV_KEYS) {
+		const value = env[required.key];
+		// Check if key exists and has a non-empty value
+		if (!value || value.trim() === "") {
+			missing.push(required);
+		}
+	}
+
+	return {
+		allPresent: missing.length === 0,
+		missing,
+		envExists: true,
+	};
+}
+
 interface ConfigPrompt {
 	key: string;
 	label: string;


### PR DESCRIPTION
## Summary
- Add `REQUIRED_ENV_KEYS` array and `checkRequiredKeysExist()` function to check for required keys
- Update `ck init` to check for required keys existence, not just `.env` file
- Add setup wizard to `ck new` (was never triggered before)
- Add `env-keys-checker` for `ck doctor` to warn on missing required keys
- Update docs with new setup wizard behavior

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] Tests pass (3 flaky integration tests unrelated to this change)
- [x] Build passes

Closes #322