### PR TITLE
fix: deduplicate shell hook skip warning in dashboard migration

### DIFF
--- a/src/domains/web-server/routes/migration-routes.ts
+++ b/src/domains/web-server/routes/migration-routes.ts
@@ -739,6 +739,9 @@ function tagResults(
 	}
 }
 
+/** Track whether shell hook skip warning has been shown this session to avoid repeated noise */
+let shellHookWarningShown = false;
+
 async function discoverMigrationItems(
 	include: MigrationIncludeOptions,
 	configSource?: string,
@@ -759,7 +762,8 @@ async function discoverMigrationItems(
 		rulesSourcePath ? discoverRules(rulesSourcePath) : Promise.resolve([]),
 		hooksSource
 			? discoverHooks(hooksSource).then(({ items, skippedShellHooks }) => {
-					if (skippedShellHooks.length > 0) {
+					if (skippedShellHooks.length > 0 && !shellHookWarningShown) {
+						shellHookWarningShown = true;
 						console.warn(
 							`[migrate] Skipping ${skippedShellHooks.length} shell hook(s) not supported for migration (node-runnable only): ${skippedShellHooks.join(", ")}`,
 						);


### PR DESCRIPTION
## Summary
- `discoverMigrationItems()` called from 4 dashboard API endpoints (discovery, reconcile, execute, dry-run)
- Each call triggered `discoverHooks()` which logged the shell hook warning via `console.warn()`
- Added module-level `shellHookWarningShown` flag to show the warning once per session

Closes #474

**Paired with:** claudekit/claudekit-engineer#562 (fixes deletion path mismatch so the hooks get cleaned up)

## Test plan
- [ ] Run `ck migrate` via dashboard — verify warning appears at most once
- [ ] All 23 migration-routes tests pass
- [ ] All 27 config-discovery tests pass