### PR TITLE
fix(cli): add bun runtime fallback for dev releases without binaries

### DIFF
--- a/bin/ck.js
+++ b/bin/ck.js
@@ -51,14 +51,18 @@ const getErrorMessage = (err) => {
  * Check if bun runtime is available on the system.
  * Used to run dist/index.js with bun when no platform binary exists (e.g., dev releases).
  * dist/index.js may contain bun-specific imports (bun:sqlite) that Node.js can't handle.
+ * Result is cached to avoid repeated execSync calls across fallback paths.
  */
+let _bunAvailable = undefined;
 const hasBun = () => {
+	if (_bunAvailable !== undefined) return _bunAvailable;
 	try {
-		execSync("bun --version", { stdio: "ignore" });
-		return true;
+		execSync("bun --version", { stdio: "ignore", timeout: 3000 });
+		_bunAvailable = true;
 	} catch {
-		return false;
+		_bunAvailable = false;
 	}
+	return _bunAvailable;
 };
 
 /**
@@ -176,11 +180,19 @@ const runBinary = (binaryPath) => {
 				await runWithNode(true);
 				resolve();
 			} catch (fallbackErr) {
+				const fallbackMsg = getErrorMessage(fallbackErr);
 				console.error(`❌ Binary failed: ${getErrorMessage(err)}`);
-				console.error(`❌ Fallback also failed: ${getErrorMessage(fallbackErr)}`);
-				console.error(
-					"Please report this issue at: https://github.com/mrgoonie/claudekit-cli/issues",
-				);
+				console.error(`❌ Fallback also failed: ${fallbackMsg}`);
+				if (fallbackMsg.includes("bun:") || fallbackMsg.includes("Received protocol")) {
+					console.error("");
+					console.error("This version of ClaudeKit CLI requires the bun runtime.");
+					console.error("Install bun:  curl -fsSL https://bun.sh/install | bash");
+					console.error("Or switch to stable:  npm install -g claudekit-cli@latest");
+				} else {
+					console.error(
+						"Please report this issue at: https://github.com/mrgoonie/claudekit-cli/issues",
+					);
+				}
 				process.exit(1);
 			}
 		});
@@ -217,8 +229,15 @@ const handleFallback = async (errorPrefix, showIssueLink = false) => {
 	try {
 		await runWithNode();
 	} catch (err) {
-		console.error(`❌ ${errorPrefix}: ${getErrorMessage(err)}`);
-		if (showIssueLink) {
+		const errMsg = getErrorMessage(err);
+		console.error(`❌ ${errorPrefix}: ${errMsg}`);
+		// Detect bun-specific import failures and guide user to install bun
+		if (errMsg.includes("bun:") || errMsg.includes("Received protocol")) {
+			console.error("");
+			console.error("This version of ClaudeKit CLI requires the bun runtime.");
+			console.error("Install bun:  curl -fsSL https://bun.sh/install | bash");
+			console.error("Or switch to stable:  npm install -g claudekit-cli@latest");
+		} else if (showIssueLink) {
 			console.error(
 				"Please report this issue at: https://github.com/mrgoonie/claudekit-cli/issues",
 			);

--- a/tests/wrapper.test.ts
+++ b/tests/wrapper.test.ts
@@ -123,6 +123,33 @@ describe("bin/ck.js wrapper", () => {
 			expect(runWithNodePos).toBeGreaterThan(-1);
 			expect(hasBunPos).toBeLessThan(runWithNodePos);
 		});
+
+		test("hasBun uses timeout to prevent hanging", () => {
+			const wrapperContent = readFileSync(join(binDir, "ck.js"), "utf-8");
+			expect(wrapperContent).toContain("timeout: 3000");
+		});
+
+		test("hasBun result is cached", () => {
+			const wrapperContent = readFileSync(join(binDir, "ck.js"), "utf-8");
+			expect(wrapperContent).toContain("_bunAvailable");
+		});
+	});
+
+	describe("error message UX", () => {
+		const wrapperContent = readFileSync(join(binDir, "ck.js"), "utf-8");
+
+		test("shows bun install instructions when bun: protocol fails", () => {
+			// When Node.js fails on bun: imports, user must see recovery instructions
+			expect(wrapperContent).toContain("curl -fsSL https://bun.sh/install | bash");
+			expect(wrapperContent).toContain("npm install -g claudekit-cli@latest");
+		});
+
+		test("detects bun: protocol errors in both fallback paths", () => {
+			// Both handleFallback and runBinary error paths must detect bun: errors
+			const matches = wrapperContent.match(/Received protocol/g);
+			expect(matches).not.toBeNull();
+			expect(matches?.length).toBeGreaterThanOrEqual(2);
+		});
 	});
 
 	describe("fallback conditions", () => {


### PR DESCRIPTION
## Summary

- Adds bun runtime detection to `bin/ck.js` wrapper for dev releases that don't ship platform binaries
- New fallback chain: **binary > bun > node** (was: binary > node)
- Actionable error messages when all runtimes fail — tells users exactly how to recover

## Problem

PR #500 restored the cross-platform wrapper, but dev releases still crash:
1. Dev releases don't ship platform binaries
2. Wrapper falls to `runWithNode()` which imports `dist/index.js`
3. `dist/index.js` contains `import { Database } from "bun:sqlite"`
4. Node.js ESM loader rejects `bun:` protocol
5. Error message gave zero guidance — users stuck with no recovery path

## Changes (2 commits)

### Commit 1: Bun runtime fallback
- `hasBun()` — detects bun via `bun --version` (3s timeout, cached result)
- `runWithBun()` — spawns `bun dist/index.js` with signal forwarding
- Updated `handleFallback()` and `runBinary.on('error')` — try bun before node

### Commit 2: UX hardening (from parallel review)
- `hasBun()` timeout (3s) prevents hanging on broken bun installs
- `hasBun()` result cached — avoids redundant `execSync` across fallback paths
- When `bun:` protocol error detected, shows actionable recovery:
  ```
  This version of ClaudeKit CLI requires the bun runtime.
  Install bun:  curl -fsSL https://bun.sh/install | bash
  Or switch to stable:  npm install -g claudekit-cli@latest
  ```
- Both error paths (handleFallback + runBinary) detect bun: errors

## Tests

- 8 new tests: hasBun logic, fallback priority, timeout, caching, install instructions, dual path detection
- 3667 pass, 0 fail (3718 total, 51 skip)

## UX Recovery Matrix

| User state | What they see | Recovery |
|------------|---------------|----------|
| Dev 25-28 (hardcoded path) | `Module not found /Users/duynguyen/...` | `bun add -g claudekit-cli@dev` |
| Dev 29 (no bun) | `bun:` protocol error + install instructions | Follow printed instructions |
| Dev 30+ with bun | Works via bun runtime | No action needed |
| Stable (any) | Works via platform binary | No action needed |

Ref #499