### PR TITLE
fix: suppress update notification for dev prerelease to same base stable

### DIFF
--- a/src/domains/versioning/checking/cli-version-checker.ts
+++ b/src/domains/versioning/checking/cli-version-checker.ts
@@ -7,6 +7,7 @@ import { logger } from "@/shared/logger.js";
 import { compareVersions } from "compare-versions";
 import {
 	type VersionCheckResult,
+	isDevPrereleaseOfSameBase,
 	isUpdateCheckDisabled,
 	normalizeVersion,
 } from "./version-utils.js";
@@ -37,6 +38,16 @@ export class CliVersionChecker {
 
 			const current = normalizeVersion(currentVersion);
 			const latest = normalizeVersion(latestVersion);
+
+			// Don't show update for dev prerelease to same base stable
+			// e.g., 3.31.0-dev.7 should NOT prompt to "update" to 3.31.0
+			if (isDevPrereleaseOfSameBase(current, latest)) {
+				logger.debug(
+					`CLI version check: skipping update - dev prerelease (${current}) is same base as stable (${latest})`,
+				);
+				return null;
+			}
+
 			const updateAvailable = compareVersions(latest, current) > 0;
 
 			logger.debug(

--- a/src/domains/versioning/checking/version-utils.ts
+++ b/src/domains/versioning/checking/version-utils.ts
@@ -33,14 +33,55 @@ export function normalizeVersion(version: string): string {
 }
 
 /**
+ * Extract base version and prerelease info from a version string
+ * e.g., "3.31.0-dev.7" → { base: "3.31.0", prerelease: "dev.7" }
+ * e.g., "3.31.0" → { base: "3.31.0", prerelease: null }
+ * @internal Exported for testing
+ */
+export function parseVersionParts(version: string): { base: string; prerelease: string | null } {
+	const normalized = normalizeVersion(version);
+	const [base, ...prereleaseParts] = normalized.split("-");
+	return {
+		base,
+		prerelease: prereleaseParts.length > 0 ? prereleaseParts.join("-") : null,
+	};
+}
+
+/**
+ * Check if current version is a dev prerelease of the same base as latest stable
+ * e.g., current="3.31.0-dev.7", latest="3.31.0" → true (suppress update)
+ * e.g., current="3.31.0-dev.7", latest="3.32.0" → false (show update)
+ * @internal Exported for testing
+ */
+export function isDevPrereleaseOfSameBase(currentVersion: string, latestVersion: string): boolean {
+	const current = parseVersionParts(currentVersion);
+	const latest = parseVersionParts(latestVersion);
+
+	// Only suppress if current is a dev prerelease AND latest is stable (no prerelease)
+	// AND they share the same base version
+	if (!current.prerelease?.startsWith("dev")) return false;
+	if (latest.prerelease !== null) return false;
+
+	return current.base === latest.base;
+}
+
+/**
  * Compare two version strings
  * Returns: true if latestVersion > currentVersion
+ * Handles special case: dev prereleases comparing to same base stable version
  * @internal Exported for testing
  */
 export function isNewerVersion(currentVersion: string, latestVersion: string): boolean {
 	try {
 		const current = normalizeVersion(currentVersion);
 		const latest = normalizeVersion(latestVersion);
+
+		// Special case: don't show update if on dev prerelease of same base version
+		// e.g., 3.31.0-dev.7 should NOT prompt to "update" to 3.31.0
+		if (isDevPrereleaseOfSameBase(current, latest)) {
+			return false;
+		}
+
 		return compareVersions(latest, current) > 0;
 	} catch {
 		return false;

--- a/src/domains/versioning/version-checker.ts
+++ b/src/domains/versioning/version-checker.ts
@@ -5,9 +5,11 @@
 
 // Re-export utility functions
 export {
+	isDevPrereleaseOfSameBase,
 	isNewerVersion,
 	isUpdateCheckDisabled,
 	normalizeVersion,
+	parseVersionParts,
 } from "./checking/version-utils.js";
 
 // Re-export VersionChecker class with displayNotification method preserved for backwards compatibility


### PR DESCRIPTION
## Summary
Dev versions like `3.31.0-dev.7` should NOT show "update available" to `3.31.0` stable since they're on the same release cycle.

## Problem
Users on dev channel (`3.31.0-dev.7`) saw misleading update prompts to "update" to `3.31.0` which is actually the same or older release.

## Solution
- Added `parseVersionParts()` to extract base version and prerelease tag
- Added `isDevPrereleaseOfSameBase()` to detect when current is dev prerelease of same base as stable target
- Skip update notification in this scenario

## Test plan
- [x] Unit tests for `parseVersionParts`
- [x] Unit tests for `isDevPrereleaseOfSameBase`
- [x] Unit tests for `isNewerVersion` with dev versions
- [x] Integration tests for `CliVersionChecker` with dev versions

Closes #342