### PR TITLE
feat(update): show kit version transition in ck update output

### DIFF
--- a/src/__tests__/commands/update-cli-prompt-kit.test.ts
+++ b/src/__tests__/commands/update-cli-prompt-kit.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for promptKitUpdate version display branches.
+ * Uses ONLY dependency injection — zero mock.module() to avoid cross-file contamination.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PromptKitUpdateDeps } from "@/commands/update-cli.js";
+import { promptKitUpdate } from "@/commands/update-cli.js";
+
+describe("promptKitUpdate version display", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "ck-prompt-kit-"));
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	/** Build deps with injectable exec side-effect and spinner capture */
+	function makeDeps(sideEffect?: () => void | Promise<void>) {
+		const stopCalls: string[] = [];
+		const deps: PromptKitUpdateDeps = {
+			execAsyncFn: async () => {
+				if (sideEffect) await sideEffect();
+				return { stdout: "", stderr: "" };
+			},
+			getSetupFn: (async () => ({
+				global: {
+					path: tempDir,
+					metadata: { kits: { engineer: { version: "1.0.0" } } },
+					components: { commands: 0, hooks: 0, skills: 0, workflows: 0, settings: 0 },
+				},
+				project: {
+					path: "",
+					metadata: null,
+					components: { commands: 0, hooks: 0, skills: 0, workflows: 0, settings: 0 },
+				},
+			})) as any,
+			spinnerFn: (() => ({
+				start: () => {},
+				stop: (msg: string) => stopCalls.push(msg),
+				message: "",
+			})) as any,
+		};
+		return { deps, stopCalls };
+	}
+
+	it("shows version transition when kit version changed after init", async () => {
+		await writeFile(
+			join(tempDir, "metadata.json"),
+			JSON.stringify({
+				version: "1.0.0",
+				kits: { engineer: { version: "1.0.0", installedAt: "2025-01-01T00:00:00Z" } },
+			}),
+		);
+
+		const { deps, stopCalls } = makeDeps(async () => {
+			await writeFile(
+				join(tempDir, "metadata.json"),
+				JSON.stringify({
+					version: "1.0.0",
+					kits: { engineer: { version: "2.0.0", installedAt: "2025-01-01T00:00:00Z" } },
+				}),
+			);
+		});
+
+		await promptKitUpdate(false, true, deps);
+
+		const stopMsg = stopCalls.find((m) => m.includes("->"));
+		expect(stopMsg).toBeDefined();
+		expect(stopMsg).toContain("1.0.0");
+		expect(stopMsg).toContain("2.0.0");
+		expect(stopMsg).toContain("engineer");
+	});
+
+	it("shows confirmation message when kit version unchanged", async () => {
+		await writeFile(
+			join(tempDir, "metadata.json"),
+			JSON.stringify({
+				version: "1.0.0",
+				kits: { engineer: { version: "1.0.0", installedAt: "2025-01-01T00:00:00Z" } },
+			}),
+		);
+
+		const { deps, stopCalls } = makeDeps();
+
+		await promptKitUpdate(false, true, deps);
+
+		const stopMsg = stopCalls[stopCalls.length - 1];
+		expect(stopMsg).toBeDefined();
+		expect(stopMsg).not.toContain("->");
+		expect(stopMsg).toContain("engineer@1.0.0");
+	});
+
+	it("falls back to generic message when post-init metadata is unreadable", async () => {
+		await writeFile(
+			join(tempDir, "metadata.json"),
+			JSON.stringify({
+				version: "1.0.0",
+				kits: { engineer: { version: "1.0.0", installedAt: "2025-01-01T00:00:00Z" } },
+			}),
+		);
+
+		const { deps, stopCalls } = makeDeps(async () => {
+			await rm(join(tempDir, "metadata.json"), { force: true });
+		});
+
+		await promptKitUpdate(false, true, deps);
+
+		const stopMsg = stopCalls[stopCalls.length - 1];
+		expect(stopMsg).toBe("Kit content updated");
+	});
+});

--- a/src/__tests__/commands/update-cli.test.ts
+++ b/src/__tests__/commands/update-cli.test.ts
@@ -555,7 +555,7 @@ describe("update-cli", () => {
 			// but we verify the function signature accepts the parameter
 			const { promptKitUpdate } = require("@/commands/update-cli.js");
 			expect(typeof promptKitUpdate).toBe("function");
-			expect(promptKitUpdate.length).toBeLessThanOrEqual(2);
+			expect(promptKitUpdate.length).toBeLessThanOrEqual(3);
 		});
 
 		it("all callers in updateCliCommand pass yes through opts", () => {

--- a/src/commands/update-cli.ts
+++ b/src/commands/update-cli.ts
@@ -236,9 +236,21 @@ export async function readMetadataFile(claudeDir: string): Promise<Metadata | nu
  * @param yes - Whether to skip confirmation prompt (non-interactive mode)
  * @internal Exported for testing
  */
-export async function promptKitUpdate(beta?: boolean, yes?: boolean): Promise<void> {
+/** Optional dependencies for promptKitUpdate (testing) */
+export interface PromptKitUpdateDeps {
+	execAsyncFn?: (command: string, options?: { timeout?: number }) => Promise<ExecAsyncResult>;
+	getSetupFn?: typeof getClaudeKitSetup;
+	spinnerFn?: typeof spinner;
+}
+
+export async function promptKitUpdate(
+	beta?: boolean,
+	yes?: boolean,
+	deps?: PromptKitUpdateDeps,
+): Promise<void> {
 	try {
-		const setup = await getClaudeKitSetup();
+		const execFn = deps?.execAsyncFn ?? (execAsync as ExecAsyncFn);
+		const setup = await (deps?.getSetupFn ?? getClaudeKitSetup)();
 		const hasLocal = !!setup.project.metadata;
 		const hasGlobal = !!setup.global.metadata;
 
@@ -270,6 +282,11 @@ export async function promptKitUpdate(beta?: boolean, yes?: boolean): Promise<vo
 		const initCmd = buildInitCommand(selection.isGlobal, selection.kit, beta || isBetaInstalled);
 		const promptMessage = selection.promptMessage;
 
+		// Show current kit version before update
+		if (selection.kit && kitVersion) {
+			logger.info(`Current kit version: ${selection.kit}@${kitVersion}`);
+		}
+
 		// Prompt user (skip if --yes flag)
 		if (!yes) {
 			logger.info("");
@@ -287,14 +304,31 @@ export async function promptKitUpdate(beta?: boolean, yes?: boolean): Promise<vo
 
 		// Execute the init command
 		logger.info(`Running: ${initCmd}`);
-		const s = spinner();
+		const s = (deps?.spinnerFn ?? spinner)();
 		s.start("Updating ClaudeKit content...");
 
 		try {
-			await execAsync(initCmd, {
+			await execFn(initCmd, {
 				timeout: 300000, // 5 minute timeout for init
 			});
-			s.stop("Kit content updated");
+
+			// Non-fatal: best-effort version resolution
+			let newKitVersion: string | undefined;
+			try {
+				const claudeDir = selection.isGlobal ? setup.global.path : setup.project.path;
+				const updatedMetadata = await readMetadataFile(claudeDir);
+				newKitVersion = selection.kit ? updatedMetadata?.kits?.[selection.kit]?.version : undefined;
+			} catch {
+				// version info unavailable, fall through to generic message
+			}
+
+			if (selection.kit && kitVersion && newKitVersion && kitVersion !== newKitVersion) {
+				s.stop(`Kit updated: ${selection.kit}@${kitVersion} -> ${newKitVersion}`);
+			} else if (selection.kit && newKitVersion) {
+				s.stop(`Kit content updated (${selection.kit}@${newKitVersion})`);
+			} else {
+				s.stop("Kit content updated");
+			}
 		} catch (error) {
 			s.stop("Kit update finished");
 			const errorMsg = error instanceof Error ? error.message : "unknown";


### PR DESCRIPTION
## Summary

- Display current kit version before running `ck init` during kit updates
- Show version transition (`from -> to`) after update completes
- Show version confirmation when no change occurred

Closes #467

## Test plan

- [x] Typecheck passes
- [x] 63/63 update-cli tests pass
- [x] Lint clean
- [x] Build succeeds
- [ ] Manual test: `ck update --dev -y` shows kit version info