### PR TITLE
fix: add .venv and __pycache__ to NEVER_COPY_PATTERNS

### DIFF
--- a/src/types/kit.ts
+++ b/src/types/kit.ts
@@ -53,9 +53,14 @@ export const NEVER_COPY_PATTERNS = [
 	"dist/**",
 	"build/**",
 	// Python virtual environments (prevents EMFILE on Windows with large venvs)
+	// Root level
 	".venv/**",
 	"venv/**",
 	"__pycache__/**",
+	// Nested at any depth (e.g., skills/.venv, mypackage/__pycache__)
+	"**/.venv/**",
+	"**/venv/**",
+	"**/__pycache__/**",
 ];
 
 // User configuration files that should only be skipped if they already exist


### PR DESCRIPTION
## Summary
- Adds `.venv/**`, `venv/**`, and `__pycache__/**` to `NEVER_COPY_PATTERNS`
- Prevents EMFILE 'too many open files' error on Windows during legacy migration

## Root Cause
The installation merger's FileScanner processes all files including Python venvs. On Windows, large venvs (34K+ files) exhaust file descriptors even with concurrency limiting.

## Test plan
- [x] Typecheck passes
- [x] Lint passes  
- [x] Unit tests pass (file-operations, installation domains)
- [ ] Manual test on Windows with large skills/.venv

Closes #325