### PR TITLE
hotfix(merger): migrate deprecated hook matchers during settings merge

### DIFF
--- a/__tests__/domains/installation/merger/settings-processor.test.ts
+++ b/__tests__/domains/installation/merger/settings-processor.test.ts
@@ -196,6 +196,160 @@ describe("SettingsProcessor", () => {
 		});
 	});
 
+	describe("deprecated matcher migration", () => {
+		it("should migrate wildcard matcher to narrowed matcher from source", async () => {
+			// Source: new narrowed matcher
+			const sourceSettings = {
+				hooks: {
+					PostToolUse: [
+						{
+							matcher: "Bash|Edit|Write|MultiEdit|NotebookEdit",
+							hooks: [
+								{
+									type: "command",
+									command: 'node "$HOME"/.claude/hooks/usage-context-awareness.cjs',
+									timeout: 10,
+								},
+							],
+						},
+					],
+				},
+			};
+			const sourceFile = join(sourceDir, "settings.json");
+			await writeFile(sourceFile, JSON.stringify(sourceSettings), "utf-8");
+
+			// Destination: old wildcard matcher (what existing users have)
+			const destSettings = {
+				hooks: {
+					PostToolUse: [
+						{
+							matcher: "*",
+							hooks: [
+								{
+									type: "command",
+									command: 'node "$HOME"/.claude/hooks/usage-context-awareness.cjs',
+								},
+							],
+						},
+					],
+				},
+			};
+			const destFile = join(destDir, "settings.json");
+			await writeFile(destFile, JSON.stringify(destSettings), "utf-8");
+
+			const processor = new SettingsProcessor();
+			processor.setGlobalFlag(true);
+			processor.setProjectDir(destDir);
+			await processor.processSettingsJson(sourceFile, destFile);
+
+			const result = JSON.parse(await readFile(destFile, "utf-8"));
+
+			// Should have migrated matcher from "*" to narrowed
+			expect(result.hooks.PostToolUse).toHaveLength(1);
+			const entry = result.hooks.PostToolUse[0];
+			expect(entry.matcher).toBe("Bash|Edit|Write|MultiEdit|NotebookEdit");
+			// Should also sync timeout from source
+			expect(entry.hooks[0].timeout).toBe(10);
+		});
+
+		it("should not migrate matcher when commands don't overlap", async () => {
+			const sourceSettings = {
+				hooks: {
+					PostToolUse: [
+						{
+							matcher: "Edit|Write",
+							hooks: [{ type: "command", command: 'node "$HOME"/.claude/hooks/new-hook.cjs' }],
+						},
+					],
+				},
+			};
+			const sourceFile = join(sourceDir, "settings.json");
+			await writeFile(sourceFile, JSON.stringify(sourceSettings), "utf-8");
+
+			const destSettings = {
+				hooks: {
+					PostToolUse: [
+						{
+							matcher: "*",
+							hooks: [
+								{
+									type: "command",
+									command: 'node "$HOME"/.claude/hooks/different-hook.cjs',
+								},
+							],
+						},
+					],
+				},
+			};
+			const destFile = join(destDir, "settings.json");
+			await writeFile(destFile, JSON.stringify(destSettings), "utf-8");
+
+			const processor = new SettingsProcessor();
+			processor.setGlobalFlag(true);
+			processor.setProjectDir(destDir);
+			await processor.processSettingsJson(sourceFile, destFile);
+
+			const result = JSON.parse(await readFile(destFile, "utf-8"));
+
+			// Should keep "*" because commands are different
+			const starEntry = result.hooks.PostToolUse.find(
+				(e: { matcher?: string }) => e.matcher === "*",
+			);
+			expect(starEntry).toBeDefined();
+		});
+
+		it("should handle local install path variables during matcher migration", async () => {
+			const sourceSettings = {
+				hooks: {
+					PostToolUse: [
+						{
+							matcher: "Bash|Edit|Write|MultiEdit|NotebookEdit",
+							hooks: [
+								{
+									type: "command",
+									command: "node .claude/hooks/usage-context-awareness.cjs",
+									timeout: 10,
+								},
+							],
+						},
+					],
+				},
+			};
+			const sourceFile = join(sourceDir, "settings.json");
+			await writeFile(sourceFile, JSON.stringify(sourceSettings), "utf-8");
+
+			// Dest has path var expanded version
+			const destSettings = {
+				hooks: {
+					PostToolUse: [
+						{
+							matcher: "*",
+							hooks: [
+								{
+									type: "command",
+									command: `node "${HOME_VAR}"/.claude/hooks/usage-context-awareness.cjs`,
+								},
+							],
+						},
+					],
+				},
+			};
+			const destFile = join(destDir, "settings.json");
+			await writeFile(destFile, JSON.stringify(destSettings), "utf-8");
+
+			const processor = new SettingsProcessor();
+			processor.setGlobalFlag(true);
+			processor.setProjectDir(destDir);
+			await processor.processSettingsJson(sourceFile, destFile);
+
+			const result = JSON.parse(await readFile(destFile, "utf-8"));
+
+			// Should still migrate because normalizeCommand handles path vars
+			expect(result.hooks.PostToolUse).toHaveLength(1);
+			expect(result.hooks.PostToolUse[0].matcher).toBe("Bash|Edit|Write|MultiEdit|NotebookEdit");
+		});
+	});
+
 	describe("fresh install (no destination)", () => {
 		it("should write source content directly when no destination exists", async () => {
 			const sourceSettings = {

--- a/src/domains/installation/merger/settings-processor.ts
+++ b/src/domains/installation/merger/settings-processor.ts
@@ -1,5 +1,6 @@
 import { InstalledSettingsTracker } from "@/domains/config/installed-settings-tracker.js";
 import { type SettingsJson, SettingsMerger } from "@/domains/config/settings-merger.js";
+import { normalizeCommand } from "@/shared/command-normalizer.js";
 import { isWindows } from "@/shared/environment.js";
 import { logger } from "@/shared/logger.js";
 import type { InstalledSettings } from "@/types";
@@ -169,6 +170,9 @@ export class SettingsProcessor {
 			return;
 		}
 
+		// Migrate deprecated matchers before merge so deduplication works correctly
+		this.migrateDeprecatedMatchers(destSettings, sourceSettings);
+
 		// Load previously installed settings for respecting user deletions
 		let installedSettings: InstalledSettings = { hooks: [], mcpServers: [] };
 		if (this.tracker) {
@@ -216,6 +220,68 @@ export class SettingsProcessor {
 		// Write merged settings
 		await SettingsMerger.writeSettingsFile(destFile, mergeResult.merged);
 		logger.success("Merged settings.json (user customizations preserved)");
+	}
+
+	/**
+	 * Migrate deprecated hook matchers in destination settings to match source.
+	 * Fixes the merge gap where matcher change (e.g., "*" -> "Bash|Edit|...") causes
+	 * the merger to skip updates because command dedup sees the hook as already present
+	 * under the old matcher, while the new matcher is treated as a different entry.
+	 *
+	 * Runs before merge so deduplication sees correct matchers.
+	 */
+	private migrateDeprecatedMatchers(
+		destSettings: SettingsJson,
+		sourceSettings: SettingsJson,
+	): void {
+		if (!destSettings.hooks || !sourceSettings.hooks) return;
+
+		for (const [eventName, sourceEntries] of Object.entries(sourceSettings.hooks)) {
+			const destEntries = destSettings.hooks[eventName];
+			if (!destEntries) continue;
+
+			for (const sourceEntry of sourceEntries) {
+				if (!("matcher" in sourceEntry) || !sourceEntry.matcher) continue;
+				if (!("hooks" in sourceEntry) || !sourceEntry.hooks) continue;
+
+				const sourceCommands = new Set(
+					sourceEntry.hooks.map((h) => normalizeCommand(h.command)).filter((c) => c.length > 0),
+				);
+				if (sourceCommands.size === 0) continue;
+
+				// Find dest entries with DIFFERENT matcher but SAME commands
+				for (const destEntry of destEntries) {
+					if (!("matcher" in destEntry)) continue;
+					if (destEntry.matcher === sourceEntry.matcher) continue; // Already matching
+					if (!("hooks" in destEntry) || !destEntry.hooks) continue;
+
+					const destCommands = destEntry.hooks
+						.map((h) => normalizeCommand(h.command))
+						.filter((c) => c.length > 0);
+
+					// Check if any dest commands overlap with source commands
+					const hasOverlap = destCommands.some((cmd) => sourceCommands.has(cmd));
+					if (!hasOverlap) continue;
+
+					const oldMatcher = destEntry.matcher;
+					// Migrate: update matcher and merge timeout from source
+					destEntry.matcher = sourceEntry.matcher;
+
+					// Also sync timeout from source hooks to dest hooks
+					for (const destHook of destEntry.hooks) {
+						const normalizedDest = normalizeCommand(destHook.command);
+						const matchingSource = sourceEntry.hooks.find(
+							(sh) => normalizeCommand(sh.command) === normalizedDest,
+						);
+						if (matchingSource?.timeout !== undefined) {
+							destHook.timeout = matchingSource.timeout;
+						}
+					}
+
+					logger.info(`Migrated ${eventName} matcher: "${oldMatcher}" -> "${sourceEntry.matcher}"`);
+				}
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes the settings merge gap where existing users running `ck update` retain the old `matcher: "*"` on PostToolUse hooks instead of getting the narrowed `Bash|Edit|Write|MultiEdit|NotebookEdit` matcher from the engineer kit.

**Paired with:** claudekit-engineer PR #496 (cherry-picks hook fixes to main)

## Root Cause

The merger deduplicates by **command string**. When source has a narrowed matcher and destination has `*` for the same command, the merger sees the command already exists and skips the new entry — preserving the broken `*` matcher.

## Fix

Added `migrateDeprecatedMatchers()` pre-merge step in `SettingsProcessor.selectiveMergeSettings()`:
1. For each hook event, compare source and dest entries
2. If dest has a different matcher but overlapping commands → migrate matcher to match source
3. Also syncs `timeout` from source hooks

This runs **before** the merge, so deduplication sees correct matchers and works naturally.

## Test plan

- [x] 3 new tests: wildcard migration, non-overlapping skip, path variable handling
- [x] All 9 settings-processor tests pass
- [x] Full suite: 2508 pass (7 pre-existing failures unrelated)
- [x] Typecheck + lint clean

## Files changed

- `src/domains/installation/merger/settings-processor.ts` — add `migrateDeprecatedMatchers()` method + call before merge
- `__tests__/domains/installation/merger/settings-processor.test.ts` — 3 new tests