### PR TITLE
fix(release): add hotfix commit type and conventionalcommits preset

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -12,8 +12,36 @@ const isDevBranch = branchName === "dev";
 export default {
 	branches: ["main", { name: "dev", prerelease: "dev", channel: "dev" }],
 	plugins: [
-		"@semantic-release/commit-analyzer",
-		"@semantic-release/release-notes-generator",
+		[
+			"@semantic-release/commit-analyzer",
+			{
+				preset: "conventionalcommits",
+				releaseRules: [
+					{ type: "feat", release: "minor" },
+					{ type: "fix", release: "patch" },
+					{ type: "hotfix", release: "patch" },
+					{ type: "perf", release: "patch" },
+					{ type: "refactor", release: "patch" },
+				],
+			},
+		],
+		[
+			"@semantic-release/release-notes-generator",
+			{
+				preset: "conventionalcommits",
+				presetConfig: {
+					types: [
+						{ type: "feat", section: "🚀 Features" },
+						{ type: "hotfix", section: "🔥 Hotfixes" },
+						{ type: "fix", section: "🐞 Bug Fixes" },
+						{ type: "perf", section: "⚡ Performance Improvements" },
+						{ type: "refactor", section: "♻️ Code Refactoring" },
+						{ type: "docs", section: "📚 Documentation" },
+						{ type: "test", section: "✅ Tests" },
+					],
+				},
+			},
+		],
 		"@semantic-release/changelog",
 		[
 			"./scripts/build-binaries-after-version-bump.js",

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "claudekit-cli",
@@ -46,6 +47,7 @@
         "@types/tar": "^6.1.13",
         "@types/tmp": "^0.2.6",
         "@types/ws": "^8.18.1",
+        "conventional-changelog-conventionalcommits": "^9.1.0",
         "semantic-release": "^24.2.0",
         "typescript": "^5.7.2",
       },
@@ -271,6 +273,8 @@
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "conventional-changelog-angular": ["conventional-changelog-angular@8.1.0", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w=="],
+
+    "conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@9.1.0", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-MnbEysR8wWa8dAEvbj5xcBgJKQlX/m0lhS8DsyAAWDHdfs2faDJxTgzRYlRYpXSe7UiKrIIlB4TrBKU9q9DgkA=="],
 
     "conventional-changelog-writer": ["conventional-changelog-writer@8.2.0", "", { "dependencies": { "conventional-commits-filter": "^5.0.0", "handlebars": "^4.7.7", "meow": "^13.0.0", "semver": "^7.5.2" }, "bin": { "conventional-changelog-writer": "dist/cli/index.js" } }, "sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw=="],
 

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
 		"@types/tar": "^6.1.13",
 		"@types/tmp": "^0.2.6",
 		"@types/ws": "^8.18.1",
+		"conventional-changelog-conventionalcommits": "^9.1.0",
 		"semantic-release": "^24.2.0",
 		"typescript": "^5.7.2"
 	}


### PR DESCRIPTION
## Summary
- Add `hotfix:` commit type → distinct "Hotfixes" section in CHANGELOG, GitHub releases, Discord
- Switch to `conventionalcommits` preset for custom section headers with emojis
- Matches Engineer Kit release note style

## Files Changed
- `.releaserc.js` — semantic release config (+30 lines)
- `package.json` + `bun.lock` — `conventional-changelog-conventionalcommits` dev dep

## Test plan
- [ ] `hotfix:` commits trigger patch version bump
- [ ] Release notes show emoji section headers
- [ ] Existing `fix:` and `feat:` still work