### PR TITLE
fix(config): support intentional remote dashboard access

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ ck --help
 # Open config dashboard immediately
 ck config
 
+# Expose the dashboard intentionally to your LAN/Tailscale
+ck config --host 0.0.0.0 --no-open
+
 # Command-level help (recommended)
 ck config --help
 ck skills --help
@@ -98,6 +101,23 @@ ck agents --help
 ck commands --help
 ck migrate --help
 ```
+
+### Config Dashboard Access
+
+By default, `ck config` binds the dashboard to `127.0.0.1` for local-only access.
+
+Use `--host` when you intentionally want remote access from another device on the same trusted network:
+
+```bash
+# Bind to all interfaces
+ck config --host 0.0.0.0 --no-open
+
+# Bind to a specific interface or hostname
+ck config --host 100.88.12.4 --no-open
+ck config --host dashboard.local --no-open
+```
+
+The dashboard still enforces same-origin browser access. Remote access works when you open the UI from the same host/origin that reaches the server, instead of relying on a hardcoded IP allowlist.
 
 ### Create New Project
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -184,7 +184,7 @@ Custom renderer with theme support and NO_COLOR compliance. CommandHelp, OptionG
 Express server with Vite HMR on single port (3456-3460 auto-fallback). 6 pages, 45+ components, 16 API routes, WebSocket support.
 
 ### web-server/ + claude-data/ - Hook Diagnostics
-`/api/system/hook-diagnostics` exposes recent structured hook activity for the Config UI. `hook-log-reader.ts` resolves global installs (`~/.claude/hooks/.logs/hook-log.jsonl`) and project installs (`<project>/.claude/hooks/.logs/hook-log.jsonl`), supports registry-backed and discovered project ids, tolerates malformed JSONL lines, and returns summary counts for dashboard rendering. These routes are intended for the local `ck config` dashboard, so they currently rely on local access rather than per-route rate limiting.
+`/api/system/hook-diagnostics` exposes recent structured hook activity for the Config UI. `hook-log-reader.ts` resolves global installs (`~/.claude/hooks/.logs/hook-log.jsonl`) and project installs (`<project>/.claude/hooks/.logs/hook-log.jsonl`), supports registry-backed and discovered project ids, tolerates malformed JSONL lines, and returns summary counts for dashboard rendering. These routes default to local-only access, but `ck config --host ...` can expose the dashboard intentionally while keeping same-origin browser validation in place.
 
 ### api-key/ - API Key Management (NEW)
 Secure storage and validation of API keys (Gemini, Discord, Telegram, OpenAI, etc.).
@@ -270,7 +270,7 @@ Tracks shared files, enables cross-kit file checking via `setMultiKitContext()`.
 ## Dashboard Architecture (NEW)
 
 ### Entry Point
-`ck config ui` launches Express+Vite server on single port (3456-3460 auto-fallback).
+`ck config ui` launches an Express+Vite server on a single port (3456-3460 auto-fallback). Default bind host is `127.0.0.1`; `--host` enables intentional LAN/Tailscale/custom-host access.
 
 ### Frontend (React+Vite)
 - **6 Main Pages**: GlobalConfig, ProjectConfig, Migrate, Skills, Onboarding, ProjectDashboard

--- a/src/__tests__/commands/config/config-command-orchestrator-routing.test.ts
+++ b/src/__tests__/commands/config/config-command-orchestrator-routing.test.ts
@@ -50,7 +50,7 @@ describe("configCommand", () => {
 		});
 
 		it("launches dashboard when called with options object as second param", async () => {
-			const options = { port: 3000, noOpen: true } as unknown as ConfigCommandOptions;
+			const options = { port: 3000, noOpen: true, host: "0.0.0.0" } as ConfigCommandOptions;
 			await configCommand(undefined, options);
 			expect(mockConfigUICommand).toHaveBeenCalledTimes(1);
 			expect(mockConfigUICommand).toHaveBeenCalledWith(options);
@@ -72,13 +72,13 @@ describe("configCommand", () => {
 		});
 
 		it("passes options from second parameter when object", async () => {
-			const options = { port: 3456, dev: true } as unknown as ConfigCommandOptions;
+			const options = { port: 3456, dev: true, host: "0.0.0.0" } as ConfigCommandOptions;
 			await configCommand("ui", options);
 			expect(mockConfigUICommand).toHaveBeenCalledWith(options);
 		});
 
 		it("passes options from fourth parameter when present", async () => {
-			const options = { port: 4000, noOpen: true } as unknown as ConfigCommandOptions;
+			const options = { port: 4000, noOpen: true, host: "192.168.1.50" } as ConfigCommandOptions;
 			await configCommand("ui", undefined, undefined, options);
 			expect(mockConfigUICommand).toHaveBeenCalledWith(options);
 		});

--- a/src/__tests__/domains/web-server/middleware/cors.test.ts
+++ b/src/__tests__/domains/web-server/middleware/cors.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "bun:test";
+import {
+	corsMiddleware,
+	getRequestOrigins,
+	isAllowedOrigin,
+} from "@/domains/web-server/middleware/cors.js";
+import type { Request, Response } from "express";
+
+type MockResponse = {
+	headers: Map<string, string>;
+	jsonBody: unknown;
+	sendStatusCode: number | null;
+	statusCode: number | null;
+	getHeader(name: string): string | undefined;
+	json(body: unknown): MockResponse;
+	sendStatus(code: number): MockResponse;
+	setHeader(name: string, value: string): MockResponse;
+	status(code: number): MockResponse;
+};
+
+function createRequest({
+	host,
+	origin,
+	method = "GET",
+	forwardedHost,
+	forwardedProto,
+	protocol = "http",
+}: {
+	host?: string;
+	origin?: string;
+	method?: string;
+	forwardedHost?: string;
+	forwardedProto?: string;
+	protocol?: string;
+}): Request {
+	return {
+		headers: {
+			host,
+			origin,
+			"x-forwarded-host": forwardedHost,
+			"x-forwarded-proto": forwardedProto,
+		},
+		method,
+		protocol,
+	} as unknown as Request;
+}
+
+function createResponse(): MockResponse {
+	const headers = new Map<string, string>();
+
+	return {
+		headers,
+		jsonBody: null,
+		sendStatusCode: null,
+		statusCode: null,
+		getHeader(name: string): string | undefined {
+			return headers.get(name);
+		},
+		json(body: unknown): MockResponse {
+			this.jsonBody = body;
+			return this;
+		},
+		sendStatus(code: number): MockResponse {
+			this.sendStatusCode = code;
+			return this;
+		},
+		setHeader(name: string, value: string): MockResponse {
+			headers.set(name, value);
+			return this;
+		},
+		status(code: number): MockResponse {
+			this.statusCode = code;
+			return this;
+		},
+	};
+}
+
+describe("corsMiddleware", () => {
+	test("allows same-origin remote requests without a localhost allowlist", () => {
+		const req = createRequest({
+			host: "100.88.12.4:3456",
+			origin: "http://100.88.12.4:3456",
+		});
+		const res = createResponse();
+		let nextCalled = false;
+
+		corsMiddleware(req, res as unknown as Response, () => {
+			nextCalled = true;
+		});
+
+		expect(nextCalled).toBe(true);
+		expect(res.getHeader("Access-Control-Allow-Origin")).toBe("http://100.88.12.4:3456");
+		expect(res.statusCode).toBeNull();
+	});
+
+	test("allows proxied same-origin https requests when forwarded headers are present", () => {
+		const req = createRequest({
+			host: "127.0.0.1:3456",
+			origin: "https://dashboard.example.com",
+			forwardedHost: "dashboard.example.com",
+			forwardedProto: "https",
+		});
+
+		expect(isAllowedOrigin("https://dashboard.example.com", req)).toBe(true);
+		expect(getRequestOrigins(req)).toContain("https://dashboard.example.com");
+	});
+
+	test("allows local frontend development origins", () => {
+		const req = createRequest({
+			host: "localhost:3456",
+			origin: "http://localhost:5173",
+		});
+		const res = createResponse();
+		let nextCalled = false;
+
+		corsMiddleware(req, res as unknown as Response, () => {
+			nextCalled = true;
+		});
+
+		expect(nextCalled).toBe(true);
+		expect(res.getHeader("Access-Control-Allow-Origin")).toBe("http://localhost:5173");
+	});
+
+	test("rejects unrelated cross-origin requests", () => {
+		const req = createRequest({
+			host: "100.88.12.4:3456",
+			origin: "https://evil.example.com",
+		});
+		const res = createResponse();
+		let nextCalled = false;
+
+		corsMiddleware(req, res as unknown as Response, () => {
+			nextCalled = true;
+		});
+
+		expect(nextCalled).toBe(false);
+		expect(res.statusCode).toBe(403);
+		expect(res.jsonBody).toEqual({ error: "Forbidden: invalid origin" });
+	});
+
+	test("rejects malformed origin headers", () => {
+		const req = createRequest({
+			host: "localhost:3456",
+			origin: "not-a-valid-origin",
+		});
+		const res = createResponse();
+
+		corsMiddleware(req, res as unknown as Response, () => {});
+
+		expect(res.statusCode).toBe(403);
+	});
+
+	test("returns 204 for valid preflight requests", () => {
+		const req = createRequest({
+			host: "100.88.12.4:3456",
+			origin: "http://100.88.12.4:3456",
+			method: "OPTIONS",
+		});
+		const res = createResponse();
+		let nextCalled = false;
+
+		corsMiddleware(req, res as unknown as Response, () => {
+			nextCalled = true;
+		});
+
+		expect(res.sendStatusCode).toBe(204);
+		expect(nextCalled).toBe(false);
+	});
+});

--- a/src/__tests__/domains/web-server/server.test.ts
+++ b/src/__tests__/domains/web-server/server.test.ts
@@ -16,6 +16,7 @@ interface LifecycleMockState {
 	fileWatcherStartCalls: number;
 	fileWatcherStopCalls: number;
 	listenPorts: number[];
+	listenHosts: Array<string | undefined>;
 	closeCalls: number;
 }
 
@@ -30,8 +31,9 @@ class MockHttpServer extends EventEmitter {
 		return this;
 	}
 
-	listen(port: number): this {
+	listen(port: number, host?: string): this {
 		state.listenPorts.push(port);
+		state.listenHosts.push(host);
 
 		if (state.listenError) {
 			queueMicrotask(() => this.emit("error", state.listenError as Error));
@@ -66,6 +68,7 @@ const createDefaultState = (): LifecycleMockState => ({
 	fileWatcherStartCalls: 0,
 	fileWatcherStopCalls: 0,
 	listenPorts: [],
+	listenHosts: [],
 	closeCalls: 0,
 });
 
@@ -166,6 +169,8 @@ describe("web-server lifecycle", () => {
 		expect(server?.keepAliveTimeout).toBe(65000);
 		expect(server?.headersTimeout).toBe(66000);
 		expect(state.listenPorts).toEqual([state.port]);
+		expect(state.listenHosts).toEqual(["127.0.0.1"]);
+		expect(app.host).toBe("127.0.0.1");
 		expect(registerRoutesMock).toHaveBeenCalledTimes(1);
 		expect(serveStaticMock).toHaveBeenCalledTimes(1);
 		expect(openMock).not.toHaveBeenCalled();
@@ -190,6 +195,14 @@ describe("web-server lifecycle", () => {
 		const app = await createAppServer({ openBrowser: true, devMode: false });
 		expect(openMock).toHaveBeenCalledTimes(1);
 		expect(openMock).toHaveBeenCalledWith(`http://localhost:${state.port}`);
+		await app.close();
+	});
+
+	test("binds to custom host and still opens localhost for wildcard hosts", async () => {
+		const app = await createAppServer({ host: "0.0.0.0", openBrowser: true, devMode: false });
+		expect(state.listenHosts).toEqual(["0.0.0.0"]);
+		expect(openMock).toHaveBeenCalledWith(`http://localhost:${state.port}`);
+		expect(app.host).toBe("0.0.0.0");
 		await app.close();
 	});
 

--- a/src/cli/command-registry.ts
+++ b/src/cli/command-registry.ts
@@ -276,6 +276,7 @@ export function registerCommands(cli: ReturnType<typeof cac>): void {
 		.option("-l, --local", "Use local config (.claude/.ck.json)")
 		.option("--json", "Output in JSON format")
 		.option("--port <port>", "Port for UI server (default: auto)")
+		.option("--host <host>", "Bind dashboard host (default: 127.0.0.1)")
 		.option("--no-open", "Don't auto-open browser")
 		.option("--dev", "Run UI in development mode with HMR")
 		.action(async (action, key, value, options) => {

--- a/src/commands/config/config-command.ts
+++ b/src/commands/config/config-command.ts
@@ -60,9 +60,10 @@ export async function configCommand(
 	// Default: launch dashboard (bare `ck config`)
 	const rawOpts = options || (typeof keyOrOptions === "object" ? keyOrOptions : {});
 	const uiOpts: ConfigUIOptions = {
-		port: (rawOpts as ConfigUIOptions)?.port,
-		noOpen: (rawOpts as ConfigUIOptions)?.noOpen,
-		dev: (rawOpts as ConfigUIOptions)?.dev,
+		port: rawOpts.port,
+		noOpen: rawOpts.noOpen,
+		dev: rawOpts.dev,
+		host: rawOpts.host,
 	};
 	return configUICommand(uiOpts);
 }

--- a/src/commands/config/config-ui-command.ts
+++ b/src/commands/config/config-ui-command.ts
@@ -7,19 +7,24 @@
  *   → DO NOT use `cd src/ui && bun dev` alone (no API backend)
  */
 
+import { networkInterfaces } from "node:os";
 import { logger } from "@/shared/logger.js";
 import pc from "picocolors";
 import type { ConfigUIOptions } from "./types.js";
 
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+const WILDCARD_HOSTS = new Set(["0.0.0.0", "::"]);
+
 export async function configUICommand(options: ConfigUIOptions = {}): Promise<void> {
 	const { port, dev = false } = options;
+	const host = options.host?.trim() || undefined;
 	// cac converts --no-open to { open: false }, handle both formats
 	const noOpen = (options as Record<string, unknown>).open === false || options.noOpen === true;
 
 	try {
 		// Check if port is in use (when explicitly specified)
 		if (port) {
-			const isAvailable = await checkPort(port);
+			const isAvailable = await checkPort(port, host);
 			if (!isAvailable) {
 				logger.error(`Port ${port} is already in use`);
 				logger.info("Try: ck config (auto-selects available port)");
@@ -37,14 +42,20 @@ export async function configUICommand(options: ConfigUIOptions = {}): Promise<vo
 			port,
 			openBrowser: !noOpen,
 			devMode: dev,
+			host,
 		});
 
-		// Pretty print URL
-		const url = `http://localhost:${server.port}`;
+		const urls = getDashboardUrls(server.host, server.port);
 		console.log();
 		console.log(pc.bold("  ClaudeKit Dashboard"));
 		console.log(pc.dim("  ─────────────────────"));
-		console.log(`  ${pc.green("➜")} Local: ${pc.cyan(url)}`);
+		if (urls.local) {
+			console.log(`  ${pc.green("➜")} Local: ${pc.cyan(urls.local)}`);
+		}
+		for (const url of urls.network) {
+			console.log(`  ${pc.green(urls.local ? "•" : "➜")} Network: ${pc.cyan(url)}`);
+		}
+		console.log(`  ${pc.green("•")} Bind: ${pc.cyan(server.host)}`);
 		console.log();
 		console.log(pc.dim("  Press Ctrl+C to stop"));
 		console.log();
@@ -78,7 +89,7 @@ export async function configUICommand(options: ConfigUIOptions = {}): Promise<vo
 	}
 }
 
-async function checkPort(port: number): Promise<boolean> {
+async function checkPort(port: number, host?: string): Promise<boolean> {
 	const { createServer } = await import("node:net");
 	return new Promise((resolve) => {
 		const server = createServer();
@@ -87,6 +98,48 @@ async function checkPort(port: number): Promise<boolean> {
 			server.close();
 			resolve(true);
 		});
-		server.listen(port);
+		server.listen(port, host);
 	});
+}
+
+function getDashboardUrls(host: string, port: number): { local: string | null; network: string[] } {
+	if (WILDCARD_HOSTS.has(host)) {
+		return {
+			local: `http://localhost:${port}`,
+			network: getDetectedNetworkUrls(port),
+		};
+	}
+
+	if (LOOPBACK_HOSTS.has(host)) {
+		return {
+			local: `http://localhost:${port}`,
+			network: [],
+		};
+	}
+
+	return {
+		local: null,
+		network: [buildDashboardUrl(host, port)],
+	};
+}
+
+function getDetectedNetworkUrls(port: number): string[] {
+	const urls = new Set<string>();
+
+	for (const addresses of Object.values(networkInterfaces())) {
+		for (const address of addresses ?? []) {
+			if (address.internal) {
+				continue;
+			}
+
+			urls.add(buildDashboardUrl(address.address, port));
+		}
+	}
+
+	return Array.from(urls).sort();
+}
+
+function buildDashboardUrl(host: string, port: number): string {
+	const formattedHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+	return `http://${formattedHost}:${port}`;
 }

--- a/src/commands/config/types.ts
+++ b/src/commands/config/types.ts
@@ -6,12 +6,17 @@ export interface ConfigCommandOptions {
 	global?: boolean;
 	local?: boolean;
 	json?: boolean;
+	port?: number;
+	noOpen?: boolean;
+	dev?: boolean;
+	host?: string;
 }
 
 export interface ConfigUIOptions {
 	port?: number;
 	noOpen?: boolean;
 	dev?: boolean;
+	host?: string;
 }
 
 export interface ConfigContext {

--- a/src/domains/help/commands/config-command-help.ts
+++ b/src/domains/help/commands/config-command-help.ts
@@ -16,6 +16,10 @@ export const configCommandHelp: CommandHelp = {
 			description: "Launch the web dashboard (same as 'ck config ui')",
 		},
 		{
+			command: "ck config --host 0.0.0.0 --no-open",
+			description: "Expose the dashboard to your network intentionally",
+		},
+		{
 			command: "ck config set defaults.kit engineer",
 			description: "Set a config value from the CLI",
 		},
@@ -63,6 +67,10 @@ export const configCommandHelp: CommandHelp = {
 					description: "Port for dashboard server",
 				},
 				{
+					flags: "--host <host>",
+					description: "Bind dashboard host (default: 127.0.0.1)",
+				},
+				{
 					flags: "--no-open",
 					description: "Do not auto-open browser when launching dashboard",
 				},
@@ -86,7 +94,7 @@ export const configCommandHelp: CommandHelp = {
 		{
 			title: "Notes",
 			content:
-				"Run 'ck config --help' to see both CLI actions and dashboard flags. Running bare 'ck config' opens the dashboard directly.",
+				"Run 'ck config --help' to see both CLI actions and dashboard flags. Running bare 'ck config' opens the dashboard directly. Use '--host' to expose the dashboard intentionally beyond localhost.",
 		},
 	],
 };

--- a/src/domains/web-server/middleware/cors.ts
+++ b/src/domains/web-server/middleware/cors.ts
@@ -1,29 +1,30 @@
 /**
- * CORS middleware for local development
+ * Origin validation middleware for the dashboard API.
  */
 
 import type { NextFunction, Request, Response } from "express";
 
+const LOCAL_DEV_ORIGINS = new Set(
+	["localhost", "127.0.0.1", "[::1]"].flatMap((host) => [
+		`http://${host}:3000`,
+		`http://${host}:3456`,
+		`http://${host}:5173`,
+	]),
+);
+
 export function corsMiddleware(req: Request, res: Response, next: NextFunction): void {
-	// CSRF protection: reject requests with invalid origin header
-	const origin = req.headers.origin;
-	if (origin && !origin.match(/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/)) {
+	const origin = getHeaderValue(req.headers.origin);
+	const normalizedOrigin = origin ? normalizeOrigin(origin) : null;
+
+	// CSRF protection: reject requests whose Origin does not match the active request host
+	if (origin && (!normalizedOrigin || !isAllowedOrigin(normalizedOrigin, req))) {
 		res.status(403).json({ error: "Forbidden: invalid origin" });
 		return;
 	}
 
-	// Allow local development origins
-	const allowedOrigins = [
-		"http://localhost:3000",
-		"http://localhost:3456",
-		"http://localhost:5173", // Vite default
-		"http://127.0.0.1:3000",
-		"http://127.0.0.1:3456",
-		"http://127.0.0.1:5173",
-	];
-
-	if (origin && allowedOrigins.includes(origin)) {
-		res.setHeader("Access-Control-Allow-Origin", origin);
+	if (normalizedOrigin) {
+		appendVaryHeader(res, "Origin");
+		res.setHeader("Access-Control-Allow-Origin", normalizedOrigin);
 	}
 
 	res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
@@ -36,4 +37,85 @@ export function corsMiddleware(req: Request, res: Response, next: NextFunction):
 	}
 
 	next();
+}
+
+export function isAllowedOrigin(origin: string, req: Request): boolean {
+	if (LOCAL_DEV_ORIGINS.has(origin)) {
+		return true;
+	}
+
+	return getRequestOrigins(req).has(origin);
+}
+
+export function getRequestOrigins(req: Request): Set<string> {
+	const origins = new Set<string>();
+	const hosts = getHeaderValues(req.headers["x-forwarded-host"]).concat(
+		getHeaderValues(req.headers.host),
+	);
+	const protocols = getForwardedProtocols(req);
+
+	for (const host of hosts) {
+		for (const protocol of protocols) {
+			origins.add(`${protocol}://${host}`);
+		}
+	}
+
+	return origins;
+}
+
+function getForwardedProtocols(req: Request): string[] {
+	const forwarded = getHeaderValues(req.headers["x-forwarded-proto"]).map((value) =>
+		value.toLowerCase(),
+	);
+	const current =
+		typeof req.protocol === "string" && req.protocol ? [req.protocol.toLowerCase()] : ["http"];
+
+	return Array.from(
+		new Set([...forwarded, ...current].filter((value) => value === "http" || value === "https")),
+	);
+}
+
+function normalizeOrigin(origin: string): string | null {
+	try {
+		return new URL(origin).origin;
+	} catch {
+		return null;
+	}
+}
+
+function getHeaderValue(value: string | string[] | undefined): string | undefined {
+	if (Array.isArray(value)) {
+		return value[0];
+	}
+	return value;
+}
+
+function getHeaderValues(value: string | string[] | undefined): string[] {
+	const raw = Array.isArray(value) ? value.join(",") : value;
+	if (!raw) {
+		return [];
+	}
+
+	return raw
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter(Boolean);
+}
+
+function appendVaryHeader(res: Response, value: string): void {
+	const current = res.getHeader("Vary");
+	if (!current) {
+		res.setHeader("Vary", value);
+		return;
+	}
+
+	const entries = String(current)
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter(Boolean);
+
+	if (!entries.includes(value)) {
+		entries.push(value);
+		res.setHeader("Vary", entries.join(", "));
+	}
 }

--- a/src/domains/web-server/server.ts
+++ b/src/domains/web-server/server.ts
@@ -16,8 +16,17 @@ import { serveStatic } from "./static-server.js";
 import type { ServerInstance, ServerOptions } from "./types.js";
 import { WebSocketManager } from "./websocket-manager.js";
 
+const DEFAULT_DASHBOARD_HOST = "127.0.0.1";
+const LOOPBACK_OPEN_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+const WILDCARD_HOSTS = new Set(["0.0.0.0", "::"]);
+
 export async function createAppServer(options: ServerOptions = {}): Promise<ServerInstance> {
-	const { port: preferredPort, openBrowser = true, devMode = false } = options;
+	const {
+		port: preferredPort,
+		openBrowser = true,
+		devMode = false,
+		host = DEFAULT_DASHBOARD_HOST,
+	} = options;
 
 	// Get available port
 	const port = await getPort({ port: preferredPort || [3456, 3457, 3458, 3459, 3460] });
@@ -74,17 +83,17 @@ export async function createAppServer(options: ServerOptions = {}): Promise<Serv
 
 			server.once("listening", onListening);
 			server.once("error", onError);
-			server.listen(port);
+			server.listen(port, host);
 		});
 
-		logger.debug(`Server listening on port ${port}`);
+		logger.debug(`Server listening on ${host}:${port}`);
 
 		if (openBrowser) {
 			try {
-				await open(`http://localhost:${port}`);
+				await open(getBrowserUrl(host, port));
 			} catch (err) {
 				logger.warning(`Failed to open browser: ${err instanceof Error ? err.message : err}`);
-				logger.info(`Open http://localhost:${port} manually`);
+				logger.info(`Open ${getBrowserUrl(host, port)} manually`);
 			}
 		}
 	} catch (error) {
@@ -96,6 +105,7 @@ export async function createAppServer(options: ServerOptions = {}): Promise<Serv
 
 	return {
 		port,
+		host,
 		server,
 		close: async () => {
 			fileWatcher?.stop();
@@ -158,4 +168,16 @@ async function setupViteDevServer(
 
 		serveStatic(app);
 	}
+}
+
+function getBrowserUrl(host: string, port: number): string {
+	if (WILDCARD_HOSTS.has(host) || LOOPBACK_OPEN_HOSTS.has(host)) {
+		return `http://localhost:${port}`;
+	}
+
+	return `http://${formatHostForUrl(host)}:${port}`;
+}
+
+function formatHostForUrl(host: string): string {
+	return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
 }

--- a/src/domains/web-server/types.ts
+++ b/src/domains/web-server/types.ts
@@ -8,10 +8,12 @@ export interface ServerOptions {
 	port?: number;
 	openBrowser?: boolean;
 	devMode?: boolean;
+	host?: string;
 }
 
 export interface ServerInstance {
 	port: number;
+	host: string;
 	server: Server;
 	close: () => Promise<void>;
 }


### PR DESCRIPTION
## Summary
- add `--host` to `ck config` so remote dashboard exposure is an explicit opt-in
- default the dashboard server to `127.0.0.1` instead of implicitly binding all interfaces
- replace localhost-only origin checks with request-aware same-origin validation that also respects proxy forwarded headers
- preserve local frontend development origins and add regression coverage for host binding and remote/proxied access

## Related
- Docs PR: claudekit/claudekit-docs#128

## Testing
- `bun test src/__tests__/commands/config/config-command-orchestrator-routing.test.ts src/__tests__/domains/web-server/server.test.ts src/__tests__/domains/web-server/middleware/cors.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run lint`

Closes #514