### PR TITLE
fix: resolve ETARGET on ck update when npm registry differs (#438)

### DIFF
--- a/src/commands/update-cli.ts
+++ b/src/commands/update-cli.ts
@@ -270,6 +270,17 @@ export async function updateCliCommand(options: UpdateCliOptions): Promise<void>
 		);
 		logger.verbose(`Detected package manager: ${pm}`);
 
+		// Resolve the registry URL: user-provided --registry > user's npm config > default
+		// This ensures version checks and install commands use the same registry
+		let registryUrl = opts.registry;
+		if (!registryUrl && pm === "npm") {
+			const userRegistry = await PackageManagerDetector.getNpmRegistryUrl();
+			if (userRegistry) {
+				registryUrl = userRegistry;
+				logger.verbose(`Using npm configured registry: ${registryUrl}`);
+			}
+		}
+
 		// Fetch target version from npm registry
 		s.start("Checking for updates...");
 		let targetVersion: string | null = null;
@@ -279,7 +290,7 @@ export async function updateCliCommand(options: UpdateCliOptions): Promise<void>
 			const exists = await NpmRegistryClient.versionExists(
 				CLAUDEKIT_CLI_NPM_PACKAGE_NAME,
 				opts.release,
-				opts.registry,
+				registryUrl,
 			);
 			if (!exists) {
 				s.stop("Version not found");
@@ -293,14 +304,14 @@ export async function updateCliCommand(options: UpdateCliOptions): Promise<void>
 			// Dev version requested (--dev or --beta alias)
 			targetVersion = await NpmRegistryClient.getDevVersion(
 				CLAUDEKIT_CLI_NPM_PACKAGE_NAME,
-				opts.registry,
+				registryUrl,
 			);
 			if (!targetVersion) {
 				s.stop("No dev version available");
 				logger.warning("No dev version found. Using latest stable version instead.");
 				targetVersion = await NpmRegistryClient.getLatestVersion(
 					CLAUDEKIT_CLI_NPM_PACKAGE_NAME,
-					opts.registry,
+					registryUrl,
 				);
 			} else {
 				s.stop(`Latest dev version: ${targetVersion}`);
@@ -309,7 +320,7 @@ export async function updateCliCommand(options: UpdateCliOptions): Promise<void>
 			// Latest stable version
 			targetVersion = await NpmRegistryClient.getLatestVersion(
 				CLAUDEKIT_CLI_NPM_PACKAGE_NAME,
-				opts.registry,
+				registryUrl,
 			);
 			s.stop(`Latest version: ${targetVersion || "unknown"}`);
 		}
@@ -317,7 +328,7 @@ export async function updateCliCommand(options: UpdateCliOptions): Promise<void>
 		// Handle failure to fetch version
 		if (!targetVersion) {
 			throw new CliUpdateError(
-				`Failed to fetch version information from npm registry. Check your internet connection and try again. Manual update: ${PackageManagerDetector.getUpdateCommand(pm, CLAUDEKIT_CLI_NPM_PACKAGE_NAME)}`,
+				`Failed to fetch version information from npm registry. Check your internet connection and try again. Manual update: ${PackageManagerDetector.getUpdateCommand(pm, CLAUDEKIT_CLI_NPM_PACKAGE_NAME, undefined, registryUrl)}`,
 			);
 		}
 
@@ -372,11 +383,12 @@ export async function updateCliCommand(options: UpdateCliOptions): Promise<void>
 			}
 		}
 
-		// Execute update
+		// Execute update — pass registryUrl to ensure npm install uses the same registry we checked
 		const updateCmd = PackageManagerDetector.getUpdateCommand(
 			pm,
 			CLAUDEKIT_CLI_NPM_PACKAGE_NAME,
 			targetVersion,
+			registryUrl,
 		);
 		logger.info(`Running: ${updateCmd}`);
 
@@ -445,7 +457,7 @@ export async function updateCliCommand(options: UpdateCliOptions): Promise<void>
 		}
 	} catch (error) {
 		if (error instanceof CliUpdateError) {
-			logger.error(error.message);
+			// Already logged by the inner catch — just re-throw without duplicate logging
 			throw error;
 		}
 		const errorMessage = error instanceof Error ? error.message : "Unknown error";

--- a/src/domains/installation/package-manager-detector.ts
+++ b/src/domains/installation/package-manager-detector.ts
@@ -23,6 +23,7 @@ import {
 	getBunUpdateCommand,
 	getBunVersion,
 	getBunVersionCommand,
+	getNpmRegistryUrl,
 	getNpmUpdateCommand,
 	getNpmVersion,
 	getNpmVersionCommand,
@@ -147,8 +148,16 @@ export class PackageManagerDetector {
 		}
 	}
 
+	/** Get the user's configured npm registry URL (npm only) */
+	static getNpmRegistryUrl = getNpmRegistryUrl;
+
 	/** Get the command to update a global package */
-	static getUpdateCommand(pm: PackageManager, packageName: string, version?: string): string {
+	static getUpdateCommand(
+		pm: PackageManager,
+		packageName: string,
+		version?: string,
+		registryUrl?: string,
+	): string {
 		if (!isValidPackageName(packageName)) throw new Error(`Invalid package name: ${packageName}`);
 		if (version && !isValidVersion(version)) throw new Error(`Invalid version: ${version}`);
 
@@ -160,13 +169,18 @@ export class PackageManagerDetector {
 			case "pnpm":
 				return getPnpmUpdateCommand(packageName, version);
 			default:
-				return getNpmUpdateCommand(packageName, version);
+				return getNpmUpdateCommand(packageName, version, registryUrl);
 		}
 	}
 
 	/** Get the command to install a global package */
-	static getInstallCommand(pm: PackageManager, packageName: string, version?: string): string {
-		return PackageManagerDetector.getUpdateCommand(pm, packageName, version);
+	static getInstallCommand(
+		pm: PackageManager,
+		packageName: string,
+		version?: string,
+		registryUrl?: string,
+	): string {
+		return PackageManagerDetector.getUpdateCommand(pm, packageName, version, registryUrl);
 	}
 
 	/** Get human-readable name for package manager */

--- a/src/domains/installation/package-managers/index.ts
+++ b/src/domains/installation/package-managers/index.ts
@@ -8,6 +8,7 @@ export {
 	getNpmVersion,
 	isNpmAvailable,
 	getNpmUpdateCommand,
+	getNpmRegistryUrl,
 } from "./npm-detector.js";
 
 export {

--- a/src/domains/installation/package-managers/npm-detector.ts
+++ b/src/domains/installation/package-managers/npm-detector.ts
@@ -62,9 +62,32 @@ export async function isNpmAvailable(): Promise<boolean> {
 }
 
 /**
- * Get npm update command
+ * Get the user's configured npm registry URL.
+ * Returns null if detection fails (falls back to npm default).
  */
-export function getNpmUpdateCommand(packageName: string, version?: string): string {
+export async function getNpmRegistryUrl(): Promise<string | null> {
+	try {
+		const cmd = isWindows() ? "npm.cmd config get registry" : "npm config get registry";
+		const { stdout } = await execAsync(cmd, { timeout: getPmVersionCommandTimeoutMs() });
+		const url = stdout.trim();
+		if (url?.startsWith("http")) {
+			return url.replace(/\/$/, "");
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Get npm update command
+ * @param registryUrl - Optional registry URL to ensure install uses same registry as version check
+ */
+export function getNpmUpdateCommand(
+	packageName: string,
+	version?: string,
+	registryUrl?: string,
+): string {
 	if (!isValidPackageName(packageName)) {
 		throw new Error(`Invalid package name: ${packageName}`);
 	}
@@ -73,7 +96,8 @@ export function getNpmUpdateCommand(packageName: string, version?: string): stri
 	}
 
 	const versionSuffix = version ? `@${version}` : "@latest";
+	const registryFlag = registryUrl ? ` --registry ${registryUrl}` : "";
 	return isWindows()
-		? `npm.cmd install -g ${packageName}${versionSuffix}`
-		: `npm install -g ${packageName}${versionSuffix}`;
+		? `npm.cmd install -g ${packageName}${versionSuffix}${registryFlag}`
+		: `npm install -g ${packageName}${versionSuffix}${registryFlag}`;
 }


### PR DESCRIPTION
## Summary
- **Root cause:** `ck update` checked versions against `registry.npmjs.org` (hardcoded) but ran `npm install` using user's configured registry (e.g. corporate mirror) — if the mirror hadn't synced the latest version, install failed with ETARGET
- Detects user's npm registry via `npm config get registry` and uses it consistently for both version checks AND install commands
- `--registry` CLI flag now also passed to the actual `npm install` command (was only used for API checks)
- Fixed duplicate error logging (inner catch already logged before re-throw to outer catch)

Closes #438

## Test plan
- [ ] `bun run typecheck && bun run lint:fix && bun test && bun run build` passes
- [ ] `ck update` works for npm users with default registry
- [ ] `ck update --registry https://registry.npmjs.org` explicitly passes registry to install
- [ ] Users with custom `.npmrc` registry now have consistent version resolution