### PR TITLE
feat(migrate): add --force flag to override skip decisions

### DIFF
--- a/src/cli/command-registry.ts
+++ b/src/cli/command-registry.ts
@@ -309,6 +309,7 @@ export function registerCommands(cli: ReturnType<typeof cac>): void {
 			"Custom CLAUDE.md source path (config only, not agents/commands/skills)",
 		)
 		.option("--dry-run", "Preview migration targets without writing files")
+		.option("-f, --force", "Force reinstall deleted/edited items")
 		.action(async (options) => {
 			if (options.agent && !Array.isArray(options.agent)) {
 				options.agent = [options.agent];

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -47,6 +47,7 @@ export interface MigrateOptions {
 	skipRules?: boolean;
 	source?: string;
 	dryRun?: boolean;
+	force?: boolean;
 }
 
 /**
@@ -357,6 +358,7 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			registry,
 			targetStates,
 			providerConfigs,
+			force: options.force,
 		});
 
 		reconcileSpinner.stop("Plan computed");

--- a/src/commands/portable/plan-display.ts
+++ b/src/commands/portable/plan-display.ts
@@ -166,7 +166,8 @@ function summarizeExecutionResults(results: PortableInstallResult[]): {
 }
 
 /**
- * Display migration summary after execution
+ * Display migration summary after execution.
+ * Uses plan-based counts (accurate) as primary display, with execution failures from results.
  */
 export function displayMigrationSummary(
 	plan: ReconcilePlan,
@@ -180,39 +181,27 @@ export function displayMigrationSummary(
 	const { summary } = plan;
 	const resultSummary = summarizeExecutionResults(results);
 
-	if (results.length > 0) {
-		// Execution-aligned results for this run.
-		if (resultSummary.applied > 0) {
-			console.log(
-				`  ${options.color ? pc.green("[OK]") : "[OK]"} ${resultSummary.applied} applied`,
-			);
-		}
-		if (resultSummary.skipped > 0) {
-			console.log(`  ${options.color ? pc.dim("[i]") : "[i]"}  ${resultSummary.skipped} skipped`);
-		}
-		if (resultSummary.failed > 0) {
-			console.log(`  ${options.color ? pc.red("[X]") : "[X]"} ${resultSummary.failed} failed`);
-		}
-	} else {
-		// Fallback to plan counts when execution result detail is unavailable.
-		if (summary.install > 0) {
-			console.log(
-				`  ${options.color ? pc.green("[OK]") : "[OK]"} ${summary.install} install (planned)`,
-			);
-		}
-		if (summary.update > 0) {
-			console.log(
-				`  ${options.color ? pc.green("[OK]") : "[OK]"} ${summary.update} update (planned)`,
-			);
-		}
-		if (summary.skip > 0) {
-			console.log(
-				`  ${options.color ? pc.dim("[i]") : "[i]"}  ${summary.skip} unchanged (planned)`,
-			);
-		}
-		if (summary.delete > 0) {
-			console.log(`  ${options.color ? pc.dim("[-]") : "[-]"}  ${summary.delete} delete (planned)`);
-		}
+	// Plan-based counts are the source of truth for what happened
+	const installed = summary.install;
+	const updated = summary.update;
+	const skipped = summary.skip;
+	const deleted = summary.delete;
+	const failed = resultSummary.failed;
+
+	if (installed > 0) {
+		console.log(`  ${options.color ? pc.green("[OK]") : "[OK]"} ${installed} installed`);
+	}
+	if (updated > 0) {
+		console.log(`  ${options.color ? pc.green("[OK]") : "[OK]"} ${updated} updated`);
+	}
+	if (skipped > 0) {
+		console.log(`  ${options.color ? pc.dim("[i]") : "[i]"}  ${skipped} skipped`);
+	}
+	if (deleted > 0) {
+		console.log(`  ${options.color ? pc.dim("[-]") : "[-]"}  ${deleted} deleted`);
+	}
+	if (failed > 0) {
+		console.log(`  ${options.color ? pc.red("[X]") : "[X]"} ${failed} failed`);
 	}
 
 	// Conflict resolutions

--- a/src/commands/portable/reconcile-types.ts
+++ b/src/commands/portable/reconcile-types.ts
@@ -94,6 +94,7 @@ export interface ReconcileInput {
 	targetStates: Map<string, TargetFileState>; // path → current disk state
 	manifest?: PortableManifest | null; // From portable-manifest.json (Phase 4)
 	providerConfigs: ReconcileProviderInput[]; // Provider metadata only, no I/O
+	force?: boolean; // Override skip decisions for deleted/edited targets
 }
 
 /** Output plan from reconcile function */

--- a/src/commands/portable/reconciler.ts
+++ b/src/commands/portable/reconciler.ts
@@ -341,12 +341,15 @@ function determineAction(
 
 	// Target file deleted by user
 	if (targetChangeState === "deleted") {
+		const forceReinstall = input.force && !sourceChanged;
 		return {
 			...common,
-			action: sourceChanged ? "install" : "skip",
+			action: sourceChanged || forceReinstall ? "install" : "skip",
 			reason: sourceChanged
 				? "Target was deleted, CK has updates — reinstalling"
-				: "Target was deleted by user, CK unchanged — respecting deletion",
+				: forceReinstall
+					? "Force reinstall (target was deleted)"
+					: "Target was deleted by user, CK unchanged — respecting deletion",
 			sourceChecksum: convertedChecksum,
 			registeredSourceChecksum,
 		};
@@ -382,8 +385,10 @@ function determineAction(
 	if (!sourceChanged && targetChanged) {
 		return {
 			...common,
-			action: "skip",
-			reason: "User edited, CK unchanged — preserving edits",
+			action: input.force ? "install" : "skip",
+			reason: input.force
+				? "Force overwrite (user edits)"
+				: "User edited, CK unchanged — preserving edits",
 			sourceChecksum: convertedChecksum,
 			registeredSourceChecksum,
 			currentTargetChecksum: normalizeChecksum(targetState?.currentChecksum),

--- a/src/domains/help/commands/migrate-command-help.ts
+++ b/src/domains/help/commands/migrate-command-help.ts
@@ -40,6 +40,10 @@ export const migrateCommandHelp: CommandHelp = {
 					flags: "-y, --yes",
 					description: "Skip confirmation prompts",
 				},
+				{
+					flags: "-f, --force",
+					description: "Force reinstall deleted/edited items",
+				},
 			],
 		},
 		{


### PR DESCRIPTION
## Summary
- Adds `-f`/`--force` flag to `ck migrate` that overrides reconciler skip decisions for deleted and user-edited targets
- Fixes misleading "56 applied" summary when 0 items were actually installed — now shows accurate plan-based counts (installed/updated/skipped/deleted)

## Changes
| File | Change |
|------|--------|
| `reconcile-types.ts` | Added `force?: boolean` to `ReconcileInput` |
| `reconciler.ts` | Case 4 (deleted+unchanged) and Case 6 (user-edited+unchanged) respect `force` flag |
| `migrate-command.ts` | Added `force` to `MigrateOptions`, passed to `reconcile()` |
| `command-registry.ts` | Added `-f, --force` CLI option |
| `migrate-command-help.ts` | Added `--force` to help docs |
| `plan-display.ts` | Summary uses plan-based counts instead of inflated execution results |
| `reconciler.test.ts` | 2 new force mode test cases |

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint:fix` — no fixes needed
- [x] 21/21 reconciler tests pass (including 2 new force mode tests)
- [x] `bun run build` succeeds
- [ ] Manual: `ck migrate --agent codex -g --force` reinstalls deleted items
- [ ] Manual: `ck migrate -f` overwrites user-edited files
- [ ] Manual: `ck migrate` (no flag) behavior unchanged