### PR TITLE
fix: Transform content before checksumming in release manifest

### DIFF
--- a/scripts/generate-release-manifest.ts
+++ b/scripts/generate-release-manifest.ts
@@ -11,9 +11,12 @@
  */
 import { createHash } from "node:crypto";
 import { readFile, readdir, stat } from "node:fs/promises";
-import { extname, join, relative } from "node:path";
+import { join, relative } from "node:path";
 import { writeFile } from "fs-extra";
-import { transformContent } from "../src/services/transformers/global-path-transformer.js";
+import {
+	shouldTransformFile,
+	transformContent,
+} from "../src/services/transformers/global-path-transformer.js";
 
 interface ReleaseManifest {
 	version: string;
@@ -50,32 +53,6 @@ const SKIP_DIRS = [
 
 // Files to skip (hidden files except specific ones)
 const INCLUDE_HIDDEN = [".gitignore", ".repomixignore", ".mcp.json"];
-
-// Extensions that undergo path transformation during global install
-// Must match TRANSFORMABLE_EXTENSIONS in global-path-transformer.ts
-const TRANSFORMABLE_EXTENSIONS = new Set([
-	".md",
-	".js",
-	".ts",
-	".json",
-	".sh",
-	".ps1",
-	".yaml",
-	".yml",
-	".toml",
-]);
-
-// Files to always transform regardless of extension
-const ALWAYS_TRANSFORM_FILES = new Set(["CLAUDE.md", "claude.md"]);
-
-/**
- * Check if file should have path transformation applied
- */
-function shouldTransformFile(filename: string): boolean {
-	const ext = extname(filename).toLowerCase();
-	const basename = filename.split("/").pop() || filename;
-	return TRANSFORMABLE_EXTENSIONS.has(ext) || ALWAYS_TRANSFORM_FILES.has(basename);
-}
 
 /**
  * Calculate SHA-256 checksum from content string

--- a/src/services/transformers/global-path-transformer.ts
+++ b/src/services/transformers/global-path-transformer.ts
@@ -55,8 +55,11 @@ export function normalizePathSeparators(path: string): string {
 	return path.replace(/(?<!:)\/(?!\/)/g, "\\");
 }
 
-// File extensions to transform
-const TRANSFORMABLE_EXTENSIONS = new Set([
+/**
+ * File extensions that undergo path transformation during global install
+ * Exported for use in release manifest generation
+ */
+export const TRANSFORMABLE_EXTENSIONS = new Set([
 	".md",
 	".js",
 	".ts",
@@ -68,8 +71,11 @@ const TRANSFORMABLE_EXTENSIONS = new Set([
 	".toml",
 ]);
 
-// Files to always transform regardless of extension
-const ALWAYS_TRANSFORM_FILES = new Set(["CLAUDE.md", "claude.md"]);
+/**
+ * Files to always transform regardless of extension
+ * Exported for use in release manifest generation
+ */
+export const ALWAYS_TRANSFORM_FILES = new Set(["CLAUDE.md", "claude.md"]);
 
 /**
  * Transform path references in file content
@@ -205,8 +211,9 @@ export function transformContent(content: string): { transformed: string; change
 
 /**
  * Check if a file should be transformed based on extension or name
+ * Exported for use in release manifest generation
  */
-function shouldTransformFile(filename: string): boolean {
+export function shouldTransformFile(filename: string): boolean {
 	const ext = extname(filename).toLowerCase();
 	const basename = filename.split("/").pop() || filename;
 


### PR DESCRIPTION
## Summary
- Fix #328
- Transform content before checksumming in `generate-release-manifest.ts`
- Eliminates false "modified" file classifications during `ck init -g` migration

## Changes
- Import `transformContent` from global-path-transformer
- Apply path transformation (.claude/ → $HOME/.claude/) before checksumming
- Add helper functions for transformable file detection and content checksumming

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] Build passes
- [x] Unit tests pass (integration tests have pre-existing network failures unrelated to this change)