### PR TITLE
feat(skills): consolidate gemini-cli skill paths to .agents/skills

### DIFF
--- a/src/commands/skills/agents.ts
+++ b/src/commands/skills/agents.ts
@@ -51,8 +51,11 @@ export const agents: Record<AgentType, AgentConfig> = {
 	"gemini-cli": {
 		name: "gemini-cli",
 		displayName: "Gemini CLI",
-		projectPath: ".agents/skills", // Gemini CLI reads .agents/skills/ with precedence over .gemini/skills/
-		globalPath: join(home, ".agents/skills"), // Consolidated: .agents/ is universally usable across agents
+		// Shares projectPath with amp — intentional: .agents/skills/ is a universal shared directory
+		// that multiple agents read. globalPath also shared with amp/windsurf/codex at ~/.agents/skills/.
+		// See also: LEGACY_SKILL_PATHS in skills-installer.ts, REGISTRY_PATH_MIGRATIONS in skills-registry.ts
+		projectPath: ".agents/skills",
+		globalPath: join(home, ".agents/skills"),
 		detect: async () => existsSync(join(home, ".gemini")),
 	},
 	antigravity: {

--- a/src/commands/skills/skills-installer.ts
+++ b/src/commands/skills/skills-installer.ts
@@ -9,7 +9,8 @@ import { agents, getInstallPath, isSkillInstalled } from "./agents.js";
 import { addInstallation, readRegistry, writeRegistry } from "./skills-registry.js";
 import type { AgentType, InstallResult, SkillInfo } from "./types.js";
 
-/** Legacy paths that were consolidated to .agents/skills — keyed by agent type */
+/** Legacy paths that were consolidated to .agents/skills — keyed by agent type
+ * Keep in sync with REGISTRY_PATH_MIGRATIONS in skills-registry.ts */
 const LEGACY_SKILL_PATHS: Partial<Record<AgentType, { project: string; global: string }>> = {
 	"gemini-cli": {
 		project: ".gemini/skills",
@@ -113,8 +114,13 @@ export async function installSkillForAgent(
 	}
 
 	try {
-		// Clean up legacy skill path if this agent was consolidated (e.g., .gemini/skills -> .agents/skills)
-		await cleanupLegacySkillPath(skill.name, agent, options.global);
+		// Best-effort cleanup of legacy skill path (e.g., .gemini/skills -> .agents/skills)
+		// Non-fatal: cleanup failure should never block a valid install to the new path
+		try {
+			await cleanupLegacySkillPath(skill.name, agent, options.global);
+		} catch {
+			// Silently continue — legacy cleanup is best-effort
+		}
 
 		// Ensure parent directory exists
 		const parentDir = dirname(targetPath);

--- a/src/commands/skills/skills-registry.ts
+++ b/src/commands/skills/skills-registry.ts
@@ -53,7 +53,8 @@ function getCliVersion(): string {
 	}
 }
 
-/** Legacy path segments to migrate in registry entries (old -> new) */
+/** Legacy path segments to migrate in registry entries (old -> new)
+ * Keep in sync with LEGACY_SKILL_PATHS in skills-installer.ts */
 const REGISTRY_PATH_MIGRATIONS: Array<{ agent: string; oldSegment: string; newSegment: string }> = [
 	{
 		agent: "gemini-cli",
@@ -98,9 +99,13 @@ export async function readRegistry(): Promise<SkillRegistry> {
 		const data = JSON.parse(content);
 		const registry = SkillRegistrySchema.parse(data);
 
-		// Auto-migrate legacy paths and persist if changed
+		// Auto-migrate legacy paths and persist if changed (best-effort write)
 		if (migrateRegistryPaths(registry)) {
-			await writeFile(REGISTRY_PATH, JSON.stringify(registry, null, 2), "utf-8");
+			try {
+				await writeFile(REGISTRY_PATH, JSON.stringify(registry, null, 2), "utf-8");
+			} catch {
+				// Migration write is best-effort — don't lose the parsed registry on write failure
+			}
 		}
 
 		return registry;


### PR DESCRIPTION
## Summary
- Gemini CLI reads `~/.agents/skills/` with precedence over `~/.gemini/skills/`, making `.agents/` the universal agent-agnostic path
- Update `ck skill` agent registry to install to `.agents/skills` instead of `.gemini/skills` (aligns with `ck migrate` which already targets `.agents/skills`)
- Auto-cleanup: on install, remove legacy `.gemini/skills/<name>` copies; on registry read, auto-migrate old paths

Closes #530

## Test plan
- [x] All 122 related tests pass (skills + provider-registry + migration-result-utils)
- [x] Full suite: 3787 pass, 0 fail
- [x] Typecheck + lint + build pass
- [ ] Manual: verify `ck skill install` targets `~/.agents/skills/` for gemini-cli
- [ ] Manual: verify old `~/.gemini/skills/` entries auto-migrate in registry