### PR TITLE
feat(config): editable Claude settings panel in System tab

### DIFF
--- a/src/domains/web-server/routes/settings-routes.ts
+++ b/src/domains/web-server/routes/settings-routes.ts
@@ -2,13 +2,44 @@
  * Settings API routes
  */
 
+import { homedir } from "node:os";
 import {
+	backupAndSaveSettings,
 	countHooks,
 	countMcpServers,
 	getCurrentModel,
+	getSettingsPath,
 	readSettings,
 } from "@/services/claude-data/index.js";
 import type { Express, Request, Response } from "express";
+import { z } from "zod";
+
+const HookGroupSchema = z
+	.object({
+		matcher: z.string().optional(),
+		hooks: z.array(z.unknown()),
+	})
+	.passthrough();
+
+const ClaudeSettingsWriteSchema = z
+	.object({
+		model: z.string().optional(),
+		includeCoAuthoredBy: z.boolean().optional(),
+		permissions: z
+			.object({
+				allow: z.array(z.string()).optional(),
+				deny: z.array(z.string()).optional(),
+				defaultMode: z.string().optional(),
+			})
+			.passthrough()
+			.optional(),
+		hooks: z.record(z.array(HookGroupSchema)).optional(),
+		mcpServers: z.record(z.unknown()).optional(),
+		statusLine: z.unknown().optional(),
+		enabledPlugins: z.record(z.unknown()).optional(),
+		effortLevel: z.string().optional(),
+	})
+	.passthrough();
 
 export function registerSettingsRoutes(app: Express): void {
 	// GET /api/settings - Read Claude settings
@@ -26,9 +57,60 @@ export function registerSettingsRoutes(app: Express): void {
 				hookCount,
 				mcpServerCount,
 				permissions: settings?.permissions || null,
+				settingsPath: "~/.claude/settings.json",
+				settingsExists: settings !== null,
+				settings: settings ?? {},
 			});
 		} catch (error) {
 			res.status(500).json({ error: "Failed to read settings" });
+		}
+	});
+
+	// GET /api/settings/raw - Read full ~/.claude/settings.json for JSON viewer
+	app.get("/api/settings/raw", async (_req: Request, res: Response) => {
+		try {
+			const settings = await readSettings();
+			res.json({
+				path: "~/.claude/settings.json",
+				exists: settings !== null,
+				settings: settings ?? {},
+			});
+		} catch (error) {
+			res.status(500).json({ error: "Failed to read settings file" });
+		}
+	});
+
+	// PUT /api/settings/raw - Save full ~/.claude/settings.json with backup
+	app.put("/api/settings/raw", async (req: Request, res: Response) => {
+		try {
+			const payload = req.body as { settings?: unknown };
+			if (!payload || typeof payload !== "object" || payload.settings === undefined) {
+				res.status(400).json({ error: "Missing settings payload" });
+				return;
+			}
+			if (payload.settings === null || typeof payload.settings !== "object") {
+				res.status(400).json({ error: "settings must be a JSON object" });
+				return;
+			}
+
+			const validation = ClaudeSettingsWriteSchema.safeParse(payload.settings);
+			if (!validation.success) {
+				res.status(400).json({
+					error: "Settings validation failed",
+					details: validation.error.issues,
+				});
+				return;
+			}
+
+			const saveResult = await backupAndSaveSettings(validation.data as Record<string, unknown>);
+			res.json({
+				success: true,
+				path: "~/.claude/settings.json",
+				backupPath: saveResult.backupPath ? saveResult.backupPath.replace(homedir(), "~") : null,
+				absolutePath: getSettingsPath(),
+			});
+		} catch (error) {
+			res.status(500).json({ error: "Failed to save settings file" });
 		}
 	});
 }

--- a/src/ui/src/components/JsonEditor.tsx
+++ b/src/ui/src/components/JsonEditor.tsx
@@ -36,6 +36,9 @@ const createDashboardTheme = () => {
 			color: "var(--dash-text)",
 			height: "100%",
 		},
+		".cm-editor": {
+			height: "100% !important",
+		},
 		".cm-content": {
 			caretColor: "var(--dash-accent)",
 			fontFamily: "'JetBrains Mono', Menlo, monospace",
@@ -73,8 +76,9 @@ const createDashboardTheme = () => {
 			outline: "1px solid var(--dash-accent)",
 		},
 		".cm-scroller": {
-			overflow: "auto",
-			minHeight: "100%",
+			overflow: "auto !important",
+			height: "100%",
+			maxHeight: "100%",
 		},
 	});
 

--- a/src/ui/src/components/config-editor/config-editor-header.tsx
+++ b/src/ui/src/components/config-editor/config-editor-header.tsx
@@ -15,6 +15,8 @@ export interface ConfigEditorHeaderProps {
 	showResetConfirm: boolean;
 	setShowResetConfirm: (show: boolean) => void;
 	badge?: React.ReactNode;
+	showActions?: boolean;
+	showFilePath?: boolean;
 }
 
 export const ConfigEditorHeader: React.FC<ConfigEditorHeaderProps> = ({
@@ -28,6 +30,8 @@ export const ConfigEditorHeader: React.FC<ConfigEditorHeaderProps> = ({
 	showResetConfirm,
 	setShowResetConfirm,
 	badge,
+	showActions = true,
+	showFilePath = true,
 }) => {
 	const { t } = useI18n();
 
@@ -56,57 +60,59 @@ export const ConfigEditorHeader: React.FC<ConfigEditorHeaderProps> = ({
 				</button>
 				<h1 className="text-xl font-bold tracking-tight text-dash-text">{title}</h1>
 				{badge}
-				<span className="text-xs text-dash-text-muted mono">{filePath}</span>
+				{showFilePath && <span className="text-xs text-dash-text-muted mono">{filePath}</span>}
 			</div>
 
-			<div className="flex items-center gap-2 relative">
-				{showResetConfirm ? (
-					<div className="flex items-center gap-2 bg-red-500/10 border border-red-500/30 rounded-lg px-2 py-1 animate-in fade-in duration-200">
-						<span className="text-xs text-red-500 font-medium">{t("confirmReset")}</span>
+			{showActions && (
+				<div className="flex items-center gap-2 relative">
+					{showResetConfirm ? (
+						<div className="flex items-center gap-2 bg-red-500/10 border border-red-500/30 rounded-lg px-2 py-1 animate-in fade-in duration-200">
+							<span className="text-xs text-red-500 font-medium">{t("confirmReset")}</span>
+							<button
+								onClick={onReset}
+								className="px-2 py-0.5 rounded bg-red-500 text-white text-xs font-bold hover:bg-red-600 transition-colors"
+							>
+								{t("confirm")}
+							</button>
+							<button
+								onClick={() => setShowResetConfirm(false)}
+								className="px-2 py-0.5 rounded bg-dash-surface text-dash-text-secondary text-xs font-bold hover:bg-dash-surface-hover transition-colors border border-dash-border"
+							>
+								{t("cancel")}
+							</button>
+						</div>
+					) : (
 						<button
-							onClick={onReset}
-							className="px-2 py-0.5 rounded bg-red-500 text-white text-xs font-bold hover:bg-red-600 transition-colors"
+							onClick={() => setShowResetConfirm(true)}
+							className="px-3 py-1.5 rounded-lg bg-dash-surface text-xs font-bold text-dash-text-secondary hover:bg-dash-surface-hover transition-colors border border-dash-border"
 						>
-							{t("confirm")}
+							{t("resetToDefault")}
 						</button>
-						<button
-							onClick={() => setShowResetConfirm(false)}
-							className="px-2 py-0.5 rounded bg-dash-surface text-dash-text-secondary text-xs font-bold hover:bg-dash-surface-hover transition-colors border border-dash-border"
-						>
-							{t("cancel")}
-						</button>
-					</div>
-				) : (
+					)}
+
 					<button
-						onClick={() => setShowResetConfirm(true)}
-						className="px-3 py-1.5 rounded-lg bg-dash-surface text-xs font-bold text-dash-text-secondary hover:bg-dash-surface-hover transition-colors border border-dash-border"
+						onClick={onSave}
+						disabled={!!syntaxError || saveStatus === "saving"}
+						className={`px-3 py-1.5 rounded-lg text-xs font-bold transition-all tracking-widest uppercase ${
+							syntaxError
+								? "bg-dash-surface text-dash-text-muted cursor-not-allowed border border-dash-border"
+								: saveStatus === "saved"
+									? "bg-green-500 text-white shadow-lg shadow-green-500/20"
+									: saveStatus === "error"
+										? "bg-red-500 text-white"
+										: "bg-dash-accent text-dash-bg hover:bg-dash-accent-hover shadow-lg shadow-dash-accent/20"
+						}`}
 					>
-						{t("resetToDefault")}
-					</button>
-				)}
-
-				<button
-					onClick={onSave}
-					disabled={!!syntaxError || saveStatus === "saving"}
-					className={`px-3 py-1.5 rounded-lg text-xs font-bold transition-all tracking-widest uppercase ${
-						syntaxError
-							? "bg-dash-surface text-dash-text-muted cursor-not-allowed border border-dash-border"
+						{saveStatus === "saving"
+							? t("saving")
 							: saveStatus === "saved"
-								? "bg-green-500 text-white shadow-lg shadow-green-500/20"
+								? t("saved")
 								: saveStatus === "error"
-									? "bg-red-500 text-white"
-									: "bg-dash-accent text-dash-bg hover:bg-dash-accent-hover shadow-lg shadow-dash-accent/20"
-					}`}
-				>
-					{saveStatus === "saving"
-						? t("saving")
-						: saveStatus === "saved"
-							? t("saved")
-							: saveStatus === "error"
-								? t("saveFailed")
-								: t("saveChanges")}
-				</button>
-			</div>
+									? t("saveFailed")
+									: t("saveChanges")}
+					</button>
+				</div>
+			)}
 		</div>
 	);
 };

--- a/src/ui/src/components/config-editor/config-editor-json-panel.tsx
+++ b/src/ui/src/components/config-editor/config-editor-json-panel.tsx
@@ -13,6 +13,10 @@ export interface ConfigEditorJsonPanelProps {
 	syntaxError: string | null;
 	onChange: (text: string) => void;
 	onCursorLineChange: (line: number) => void;
+	readOnly?: boolean;
+	headerTitle?: string;
+	headerPath?: string;
+	headerActions?: React.ReactNode;
 }
 
 export const ConfigEditorJsonPanel: React.FC<ConfigEditorJsonPanelProps> = ({
@@ -23,29 +27,54 @@ export const ConfigEditorJsonPanel: React.FC<ConfigEditorJsonPanelProps> = ({
 	syntaxError,
 	onChange,
 	onCursorLineChange,
+	readOnly = false,
+	headerTitle,
+	headerPath,
+	headerActions,
 }) => {
 	const { t } = useI18n();
+	const handleEditorWheelCapture = (event: React.WheelEvent<HTMLDivElement>) => {
+		if (readOnly) return;
+		const target = event.target as HTMLElement;
+		if (!target.closest(".cm-editor")) return;
+		const container = event.currentTarget;
+		if (container.scrollHeight <= container.clientHeight) return;
+		container.scrollTop += event.deltaY;
+	};
 
 	return (
 		<div
 			style={{ width: `${width}%` }}
-			className="bg-dash-surface border border-dash-border rounded-xl overflow-hidden flex flex-col shadow-sm min-w-0"
+			className="bg-dash-surface border border-dash-border rounded-xl overflow-hidden flex flex-col shadow-sm min-w-0 h-full"
 		>
 			<div className="p-3 border-b border-dash-border bg-dash-surface-hover/50 shrink-0">
-				<h3 className="text-xs font-bold text-dash-text-secondary uppercase tracking-widest">
-					{t("jsonTab")}
-				</h3>
+				<div className="flex items-end justify-between gap-3">
+					<div className="min-w-0">
+						<h3 className="text-xs font-bold text-dash-text-secondary uppercase tracking-widest">
+							{headerTitle ?? t("jsonTab")}
+						</h3>
+						{headerPath && (
+							<p className="mt-1 mono text-[11px] text-dash-text-muted truncate">{headerPath}</p>
+						)}
+					</div>
+					{headerActions && <div className="flex items-center gap-2 shrink-0">{headerActions}</div>}
+				</div>
 			</div>
-			<div className="flex-1 min-h-0 overflow-auto">
+			<div className="flex-1 min-h-0 overflow-auto" onWheelCapture={handleEditorWheelCapture}>
 				{isLoading ? (
 					<div className="h-full flex items-center justify-center">
 						<div className="animate-pulse text-dash-text-muted text-sm">{t("loading")}</div>
 					</div>
+				) : readOnly ? (
+					<pre className="h-full overflow-auto p-4 font-mono text-xs leading-4 text-dash-text whitespace-pre m-0">
+						{jsonText}
+					</pre>
 				) : (
 					<JsonEditor
 						value={jsonText}
 						onChange={onChange}
 						onCursorLineChange={onCursorLineChange}
+						readOnly={readOnly}
 						className="[&_.cm-content]:text-xs [&_.cm-content]:leading-4 [&_.cm-gutters]:text-xs [&_.cm-gutters]:leading-4"
 					/>
 				)}
@@ -57,6 +86,7 @@ export const ConfigEditorJsonPanel: React.FC<ConfigEditorJsonPanelProps> = ({
 					<span>L:{cursorLine + 1}</span>
 				</div>
 				<div className="flex items-center gap-2">
+					{readOnly && <span>{t("readOnly")}</span>}
 					{syntaxError ? (
 						<>
 							<div className="w-1.5 h-1.5 rounded-full bg-red-500" />

--- a/src/ui/src/components/system-settings-json-card.tsx
+++ b/src/ui/src/components/system-settings-json-card.tsx
@@ -1,0 +1,178 @@
+/**
+ * SystemSettingsJsonCard - Read-only viewer for ~/.claude/settings.json
+ * Reuses Config tab JSON panel for consistent UX.
+ */
+import type React from "react";
+import { useEffect, useState } from "react";
+import { useI18n } from "../i18n";
+import { fetchSettingsFile, saveSettingsFile } from "../services/api";
+import { ConfigEditorJsonPanel } from "./config-editor";
+
+const SETTINGS_FALLBACK_PATH = "~/.claude/settings.json";
+const EMPTY_JSON_TEXT = "{}";
+
+const SystemSettingsJsonCard: React.FC = () => {
+	const { t } = useI18n();
+	const [isLoading, setIsLoading] = useState(true);
+	const [settingsPath, setSettingsPath] = useState(SETTINGS_FALLBACK_PATH);
+	const [originalJsonText, setOriginalJsonText] = useState(EMPTY_JSON_TEXT);
+	const [settingsJsonText, setSettingsJsonText] = useState(EMPTY_JSON_TEXT);
+	const [cursorLine, setCursorLine] = useState(0);
+	const [exists, setExists] = useState(false);
+	const [loadFailed, setLoadFailed] = useState(false);
+	const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+	const [syntaxError, setSyntaxError] = useState<string | null>(null);
+	const [saveFeedback, setSaveFeedback] = useState<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+
+		const loadSettings = async () => {
+			setIsLoading(true);
+			setLoadFailed(false);
+
+			try {
+				const data = await fetchSettingsFile();
+				if (cancelled) return;
+				const normalized = JSON.stringify(data.settings ?? {}, null, 2);
+				setSettingsPath(data.path || SETTINGS_FALLBACK_PATH);
+				setExists(Boolean(data.exists));
+				setOriginalJsonText(normalized);
+				setSettingsJsonText(normalized);
+				setSyntaxError(null);
+			} catch {
+				if (cancelled) return;
+				setLoadFailed(true);
+				setExists(false);
+				setSettingsPath(SETTINGS_FALLBACK_PATH);
+				setOriginalJsonText(EMPTY_JSON_TEXT);
+				setSettingsJsonText(EMPTY_JSON_TEXT);
+			} finally {
+				if (!cancelled) setIsLoading(false);
+			}
+		};
+
+		void loadSettings();
+
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const handleJsonChange = (text: string) => {
+		setSettingsJsonText(text);
+		setSaveFeedback(null);
+		try {
+			JSON.parse(text);
+			setSyntaxError(null);
+		} catch (error) {
+			setSyntaxError(error instanceof Error ? error.message : "Invalid JSON");
+		}
+	};
+
+	const handleReset = () => {
+		setSettingsJsonText(originalJsonText);
+		setSyntaxError(null);
+		setSaveFeedback(null);
+		setSaveStatus("idle");
+	};
+
+	const handleSave = async () => {
+		if (isLoading || syntaxError) return;
+		setSaveStatus("saving");
+		setSaveFeedback(null);
+
+		try {
+			const parsed = JSON.parse(settingsJsonText) as Record<string, unknown>;
+			const normalized = JSON.stringify(parsed, null, 2);
+			const result = await saveSettingsFile(parsed);
+			setOriginalJsonText(normalized);
+			setSettingsJsonText(normalized);
+			setExists(true);
+			setSaveStatus("saved");
+			setSaveFeedback(
+				result.backupPath ? `${t("settingsBackupSaved")}: ${result.backupPath}` : t("saved"),
+			);
+			setTimeout(() => setSaveStatus("idle"), 2000);
+		} catch (error) {
+			setSaveStatus("error");
+			setSaveFeedback(error instanceof Error ? error.message : t("saveFailed"));
+			setTimeout(() => setSaveStatus("idle"), 3000);
+		}
+	};
+
+	const hasChanges = settingsJsonText !== originalJsonText;
+
+	return (
+		<section className="h-full min-h-0 flex flex-col rounded-xl border border-dash-border bg-dash-surface p-3 shadow-sm">
+			<div className="mb-2 flex items-end justify-between gap-3 px-1">
+				<div className="min-w-0">
+					<h3 className="text-sm font-semibold uppercase tracking-wide text-dash-text">
+						{t("settingsJsonHeading")}
+					</h3>
+					<p className="mono text-[11px] text-dash-text-muted truncate">{settingsPath}</p>
+				</div>
+				<div className="flex items-center gap-2">
+					<button
+						type="button"
+						onClick={handleReset}
+						disabled={isLoading || !hasChanges || saveStatus === "saving"}
+						className="px-3 py-1.5 rounded-lg bg-dash-surface text-xs font-bold text-dash-text-secondary hover:bg-dash-surface-hover transition-colors border border-dash-border disabled:opacity-50 disabled:cursor-not-allowed"
+					>
+						{t("discard")}
+					</button>
+					<button
+						type="button"
+						onClick={handleSave}
+						disabled={isLoading || saveStatus === "saving" || !!syntaxError || !hasChanges}
+						className={`px-3 py-1.5 rounded-lg text-xs font-bold transition-all tracking-widest uppercase disabled:opacity-50 disabled:cursor-not-allowed ${
+							saveStatus === "saved"
+								? "bg-green-500 text-white shadow-lg shadow-green-500/20"
+								: saveStatus === "error"
+									? "bg-red-500 text-white"
+									: "bg-dash-accent text-dash-bg hover:bg-dash-accent-hover shadow-lg shadow-dash-accent/20"
+						}`}
+					>
+						{saveStatus === "saving"
+							? t("saving")
+							: saveStatus === "saved"
+								? t("saved")
+								: saveStatus === "error"
+									? t("saveFailed")
+									: t("saveChanges")}
+					</button>
+				</div>
+			</div>
+
+			<div className="flex-1 min-h-0">
+				<ConfigEditorJsonPanel
+					width={100}
+					isLoading={isLoading}
+					jsonText={settingsJsonText}
+					cursorLine={cursorLine}
+					syntaxError={syntaxError}
+					onChange={handleJsonChange}
+					onCursorLineChange={setCursorLine}
+				/>
+			</div>
+
+			{saveFeedback && (
+				<p
+					className={`mt-2 px-1 text-xs ${saveStatus === "error" ? "text-red-500" : "text-dash-text-muted"}`}
+				>
+					{saveFeedback}
+				</p>
+			)}
+
+			{!isLoading && !loadFailed && !exists && (
+				<p className="mt-2 px-1 text-xs text-dash-text-muted">{t("settingsJsonMissing")}</p>
+			)}
+
+			{!isLoading && loadFailed && (
+				<p className="mt-2 px-1 text-xs text-red-500">{t("settingsJsonLoadFailed")}</p>
+			)}
+		</section>
+	);
+};
+
+export default SystemSettingsJsonCard;

--- a/src/ui/src/i18n/translations.ts
+++ b/src/ui/src/i18n/translations.ts
@@ -107,6 +107,7 @@ export const translations = {
 		systemTab: "System",
 		formTab: "Form",
 		jsonTab: "JSON",
+		readOnly: "Read-only",
 		installedKit: "Installed Kit",
 		kitVersion: "Kit Version",
 		installedOn: "Installed On",
@@ -183,6 +184,10 @@ export const translations = {
 		noUpdatesFound: "No updates found. Checked components are up to date.",
 		noUpToDateYet: "No components are up to date yet.",
 		configWorkspaceHint: "Edit configuration or manage system updates from one workspace.",
+		settingsJsonHeading: "Claude Settings JSON",
+		settingsJsonMissing: "No settings file found at ~/.claude/settings.json.",
+		settingsJsonLoadFailed: "Failed to load ~/.claude/settings.json.",
+		settingsBackupSaved: "Backup saved",
 
 		// AddProjectModal.tsx
 		addProjectTitle: "Add Project",
@@ -627,6 +632,7 @@ export const translations = {
 		systemTab: "Hệ thống",
 		formTab: "Biểu mẫu",
 		jsonTab: "JSON",
+		readOnly: "Chỉ đọc",
 		installedKit: "Kit đã cài",
 		kitVersion: "Phiên bản Kit",
 		installedOn: "Cài đặt vào",
@@ -703,6 +709,10 @@ export const translations = {
 		noUpdatesFound: "Không có bản cập nhật. Các thành phần đã kiểm tra đều mới nhất.",
 		noUpToDateYet: "Chưa có thành phần nào ở trạng thái đã cập nhật.",
 		configWorkspaceHint: "Chỉnh sửa cấu hình hoặc quản lý cập nhật hệ thống trong một màn hình.",
+		settingsJsonHeading: "JSON Cài đặt Claude",
+		settingsJsonMissing: "Không tìm thấy tệp ~/.claude/settings.json.",
+		settingsJsonLoadFailed: "Không thể tải ~/.claude/settings.json.",
+		settingsBackupSaved: "Đã lưu bản sao lưu",
 
 		// AddProjectModal.tsx
 		addProjectTitle: "Thêm dự án",


### PR DESCRIPTION
## Summary
- add right-column Claude settings panel in Global Config > System tab
- make ~/.claude/settings.json editable with JSON validation and save/discard controls
- add backup-on-save support and raw settings read/write API endpoints
- align System tab column tops and remove duplicate global Save/Reset actions on System tab
- unify Config tab by moving ~/.claude/.ck.json path + Save/Reset into JSON panel header

## Validation
- bun run typecheck
- bunx biome check on modified UI files
- manual UI verification at /config/global for Config + System tabs