### PR TITLE
fix: suppress expected dev Bun fallback warning

### DIFF
--- a/bin/ck.js
+++ b/bin/ck.js
@@ -7,7 +7,7 @@
  */
 
 import { execSync, spawn, spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -64,6 +64,26 @@ const hasBun = () => {
 	}
 	return _bunAvailable;
 };
+
+let _installedVersion = undefined;
+const readInstalledPackageVersion = () => {
+	if (_installedVersion !== undefined) return _installedVersion;
+	try {
+		const packageJsonPath = join(__dirname, "..", "package.json");
+		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+		_installedVersion = typeof packageJson.version === "string" ? packageJson.version : null;
+	} catch {
+		_installedVersion = null;
+	}
+	return _installedVersion;
+};
+
+const isExpectedBunOnlyRelease = () => {
+	const version = readInstalledPackageVersion();
+	return typeof version === "string" && /-dev\.\d+$/i.test(version);
+};
+
+const shouldWarnForBunFallback = () => !isExpectedBunOnlyRelease();
 
 /**
  * Run CLI via bun runtime. Preferred over Node.js when dist/index.js contains
@@ -213,11 +233,11 @@ const runBinary = (binaryPath) => {
  * @param {string} errorPrefix - Prefix for error message if all fallbacks fail
  * @param {boolean} showIssueLink - Whether to show issue reporting link
  */
-const handleFallback = async (errorPrefix, showIssueLink = false) => {
+const handleFallback = async (errorPrefix, showIssueLink = false, showBunWarning = true) => {
 	// Prefer bun — dist/index.js may contain bun-specific imports (bun:sqlite)
 	// runWithBun calls process.exit() on success — won't return here
 	if (hasBun()) {
-		runWithBun(true);
+		runWithBun(showBunWarning);
 	}
 	// Last resort: Node.js (works for stable builds without bun: imports)
 	try {
@@ -245,13 +265,14 @@ const handleFallback = async (errorPrefix, showIssueLink = false) => {
  */
 const main = async () => {
 	const binaryPath = getBinaryPath();
+	const showBunWarning = shouldWarnForBunFallback();
 
 	if (!binaryPath) {
 		// No binary for this platform - use Node.js fallback
-		await handleFallback("Failed to run CLI");
+		await handleFallback("Failed to run CLI", false, showBunWarning);
 	} else if (!existsSync(binaryPath)) {
 		// Binary should exist but doesn't - try fallback
-		await handleFallback("Binary not found and fallback failed", true);
+		await handleFallback("Binary not found and fallback failed", true, showBunWarning);
 	} else {
 		// Execute the binary (handles its own fallback on error)
 		await runBinary(binaryPath);

--- a/tests/wrapper.test.ts
+++ b/tests/wrapper.test.ts
@@ -134,6 +134,25 @@ describe("bin/ck.js wrapper", () => {
 			const wrapperContent = readFileSync(join(binDir, "ck.js"), "utf-8");
 			expect(wrapperContent).toContain("_bunAvailable");
 		});
+
+		test("dev prereleases are treated as expected Bun-only installs", () => {
+			const isExpectedBunOnlyRelease = (version: string | null | undefined): boolean => {
+				return typeof version === "string" && /-dev\.\d+$/i.test(version);
+			};
+
+			expect(isExpectedBunOnlyRelease("3.38.0-dev.2")).toBe(true);
+			expect(isExpectedBunOnlyRelease("3.38.0-DEV.12")).toBe(true);
+			expect(isExpectedBunOnlyRelease("3.38.0")).toBe(false);
+			expect(isExpectedBunOnlyRelease("3.38.0-beta.2")).toBe(false);
+			expect(isExpectedBunOnlyRelease(undefined)).toBe(false);
+		});
+
+		test("wrapper suppresses Bun fallback warnings for expected dev releases", () => {
+			const wrapperContent = readFileSync(join(binDir, "ck.js"), "utf-8");
+			expect(wrapperContent).toContain("isExpectedBunOnlyRelease");
+			expect(wrapperContent).toContain("shouldWarnForBunFallback");
+			expect(wrapperContent).toContain("/-dev\\.\\d+$/i");
+		});
 	});
 
 	describe("error message UX", () => {


### PR DESCRIPTION
## Summary
- suppress the wrapper warning when a dev prerelease intentionally runs via the Bun runtime
- keep warnings for actual binary failure paths outside the expected dev fallback case
- add wrapper tests for the dev-channel Bun-only policy

## Validation
- bun test tests/wrapper.test.ts
- bun run validate
- node bin/ck.js --version

Closes #533