### PR TITLE
fix(portable): comment out effort field in Codex TOML output

### DIFF
--- a/src/commands/portable/__tests__/fm-to-codex-toml.test.ts
+++ b/src/commands/portable/__tests__/fm-to-codex-toml.test.ts
@@ -67,10 +67,12 @@ describe("convertFmToCodexToml", () => {
 		expect(result.warnings).toEqual([]);
 	});
 
-	it("resolves known model via taxonomy (opus → gpt-5.4 + xhigh)", () => {
+	it("resolves known model via taxonomy (opus → gpt-5.4, effort commented)", () => {
 		const result = convertFmToCodexToml(makeItem());
 		expect(result.content).toContain('model = "gpt-5.4"');
-		expect(result.content).toContain('effort = "xhigh"');
+		// effort is commented out — Codex doesn't support this field yet
+		expect(result.content).toContain('# effort = "xhigh"');
+		expect(result.content).not.toMatch(/\neffort = /);
 		expect(result.content).not.toContain('# model = "opus"');
 		expect(result.warnings).toEqual([]);
 	});

--- a/src/commands/portable/converters/fm-to-codex-toml.ts
+++ b/src/commands/portable/converters/fm-to-codex-toml.ts
@@ -98,8 +98,9 @@ export function convertFmToCodexToml(item: PortableItem): ConversionResult {
 	}
 	if (modelResult.resolved) {
 		lines.push(`model = ${JSON.stringify(modelResult.resolved.model)}`);
+		// effort is tracked in taxonomy but not yet supported by Codex — comment out for future use
 		if (modelResult.resolved.effort) {
-			lines.push(`effort = ${JSON.stringify(modelResult.resolved.effort)}`);
+			lines.push(`# effort = ${JSON.stringify(modelResult.resolved.effort)}`);
 		}
 	} else if (
 		typeof item.frontmatter.model === "string" &&


### PR DESCRIPTION
## Summary

- Codex doesn't support the `effort` field in agent TOML files, causing `unknown field` warnings on every agent definition
- Changed converter to output `# effort = "xhigh"` (commented) instead of `effort = "xhigh"`
- Taxonomy data preserved for future use when Codex adds support

## Migration

Existing users auto-fix on next `ck migrate` or `ck init` — converter regenerates TOML with commented effort, registry detects checksum change, overwrites stale files. No manual intervention needed.

Closes the Codex deserialization warnings reported on all 14 agent TOML files.

## Test plan

- [x] Converter test updated to assert `# effort` (commented) and no bare `effort =`
- [x] All 3383 tests pass
- [x] Quality gate (typecheck + lint + build) passes
- [x] Verified generated TOML output manually