### PR TITLE
fix(dashboard): correct UI dist path resolution for global install

### DIFF
--- a/src/domains/web-server/static-server.ts
+++ b/src/domains/web-server/static-server.ts
@@ -13,10 +13,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 function resolveUiDistPath(): string {
 	// Try multiple paths to support both dev and production modes
 	const candidates = [
-		// Dev mode with bun: cwd -> dist/ui (highest priority for dev)
+		// Production (npm install -g): dist/index.js → dist/ui/ (same directory)
+		join(__dirname, "ui"),
+		// Dev mode: running from CLI repo root
 		join(process.cwd(), "dist", "ui"),
-		// Production: dist/index.js -> dist/ui/
-		join(__dirname, "..", "..", "ui"),
 		// Dev mode alternative: src/ui/dist (if built there)
 		join(process.cwd(), "src", "ui", "dist"),
 	];


### PR DESCRIPTION
## Problem

`ck config` fails to find UI dist when run from any directory other than the CLI repo root.

**Before:**
```typescript
candidates = [
  join(process.cwd(), "dist", "ui"),      // Only works in CLI repo
  join(__dirname, "..", "..", "ui"),      // Wrong path (goes to package/ui)
  ...
]
```

**After:**
```typescript
candidates = [
  join(__dirname, "ui"),                   // Production: dist/index.js → dist/ui/
  join(process.cwd(), "dist", "ui"),       // Dev: running from CLI repo
  ...
]
```

## Why this works

- **Production** (npm install -g): `__dirname` = `/usr/lib/node_modules/claudekit-cli/dist/`
  - `join(__dirname, "ui")` = `/usr/lib/node_modules/claudekit-cli/dist/ui/` ✅
- **Dev** (bun run src/index.ts): Falls through to `cwd/dist/ui` ✅

## Test plan

- [x] `bun run ui:build` works
- [x] Quality gate passes
- [ ] After merge + release: `npm install -g claudekit-cli@dev && ck config` opens dashboard from any directory

Closes #365