### PR TITLE
hotfix: skip install smoke test for cross-compiled builds

### DIFF
--- a/scripts/prepublish-check.js
+++ b/scripts/prepublish-check.js
@@ -590,7 +590,16 @@ async function verifyPackageReadyForPublish({
 
 	try {
 		verifyPackManifest({ logger, manifest, binaryMode: resolvedBinaryMode, targetPlatform });
-		if (smokeInstall) {
+
+		// Skip install+run smoke test for cross-compilation — the target binary can't execute
+		// on the host architecture, and the CLI wrapper falls back to Node which can't handle
+		// bun: protocol imports. Static checks above (manifest, artifacts) are sufficient.
+		const isCrossCompile = targetPlatform && targetPlatform !== getCurrentPlatformKey();
+		if (isCrossCompile) {
+			logger.log(
+				`Skipped install smoke test (cross-compiling ${targetPlatform} on ${getCurrentPlatformKey()})`,
+			);
+		} else if (smokeInstall) {
 			await verifyInstalledCli({ logger, tarballPath, expectedVersion, targetPlatform });
 		}
 	} finally {


### PR DESCRIPTION
## Summary
Skip `verifyInstalledCli` (npm install + ck --version + dashboard smoke) for cross-compiled builds. The CLI wrapper falls back to Node.js which can't handle `bun:` protocol imports, causing the check to fail on ARM runners building x64 binaries.

Static checks (tarball manifest, binary existence) are sufficient for cross-compile validation.

## Root Cause
`build-binaries.yml` runs on `macos-latest` (ARM64) for both darwin-arm64 and darwin-x64. The darwin-x64 job cross-compiles via `--target bun-darwin-x64`, but `verifyInstalledCli` tries to execute `ck --version` which requires the correct arch binary or Bun runtime.