### PR TITLE
feat: support CLAUDE_CONFIG_DIR env var in getGlobalKitDir()

### DIFF
--- a/src/shared/path-resolver.ts
+++ b/src/shared/path-resolver.ts
@@ -232,16 +232,22 @@ export class PathResolver {
 	 *
 	 * @returns Global kit installation directory path
 	 *
-	 * All platforms use: ~/.claude/
-	 * - macOS: ~/.claude/
-	 * - Windows: %USERPROFILE%\.claude\ (e.g., C:\Users\[USERNAME]\.claude)
-	 * - Linux: ~/.claude/
+	 * Resolution order:
+	 * 1. CK_TEST_HOME (test isolation)
+	 * 2. CLAUDE_CONFIG_DIR (multi-profile support, e.g. ~/.claude-personal)
+	 * 3. ~/.claude/ (default on all platforms)
 	 */
 	static getGlobalKitDir(): string {
 		// Test mode override - use isolated directory
 		const testHome = PathResolver.getTestHomeDir();
 		if (testHome) {
 			return join(testHome, ".claude");
+		}
+
+		// Respect CLAUDE_CONFIG_DIR for multi-profile support
+		const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+		if (claudeConfigDir) {
+			return claudeConfigDir;
 		}
 
 		// All platforms: ~/.claude/

--- a/tests/utils/path-resolver.test.ts
+++ b/tests/utils/path-resolver.test.ts
@@ -208,6 +208,30 @@ describe("PathResolver", () => {
 			// Restore
 			process.env.APPDATA = originalAppData;
 		});
+
+		it("should respect CLAUDE_CONFIG_DIR when set", () => {
+			process.env.CLAUDE_CONFIG_DIR = "/custom/claude-personal";
+
+			const globalKitDir = PathResolver.getGlobalKitDir();
+			expect(globalKitDir).toBe("/custom/claude-personal");
+		});
+
+		it("should ignore empty CLAUDE_CONFIG_DIR", () => {
+			process.env.CLAUDE_CONFIG_DIR = "";
+
+			const globalKitDir = PathResolver.getGlobalKitDir();
+			expect(globalKitDir).toBe(join(homedir(), ".claude"));
+		});
+
+		it("should prioritize CK_TEST_HOME over CLAUDE_CONFIG_DIR", () => {
+			process.env.CK_TEST_HOME = tmpdir();
+			process.env.CLAUDE_CONFIG_DIR = "/custom/claude-personal";
+
+			const globalKitDir = PathResolver.getGlobalKitDir();
+			expect(globalKitDir).toBe(join(tmpdir(), ".claude"));
+
+			process.env.CK_TEST_HOME = undefined;
+		});
 	});
 
 	describe("getPathPrefix", () => {


### PR DESCRIPTION
## Summary
- Add `CLAUDE_CONFIG_DIR` env var support in `PathResolver.getGlobalKitDir()` for multi-profile users
- Resolution order: `CK_TEST_HOME` > `CLAUDE_CONFIG_DIR` > `~/.claude/`
- Empty string is treated as unset (falls through to default)

## Test plan
- [x] New test: `CLAUDE_CONFIG_DIR` returns custom path when set
- [x] New test: empty `CLAUDE_CONFIG_DIR` falls through to default
- [x] New test: `CK_TEST_HOME` takes priority over `CLAUDE_CONFIG_DIR`
- [x] All 3670 existing tests pass (0 regressions)
- [x] Full quality gate: typecheck + lint + test + build

Closes #490