### PR TITLE
fix: flatten nested commands for flat-only providers

### DIFF
--- a/src/commands/portable/portable-installer.ts
+++ b/src/commands/portable/portable-installer.ts
@@ -310,8 +310,17 @@ async function installPerFile(
 				warnings: result.warnings.length > 0 ? result.warnings : undefined,
 			};
 		}
+		// Flatten nested filename if provider doesn't support nested commands
+		let resolvedFilename = result.filename;
+		if (pathConfig.nestedCommands === false && resolvedFilename.includes("/")) {
+			const extIdx = resolvedFilename.lastIndexOf(".");
+			const ext = extIdx >= 0 ? resolvedFilename.substring(extIdx) : "";
+			const nameWithoutExt = extIdx >= 0 ? resolvedFilename.substring(0, extIdx) : resolvedFilename;
+			resolvedFilename = `${nameWithoutExt.replace(/\//g, "-")}${ext}`;
+		}
+
 		targetPath =
-			pathConfig.writeStrategy === "single-file" ? basePath : join(basePath, result.filename);
+			pathConfig.writeStrategy === "single-file" ? basePath : join(basePath, resolvedFilename);
 
 		// Guard against path traversal
 		const resolvedTarget = resolve(targetPath);

--- a/src/commands/portable/provider-registry.ts
+++ b/src/commands/portable/provider-registry.ts
@@ -201,6 +201,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			format: "direct-copy",
 			writeStrategy: "per-file",
 			fileExtension: ".md",
+			nestedCommands: false, // Codex scans top-level only
 		},
 		skills: {
 			projectPath: ".codex/skills",
@@ -380,6 +381,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			format: "direct-copy",
 			writeStrategy: "per-file",
 			fileExtension: ".md",
+			nestedCommands: false, // Windsurf workflows are flat
 		},
 		skills: {
 			projectPath: ".windsurf/skills",
@@ -563,6 +565,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			format: "direct-copy",
 			writeStrategy: "per-file",
 			fileExtension: ".md",
+			nestedCommands: false, // Antigravity nesting support unknown, flatten to be safe
 		},
 		skills: {
 			projectPath: ".agent/skills",

--- a/src/commands/portable/types.ts
+++ b/src/commands/portable/types.ts
@@ -54,6 +54,7 @@ export interface ProviderPathConfig {
 	writeStrategy: WriteStrategy;
 	fileExtension: string; // e.g., ".md", ".mdc", ".toml"
 	charLimit?: number; // Max characters per file (e.g., Windsurf 12K)
+	nestedCommands?: boolean; // false = flatten nested paths with "-" separator (default: true)
 }
 
 /** Provider's level of subagent/delegation support */


### PR DESCRIPTION
## Summary

- Added `nestedCommands?: boolean` flag to `ProviderPathConfig` type
- Set `nestedCommands: false` for Codex, Windsurf, and Antigravity (flat-only providers)
- Installer now flattens nested filenames with `-` separator when `nestedCommands === false` (e.g., `review/codebase/parallel.md` → `review-codebase-parallel.md`)
- Providers without the flag (or `true`) preserve folder nesting as before

## Test plan

- [x] Verify `test/ui` → `test-ui.md` for Codex
- [x] Verify `review/codebase/parallel` → `review-codebase-parallel.md` for Codex
- [x] Verify OpenCode preserves nested `test/ui.md` folder structure
- [x] Verify flat commands (no `/`) are unaffected by the flag
- [x] All 8 portable-installer tests pass
- [x] Typecheck, lint, build pass

Closes #399