### PR TITLE
fix: reduce JSON panel font size in config editor

### DIFF
--- a/src/ui/src/components/JsonEditor.tsx
+++ b/src/ui/src/components/JsonEditor.tsx
@@ -21,6 +21,8 @@ interface JsonEditorProps {
 	height?: string;
 	/** Whether editor is read-only */
 	readOnly?: boolean;
+	/** Optional wrapper class for scoped styling from parent panels */
+	className?: string;
 }
 
 /**
@@ -97,6 +99,7 @@ const JsonEditor: React.FC<JsonEditorProps> = ({
 	onCursorLineChange,
 	height = "100%",
 	readOnly = false,
+	className,
 }) => {
 	// Memoize extensions to avoid recreating on every render
 	const extensions = useMemo(
@@ -115,7 +118,9 @@ const JsonEditor: React.FC<JsonEditorProps> = ({
 	}, [onCursorLineChange]);
 
 	return (
-		<div className="h-full [&_.cm-editor]:h-full [&_.cm-editor]:outline-none [&_.cm-focused]:outline-none">
+		<div
+			className={`h-full [&_.cm-editor]:h-full [&_.cm-editor]:outline-none [&_.cm-focused]:outline-none ${className ?? ""}`.trim()}
+		>
 			<CodeMirror
 				value={value}
 				height={height}

--- a/src/ui/src/components/config-editor/config-editor-json-panel.tsx
+++ b/src/ui/src/components/config-editor/config-editor-json-panel.tsx
@@ -42,13 +42,12 @@ export const ConfigEditorJsonPanel: React.FC<ConfigEditorJsonPanelProps> = ({
 						<div className="animate-pulse text-dash-text-muted text-sm">{t("loading")}</div>
 					</div>
 				) : (
-					<div className="[&_.cm-content]:text-xs [&_.cm-content]:leading-5 [&_.cm-gutters]:text-xs [&_.cm-gutters]:leading-5">
-						<JsonEditor
-							value={jsonText}
-							onChange={onChange}
-							onCursorLineChange={onCursorLineChange}
-						/>
-					</div>
+					<JsonEditor
+						value={jsonText}
+						onChange={onChange}
+						onCursorLineChange={onCursorLineChange}
+						className="[&_.cm-content]:text-xs [&_.cm-content]:leading-4 [&_.cm-gutters]:text-xs [&_.cm-gutters]:leading-4"
+					/>
 				)}
 			</div>
 			<div className="px-4 py-2 bg-dash-surface-hover/30 border-t border-dash-border text-[10px] text-dash-text-muted flex justify-between uppercase tracking-widest font-bold">


### PR DESCRIPTION
## Summary
- reduce CodeMirror content and gutter font size in Config Editor JSON panel
- align JSON panel typography closer to dashboard baseline

## Validation
- bun install --silent && bun run build (src/ui)

## Notes
- scoped to Config Editor JSON panel only; no global editor theme changes