### PR TITLE
fix(watch): resolve Windows issues with verbose flag, lock paths, and ECOMPROMISED

### DIFF
--- a/src/__tests__/shared/process-lock.test.ts
+++ b/src/__tests__/shared/process-lock.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { access, rm } from "node:fs/promises";
 import os from "node:os";
 import { join } from "node:path";
-import { withProcessLock } from "@/shared/process-lock";
+import { getLockPaths, withProcessLock } from "@/shared/process-lock";
 
 const LOCKS_DIR = join(os.homedir(), ".claudekit", "locks");
 
@@ -98,5 +98,33 @@ describe("withProcessLock", () => {
 		// Lock file should not exist — proper-lockfile creates a .lock dir
 		const lockPath = join(LOCKS_DIR, "test-cleanup.lock");
 		await expect(access(lockPath)).rejects.toThrow();
+	});
+
+	it("should accept 'long' duration without changing behavior", async () => {
+		const result = await withProcessLock("test-long", async () => "ok", "long");
+		expect(result).toBe("ok");
+		// Second call should succeed (lock released)
+		const result2 = await withProcessLock("test-long", async () => "ok2", "long");
+		expect(result2).toBe("ok2");
+	});
+
+	it("should default to 'short' duration when omitted", async () => {
+		// Existing 2-arg signature still works (backward compat)
+		const result = await withProcessLock("test-default", async () => "default");
+		expect(result).toBe("default");
+	});
+});
+
+describe("getLockPaths", () => {
+	it("should return resource and lockfile paths", () => {
+		const paths = getLockPaths("ck-watch");
+		expect(paths.resource).toBe(join(LOCKS_DIR, "ck-watch.lock"));
+		expect(paths.lockfile).toBe(join(LOCKS_DIR, "ck-watch.lock.lock"));
+	});
+
+	it("should handle arbitrary lock names", () => {
+		const paths = getLockPaths("migration");
+		expect(paths.resource).toBe(join(LOCKS_DIR, "migration.lock"));
+		expect(paths.lockfile).toBe(join(LOCKS_DIR, "migration.lock.lock"));
 	});
 });

--- a/src/commands/watch/phases/claude-invoker.ts
+++ b/src/commands/watch/phases/claude-invoker.ts
@@ -46,6 +46,11 @@ export async function invokeClaude(options: {
 		tools,
 	];
 
+	// Claude CLI requires --verbose when using -p --output-format stream-json
+	if (outputFormat === "stream-json") {
+		args.push("--verbose");
+	}
+
 	const child = spawn("claude", args, {
 		cwd: options.cwd,
 		stdio: ["pipe", "pipe", "pipe"],
@@ -156,7 +161,8 @@ function logStreamEvent(chunk: string): void {
  * Parse stream-json (NDJSON) output — extract final result text from the last "result" event
  */
 function parseStreamJsonOutput(stdout: string): ClaudeResult {
-	const lines = stdout.split("\n").filter(Boolean);
+	// Strip carriage returns for Windows compatibility (CRLF → LF)
+	const lines = stdout.replace(/\r/g, "").split("\n").filter(Boolean);
 
 	// Find the last "result" event
 	for (let i = lines.length - 1; i >= 0; i--) {

--- a/src/commands/watch/phases/claude-invoker.ts
+++ b/src/commands/watch/phases/claude-invoker.ts
@@ -120,7 +120,8 @@ function collectClaudeOutput(
  * Each line is a JSON object: tool_use, tool_result, assistant message, result, etc.
  */
 function logStreamEvent(chunk: string): void {
-	for (const line of chunk.split("\n").filter(Boolean)) {
+	// Strip carriage returns for Windows CRLF compatibility
+	for (const line of chunk.replace(/\r/g, "").split("\n").filter(Boolean)) {
 		try {
 			const event = JSON.parse(line) as Record<string, unknown>;
 			const type = event.type as string;

--- a/src/commands/watch/watch-command.ts
+++ b/src/commands/watch/watch-command.ts
@@ -7,10 +7,9 @@
 
 import { existsSync } from "node:fs";
 import { rm } from "node:fs/promises";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { logger } from "@/shared/logger.js";
-import { withProcessLock } from "@/shared/process-lock.js";
+import { getLockPaths, withProcessLock } from "@/shared/process-lock.js";
 import pc from "picocolors";
 import { runPollCycle } from "./phases/poll-cycle.js";
 import { scanForRepos } from "./phases/repo-scanner.js";
@@ -68,84 +67,90 @@ export async function watchCommand(options: WatchCommandOptions): Promise<void> 
 
 		printBanner(repos, pollInterval, options);
 
-		await withProcessLock(LOCK_NAME, async () => {
-			const shutdown = async () => {
-				if (abortRequested) return;
-				abortRequested = true;
-				watchLog.info("Shutdown requested, finishing current task...");
+		await withProcessLock(
+			LOCK_NAME,
+			async () => {
+				const shutdown = async () => {
+					if (abortRequested) return;
+					abortRequested = true;
+					watchLog.info("Shutdown requested, finishing current task...");
 
-				for (const repo of repos) {
-					for (const issue of Object.values(repo.state.activeIssues)) {
-						if (issue.status === "brainstorming" || issue.status === "planning") {
-							issue.status = "new";
-						}
-					}
-					if (repo.state.currentlyImplementing !== null) {
-						watchLog.info(
-							`Implementation in progress for #${repo.state.currentlyImplementing}, reverting to awaiting_approval`,
-						);
-						const numStr = String(repo.state.currentlyImplementing);
-						if (repo.state.activeIssues[numStr]) {
-							repo.state.activeIssues[numStr].status = "awaiting_approval";
-						}
-						repo.state.currentlyImplementing = null;
-					}
-					await saveWatchState(repo.projectDir, repo.state);
-					if (repo.config.worktree.enabled) {
-						await cleanupAllWorktrees(repo.projectDir).catch(() => {});
-					}
-				}
-
-				watchLog.printSummary(stats);
-				watchLog.close();
-			};
-
-			process.on("SIGINT", shutdown);
-			process.on("SIGTERM", shutdown);
-
-			try {
-				while (!abortRequested) {
 					for (const repo of repos) {
-						if (abortRequested) break;
-
-						if (Date.now() - repo.hourStart > 3600_000) {
-							repo.processedThisHour = 0;
-							repo.hourStart = Date.now();
-							repo.state.processedThisHour = 0;
-							repo.state.hourStart = new Date(repo.hourStart).toISOString();
+						for (const issue of Object.values(repo.state.activeIssues)) {
+							if (issue.status === "brainstorming" || issue.status === "planning") {
+								issue.status = "new";
+							}
 						}
-
-						try {
-							repo.processedThisHour = await runPollCycle(
-								repo.setup,
-								repo.config,
-								repo.state,
-								options,
-								watchLog,
-								stats,
-								repo.projectDir,
-								repo.processedThisHour,
-								() => abortRequested,
-								repo.hourStart,
+						if (repo.state.currentlyImplementing !== null) {
+							watchLog.info(
+								`Implementation in progress for #${repo.state.currentlyImplementing}, reverting to awaiting_approval`,
 							);
-						} catch (error) {
-							const repoId = `${repo.setup.repoOwner}/${repo.setup.repoName}`;
-							watchLog.error(`Poll cycle failed for ${repoId}`, error as Error);
-							stats.errors++;
+							const numStr = String(repo.state.currentlyImplementing);
+							if (repo.state.activeIssues[numStr]) {
+								repo.state.activeIssues[numStr].status = "awaiting_approval";
+							}
+							repo.state.currentlyImplementing = null;
+						}
+						await saveWatchState(repo.projectDir, repo.state);
+						if (repo.config.worktree.enabled) {
+							await cleanupAllWorktrees(repo.projectDir).catch(() => {});
 						}
 					}
 
-					if (!abortRequested) await sleep(pollInterval);
+					watchLog.printSummary(stats);
+					watchLog.close();
+				};
+
+				process.on("SIGINT", shutdown);
+				process.on("SIGTERM", shutdown);
+
+				try {
+					while (!abortRequested) {
+						for (const repo of repos) {
+							if (abortRequested) break;
+
+							if (Date.now() - repo.hourStart > 3600_000) {
+								repo.processedThisHour = 0;
+								repo.hourStart = Date.now();
+								repo.state.processedThisHour = 0;
+								repo.state.hourStart = new Date(repo.hourStart).toISOString();
+							}
+
+							try {
+								repo.processedThisHour = await runPollCycle(
+									repo.setup,
+									repo.config,
+									repo.state,
+									options,
+									watchLog,
+									stats,
+									repo.projectDir,
+									repo.processedThisHour,
+									() => abortRequested,
+									repo.hourStart,
+								);
+							} catch (error) {
+								const repoId = `${repo.setup.repoOwner}/${repo.setup.repoName}`;
+								watchLog.error(`Poll cycle failed for ${repoId}`, error as Error);
+								stats.errors++;
+							}
+						}
+
+						if (!abortRequested) await sleep(pollInterval);
+					}
+				} finally {
+					process.removeListener("SIGINT", shutdown);
+					process.removeListener("SIGTERM", shutdown);
 				}
-			} finally {
-				process.removeListener("SIGINT", shutdown);
-				process.removeListener("SIGTERM", shutdown);
-			}
-		});
+			},
+			"long",
+		);
 	} catch (error) {
 		const err = error as Error;
 		if (err.message?.includes("Another ClaudeKit process")) {
 			logger.error("Another ck watch instance is already running. Use --force to override.");
+		} else if (err.message?.includes("Lock was compromised")) {
+			logger.error("Lock was compromised (stale or externally removed). Use --force to restart.");
 		} else {
 			watchLog.error("Watch command failed", err);
 			console.error(`[ck watch] Fatal: ${err.message}`);
@@ -247,11 +252,15 @@ async function resetState(
 	watchLog.info(`Watch state reset (--force) for ${projectDir}`);
 }
 
-/** Force-remove stale lock file so a new instance can start */
+/** Force-remove stale lock file so a new instance can start.
+ * Removes both the resource file and the proper-lockfile lock directory (.lock.lock). */
 async function forceRemoveLock(watchLog: WatchLogger): Promise<void> {
-	const lockPath = join(homedir(), ".claudekit", "locks", `${LOCK_NAME}.lock`);
+	const { resource, lockfile } = getLockPaths(LOCK_NAME);
 	try {
-		await rm(lockPath, { recursive: true, force: true });
+		await Promise.all([
+			rm(resource, { recursive: true, force: true }),
+			rm(lockfile, { recursive: true, force: true }),
+		]);
 		watchLog.info("Removed existing lock file (--force)");
 	} catch {
 		/* lock file may not exist */

--- a/src/shared/process-lock.ts
+++ b/src/shared/process-lock.ts
@@ -11,11 +11,15 @@ import lockfile from "proper-lockfile";
 import { logger } from "./logger.js";
 
 /**
- * Lock configuration
+ * Lock duration presets — short-lived commands vs long-running daemons.
+ * "short": 1-min stale (install, migrate) — fast recovery from orphaned locks.
+ * "long": 5-min stale (ck watch) — tolerates Windows/Bun timer drift and NTFS latency.
  */
-const LOCK_CONFIG = {
-	stale: 60000, // 1 minute — faster recovery from orphaned locks
-	retries: 0, // Fail immediately if locked
+export type LockDuration = "short" | "long";
+
+const LOCK_CONFIGS: Record<LockDuration, { stale: number; retries: number }> = {
+	short: { stale: 60_000, retries: 0 },
+	long: { stale: 300_000, retries: 0 },
 };
 
 /**
@@ -81,23 +85,51 @@ async function ensureLocksDir(): Promise<void> {
 }
 
 /**
+ * Get both the resource path and the lockfile directory path for a lock name.
+ * proper-lockfile creates a directory at `<path>.lock` to hold the actual lock,
+ * so for lockPath "ck-watch.lock" the real lock artifact is "ck-watch.lock.lock".
+ */
+export function getLockPaths(lockName: string): { resource: string; lockfile: string } {
+	const resource = join(getLocksDir(), `${lockName}.lock`);
+	return { resource, lockfile: `${resource}.lock` };
+}
+
+/**
  * Execute function with process lock
  *
  * @param lockName Name of the lock file (e.g., 'engineer-install', 'migration')
  * @param fn Function to execute with lock held
+ * @param duration Lock duration preset — "short" (default) or "long" for daemons like ck watch
  * @returns Result of the function
  * @throws {Error} If lock cannot be acquired or function fails
  */
-export async function withProcessLock<T>(lockName: string, fn: () => Promise<T>): Promise<T> {
+export async function withProcessLock<T>(
+	lockName: string,
+	fn: () => Promise<T>,
+	duration: LockDuration = "short",
+): Promise<T> {
 	registerCleanupHandlers();
 	await ensureLocksDir();
 
-	const lockPath = join(getLocksDir(), `${lockName}.lock`);
+	const { resource: lockPath } = getLockPaths(lockName);
+	const config = LOCK_CONFIGS[duration];
 
 	let release: (() => Promise<void>) | undefined;
 
 	try {
-		release = await lockfile.lock(lockPath, { ...LOCK_CONFIG, realpath: false });
+		release = await lockfile.lock(lockPath, {
+			...config,
+			realpath: false,
+			// For long-running commands, log compromise instead of crashing.
+			// proper-lockfile calls this when the lock's mtime refresh fails
+			// (e.g., Windows timer drift, NTFS latency, busy event loop).
+			onCompromised:
+				duration === "long"
+					? (err: Error) => {
+							logger.warning(`Lock "${lockName}" compromised: ${err.message}. Continuing...`);
+						}
+					: undefined,
+		});
 		activeLocks.add(lockName);
 		return await fn();
 	} catch (e) {
@@ -105,6 +137,11 @@ export async function withProcessLock<T>(lockName: string, fn: () => Promise<T>)
 		if (error.code === "ELOCKED") {
 			throw new Error(
 				`Another ClaudeKit process is running.\n\nOperation: ${lockName}\nWait for it to complete or remove lock: ${lockPath}`,
+			);
+		}
+		if (error.code === "ECOMPROMISED") {
+			throw new Error(
+				`Lock was compromised (stale or externally removed).\n\nOperation: ${lockName}\nUse --force to clear and restart.`,
 			);
 		}
 		throw e;

--- a/src/shared/process-lock.ts
+++ b/src/shared/process-lock.ts
@@ -43,8 +43,7 @@ function getLocksDir(): string {
 function cleanupLocks(): void {
 	for (const name of activeLocks) {
 		try {
-			const lockPath = join(getLocksDir(), `${name}.lock`);
-			lockfile.unlockSync(lockPath, { realpath: false });
+			lockfile.unlockSync(getLockPaths(name).resource, { realpath: false });
 		} catch {
 			// Best effort — lock will become stale after timeout.
 			// Wrap logger call since it may throw during process exit.

--- a/src/shared/process-lock.ts
+++ b/src/shared/process-lock.ts
@@ -147,10 +147,16 @@ export async function withProcessLock<T>(
 		throw e;
 	} finally {
 		if (release) {
-			// Keep lockName in registry during release() so the exit handler can
-			// clean up via unlockSync if the process terminates mid-release.
-			// A redundant unlockSync after release() completes is harmless (caught by try/catch).
-			await release();
+			try {
+				await release();
+			} catch (releaseErr) {
+				// After onCompromised fires, proper-lockfile marks the lock as released internally.
+				// Calling release() then rejects with ERELEASED — expected and safe to ignore.
+				const code = (releaseErr as { code?: string }).code;
+				if (code !== "ERELEASED") {
+					logger.warning(`Failed to release lock "${lockName}": ${(releaseErr as Error).message}`);
+				}
+			}
 		}
 		activeLocks.delete(lockName);
 	}


### PR DESCRIPTION
## Summary

Fixes 3 bugs in `ck watch` on Windows (claudekit/claudekit-engineer#589):

- **Missing `--verbose` flag**: Claude CLI now requires `--verbose` when using `-p --output-format stream-json`. Added the flag to spawned args.
- **Wrong lock path in `--force`**: `forceRemoveLock()` was deleting `ck-watch.lock` but `proper-lockfile` creates the actual lock at `ck-watch.lock.lock`. Now removes both paths via centralized `getLockPaths()` helper.
- **ECOMPROMISED crashes**: Long-running sessions crash with unhandled `ECOMPROMISED` errors when Windows/Bun timer drift prevents lock mtime refresh. Added duration-aware lock config (`"long"` = 5-min stale threshold) and `onCompromised` callback that logs a warning instead of crashing.

### Additional improvements
- Strip `\r` in stream-json NDJSON parsing for Windows CRLF compatibility
- Export `getLockPaths()` to centralize lock path knowledge
- Handle `ECOMPROMISED` with actionable error message ("Use --force to restart")

## Test plan
- [x] All 3797 tests pass (0 failures)
- [x] Typecheck clean
- [x] Lint clean
- [x] Build succeeds
- [x] New tests for `LockDuration` parameter and `getLockPaths()` helper
- [ ] Manual verification on Windows + Bun (requires Windows environment)

Closes claudekit/claudekit-engineer#589