### PR TITLE
hotfix(cli): default ck update to stable channel

### DIFF
--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -491,7 +491,7 @@ Business logic by domain with facade pattern.
 **installation/** - Download (streaming), extract (ZIP/TAR with security validation), merge (selective, multi-kit aware), package manager detection
 **skills/** - Detection (config, dependencies, scripts), customization scanning (hashing), migration executor (backup/rollback)
 **ui/** - Interactive prompts (kit/version selection, confirmations), ownership display (3-state model)
-**versioning/** - Version checking (CLI/kit) with caching (7-day TTL), selection UI, beta/prerelease filtering
+**versioning/** - Version checking (CLI/kit) with caching (7-day TTL), stable-by-default CLI updates, selection UI, beta/prerelease filtering
 **help/** - Custom help renderer with theme support, NO_COLOR compliance
 **sync/** - Passive update checking, merge UI preview (NEW)
 **web-server/** - Express+Vite dashboard server, WebSocket, HMR (NEW)

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -175,7 +175,7 @@ Detection (config, dependencies, scripts), customization scanning with hash comp
 Prompts for kit/version selection, confirmations. Ownership display for multi-kit awareness.
 
 ### versioning/ - Version Management
-CLI version checker with caching (7-day TTL). Kit version checker. Selection UI with beta/prerelease filtering.
+CLI version checker with caching (7-day TTL) and stable-by-default self-update behavior. Kit version checker. Selection UI with beta/prerelease filtering.
 
 ### help/ - Help System
 Custom renderer with theme support and NO_COLOR compliance. CommandHelp, OptionGroup, ColorTheme interfaces.

--- a/src/__tests__/commands/update-cli.test.ts
+++ b/src/__tests__/commands/update-cli.test.ts
@@ -675,7 +675,7 @@ describe("update-cli", () => {
 		});
 	});
 
-	describe("updateCliCommand prerelease channel selection", () => {
+	describe("updateCliCommand channel selection", () => {
 		const baseOptions = {
 			check: false,
 			yes: true,
@@ -726,7 +726,26 @@ describe("update-cli", () => {
 			};
 		}
 
-		it("prefers dev dist-tag for prerelease installs without requiring --dev", async () => {
+		it("defaults to latest stable for prerelease installs when no prerelease flag is set", async () => {
+			const deps = createDeps({
+				currentVersion: "3.36.0-dev.35",
+				devVersion: "3.36.0-dev.37",
+				latestVersion: "3.36.1",
+				activeVersion: "3.36.1",
+			});
+
+			await updateCliCommand(baseOptions, deps);
+
+			expect(deps.npmRegistryClient.getDevVersion).not.toHaveBeenCalled();
+			expect(deps.npmRegistryClient.getLatestVersion).toHaveBeenCalledTimes(1);
+			expect(deps.execAsyncFn).toHaveBeenCalledWith(
+				"npm install -g claudekit-cli@3.36.1",
+				expect.any(Object),
+			);
+			expect(deps.promptKitUpdateFn).toHaveBeenCalledWith(false, true);
+		});
+
+		it("uses the dev dist-tag when --dev is explicitly requested", async () => {
 			const deps = createDeps({
 				currentVersion: "3.36.0-dev.35",
 				devVersion: "3.36.0-dev.37",
@@ -734,7 +753,7 @@ describe("update-cli", () => {
 				activeVersion: "3.36.0-dev.37",
 			});
 
-			await updateCliCommand(baseOptions, deps);
+			await updateCliCommand({ ...baseOptions, dev: true }, deps);
 
 			expect(deps.npmRegistryClient.getDevVersion).toHaveBeenCalledTimes(1);
 			expect(deps.npmRegistryClient.getLatestVersion).not.toHaveBeenCalled();
@@ -745,7 +764,7 @@ describe("update-cli", () => {
 			expect(deps.promptKitUpdateFn).toHaveBeenCalledWith(true, true);
 		});
 
-		it("falls back to latest stable when prerelease installs have no dev dist-tag", async () => {
+		it("falls back to latest stable when explicit prerelease channel has no dev dist-tag", async () => {
 			const deps = createDeps({
 				currentVersion: "3.36.0-dev.35",
 				devVersion: null,
@@ -753,7 +772,7 @@ describe("update-cli", () => {
 				activeVersion: "3.36.1",
 			});
 
-			await updateCliCommand(baseOptions, deps);
+			await updateCliCommand({ ...baseOptions, beta: true }, deps);
 
 			expect(deps.npmRegistryClient.getDevVersion).toHaveBeenCalledTimes(1);
 			expect(deps.npmRegistryClient.getLatestVersion).toHaveBeenCalledTimes(1);

--- a/src/commands/update-cli.ts
+++ b/src/commands/update-cli.ts
@@ -658,9 +658,9 @@ export async function updateCliCommand(
 		// Fetch target version from npm registry
 		s.start("Checking for updates...");
 		let targetVersion: string | null = null;
-		const preferInstalledPrereleaseChannel =
-			!opts.release && !(opts.dev || opts.beta) && isPrereleaseVersion(currentVersion);
-		const usePrereleaseChannel = opts.dev || opts.beta || preferInstalledPrereleaseChannel;
+		// Default `ck update` to the stable `latest` dist-tag. Prerelease updates are opt-in
+		// via --dev/--beta so users can recover cleanly from accidental prerelease installs.
+		const usePrereleaseChannel = opts.dev || opts.beta;
 
 		if (opts.release && opts.release !== "latest") {
 			// Specific version requested

--- a/src/domains/help/commands/update-command-help.ts
+++ b/src/domains/help/commands/update-command-help.ts
@@ -72,7 +72,7 @@ export const updateCommandHelp: CommandHelp = {
 		{
 			title: "Note",
 			content:
-				"'ck update' updates the CLI tool only. To update kit content (skills, commands, rules), use 'ck init' for local or 'ck init -g' for global. Use --yes to skip all prompts (both CLI and kit content update) for non-interactive/CI usage.",
+				"'ck update' updates the CLI tool only and defaults to the latest stable release. Use '--beta' to opt into prerelease CLI builds. To update kit content (skills, commands, rules), use 'ck init' for local or 'ck init -g' for global. Use --yes to skip all prompts (both CLI and kit content update) for non-interactive/CI usage.",
 		},
 	],
 };

--- a/src/domains/versioning/checking/cli-version-checker.ts
+++ b/src/domains/versioning/checking/cli-version-checker.ts
@@ -12,7 +12,6 @@ import { compareVersions } from "compare-versions";
 import {
 	type VersionCheckResult,
 	isPrereleaseOfSameBase,
-	isPrereleaseVersion,
 	isUpdateCheckDisabled,
 	normalizeVersion,
 } from "./version-utils.js";
@@ -31,10 +30,10 @@ export class CliVersionChecker {
 		}
 
 		try {
-			const latestVersion = isPrereleaseVersion(currentVersion)
-				? ((await NpmRegistryClient.getDevVersion(CLAUDEKIT_CLI_NPM_PACKAGE_NAME)) ??
-					(await NpmRegistryClient.getLatestVersion(CLAUDEKIT_CLI_NPM_PACKAGE_NAME)))
-				: await NpmRegistryClient.getLatestVersion(CLAUDEKIT_CLI_NPM_PACKAGE_NAME);
+			// Passive notifications should track the stable channel by default.
+			const latestVersion = await NpmRegistryClient.getLatestVersion(
+				CLAUDEKIT_CLI_NPM_PACKAGE_NAME,
+			);
 
 			if (!latestVersion) {
 				logger.debug("Failed to fetch latest CLI version from npm");

--- a/tests/lib/version-checker.test.ts
+++ b/tests/lib/version-checker.test.ts
@@ -304,7 +304,7 @@ describe("CliVersionChecker", () => {
 		expect(result?.latestVersion).toBe("2.0.0");
 	});
 
-	test("prefers dev dist-tag for prerelease installs", async () => {
+	test("uses latest stable for prerelease installs even when a dev dist-tag exists", async () => {
 		Object.defineProperty(process.stdout, "isTTY", {
 			value: true,
 			writable: true,
@@ -328,7 +328,7 @@ describe("CliVersionChecker", () => {
 		const result = await CliVersionChecker.check("3.36.0-dev.35");
 		expect(result).not.toBeNull();
 		expect(result?.updateAvailable).toBe(true);
-		expect(result?.latestVersion).toBe("3.36.0-dev.37");
+		expect(result?.latestVersion).toBe("3.36.1");
 	});
 
 	test("still uses latest stable for stable installs even when dev dist-tag exists", async () => {


### PR DESCRIPTION
## Problem
`ck update` followed the prerelease dist-tag whenever the installed CLI version was prerelease, even if the user did not pass `--dev` or `--beta`. That kept affected installs pinned to `dev` and hid newer stable releases.

Closes #572.

## What This PR Changes
- defaults `ck update` back to the stable `latest` dist-tag unless `--dev` or `--beta` is explicitly provided
- makes passive CLI version checks track stable releases by default as well
- updates regression coverage for default-stable, explicit `--dev`, and prerelease fallback behavior
- clarifies command help and architecture docs to reflect the stable-by-default behavior

## Validation
- `bun run validate`
- targeted regression tests for `update-cli` and `CliVersionChecker`

## Notes
- explicit prerelease updates still work via `ck update --dev` or `ck update --beta`
- this hotfix stays on the existing `#343` suppression rule for same-base prerelease→stable notification noise
