### PR TITLE
fix: add regex fallback for frontmatter parser (#558)

### DIFF
--- a/__tests__/commands/portable/frontmatter-parser.test.ts
+++ b/__tests__/commands/portable/frontmatter-parser.test.ts
@@ -65,7 +65,7 @@ Body.`;
 		expect(result.warnings).toEqual([]);
 	});
 
-	it("handles malformed frontmatter by returning empty frontmatter", () => {
+	it("recovers malformed frontmatter via regex fallback", () => {
 		const content = `---
 name: Broken
 invalid yaml: [unclosed
@@ -74,10 +74,49 @@ Body.`;
 
 		const result = parseFrontmatter(content);
 
-		// Should not throw, returns empty frontmatter and original content
+		// Fallback extracts what it can from malformed YAML
+		expect(result.frontmatter.name).toBe("Broken");
+		expect(result.body).toBe("Body.");
+		expect(result.warnings).toEqual([]);
+	});
+
+	it("handles unquoted description with colons (marketing agent pattern)", () => {
+		const content = `---
+name: campaign-debugger
+description: Use this agent for debugging. Examples:\\n\\n<example>\\nContext: The user needs help.\\n</example>
+model: sonnet
+---
+Body content.`;
+
+		const result = parseFrontmatter(content);
+
+		expect(result.frontmatter.name).toBe("campaign-debugger");
+		expect(result.frontmatter.description).toContain("Use this agent");
+		expect(result.frontmatter.model).toBe("sonnet");
+		expect(result.body).toBe("Body content.");
+	});
+
+	it("handles unquoted argument-hint with brackets", () => {
+		const content = `---
+description: A command
+argument-hint: [type] [topic]
+---
+Body.`;
+
+		const result = parseFrontmatter(content);
+
+		expect(result.frontmatter.description).toBe("A command");
+		expect(result.frontmatter.argumentHint).toBe("[type] [topic]");
+		expect(result.body).toBe("Body.");
+	});
+
+	it("returns empty frontmatter when no frontmatter block exists", () => {
+		const content = "No frontmatter delimiters here.";
+
+		const result = parseFrontmatter(content);
+
 		expect(Object.keys(result.frontmatter).length).toBe(0);
 		expect(result.body.length).toBeGreaterThan(0);
-		expect(result.warnings).toEqual([]);
 	});
 
 	it("handles empty content string", () => {

--- a/src/commands/portable/frontmatter-parser.ts
+++ b/src/commands/portable/frontmatter-parser.ts
@@ -26,6 +26,53 @@ function truncateField(value: string, field: string, warnings: string[]): string
 	return value;
 }
 
+/** Known frontmatter keys that map to ParsedFrontmatter fields */
+const KNOWN_KEYS: Record<string, keyof ParsedFrontmatter> = {
+	name: "name",
+	description: "description",
+	model: "model",
+	tools: "tools",
+	memory: "memory",
+	"argument-hint": "argumentHint",
+};
+
+/**
+ * Regex-based fallback parser for when gray-matter/js-yaml fails on
+ * unquoted YAML values containing colons, brackets, or other special chars.
+ * Extracts simple key: value pairs from the frontmatter block.
+ */
+function parseFrontmatterFallback(content: string): FrontmatterParseResult | null {
+	const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+	if (!fmMatch) return null;
+
+	const fmBlock = fmMatch[1];
+	const body = content.slice(fmMatch[0].length);
+	const frontmatter: ParsedFrontmatter = {};
+	const warnings: string[] = [];
+
+	// Match key: value lines (value runs to end of line or next key)
+	// Handles single-quoted, double-quoted, and unquoted values
+	const lines = fmBlock.split(/\r?\n/);
+	for (const line of lines) {
+		const keyMatch = line.match(/^([a-zA-Z][\w-]*)\s*:\s*(.*)/);
+		if (!keyMatch) continue;
+
+		const [, rawKey, rawValue] = keyMatch;
+		// Strip surrounding quotes (single or double)
+		const value = rawValue.replace(/^(['"])(.*)\1$/, "$2").trim();
+		if (!value) continue;
+
+		const mappedKey = KNOWN_KEYS[rawKey];
+		if (mappedKey) {
+			frontmatter[mappedKey] = truncateField(value, String(mappedKey), warnings);
+		} else {
+			frontmatter[rawKey] = value;
+		}
+	}
+
+	return { frontmatter, body: body.trim(), warnings };
+}
+
 /**
  * Parse frontmatter and body from markdown content string
  */
@@ -57,6 +104,16 @@ export function parseFrontmatter(content: string): FrontmatterParseResult {
 
 		return { frontmatter, body: body.trim(), warnings };
 	} catch (error) {
+		// gray-matter failed (e.g. unquoted YAML values with colons/brackets).
+		// Try regex-based fallback before giving up.
+		const fallback = parseFrontmatterFallback(content);
+		if (fallback && Object.keys(fallback.frontmatter).length > 0) {
+			logger.verbose(
+				`Failed to parse frontmatter: ${error instanceof Error ? error.message : "Unknown error"} (recovered via fallback)`,
+			);
+			return fallback;
+		}
+
 		logger.warning(
 			`Failed to parse frontmatter: ${error instanceof Error ? error.message : "Unknown error"}`,
 		);


### PR DESCRIPTION
## Summary

- Add regex-based fallback to `frontmatter-parser.ts` when gray-matter/js-yaml fails on unquoted YAML values
- Recovers metadata from files with colons in `<example>` blocks or brackets in `argument-hint` fields
- Downgrade warning to verbose level when fallback succeeds — eliminates ~35 warnings during `ck migrate`

## Root Cause

Marketing kit agent files have unquoted `description:` values containing YAML-breaking colons (e.g., `Context: The user...` inside `<example>` blocks). Marketing command files have unquoted `argument-hint:` values with brackets (e.g., `[type] [topic]`) interpreted as YAML flow sequences.

## Test Plan

- [x] All 12 frontmatter parser tests pass (3 new test cases added)
- [x] Full test suite: 3750 pass, 0 fail
- [x] Verified 100% recovery: all 43 previously-failing marketing files parse successfully with fallback
- [x] Engineer package files still parse via primary gray-matter path (no regression)

Closes #558