### PR TITLE
fix: ck update -y skips kit version check when CLI is newer than stable

### DIFF
--- a/src/commands/update-cli.ts
+++ b/src/commands/update-cli.ts
@@ -521,6 +521,7 @@ export async function updateCliCommand(
 		if (comparison > 0 && !opts.release && !isDevChannelSwitch) {
 			// Current version is newer (edge case with beta/local versions)
 			outro(`[+] Current version (${currentVersion}) is newer than latest (${targetVersion})`);
+			await promptKitUpdateFn(opts.dev || opts.beta, opts.yes);
 			return;
 		}
 


### PR DESCRIPTION
## Summary
- `ck update -y` (stable mode) returned early when current version was newer than latest stable, **skipping `promptKitUpdateFn()`** entirely
- `ck update --dev -y` correctly called `promptKitUpdateFn()` on all exit paths
- Added the missing `await promptKitUpdateFn()` call to the "current is newer" early return path (line 523)

Closes #485

## Test plan
- [x] All 3340 existing tests pass (0 failures)
- [x] Existing structural test validates all `promptKitUpdateFn` callers pass `opts.yes`
- [ ] Manual: run `ck update -y` on a dev prerelease — should now show kit version info
- [ ] Manual: run `ck update --dev -y` — behavior unchanged