### PR TITLE
fix: process metadata.json deletions in ck migrate

### DIFF
--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -178,7 +178,7 @@ async function processMetadataDeletions(
 			);
 		}
 	} catch (error) {
-		logger.debug(`[migrate] Deletion cleanup failed: ${error}`);
+		logger.warning(`[migrate] Deletion cleanup failed: ${error}`);
 	}
 }
 


### PR DESCRIPTION
## Summary

- `ck migrate` now processes `metadata.json` deletions array (previously only `ck init` did)
- Reuses existing `handleDeletions()` from `deletion-handler.ts` — same safety checks (ownership, path traversal prevention, recursive directory removal)
- Runs AFTER skill installation so new dirs exist before old ones are removed
- Applies to all selected providers

## Root Cause

The reconciler in `ck migrate` explicitly skips skills from orphan detection (line 487: `if (entry.type === "skill") continue`). And unlike `ck init`, `ck migrate` never called `handleDeletions()`. So when `metadata.json` lists `"skills/plan"` in deletions (because it was renamed to `skills/ck-plan`), the old directory persisted — causing duplicate skills in Claude Code.

## Changes

1 file: `src/commands/migrate/migrate-command.ts`
- Added `processMetadataDeletions()` helper — reads source metadata.json, calls `handleDeletions()` per provider
- Called after skill directory installation, before reconciler delete actions

## Test plan

- [x] `bun run typecheck` passes (no new errors)
- [x] `bun run lint:fix` passes
- [x] `bun run build` succeeds
- [ ] Manual: run `ck migrate` with old `skills/plan/` present + new metadata.json listing it in deletions — verify old dir is removed

Closes #469