### PR TITLE
fix(init): use correct metadata path for local install deletions

### DIFF
--- a/src/commands/init/phases/merge-handler.ts
+++ b/src/commands/init/phases/merge-handler.ts
@@ -184,6 +184,8 @@ export async function handleMerge(ctx: InitContext): Promise<InitContext> {
 					logger.verbose(`Preserved ${deletionResult.preservedPaths.length} user-owned file(s)`);
 				}
 			}
+		} else {
+			logger.debug(`No source metadata found at ${sourceMetadataPath}, skipping deletions`);
 		}
 	} catch (error) {
 		// Don't fail install on deletion errors - just log and continue


### PR DESCRIPTION
## Summary

- Fix metadata path resolution for local installs in deletion handler
- For local installs, look at `extractDir/.claude/metadata.json` instead of `extractDir/metadata.json`
- Add debug logging when source metadata not found

## Root Cause

In `merge-handler.ts`, the deletion handler uses `sourceDir` to find metadata. For global installs, `sourceDir` is already the `.claude` directory. For local installs, `sourceDir` is the extract root, so we need to append `.claude/`.

## Test Plan

- [x] Typecheck passes
- [x] Lint passes
- [x] Build passes
- [x] Manual test: run `ck init` (local) in temp dir - verified deprecated commands moved to `commands-archived/`

## Manual Test Results

Tested in clean temp directory with local build:
- Metadata correctly found at `.claude/metadata.json`
- Deprecated commands (cook.md, fix.md, debug.md, etc.) archived to `commands-archived/`
- Active `commands/` directory clean
- 2011 files installed, v2.9.1 downloaded successfully

Closes #376