### PR TITLE
fix(update): let ck init show kit selection in interactive mode

### DIFF
--- a/src/__tests__/commands/update-cli-auto-init.test.ts
+++ b/src/__tests__/commands/update-cli-auto-init.test.ts
@@ -100,7 +100,7 @@ describe("promptKitUpdate auto-init behavior", () => {
 		expect(execCount()).toBe(1);
 	});
 
-	test("autoInitAfterUpdate does NOT pass --yes to ck init (preserves kit selection)", async () => {
+	test("autoInitAfterUpdate does NOT pass --yes or --kit to ck init (preserves interactive prompts)", async () => {
 		loadFullConfigMock.mockResolvedValue({
 			config: { updatePipeline: { autoInitAfterUpdate: true } },
 		});
@@ -112,10 +112,24 @@ describe("promptKitUpdate auto-init behavior", () => {
 		};
 		await promptKitUpdate(false, false, deps);
 		expect(capturedCommand).not.toContain("--yes");
+		expect(capturedCommand).not.toContain("--kit");
 		expect(capturedCommand).toContain("--install-skills");
 	});
 
-	test("explicit -y flag passes --yes to ck init", async () => {
+	test("interactive mode (no -y) does NOT pass --kit, letting ck init show kit picker", async () => {
+		let capturedCommand = "";
+		const deps = makeDeps().deps;
+		deps.execAsyncFn = async (cmd: string) => {
+			capturedCommand = cmd;
+			return { stdout: "", stderr: "" };
+		};
+		await promptKitUpdate(false, false, deps);
+		expect(capturedCommand).not.toContain("--kit");
+		expect(capturedCommand).not.toContain("--yes");
+		expect(capturedCommand).toContain("ck init");
+	});
+
+	test("explicit -y flag passes both --yes and --kit to ck init (non-interactive)", async () => {
 		let capturedCommand = "";
 		const deps = makeDeps().deps;
 		deps.execAsyncFn = async (cmd: string) => {
@@ -125,6 +139,7 @@ describe("promptKitUpdate auto-init behavior", () => {
 		deps.getLatestReleaseTagFn = async () => "v2.0.0";
 		await promptKitUpdate(false, true, deps);
 		expect(capturedCommand).toContain("--yes");
+		expect(capturedCommand).toContain("--kit engineer");
 	});
 
 	test("prompts normally when autoInitAfterUpdate is disabled", async () => {

--- a/src/commands/update-cli.ts
+++ b/src/commands/update-cli.ts
@@ -412,12 +412,16 @@ export async function promptKitUpdate(
 			logger.verbose("Auto-proceeding with kit update (--yes flag)");
 		}
 
-		// Build init command — only pass --yes when user explicitly used -y flag.
-		// autoInit skips the "do you want to update?" confirmation above,
-		// but must NOT suppress ck init's own interactive prompts (kit selection, conflicts).
+		// Build init command:
+		// - Only pass --kit when -y is used (non-interactive needs pre-selected kit).
+		//   Without -y, omit --kit so ck init shows its own interactive kit picker,
+		//   letting users choose/change kits (e.g., add marketing alongside engineer).
+		// - Only pass --yes when user explicitly used -y flag.
+		//   autoInit skips the "do you want to update?" confirmation above,
+		//   but must NOT suppress ck init's own interactive prompts.
 		const initCmd = buildInitCommand(
 			selection.isGlobal,
-			selection.kit,
+			yes ? selection.kit : undefined,
 			beta || isBetaInstalled,
 			yes,
 		);


### PR DESCRIPTION
## Problem

`ck update` always passes `--kit <detected-kit>` to `ck init`, pre-selecting the first detected kit and skipping `ck init`'s interactive kit picker. Users can never choose a different kit or add marketing alongside engineer during update.

Reported by user Tre in Discord: "Previously `ck update` let me select between engineer and marketing, but now I don't see it anymore."

## What This PR Changes

Only pass `--kit` to `ck init` in non-interactive mode (`-y` flag). In interactive mode, omit `--kit` so `ck init` shows its own kit selection prompt.

### User scenarios

| Command | Update confirmation | Kit selection in `ck init` |
|---------|-------------------|---------------------------|
| `ck update` | Prompted | **Interactive** (kit picker shown) |
| `ck update -y` | Skipped | Auto-selected (first detected kit) |
| `ck update` + `autoInitAfterUpdate` | Skipped | **Interactive** (kit picker shown) |

## Validation

- [x] 76 update-cli tests pass (0 failures)
- [x] Typecheck, lint, build all pass
- [x] New test: interactive mode does NOT pass `--kit`
- [x] New test: `-y` mode passes both `--kit` and `--yes`
- [x] Existing autoInit test updated to verify no `--kit` in interactive mode