### PR TITLE
hotfix: restore dashboard assets in shipped binaries

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -63,6 +63,9 @@ jobs:
         run: mkdir -p bin
         shell: bash
 
+      - name: Build dist bundle
+        run: bun run build
+
       - name: Build dashboard UI
         run: bun run ui:build
 
@@ -87,6 +90,9 @@ jobs:
         run: |
           dir bin\${{ matrix.binary }}
         shell: cmd
+
+      - name: Smoke packaged CLI on host platform
+        run: node scripts/prepublish-check.js --host-platform-binary-only
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -22,22 +22,26 @@ jobs:
             platform: darwin
             arch: arm64
             binary: ck-darwin-arm64
+            target: bun-darwin-arm64
           - os: macos-latest  # Intel macOS
             platform: darwin
             arch: x64
             binary: ck-darwin-x64
+            target: bun-darwin-x64
 
           # Linux build
           - os: ubuntu-latest
             platform: linux
             arch: x64
             binary: ck-linux-x64
+            target: bun-linux-x64
 
           # Windows build
           - os: windows-latest
             platform: win32
             arch: x64
             binary: ck-win32-x64.exe
+            target: bun-win32-x64
 
     steps:
       - name: Checkout repository
@@ -59,13 +63,16 @@ jobs:
         run: mkdir -p bin
         shell: bash
 
+      - name: Build dashboard UI
+        run: bun run ui:build
+
       - name: Compile binary (Unix)
         if: runner.os != 'Windows'
-        run: bun build src/index.ts --compile --outfile bin/${{ matrix.binary }}
+        run: bun run scripts/compile-binary.ts --outfile bin/${{ matrix.binary }} --target ${{ matrix.target }}
 
       - name: Compile binary (Windows)
         if: runner.os == 'Windows'
-        run: bun build src/index.ts --compile --outfile bin/${{ matrix.binary }}
+        run: bun run scripts/compile-binary.ts --outfile bin/${{ matrix.binary }} --target ${{ matrix.target }}
         shell: bash
 
       - name: Verify binary (Unix)

--- a/scripts/build-binaries-after-version-bump.js
+++ b/scripts/build-binaries-after-version-bump.js
@@ -184,7 +184,7 @@ async function prepare(pluginConfig, context) {
 		}
 		logger.log("✅ bin/ck.js content integrity verified");
 
-		verifyPackageReadyForPublish({
+		await verifyPackageReadyForPublish({
 			expectedVersion: version,
 			logger,
 			requireStableBinaries: !isDevBranch,

--- a/scripts/build-binaries-after-version-bump.js
+++ b/scripts/build-binaries-after-version-bump.js
@@ -75,6 +75,12 @@ async function prepare(pluginConfig, context) {
 			);
 		}
 		logger.log(`✅ dist/index.js built (${Math.round(distStats.size / 1024)}KB)`);
+		logger.log("Building dashboard UI...");
+		execSync("bun run ui:build", { stdio: "inherit" });
+		if (!fs.existsSync("dist/ui/index.html")) {
+			throw new Error("UI build failed: dist/ui/index.html not found");
+		}
+		logger.log("✅ dist/ui built");
 
 		// Step 3: Build platform binaries (skip only for dev releases)
 		if (!skipBinaryBuilds) {
@@ -86,9 +92,10 @@ async function prepare(pluginConfig, context) {
 			// Build binary for current platform (Linux CI)
 			logger.log("Building Linux x64 binary...");
 			try {
-				execSync("bun build src/index.ts --compile --outfile bin/ck-linux-x64", {
-					stdio: "inherit",
-				});
+				execSync(
+					"bun run scripts/compile-binary.ts --outfile bin/ck-linux-x64 --target bun-linux-x64",
+					{ stdio: "inherit" },
+				);
 				execSync("chmod +x bin/ck-linux-x64", { stdio: "inherit" });
 			} catch (error) {
 				failedPlatforms.push("linux-x64");
@@ -106,7 +113,7 @@ async function prepare(pluginConfig, context) {
 				logger.log(`Building for ${platform.target}...`);
 				try {
 					execSync(
-						`bun build src/index.ts --compile --target bun-${platform.target} --outfile ${platform.output}`,
+						`bun run scripts/compile-binary.ts --outfile ${platform.output} --target bun-${platform.target}`,
 						{ stdio: "inherit" },
 					);
 					if (!platform.output.endsWith(".exe")) {

--- a/scripts/check-binary-version-sync.js
+++ b/scripts/check-binary-version-sync.js
@@ -7,6 +7,8 @@
 import { execSync } from "node:child_process";
 import fs from "node:fs";
 
+const SEMVER_PATTERN = /\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/;
+
 function validatePackageVersion() {
 	try {
 		const content = fs.readFileSync("package.json", "utf8");
@@ -16,7 +18,7 @@ function validatePackageVersion() {
 			throw new Error("package.json missing or invalid version field");
 		}
 
-		if (!/^\d+\.\d+\.\d+/.test(packageJson.version)) {
+		if (!SEMVER_PATTERN.test(packageJson.version)) {
 			throw new Error("Invalid version format in package.json");
 		}
 
@@ -44,8 +46,8 @@ function getBinaryVersion(binaryPath) {
 
 	try {
 		const output = execSync(`${binaryPath} --version`, { encoding: "utf8" });
-		const match = output.match(/(\d+\.\d+\.\d+)/);
-		return match ? match[1] : null;
+		const match = output.match(SEMVER_PATTERN);
+		return match ? match[0] : null;
 	} catch (error) {
 		return null;
 	}
@@ -64,6 +66,7 @@ function main() {
 
 	let allSynced = true;
 	const errors = [];
+	const missingBinaries = [];
 
 	for (const binary of binaries) {
 		if (fs.existsSync(binary)) {
@@ -81,12 +84,17 @@ function main() {
 				console.log(`✅ ${binary}: ${binaryVersion}`);
 			}
 		} else {
-			console.log(`⚠️  Binary not found: ${binary}`);
+			allSynced = false;
+			missingBinaries.push(binary);
+			console.log(`❌ Binary not found: ${binary}`);
 		}
 	}
 
 	if (!allSynced) {
 		console.log("\n❌ Version synchronization issues detected:");
+		if (missingBinaries.length > 0) {
+			missingBinaries.forEach((binary) => console.log(`   - Missing binary: ${binary}`));
+		}
 		errors.forEach((error) => console.log(`   - ${error}`));
 		console.log("\n💡 To fix this, run:");
 		console.log("   bun run compile:binaries");

--- a/scripts/check-binary-version-sync.js
+++ b/scripts/check-binary-version-sync.js
@@ -89,11 +89,19 @@ function main() {
 		console.log("\n❌ Version synchronization issues detected:");
 		errors.forEach((error) => console.log(`   - ${error}`));
 		console.log("\n💡 To fix this, run:");
-		console.log("   npm run compile:binary");
-		console.log("   bun build src/index.ts --compile --outfile bin/ck-darwin-arm64");
-		console.log("   bun build src/index.ts --compile --outfile bin/ck-darwin-x64");
-		console.log("   bun build src/index.ts --compile --outfile bin/ck-linux-x64");
-		console.log("   bun build src/index.ts --compile --outfile bin/ck-win32-x64.exe");
+		console.log("   bun run compile:binaries");
+		console.log(
+			"   bun run scripts/compile-binary.ts --outfile bin/ck-darwin-arm64 --target bun-darwin-arm64",
+		);
+		console.log(
+			"   bun run scripts/compile-binary.ts --outfile bin/ck-darwin-x64 --target bun-darwin-x64",
+		);
+		console.log(
+			"   bun run scripts/compile-binary.ts --outfile bin/ck-linux-x64 --target bun-linux-x64",
+		);
+		console.log(
+			"   bun run scripts/compile-binary.ts --outfile bin/ck-win32-x64.exe --target bun-win32-x64",
+		);
 		process.exit(1);
 	}
 

--- a/scripts/prepublish-check.js
+++ b/scripts/prepublish-check.js
@@ -1,18 +1,20 @@
 #!/usr/bin/env node
 
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import {
 	copyFileSync,
 	existsSync,
 	mkdtempSync,
 	readFileSync,
 	readdirSync,
+	renameSync,
 	rmSync,
 	statSync,
 	symlinkSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
 const REQUIRED_PACK_FILES = [
@@ -32,6 +34,9 @@ const PLATFORM_BINARY_BUILD_ARTIFACTS = {
 	"linux-x64": { path: "bin/ck-linux-x64", label: "Linux binary" },
 	"win32-x64": { path: "bin/ck-win32-x64.exe", label: "Windows binary" },
 };
+const DASHBOARD_HOST = "127.0.0.1";
+const DASHBOARD_STARTUP_TIMEOUT_MS = 30000;
+const DASHBOARD_POLL_INTERVAL_MS = 250;
 
 function getCurrentPlatformKey() {
 	return `${process.platform}-${process.arch}`;
@@ -162,6 +167,11 @@ function readPackageVersion() {
 	return packageJson.version;
 }
 
+function readPackageName() {
+	const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+	return packageJson.name;
+}
+
 function getDirectorySize(dir) {
 	let size = 0;
 	for (const file of readdirSync(dir)) {
@@ -249,7 +259,214 @@ function createNodeOnlyPath() {
 	return shimDir;
 }
 
-function verifyInstalledCli({ logger, tarballPath, expectedVersion }) {
+function getInstalledPackageRoot(prefixDir) {
+	const npmRoot = runCommandSync(getNpmCommand(), ["root", "--global", "--prefix", prefixDir], {
+		encoding: "utf8",
+	}).trim();
+	const packageRoot = join(npmRoot, readPackageName());
+	if (!existsSync(packageRoot)) {
+		throw new Error(`Installed package root not found at ${packageRoot}`);
+	}
+	return packageRoot;
+}
+
+function getInstalledHostBinaryPath(packageRoot) {
+	const packPath = PLATFORM_BINARY_PACK_FILES[getCurrentPlatformKey()];
+	if (!packPath) {
+		return null;
+	}
+	const binaryPath = join(packageRoot, packPath.replace(/^package[\\/]/, ""));
+	if (!existsSync(binaryPath)) {
+		throw new Error(`Installed host binary not found at ${binaryPath}`);
+	}
+	return binaryPath;
+}
+
+async function getAvailablePort() {
+	const { createServer } = await import("node:net");
+
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.once("error", reject);
+		server.listen(0, DASHBOARD_HOST, () => {
+			const address = server.address();
+			const port =
+				typeof address === "object" && address && "port" in address ? address.port : null;
+
+			server.close((closeError) => {
+				if (closeError) {
+					reject(closeError);
+					return;
+				}
+
+				if (typeof port !== "number") {
+					reject(new Error("Failed to reserve an ephemeral dashboard port"));
+					return;
+				}
+
+				resolve(port);
+			});
+		});
+	});
+}
+
+function buildRuntimeEnv(overrides = {}) {
+	return {
+		...process.env,
+		NO_COLOR: "1",
+		NON_INTERACTIVE: "true",
+		CI_SAFE_MODE: "true",
+		...overrides,
+	};
+}
+
+function formatProcessOutput(outputChunks) {
+	const output = outputChunks.join("").trim();
+	return output ? `\nProcess output:\n${output}` : "";
+}
+
+async function waitForDashboardReady(baseUrl, label, child, outputChunks, spawnErrorRef) {
+	const deadline = Date.now() + DASHBOARD_STARTUP_TIMEOUT_MS;
+
+	while (Date.now() < deadline) {
+		if (spawnErrorRef.error) {
+			throw new Error(`${label} failed to start: ${spawnErrorRef.error.message}`);
+		}
+
+		if (child.exitCode !== null) {
+			throw new Error(
+				`${label} exited before dashboard became ready (code ${child.exitCode}).${formatProcessOutput(
+					outputChunks,
+				)}`,
+			);
+		}
+
+		try {
+			const response = await fetch(`${baseUrl}/api/health`);
+			if (response.ok) {
+				return;
+			}
+		} catch {
+			// Server not ready yet.
+		}
+
+		await delay(DASHBOARD_POLL_INTERVAL_MS);
+	}
+
+	throw new Error(
+		`${label} did not become ready within ${DASHBOARD_STARTUP_TIMEOUT_MS}ms.${formatProcessOutput(
+			outputChunks,
+		)}`,
+	);
+}
+
+async function assertDashboardServesAssets(baseUrl, label) {
+	const indexResponse = await fetch(`${baseUrl}/`);
+	if (!indexResponse.ok) {
+		throw new Error(`${label} returned ${indexResponse.status} for GET /`);
+	}
+
+	const contentType = indexResponse.headers.get("content-type") ?? "";
+	if (!contentType.includes("text/html")) {
+		throw new Error(`${label} returned unexpected content type for GET /: ${contentType}`);
+	}
+
+	const html = await indexResponse.text();
+	const assetMatches = Array.from(
+		html.matchAll(/(?:src|href)=["'](\/assets\/[^"']+\.(?:js|css))["']/g),
+	);
+	if (assetMatches.length === 0) {
+		throw new Error(`${label} root HTML did not reference any hashed dashboard assets`);
+	}
+
+	const assetPath = assetMatches[0]?.[1];
+	if (!assetPath) {
+		throw new Error(`${label} HTML asset parsing returned an empty path`);
+	}
+
+	const assetResponse = await fetch(new URL(assetPath, `${baseUrl}/`));
+	if (!assetResponse.ok) {
+		throw new Error(`${label} returned ${assetResponse.status} for ${assetPath}`);
+	}
+}
+
+async function waitForProcessExit(child, timeoutMs) {
+	if (child.exitCode !== null) {
+		return;
+	}
+
+	await new Promise((resolve) => {
+		const timer = setTimeout(resolve, timeoutMs);
+		child.once("exit", () => {
+			clearTimeout(timer);
+			resolve();
+		});
+	});
+}
+
+async function stopDashboardProcess(child) {
+	if (child.exitCode !== null) {
+		return;
+	}
+
+	if (process.platform === "win32") {
+		child.kill();
+		await waitForProcessExit(child, 2000);
+
+		if (child.exitCode === null && child.pid) {
+			try {
+				runCommandSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+			} catch {
+				// Best effort cleanup. The temp install directory is removed afterwards anyway.
+			}
+			await waitForProcessExit(child, 2000);
+		}
+		return;
+	}
+
+	child.kill("SIGTERM");
+	await waitForProcessExit(child, 2000);
+
+	if (child.exitCode === null) {
+		child.kill("SIGKILL");
+		await waitForProcessExit(child, 2000);
+	}
+}
+
+async function smokeDashboardRuntime({ label, command, args, cwd, env }) {
+	const port = await getAvailablePort();
+	const baseUrl = `http://${DASHBOARD_HOST}:${port}`;
+	const outputChunks = [];
+	const spawnErrorRef = { error: null };
+	const child = spawn(
+		command,
+		[...args, "config", "ui", "--no-open", "--host", DASHBOARD_HOST, "--port", String(port)],
+		{
+			cwd,
+			env: buildRuntimeEnv(env),
+			stdio: ["ignore", "pipe", "pipe"],
+			windowsHide: true,
+		},
+	);
+
+	child.stdout?.on("data", (chunk) => outputChunks.push(chunk.toString()));
+	child.stderr?.on("data", (chunk) => outputChunks.push(chunk.toString()));
+	child.once("error", (error) => {
+		spawnErrorRef.error = error;
+	});
+
+	try {
+		await waitForDashboardReady(baseUrl, label, child, outputChunks, spawnErrorRef);
+		await assertDashboardServesAssets(baseUrl, label);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`${message}${formatProcessOutput(outputChunks)}`);
+	} finally {
+		await stopDashboardProcess(child);
+	}
+}
+
+async function verifyInstalledCli({ logger, tarballPath, expectedVersion }) {
 	const installRoot = mkdtempSync(join(tmpdir(), "ck-install-"));
 	const prefixDir = join(installRoot, "prefix");
 	const nodeOnlyPath = createNodeOnlyPath();
@@ -284,14 +501,52 @@ function verifyInstalledCli({ logger, tarballPath, expectedVersion }) {
 			throw new Error("Installed CLI help output did not contain the expected banner");
 		}
 
-		logger.log("Verified fresh Node-only install from packed tarball");
+		const packageRoot = getInstalledPackageRoot(prefixDir);
+		const installedDistPath = join(packageRoot, "dist", "index.js");
+		if (!existsSync(installedDistPath)) {
+			throw new Error(`Installed dist bundle not found at ${installedDistPath}`);
+		}
+
+		await smokeDashboardRuntime({
+			label: "Installed packaged Bun runtime",
+			command: "bun",
+			args: [installedDistPath],
+			cwd: installRoot,
+		});
+		logger.log("Verified packaged dashboard runtime via installed dist bundle");
+
+		const installedUiDir = join(packageRoot, "dist", "ui");
+		if (!existsSync(join(installedUiDir, "index.html"))) {
+			throw new Error(`Installed dashboard UI not found at ${installedUiDir}`);
+		}
+
+		const installedHostBinaryPath = getInstalledHostBinaryPath(packageRoot);
+		if (installedHostBinaryPath) {
+			const hiddenUiDir = `${installedUiDir}.__hidden__`;
+			renameSync(installedUiDir, hiddenUiDir);
+			try {
+				await smokeDashboardRuntime({
+					label: "Installed packaged host binary",
+					command: installedHostBinaryPath,
+					args: [],
+					cwd: installRoot,
+				});
+			} finally {
+				if (existsSync(hiddenUiDir)) {
+					renameSync(hiddenUiDir, installedUiDir);
+				}
+			}
+			logger.log("Verified packaged host binary serves embedded dashboard assets");
+		}
+
+		logger.log("Verified fresh Node-only install entrypoint from packed tarball");
 	} finally {
 		rmSync(installRoot, { force: true, recursive: true });
 		rmSync(nodeOnlyPath, { force: true, recursive: true });
 	}
 }
 
-function verifyPackageReadyForPublish({
+async function verifyPackageReadyForPublish({
 	logger = console,
 	expectedVersion = readPackageVersion(),
 	binaryMode,
@@ -305,7 +560,7 @@ function verifyPackageReadyForPublish({
 	try {
 		verifyPackManifest({ logger, manifest, binaryMode: resolvedBinaryMode });
 		if (smokeInstall) {
-			verifyInstalledCli({ logger, tarballPath, expectedVersion });
+			await verifyInstalledCli({ logger, tarballPath, expectedVersion });
 		}
 	} finally {
 		rmSync(packDir, { force: true, recursive: true });
@@ -318,7 +573,7 @@ const isDirectExecution =
 if (isDirectExecution) {
 	try {
 		const args = parseArgs(process.argv.slice(2));
-		verifyPackageReadyForPublish(args);
+		await verifyPackageReadyForPublish(args);
 		console.log("Pre-publish check passed!");
 	} catch (error) {
 		console.error("\nPre-publish check failed:\n");

--- a/src/__tests__/commands/config/config-command-orchestrator-routing.test.ts
+++ b/src/__tests__/commands/config/config-command-orchestrator-routing.test.ts
@@ -56,6 +56,22 @@ describe("configCommand", () => {
 			expect(mockConfigUICommand).toHaveBeenCalledWith(options);
 		});
 
+		it("preserves cac open=false normalization for bare config --no-open", async () => {
+			const options = {
+				port: 3000,
+				host: "127.0.0.1",
+				open: false,
+			} as ConfigCommandOptions & { open: boolean };
+			await configCommand(undefined, options);
+			expect(mockConfigUICommand).toHaveBeenCalledTimes(1);
+			expect(mockConfigUICommand).toHaveBeenCalledWith({
+				port: 3000,
+				noOpen: true,
+				host: "127.0.0.1",
+				dev: undefined,
+			});
+		});
+
 		it("does not call other handlers when launching dashboard", async () => {
 			await configCommand(undefined);
 			expect(mockHandleGet).not.toHaveBeenCalled();

--- a/src/__tests__/domains/web-server/static-server.test.ts
+++ b/src/__tests__/domains/web-server/static-server.test.ts
@@ -1,5 +1,8 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { tryServeFromEmbedded } from "@/domains/web-server/static-server.js";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveUiDistPath, tryServeFromEmbedded } from "@/domains/web-server/static-server.js";
 import express from "express";
 
 function createMockBlob(name: string, content: string, type: string): Blob & { name: string } {
@@ -10,6 +13,8 @@ function createMockBlob(name: string, content: string, type: string): Blob & { n
 
 // Save and restore embeddedFiles between tests
 const originalEmbeddedFiles = globalThis.Bun.embeddedFiles;
+const originalArgv1 = process.argv[1];
+const originalExecPathDescriptor = Object.getOwnPropertyDescriptor(process, "execPath");
 
 describe("tryServeFromEmbedded", () => {
 	afterAll(() => {
@@ -153,5 +158,51 @@ describe("tryServeFromEmbedded", () => {
 			const text = await res.text();
 			expect(text).toContain("prefixed");
 		});
+	});
+});
+
+describe("resolveUiDistPath", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		process.argv[1] = originalArgv1;
+		if (originalExecPathDescriptor) {
+			Object.defineProperty(process, "execPath", originalExecPathDescriptor);
+		}
+		for (const dir of tempDirs) {
+			rmSync(dir, { force: true, recursive: true });
+		}
+		tempDirs.length = 0;
+	});
+
+	function createPackagedUiLayout(): string {
+		const packageRoot = mkdtempSync(join(tmpdir(), "ck-static-ui-"));
+		tempDirs.push(packageRoot);
+		mkdirSync(join(packageRoot, "bin"), { recursive: true });
+		mkdirSync(join(packageRoot, "dist", "ui"), { recursive: true });
+		writeFileSync(join(packageRoot, "dist", "ui", "index.html"), "<html>dashboard</html>");
+		return packageRoot;
+	}
+
+	test("resolves dist/ui relative to the compiled binary path", () => {
+		const packageRoot = createPackagedUiLayout();
+		Object.defineProperty(process, "execPath", {
+			configurable: true,
+			value: join(packageRoot, "bin", "ck-darwin-arm64"),
+		});
+		process.argv[1] = "config";
+
+		expect(resolveUiDistPath()).toBe(join(packageRoot, "dist", "ui"));
+	});
+
+	test("resolves dist/ui relative to the invoked dist entrypoint", () => {
+		const packageRoot = createPackagedUiLayout();
+		Object.defineProperty(process, "execPath", {
+			configurable: true,
+			value: "/usr/local/bin/bun",
+		});
+		process.argv[1] = join(packageRoot, "dist", "index.js");
+
+		expect(resolveUiDistPath()).toBe(join(packageRoot, "dist", "ui"));
 	});
 });

--- a/src/commands/config/config-command.ts
+++ b/src/commands/config/config-command.ts
@@ -59,9 +59,11 @@ export async function configCommand(
 
 	// Default: launch dashboard (bare `ck config`)
 	const rawOpts = options || (typeof keyOrOptions === "object" ? keyOrOptions : {});
+	const openOption = (rawOpts as Record<string, unknown>).open;
+	const noOpen = rawOpts.noOpen === true || openOption === false ? true : undefined;
 	const uiOpts: ConfigUIOptions = {
 		port: rawOpts.port,
-		noOpen: rawOpts.noOpen,
+		noOpen,
 		dev: rawOpts.dev,
 		host: rawOpts.host,
 	};

--- a/src/domains/web-server/static-server.ts
+++ b/src/domains/web-server/static-server.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { dirname, extname, join } from "node:path";
+import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { logger } from "@/shared/logger.js";
 import express, { type Express, type NextFunction, type Request, type Response } from "express";
@@ -106,16 +106,35 @@ export function tryServeFromEmbedded(app: Express): boolean {
 	return true;
 }
 
-function resolveUiDistPath(): string {
-	// Try multiple paths to support both dev and production modes
-	const candidates = [
-		// Production (npm install -g): dist/index.js → dist/ui/ (same directory)
-		join(__dirname, "ui"),
-		// Dev mode: running from CLI repo root
-		join(process.cwd(), "dist", "ui"),
-		// Dev mode alternative: src/ui/dist (if built there)
-		join(process.cwd(), "src", "ui", "dist"),
-	];
+function addRuntimeUiCandidate(candidates: Set<string>, runtimePath?: string): void {
+	if (!runtimePath) {
+		return;
+	}
+
+	const looksLikePath =
+		runtimePath.includes("/") || runtimePath.includes("\\") || existsSync(runtimePath);
+	if (!looksLikePath) {
+		return;
+	}
+
+	const entryDir = dirname(resolve(runtimePath));
+	candidates.add(join(entryDir, "ui"));
+	candidates.add(join(entryDir, "..", "dist", "ui"));
+}
+
+export function resolveUiDistPath(): string {
+	const candidates = new Set<string>();
+
+	// Packaged binary installs: <package>/bin/ck-* → <package>/dist/ui
+	addRuntimeUiCandidate(candidates, process.execPath);
+	// Bun/Node fallback execution: <package>/dist/index.js or <package>/bin/ck.js
+	addRuntimeUiCandidate(candidates, process.argv[1]);
+	// Production (npm install -g): dist/index.js → dist/ui/ (same directory)
+	candidates.add(join(__dirname, "ui"));
+	// Dev mode: running from CLI repo root
+	candidates.add(join(process.cwd(), "dist", "ui"));
+	// Dev mode alternative: src/ui/dist (if built there)
+	candidates.add(join(process.cwd(), "src", "ui", "dist"));
 
 	for (const path of candidates) {
 		// Check if index.html exists to confirm it's a valid built UI
@@ -124,7 +143,7 @@ function resolveUiDistPath(): string {
 		}
 	}
 
-	return candidates[0]; // Return first candidate for error message
+	return Array.from(candidates)[0] ?? join(process.cwd(), "dist", "ui");
 }
 
 export function serveStatic(app: Express): void {


### PR DESCRIPTION
## Summary
- restore `ck config` dashboard asset discovery for packaged installs by resolving `dist/ui` relative to the executable and entrypoint paths
- switch binary builders to `scripts/compile-binary.ts` so release artifacts embed the dashboard assets
- update binary rebuild guidance to use the embedding flow

## Root Cause
Stable release binaries were compiled with plain `bun build --compile`, which produced binaries without populated `Bun.embeddedFiles`. At runtime the dashboard server then fell through to a filesystem lookup under Bun's virtual bundle root (`/$bunfs/root/ui`) instead of the installed package's `dist/ui` directory.

## Validation
- `bun test src/__tests__/domains/web-server/static-server.test.ts`
- `bun run build`
- `bun run ui:build`
- `bun run scripts/compile-binary.ts --outfile /tmp/ck-hotfix --target bun-darwin-arm64`
- `/tmp/ck-hotfix config --no-open` + `curl -I http://localhost:3458/` + `curl -I http://localhost:3458/assets/index-Dq4Gg9PL.js`
- `bun run validate`

Closes #522
