### PR TITLE
fix(dashboard): allow dotfiles in sendFile path for bun global installs

### DIFF
--- a/src/domains/web-server/static-server.ts
+++ b/src/domains/web-server/static-server.ts
@@ -50,8 +50,10 @@ export function serveStatic(app: Express): void {
 	}
 
 	// Serve static files with proper MIME types
+	// Allow dotfiles in path (e.g., ~/.bun/install/...) for global installs
 	app.use(
 		express.static(uiDistPath, {
+			dotfiles: "allow",
 			setHeaders: (res, filePath) => {
 				if (filePath.endsWith(".js")) {
 					res.setHeader("Content-Type", "application/javascript");
@@ -74,7 +76,8 @@ export function serveStatic(app: Express): void {
 		if (req.path.startsWith("/assets/") || req.path.match(/\.(js|css|ico|png|jpg|svg|woff2?)$/)) {
 			return next();
 		}
-		res.sendFile(join(uiDistPath, "index.html"));
+		// Allow dotfiles in path (e.g., ~/.bun/install/...) for global installs
+		res.sendFile(join(uiDistPath, "index.html"), { dotfiles: "allow" });
 	});
 
 	logger.debug(`Serving static files from ${uiDistPath}`);


### PR DESCRIPTION
## Summary
- Fix 404 error on SPA routes (e.g., `/config/global`) when CLI installed via `bun install -g`
- Add `{ dotfiles: "allow" }` option to `res.sendFile()` call

## Root Cause
When installed via bun globally, the package path contains `.bun` directory:
```
~/.bun/install/global/node_modules/claudekit-cli/dist/ui/index.html
```

Express's `send` module defaults `dotfiles: "ignore"`, causing any path with a directory starting with `.` to return 404.

## Test Plan
- [x] `ck config` serves `/config/global` correctly after fix
- [x] Root `/` still works
- [x] Static assets still load