### PR TITLE
hotfix: make --yes conditional in buildInitCommand to preserve kit selection prompt

### DIFF
--- a/src/__tests__/commands/update-cli.test.ts
+++ b/src/__tests__/commands/update-cli.test.ts
@@ -20,34 +20,34 @@ import { compareVersions } from "compare-versions";
 
 describe("update-cli", () => {
 	describe("buildInitCommand", () => {
-		it("builds local command with no kit (generic)", () => {
+		it("builds local command without --yes by default", () => {
 			const result = buildInitCommand(false);
-			expect(result).toBe("ck init --yes --install-skills");
+			expect(result).toBe("ck init --install-skills");
 		});
 
-		it("builds global command with no kit (generic)", () => {
+		it("builds global command without --yes by default", () => {
 			const result = buildInitCommand(true);
-			expect(result).toBe("ck init -g --yes --install-skills");
+			expect(result).toBe("ck init -g --install-skills");
 		});
 
 		it("builds local command with engineer kit", () => {
 			const result = buildInitCommand(false, "engineer");
-			expect(result).toBe("ck init --kit engineer --yes --install-skills");
+			expect(result).toBe("ck init --kit engineer --install-skills");
 		});
 
 		it("builds local command with marketing kit", () => {
 			const result = buildInitCommand(false, "marketing");
-			expect(result).toBe("ck init --kit marketing --yes --install-skills");
+			expect(result).toBe("ck init --kit marketing --install-skills");
 		});
 
 		it("builds global command with engineer kit", () => {
 			const result = buildInitCommand(true, "engineer");
-			expect(result).toBe("ck init -g --kit engineer --yes --install-skills");
+			expect(result).toBe("ck init -g --kit engineer --install-skills");
 		});
 
 		it("builds global command with marketing kit", () => {
 			const result = buildInitCommand(true, "marketing");
-			expect(result).toBe("ck init -g --kit marketing --yes --install-skills");
+			expect(result).toBe("ck init -g --kit marketing --install-skills");
 		});
 
 		it("places -g flag before --kit flag", () => {
@@ -57,38 +57,48 @@ describe("update-cli", () => {
 			expect(gIndex).toBeLessThan(kitIndex);
 		});
 
-		it("always includes --yes and --install-skills flags", () => {
+		it("includes --yes only when yes=true", () => {
+			expect(buildInitCommand(false, undefined, undefined, true)).toContain("--yes");
+			expect(buildInitCommand(true, "engineer", false, true)).toContain("--yes");
+		});
+
+		it("excludes --yes when yes is false or undefined", () => {
+			expect(buildInitCommand(false)).not.toContain("--yes");
+			expect(buildInitCommand(true, "engineer")).not.toContain("--yes");
+			expect(buildInitCommand(false, undefined, undefined, false)).not.toContain("--yes");
+		});
+
+		it("always includes --install-skills", () => {
 			const cases = [
 				buildInitCommand(false),
 				buildInitCommand(true),
 				buildInitCommand(false, "engineer"),
-				buildInitCommand(true, "marketing"),
+				buildInitCommand(true, "marketing", undefined, true),
 			];
 
 			for (const cmd of cases) {
-				expect(cmd).toContain("--yes");
 				expect(cmd).toContain("--install-skills");
 			}
 		});
 
 		it("includes --beta flag when beta is true", () => {
 			const result = buildInitCommand(false, undefined, true);
-			expect(result).toBe("ck init --yes --install-skills --beta");
+			expect(result).toBe("ck init --install-skills --beta");
 		});
 
-		it("includes --beta flag with kit and global", () => {
-			const result = buildInitCommand(true, "engineer", true);
+		it("includes --beta flag with kit and global and yes", () => {
+			const result = buildInitCommand(true, "engineer", true, true);
 			expect(result).toBe("ck init -g --kit engineer --yes --install-skills --beta");
 		});
 
 		it("does not include --beta flag when beta is false", () => {
 			const result = buildInitCommand(false, "engineer", false);
-			expect(result).toBe("ck init --kit engineer --yes --install-skills");
+			expect(result).toBe("ck init --kit engineer --install-skills");
 		});
 
 		it("does not include --beta flag when beta is undefined", () => {
 			const result = buildInitCommand(false, "engineer");
-			expect(result).toBe("ck init --kit engineer --yes --install-skills");
+			expect(result).toBe("ck init --kit engineer --install-skills");
 		});
 	});
 

--- a/src/commands/update-cli.ts
+++ b/src/commands/update-cli.ts
@@ -145,11 +145,17 @@ export function redactCommandForLog(command: string): string {
  * Build init command with appropriate flags for kit type
  * @internal Exported for testing
  */
-export function buildInitCommand(isGlobal: boolean, kit?: KitType, beta?: boolean): string {
+export function buildInitCommand(
+	isGlobal: boolean,
+	kit?: KitType,
+	beta?: boolean,
+	yes?: boolean,
+): string {
 	const parts = ["ck init"];
 	if (isGlobal) parts.push("-g");
 	if (kit) parts.push(`--kit ${kit}`);
-	parts.push("--yes --install-skills");
+	if (yes) parts.push("--yes");
+	parts.push("--install-skills");
 	if (beta) parts.push("--beta");
 	return parts.join(" ");
 }
@@ -353,7 +359,6 @@ export async function promptKitUpdate(
 			: undefined;
 		const isBetaInstalled = isBetaVersion(kitVersion);
 
-		const initCmd = buildInitCommand(selection.isGlobal, selection.kit, beta || isBetaInstalled);
 		const promptMessage = selection.promptMessage;
 
 		// Show current kit version before update
@@ -406,6 +411,14 @@ export async function promptKitUpdate(
 		} else {
 			logger.verbose("Auto-proceeding with kit update (--yes flag)");
 		}
+
+		// Build init command — only pass --yes when user explicitly used -y or autoInit is enabled
+		const initCmd = buildInitCommand(
+			selection.isGlobal,
+			selection.kit,
+			beta || isBetaInstalled,
+			yes || autoInit,
+		);
 
 		// Execute the init command
 		logger.info(`Running: ${initCmd}`);

--- a/src/domains/web-server/routes/system-routes.ts
+++ b/src/domains/web-server/routes/system-routes.ts
@@ -270,7 +270,7 @@ export function registerSystemRoutes(app: Express): void {
 
 			// Use shared buildInitCommand for parity with CLI
 			// Note: Dashboard manages global config, so always use global=true
-			commandLine = buildInitCommand(true, kitName, isBeta);
+			commandLine = buildInitCommand(true, kitName, isBeta, true);
 
 			logger.debug(`Updating kit ${kitName} (beta: ${isBeta}): ${commandLine}`);
 			res.write(`data: ${JSON.stringify({ type: "phase", name: "installing" })}\n\n`);


### PR DESCRIPTION
## Summary
- `buildInitCommand()` hardcoded `--yes` unconditionally, causing `ck update` (without `-y`) to bypass `ck init`'s kit selection prompt
- Added `yes` parameter — only passes `--yes` when user explicitly used `-y` flag or `autoInitAfterUpdate` config is enabled
- Dashboard call site passes `yes=true` since user explicitly clicked update button

## Root Cause
`--yes --install-skills` was a single hardcoded string at line 152. The function had no `yes` parameter, making the caller's `yes` value structurally unreachable.

## Test plan
- [x] All 3754 existing tests pass
- [x] Updated `buildInitCommand` tests: default calls exclude `--yes`, `yes=true` includes it
- [x] Added explicit `yes=true`/`yes=false`/`yes=undefined` coverage
- [ ] Manual: `ck update` shows kit selection prompt
- [ ] Manual: `ck update -y` skips prompt

Closes #550