### PR TITLE
fix(migrate): remove initialValues pre-selecting all detected providers

### DIFF
--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -249,7 +249,6 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 					label: providers[a].displayName,
 				})),
 				required: true,
-				initialValues: detectedProviders,
 			});
 			if (p.isCancel(selected)) {
 				p.cancel("Migrate cancelled");


### PR DESCRIPTION
## Summary

- Removed `initialValues: detectedProviders` from the multiselect in `ck migrate` command
- This was pre-checking all detected providers, making the "Select providers" step effectively useless
- Users now start with no providers selected and must explicitly choose their targets

## Root Cause

The `@clack/prompts` multiselect at line 252 had `initialValues: detectedProviders` which checked all options by default. Users who didn't manually deselect providers ended up migrating to all of them unintentionally.

## Test Plan

- [x] TypeScript compiles cleanly
- [x] Migrate scope resolver tests pass (18/18)
- [ ] Manual: Run `ck migrate --config --source ./CLAUDE.md` — multiselect should start with no providers checked

Closes #446