### PR TITLE
fix(migrate): add commands support for Antigravity and Windsurf

### DIFF
--- a/__tests__/commands/portable/provider-registry.test.ts
+++ b/__tests__/commands/portable/provider-registry.test.ts
@@ -54,14 +54,16 @@ describe("Provider Registry", () => {
 			}
 		});
 
-		it("returns limited set for commands (only 4 providers)", () => {
+		it("returns providers supporting commands (6 providers)", () => {
 			const withCommands = getProvidersSupporting("commands");
 
-			expect(withCommands).toHaveLength(4);
+			expect(withCommands).toHaveLength(6);
 			expect(withCommands).toContain("claude-code");
 			expect(withCommands).toContain("opencode");
 			expect(withCommands).toContain("codex");
 			expect(withCommands).toContain("gemini-cli");
+			expect(withCommands).toContain("antigravity");
+			expect(withCommands).toContain("windsurf");
 
 			// Verify each has non-null commands config
 			for (const provider of withCommands) {
@@ -131,9 +133,9 @@ describe("Provider Registry", () => {
 	});
 
 	describe("Commands support check", () => {
-		it("only 4 providers support commands", () => {
+		it("6 providers support commands", () => {
 			const commandsProviders = getProvidersSupporting("commands");
-			expect(commandsProviders).toHaveLength(4);
+			expect(commandsProviders).toHaveLength(6);
 		});
 
 		it("providers without commands have null commands config", () => {
@@ -183,6 +185,22 @@ describe("Provider Registry", () => {
 		it("windsurf has character limit for agents", () => {
 			const config = providers.windsurf;
 			expect(config.agents?.charLimit).toBe(12000);
+		});
+
+		it("antigravity commands use workflows path", () => {
+			const config = providers.antigravity;
+			expect(config.commands).not.toBeNull();
+			expect(config.commands?.projectPath).toBe(".agent/workflows");
+			const globalPath = config.commands?.globalPath?.replace(/\\/g, "/") ?? "";
+			expect(globalPath).toContain(".gemini/antigravity/global_workflows");
+		});
+
+		it("windsurf commands use workflows path", () => {
+			const config = providers.windsurf;
+			expect(config.commands).not.toBeNull();
+			expect(config.commands?.projectPath).toBe(".windsurf/workflows");
+			const globalPath = config.commands?.globalPath?.replace(/\\/g, "/") ?? "";
+			expect(globalPath).toContain(".codeium/windsurf/workflows");
 		});
 
 		it("codex has global-only commands", () => {

--- a/src/commands/commands/commands-command.ts
+++ b/src/commands/commands/commands-command.ts
@@ -1,6 +1,6 @@
 /**
  * Commands command — install Claude Code commands to other coding providers
- * Only 4 providers support commands: Claude Code, OpenCode, Codex, Gemini CLI
+ * 6 providers support commands: Claude Code, OpenCode, Codex, Gemini CLI, Antigravity, Windsurf
  * Unsupported providers are warned and skipped.
  */
 import * as p from "@clack/prompts";
@@ -325,7 +325,7 @@ export async function commandsCommand(options: PortableCommandOptions): Promise<
 			process.exit(1);
 		}
 
-		// Get providers that support commands (only 4: claude-code, opencode, codex, gemini-cli)
+		// Get providers that support commands
 		const cmdProviders = getProvidersSupporting("commands");
 		const detectedProviders = await detectInstalledProviders();
 		const relevantProviders = detectedProviders.filter((prov) => cmdProviders.includes(prov));

--- a/src/commands/portable/provider-registry.ts
+++ b/src/commands/portable/provider-registry.ts
@@ -366,7 +366,13 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			fileExtension: ".md",
 			charLimit: 12000,
 		},
-		commands: null, // Windsurf does not support commands
+		commands: {
+			projectPath: ".windsurf/workflows",
+			globalPath: join(home, ".codeium/windsurf/workflows"),
+			format: "direct-copy",
+			writeStrategy: "per-file",
+			fileExtension: ".md",
+		},
 		skills: {
 			projectPath: ".windsurf/skills",
 			globalPath: join(home, ".codeium/windsurf/skills"),
@@ -394,8 +400,10 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			hasAnyInstallSignal([
 				join(cwd, ".windsurf/rules"),
 				join(cwd, ".windsurf/skills"),
+				join(cwd, ".windsurf/workflows"),
 				join(home, ".codeium/windsurf/rules"),
 				join(home, ".codeium/windsurf/skills"),
+				join(home, ".codeium/windsurf/workflows"),
 			]),
 	},
 	goose: {
@@ -537,7 +545,13 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			writeStrategy: "per-file",
 			fileExtension: ".md",
 		},
-		commands: null, // Antigravity does not support commands
+		commands: {
+			projectPath: ".agent/workflows",
+			globalPath: join(home, ".gemini/antigravity/global_workflows"),
+			format: "direct-copy",
+			writeStrategy: "per-file",
+			fileExtension: ".md",
+		},
 		skills: {
 			projectPath: ".agent/skills",
 			globalPath: join(home, ".gemini/antigravity/skills"),
@@ -563,10 +577,12 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			hasAnyInstallSignal([
 				join(cwd, ".agent/rules"),
 				join(cwd, ".agent/skills"),
+				join(cwd, ".agent/workflows"),
 				join(cwd, "GEMINI.md"),
 				join(home, ".gemini/antigravity/GEMINI.md"),
 				join(home, ".gemini/antigravity/rules"),
 				join(home, ".gemini/antigravity/skills"),
+				join(home, ".gemini/antigravity/global_workflows"),
 			]),
 	},
 	cline: {


### PR DESCRIPTION
## Summary

- Antigravity uses `.agent/workflows/*.md` (triggered via `/` in IDE) — was incorrectly marked `commands: null`
- Windsurf uses `.windsurf/workflows/*.md` — same issue
- Updated provider registry with correct paths for both project and global workflows
- Updated detect() functions to include workflow directories
- Updated tests from "4 providers" → "6 providers" for commands support
- Updated stale comments in commands-command.ts

Closes #394

## Test plan

- [x] TypeScript typecheck passes
- [x] All 107 provider-registry + md-strip tests pass (0 failures)
- [x] Build succeeds
- [ ] Manual verification: run `ck config` → Migrate → select Antigravity → verify no "unsupported" warning for Commands