### PR TITLE
fix(ui): sidebar highlights project incorrectly on Skills page

### DIFF
--- a/src/ui/src/components/Sidebar.tsx
+++ b/src/ui/src/components/Sidebar.tsx
@@ -152,7 +152,10 @@ const Sidebar: React.FC<SidebarProps> = ({
 					// Highlight when on project dashboard (not config pages)
 					const isProjectConfigView = location.pathname.endsWith("/config");
 					const isActiveProject =
-						currentProjectId === project.id && !isGlobalConfigView && !isProjectConfigView && !isSkillsView;
+						currentProjectId === project.id &&
+						!isGlobalConfigView &&
+						!isProjectConfigView &&
+						!isSkillsView;
 					return (
 						<button
 							key={project.id}


### PR DESCRIPTION
## Summary

When navigating to the Skills page (`/skills`), the sidebar incorrectly showed the current project as active (highlighted). The Config Editor page correctly deactivated project highlights, but Skills was missed.

## Root Cause

`isActiveProject` in `Sidebar.tsx:155` excluded `isGlobalConfigView` and `isProjectConfigView` but not `isSkillsView`.

## Fix

Added `&& !isSkillsView` to the `isActiveProject` condition — one-line change.

## Test plan

- [ ] Navigate to Skills page — no project should be highlighted
- [ ] Navigate to Config Editor — no project should be highlighted
- [ ] Click a project — project should be highlighted, Settings items should not