### PR TITLE
fix(build): strip // @bun marker to fix UTF-8 Unicode rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"dashboard:dev": "cd src/ui && bun install --silent && cd ../.. && bun run src/index.ts config ui --dev",
 		"ui:build": "cd src/ui && bun install --silent && bun run build",
 		"ui:dev": "cd src/ui && bun run dev",
-		"build": "bun build src/index.ts --outdir dist --target node --external @octokit/rest",
+		"build": "bun build src/index.ts --outdir dist --target node --external @octokit/rest && node -e \"const fs=require('fs'),f='dist/index.js',c=fs.readFileSync(f,'utf-8');fs.writeFileSync(f,c.replace(/^#!.*\\n\\/\\/ @bun\\n/,''))\"",
 		"compile": "bun run ui:build && bun run scripts/compile-binary.ts",
 		"compile:binary": "bun run ui:build && bun run scripts/compile-binary.ts --outfile bin/ck && cp bin/ck /usr/local/bin/ck && echo '✅ Installed globally: /usr/local/bin/ck'",
 		"compile:binaries": "node scripts/build-all-binaries.js",


### PR DESCRIPTION
## Summary

Strips `#!/usr/bin/env bun` and `// @bun` markers from `dist/index.js` after build. These markers trigger bun's internal binary module loader which uses Latin-1 string encoding, corrupting multi-byte UTF-8 characters.

## Root Cause

`bun build --target node` adds `// @bun` to the output. When bun later loads this file, the marker triggers an optimized code path that interprets source text as Latin-1 instead of UTF-8. This causes box-drawing characters (`│ ◇ ℹ ✓`) to render as garbled Latin-1 bytes (`â ¹`).

**Proven by user testing:** stripping the first 2 lines (`sed '1,2d'`) from dist/index.js immediately fixed all Unicode rendering.

## Fix

Added post-build step to the `build` script in package.json that strips the bun shebang and `// @bun` annotation. The bundle remains fully functional with bun runtime.

## Tests

3670 pass, 0 fail (3721 total, 51 skip)

Ref #499