### PR TITLE
fix: promote release rebuild fix to stable

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -44,9 +44,9 @@ export default {
 		],
 		"@semantic-release/changelog",
 		[
-			// Rebuild dist+UI after semantic-release bumps package.json version.
-			// Bun inlines version at build time — must rebuild so published bundle
-			// reports the correct version via `ck --version`.
+			// This prepare plugin runs before @semantic-release/npm, so it must
+			// synchronize package.json to nextRelease.version itself before
+			// rebuilding. Bun inlines version at build time.
 			"./scripts/rebuild-after-version-bump.js",
 			{},
 		],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "claudekit-cli",
-	"version": "3.40.2",
+	"version": "3.40.2-dev.1",
 	"description": "CLI tool for bootstrapping and updating ClaudeKit projects",
 	"type": "module",
 	"repository": {

--- a/scripts/rebuild-after-version-bump.d.ts
+++ b/scripts/rebuild-after-version-bump.d.ts
@@ -1,0 +1,9 @@
+export function synchronizePackageJsonVersion(version: string, packageJsonPath?: string): boolean;
+
+export function prepare(
+	_pluginConfig: unknown,
+	context: {
+		logger: { log: (message: string) => void };
+		nextRelease?: { version?: string };
+	},
+): Promise<void>;

--- a/scripts/rebuild-after-version-bump.js
+++ b/scripts/rebuild-after-version-bump.js
@@ -8,7 +8,7 @@
  * must write nextRelease.version itself before rebuilding.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
@@ -46,9 +46,13 @@ export async function prepare(_pluginConfig, context) {
 	execSync("bun run ui:build", { stdio: "inherit" });
 
 	logger.log("Verifying packed release bundle after rebuild...");
-	execSync(`node scripts/prepublish-check.js --expected-version="${nextVersion}"`, {
-		stdio: "inherit",
-	});
+	execFileSync(
+		process.execPath,
+		["scripts/prepublish-check.js", `--expected-version=${nextVersion}`],
+		{
+			stdio: "inherit",
+		},
+	);
 
 	logger.log("Rebuild complete — dist now embeds correct version.");
 }

--- a/scripts/rebuild-after-version-bump.js
+++ b/scripts/rebuild-after-version-bump.js
@@ -1,21 +1,54 @@
 /**
- * Semantic-release prepare plugin — rebuilds dist bundle and dashboard UI
- * after version bump so the published npm package embeds the correct version.
+ * Semantic-release prepare plugin — synchronizes package.json to the next
+ * release version, rebuilds dist bundle and dashboard UI, then verifies the
+ * packed npm artifact embeds the same version.
  *
- * Bun inlines package.json at build time. Without this plugin, `ck --version`
- * would report the pre-bump version.
+ * Bun inlines package.json at build time. In semantic-release, this custom
+ * plugin runs before @semantic-release/npm prepares the final tarball, so it
+ * must write nextRelease.version itself before rebuilding.
  */
 
 import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const PACKAGE_JSON_PATH = resolve(process.cwd(), "package.json");
+
+export function synchronizePackageJsonVersion(version, packageJsonPath = PACKAGE_JSON_PATH) {
+	const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+	if (packageJson.version === version) {
+		return false;
+	}
+
+	packageJson.version = version;
+	writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, "\t")}\n`);
+	return true;
+}
 
 export async function prepare(_pluginConfig, context) {
-	const { logger } = context;
+	const { logger, nextRelease } = context;
+	const nextVersion = nextRelease?.version?.trim();
+	if (!nextVersion) {
+		throw new Error("semantic-release did not provide nextRelease.version");
+	}
+
+	const updated = synchronizePackageJsonVersion(nextVersion);
+	if (updated) {
+		logger.log(`Synchronized package.json version to ${nextVersion} before rebuild.`);
+	} else {
+		logger.log(`package.json already at ${nextVersion} before rebuild.`);
+	}
 
 	logger.log("Rebuilding dist bundle with bumped version...");
 	execSync("bun run build", { stdio: "inherit" });
 
 	logger.log("Rebuilding dashboard UI...");
 	execSync("bun run ui:build", { stdio: "inherit" });
+
+	logger.log("Verifying packed release bundle after rebuild...");
+	execSync(`node scripts/prepublish-check.js --expected-version="${nextVersion}"`, {
+		stdio: "inherit",
+	});
 
 	logger.log("Rebuild complete — dist now embeds correct version.");
 }

--- a/tests/scripts/prepublish-check.test.ts
+++ b/tests/scripts/prepublish-check.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { assertNodeCompatibleBundle } from "../../scripts/prepublish-check.js";
+import { synchronizePackageJsonVersion } from "../../scripts/rebuild-after-version-bump.js";
 
 describe("assertNodeCompatibleBundle", () => {
 	test("allows Node-safe bundles", () => {
@@ -70,6 +71,41 @@ describe("assertNodeCompatibleBundle", () => {
 		try {
 			writeFileSync(bundlePath, 'await Bun.write("out.json", data);');
 			expect(() => assertNodeCompatibleBundle(bundlePath)).toThrow("Bun.write runtime API");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("synchronizePackageJsonVersion", () => {
+	test("updates package.json before the rebuild step when semantic-release has not yet done it", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "ck-rebuild-version-sync-"));
+		const packageJsonPath = join(tempDir, "package.json");
+
+		try {
+			writeFileSync(
+				packageJsonPath,
+				`${JSON.stringify({ name: "claudekit-cli", version: "3.40.1-dev.1" }, null, "\t")}\n`,
+			);
+
+			expect(synchronizePackageJsonVersion("3.40.2", packageJsonPath)).toBe(true);
+			expect(JSON.parse(readFileSync(packageJsonPath, "utf8")).version).toBe("3.40.2");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("is a no-op when package.json already matches the target release version", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "ck-rebuild-version-noop-"));
+		const packageJsonPath = join(tempDir, "package.json");
+
+		try {
+			writeFileSync(
+				packageJsonPath,
+				`${JSON.stringify({ name: "claudekit-cli", version: "3.40.2" }, null, "\t")}\n`,
+			);
+
+			expect(synchronizePackageJsonVersion("3.40.2", packageJsonPath)).toBe(false);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary
- promote the semantic-release rebuild fix from `dev` to `main`
- publish the stable release path with the same package-version synchronization used by the verified dev prerelease
- unblock accidental prerelease installs from eventually returning to a correct stable track

## Why now
The fix has already shipped on `dev` as `v3.40.2-dev.1`, and the published dev tarball is verified to embed the correct runtime version.

Current public state before this PR:
- stable `3.40.2` is broken: package metadata says `3.40.2`, but the bundled runtime reports the stale prerelease version
- dev `3.40.2-dev.1` is fixed and published correctly

## Validation
- `bun run validate`
- verified the published `claudekit-cli@3.40.2-dev.1` tarball embeds `3.40.2-dev.1` in both `package/package.json` and `package/dist/index.js`
- verified earlier Windows recovery path on `ssh i9-bootcamp`

Closes #576
