### PR TITLE
fix: backup-then-remove strategy for standalone skill cleanup (#513)

### DIFF
--- a/src/commands/init/phases/post-install-handler.ts
+++ b/src/commands/init/phases/post-install-handler.ts
@@ -178,7 +178,12 @@ export async function handlePostInstall(ctx: InitContext): Promise<InitContext> 
 			const overlap = await cleanupOverlappingStandaloneSkills(globalClaudeDir, pluginSkillsDir);
 			if (overlap.removed.length > 0) {
 				logger.info(
-					`Cleaned up ${overlap.removed.length} standalone skill(s) now provided by /ck:* plugin`,
+					`Cleaned up ${overlap.removed.length} standalone skill(s) now provided by /ck:* plugin (backed up to skills/.backup/)`,
+				);
+			}
+			if (overlap.errors.length > 0) {
+				logger.info(
+					`Failed to clean ${overlap.errors.length} skill(s): ${overlap.errors.join(", ")}`,
 				);
 			}
 		} catch (error) {


### PR DESCRIPTION
## Summary
- Replace ownership-based preservation with unconditional backup-then-remove
- All overlapping standalone skills moved to `~/.claude/skills/.backup/` before deletion
- Fixes: metadata marks most skills as "user" (due to .env.example, .gitkeep, refs), defeating the prior ownership-check approach
- Idempotent: existing backups never overwritten, residual standalones cleaned on re-run

## Test plan
- [x] 8 unit tests covering: backup+remove, idempotency, residual cleanup, non-overlapping preservation, .backup exclusion
- [x] Typecheck passes
- [x] Biome lint passes
- [ ] Manual: `ck update --dev -y` removes standalone dupes, skills show as `/ck:*` only
- [ ] Manual: `~/.claude/skills/.backup/` contains recoverable copies

Closes #513 (follow-up to #452)