### PR TITLE
feat(ci): auto-label and close issues on dev/stable releases

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
   id-token: write
 
 jobs:
@@ -248,7 +249,7 @@ jobs:
           PREV_TAG=$(git tag --sort=-v:refname -l "v*" | grep -v "^${CURRENT_TAG}$" | head -1)
           RANGE="${PREV_TAG:+${PREV_TAG}..HEAD}"
 
-          git log ${RANGE:---no-merges -20} --no-merges --format="%s" | \
+          git log ${RANGE:---no-merges -20} --no-merges --format="%B" | \
             grep -oiP '(?:closes|fixes|resolves)\s+#\K\d+' | sort -u | \
             while read -r num; do
               gh issue edit "$num" --add-label "released on @dev" 2>/dev/null && \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
             RANGE="${PREV_STABLE}..HEAD"
           fi
 
-          git log ${RANGE:---no-merges -50} --no-merges --format="%s" | \
+          git log ${RANGE:---no-merges -50} --no-merges --format="%B" | \
             grep -oiP '(?:closes|fixes|resolves)\s+#\K\d+' | sort -u | \
             while read -r num; do
               gh issue close "$num" 2>/dev/null && \


### PR DESCRIPTION
## Summary

- **Dev releases:** Scan commits for issue refs (`closes #N`, `fixes #N`, `resolves #N`) and add `released on @dev` label
- **Stable releases:** Close referenced issues, add `released` label, remove `released on @dev` label
- Completes the release tracking lifecycle — issues no longer stay open after fixes ship

Closes #544

## Test plan

- [x] Quality gate passes (lint, typecheck, build, 3799 tests)
- [ ] Next dev release with a `closes #N` commit verifies `released on @dev` label applied
- [ ] Next stable release verifies issues closed + `released` label applied