### PR TITLE
hotfix: remove stale prefixed command duplicates on upgrade

### DIFF
--- a/src/__tests__/commands/init/phases/sync-handler-filter-deletion-paths.test.ts
+++ b/src/__tests__/commands/init/phases/sync-handler-filter-deletion-paths.test.ts
@@ -70,6 +70,22 @@ describe("filterDeletionPaths", () => {
 			const result = filterDeletionPaths(files, deletions);
 			expect(result).toHaveLength(1);
 		});
+
+		it("filters legacy prefixed command paths for engineer installs", () => {
+			const files = [
+				createTrackedFile("commands/ck/ask.md"),
+				createTrackedFile("commands/ck/bootstrap.md"),
+				createTrackedFile("skills/ask/SKILL.md"),
+			];
+			const deletions = ["commands/ask.md"];
+
+			const result = filterDeletionPaths(files, deletions, "engineer");
+			expect(result).toHaveLength(2);
+			expect(result.map((f) => f.path)).toEqual([
+				"commands/ck/bootstrap.md",
+				"skills/ask/SKILL.md",
+			]);
+		});
 	});
 
 	describe("glob pattern matching", () => {
@@ -126,6 +142,19 @@ describe("filterDeletionPaths", () => {
 			const result = filterDeletionPaths(files, deletions);
 			expect(result).toHaveLength(1);
 			expect(result[0].path).toBe("skills/debug/index.md");
+		});
+
+		it("filters legacy prefixed command globs for engineer installs", () => {
+			const files = [
+				createTrackedFile("commands/ck/plan/archive.md"),
+				createTrackedFile("commands/ck/plan/fast.md"),
+				createTrackedFile("commands/ck/review/codebase.md"),
+			];
+			const deletions = ["commands/plan/**"];
+
+			const result = filterDeletionPaths(files, deletions, "engineer");
+			expect(result).toHaveLength(1);
+			expect(result[0].path).toBe("commands/ck/review/codebase.md");
 		});
 	});
 

--- a/src/__tests__/domains/installation/deletion-handler.test.ts
+++ b/src/__tests__/domains/installation/deletion-handler.test.ts
@@ -94,6 +94,42 @@ describe("deletion-handler", () => {
 			expect(existsSync(filePath)).toBe(false);
 		});
 
+		test("deletes legacy prefixed command files for engineer installs", async () => {
+			mkdirSync(join(testDir, "commands", "ck"), { recursive: true });
+			const filePath = join(testDir, "commands", "ck", "ask.md");
+			writeFileSync(filePath, "content");
+
+			const metadata: Metadata = {
+				kits: {
+					engineer: {
+						version: "1.0.0",
+						installedAt: new Date().toISOString(),
+						files: [
+							{
+								path: "commands/ck/ask.md",
+								checksum: "d".repeat(64),
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+						],
+					},
+				},
+			};
+			writeFileSync(join(testDir, "metadata.json"), JSON.stringify(metadata));
+
+			const sourceMetadata: ClaudeKitMetadata = {
+				version: "2.0.0",
+				name: "claudekit-engineer",
+				description: "test",
+				deletions: ["commands/ask.md"],
+			};
+
+			const result = await handleDeletions(sourceMetadata, testDir, "engineer");
+
+			expect(result.deletedPaths).toContain("commands/ck/ask.md");
+			expect(existsSync(filePath)).toBe(false);
+		});
+
 		test("preserves user-owned files", async () => {
 			mkdirSync(join(testDir, "commands"), { recursive: true });
 			const filePath = join(testDir, "commands", "custom.md");

--- a/src/__tests__/shared/deletion-pattern-expander.test.ts
+++ b/src/__tests__/shared/deletion-pattern-expander.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { expandDeletionPatterns } from "@/shared/deletion-pattern-expander.js";
+
+describe("expandDeletionPatterns", () => {
+	it("returns original patterns when kit type is not provided", () => {
+		const patterns = ["commands/ask.md", "skills/ask/**"];
+		expect(expandDeletionPatterns(patterns)).toEqual(patterns);
+	});
+
+	it("expands engineer command deletions to legacy ck-prefixed paths", () => {
+		expect(expandDeletionPatterns(["commands/ask.md"], "engineer")).toEqual([
+			"commands/ask.md",
+			"commands/ck/ask.md",
+		]);
+	});
+
+	it("expands engineer command glob deletions to legacy ck-prefixed paths", () => {
+		expect(expandDeletionPatterns(["commands/plan/**"], "engineer")).toEqual([
+			"commands/plan/**",
+			"commands/ck/plan/**",
+		]);
+	});
+
+	it("does not expand already prefixed command deletions", () => {
+		expect(expandDeletionPatterns(["commands/ck/ask.md"], "engineer")).toEqual([
+			"commands/ck/ask.md",
+		]);
+	});
+
+	it("does not expand non-command deletions", () => {
+		expect(expandDeletionPatterns(["skills/ask/**", "hooks/foo.cjs"], "engineer")).toEqual([
+			"skills/ask/**",
+			"hooks/foo.cjs",
+		]);
+	});
+
+	it("expands marketing command deletions to legacy mkt-prefixed paths", () => {
+		expect(expandDeletionPatterns(["commands/email.md"], "marketing")).toEqual([
+			"commands/email.md",
+			"commands/mkt/email.md",
+		]);
+	});
+});

--- a/src/__tests__/shared/deletion-pattern-expander.test.ts
+++ b/src/__tests__/shared/deletion-pattern-expander.test.ts
@@ -27,6 +27,12 @@ describe("expandDeletionPatterns", () => {
 		]);
 	});
 
+	it("does not expand paths that are already prefixed for another known kit", () => {
+		expect(expandDeletionPatterns(["commands/mkt/email.md"], "engineer")).toEqual([
+			"commands/mkt/email.md",
+		]);
+	});
+
 	it("does not expand non-command deletions", () => {
 		expect(expandDeletionPatterns(["skills/ask/**", "hooks/foo.cjs"], "engineer")).toEqual([
 			"skills/ask/**",

--- a/src/commands/init/phases/merge-handler.ts
+++ b/src/commands/init/phases/merge-handler.ts
@@ -180,7 +180,7 @@ export async function handleMerge(ctx: InitContext): Promise<InitContext> {
 	// Handle deletions from source kit metadata (cleanup deprecated files)
 	try {
 		if (sourceMetadata?.deletions && sourceMetadata.deletions.length > 0) {
-			const deletionResult = await handleDeletions(sourceMetadata, ctx.claudeDir);
+			const deletionResult = await handleDeletions(sourceMetadata, ctx.claudeDir, ctx.kitType);
 
 			if (deletionResult.deletedPaths.length > 0) {
 				logger.info(`Removed ${deletionResult.deletedPaths.length} deprecated file(s)`);

--- a/src/commands/init/phases/sync-handler.ts
+++ b/src/commands/init/phases/sync-handler.ts
@@ -293,7 +293,7 @@ export async function executeSyncMerge(ctx: InitContext): Promise<InitContext> {
 		}
 
 		// Filter tracked files to exclude deletion paths
-		const filteredTrackedFiles = filterDeletionPaths(trackedFiles, deletions);
+		const filteredTrackedFiles = filterDeletionPaths(trackedFiles, deletions, ctx.kitType);
 		if (deletions.length > 0) {
 			const filtered = trackedFiles.length - filteredTrackedFiles.length;
 			logger.debug(`Filtered ${filtered} files matching ${deletions.length} deletion patterns`);

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -203,6 +203,8 @@ async function processMetadataDeletions(
 }
 
 function inferKitTypeFromSourceMetadata(sourceMetadata: ClaudeKitMetadata): KitType | undefined {
+	// NOTE: This relies on the source metadata name following the current
+	// claudekit-{kitType} naming convention used by published kits.
 	if (sourceMetadata.name?.includes("marketing")) return "marketing";
 	if (sourceMetadata.name?.includes("engineer")) return "engineer";
 	return undefined;

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -10,6 +10,7 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { handleDeletions } from "../../domains/installation/deletion-handler.js";
 import { logger } from "../../shared/logger.js";
+import type { KitType } from "../../types/kit.js";
 import type { ClaudeKitMetadata } from "../../types/metadata.js";
 import { discoverAgents, getAgentSourcePath } from "../agents/agents-discovery.js";
 import { discoverCommands, getCommandSourcePath } from "../commands/commands-discovery.js";
@@ -186,7 +187,11 @@ async function processMetadataDeletions(
 	if (!existsSync(claudeDir)) return;
 
 	try {
-		const result = await handleDeletions(sourceMetadata, claudeDir);
+		const result = await handleDeletions(
+			sourceMetadata,
+			claudeDir,
+			inferKitTypeFromSourceMetadata(sourceMetadata),
+		);
 		if (result.deletedPaths.length > 0) {
 			logger.verbose(
 				`[migrate] Cleaned up ${result.deletedPaths.length} deprecated path(s): ${result.deletedPaths.join(", ")}`,
@@ -195,6 +200,12 @@ async function processMetadataDeletions(
 	} catch (error) {
 		logger.warning(`[migrate] Deletion cleanup failed: ${error}`);
 	}
+}
+
+function inferKitTypeFromSourceMetadata(sourceMetadata: ClaudeKitMetadata): KitType | undefined {
+	if (sourceMetadata.name?.includes("marketing")) return "marketing";
+	if (sourceMetadata.name?.includes("engineer")) return "engineer";
+	return undefined;
 }
 
 /**

--- a/src/domains/installation/deletion-handler.ts
+++ b/src/domains/installation/deletion-handler.ts
@@ -6,6 +6,7 @@
 import { existsSync, lstatSync, readdirSync, rmSync, rmdirSync, unlinkSync } from "node:fs";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import { readManifest } from "@/services/file-operations/manifest/manifest-reader.js";
+import { expandDeletionPatterns } from "@/shared/deletion-pattern-expander.js";
 import { logger } from "@/shared/logger.js";
 import { PathResolver } from "@/shared/path-resolver.js";
 import type { ClaudeKitMetadata, KitType, Metadata, TrackedFile } from "@/types";
@@ -46,13 +47,24 @@ function findFileInMetadata(metadata: Metadata | null, path: string): TrackedFil
 	return null;
 }
 
+function findFileInMetadataForKit(
+	metadata: Metadata | null,
+	path: string,
+	kitType?: KitType,
+): TrackedFile | null {
+	if (!metadata) return null;
+	if (!kitType) return findFileInMetadata(metadata, path);
+
+	return metadata.kits?.[kitType]?.files?.find((file) => file.path === path) ?? null;
+}
+
 /**
  * Check if a path should be deleted based on ownership.
  * Returns true if path can be deleted (ck, ck-modified, or not tracked).
  * Returns false only if ownership is "user".
  */
-function shouldDeletePath(path: string, metadata: Metadata | null): boolean {
-	const tracked = findFileInMetadata(metadata, path);
+function shouldDeletePath(path: string, metadata: Metadata | null, kitType?: KitType): boolean {
+	const tracked = findFileInMetadataForKit(metadata, path, kitType);
 
 	// Not tracked = safe to delete (was installed by CK but not in metadata)
 	if (!tracked) return true;
@@ -254,8 +266,9 @@ async function updateMetadataAfterDeletion(
 export async function handleDeletions(
 	sourceMetadata: ClaudeKitMetadata,
 	claudeDir: string,
+	kitType?: KitType,
 ): Promise<DeletionResult> {
-	const deletionPatterns = sourceMetadata.deletions || [];
+	const deletionPatterns = expandDeletionPatterns(sourceMetadata.deletions || [], kitType);
 
 	if (deletionPatterns.length === 0) {
 		return { deletedPaths: [], preservedPaths: [], errors: [] };
@@ -281,7 +294,7 @@ export async function handleDeletions(
 		}
 
 		// Check ownership - preserve user files
-		if (!shouldDeletePath(path, userMetadata)) {
+		if (!shouldDeletePath(path, userMetadata, kitType)) {
 			result.preservedPaths.push(path);
 			logger.verbose(`Preserved user file: ${path}`);
 			continue;

--- a/src/domains/sync/deletion-path-filter.ts
+++ b/src/domains/sync/deletion-path-filter.ts
@@ -3,8 +3,9 @@
  * Filters tracked files matching deletion patterns to prevent
  * spurious "Skipping invalid path" warnings during upgrades.
  */
+import { expandDeletionPatterns } from "@/shared/deletion-pattern-expander.js";
 import { PathResolver } from "@/shared/path-resolver.js";
-import type { TrackedFile } from "@/types";
+import type { KitType, TrackedFile } from "@/types";
 import picomatch from "picomatch";
 
 /**
@@ -19,16 +20,19 @@ import picomatch from "picomatch";
 export function filterDeletionPaths(
 	trackedFiles: TrackedFile[],
 	deletions: string[] | undefined,
+	kitType?: KitType,
 ): TrackedFile[] {
 	if (!deletions || deletions.length === 0) {
 		return trackedFiles;
 	}
 
+	const expandedDeletions = expandDeletionPatterns(deletions, kitType);
+
 	// Build matchers for glob patterns
 	const exactPaths = new Set<string>();
 	const globMatchers: ((path: string) => boolean)[] = [];
 
-	for (const pattern of deletions) {
+	for (const pattern of expandedDeletions) {
 		if (PathResolver.isGlobPattern(pattern)) {
 			globMatchers.push(picomatch(pattern));
 		} else {

--- a/src/shared/deletion-pattern-expander.ts
+++ b/src/shared/deletion-pattern-expander.ts
@@ -13,8 +13,12 @@ function getLegacyCommandPrefix(kitType?: KitType): string | null {
 function canExpandLegacyCommandPattern(pattern: string, prefix: string): boolean {
 	if (!pattern.startsWith("commands/")) return false;
 	if (pattern.startsWith(`commands/${prefix}/`)) return false;
-	if (pattern.startsWith("commands/ck/")) return false;
-	if (pattern.startsWith("commands/mkt/")) return false;
+
+	const allPrefixes = Object.values(LEGACY_COMMAND_PREFIX_BY_KIT);
+	if (allPrefixes.some((candidate) => candidate && pattern.startsWith(`commands/${candidate}/`))) {
+		return false;
+	}
+
 	return true;
 }
 

--- a/src/shared/deletion-pattern-expander.ts
+++ b/src/shared/deletion-pattern-expander.ts
@@ -1,0 +1,45 @@
+import type { KitType } from "@/types";
+
+const LEGACY_COMMAND_PREFIX_BY_KIT: Partial<Record<KitType, string>> = {
+	engineer: "ck",
+	marketing: "mkt",
+};
+
+function getLegacyCommandPrefix(kitType?: KitType): string | null {
+	if (!kitType) return null;
+	return LEGACY_COMMAND_PREFIX_BY_KIT[kitType] ?? null;
+}
+
+function canExpandLegacyCommandPattern(pattern: string, prefix: string): boolean {
+	if (!pattern.startsWith("commands/")) return false;
+	if (pattern.startsWith(`commands/${prefix}/`)) return false;
+	if (pattern.startsWith("commands/ck/")) return false;
+	if (pattern.startsWith("commands/mkt/")) return false;
+	return true;
+}
+
+/**
+ * Expand deletion patterns so deprecated command paths also match legacy prefixed installs.
+ *
+ * Older `--prefix` installs moved commands from `commands/foo.md` to `commands/ck/foo.md`
+ * (and `commands/mkt/` for marketing). Newer kits may delete only the unprefixed source path,
+ * so upgrades need to consider both locations.
+ */
+export function expandDeletionPatterns(patterns: string[], kitType?: KitType): string[] {
+	const prefix = getLegacyCommandPrefix(kitType);
+	if (!prefix || patterns.length === 0) {
+		return [...patterns];
+	}
+
+	const expanded = new Set<string>();
+
+	for (const pattern of patterns) {
+		expanded.add(pattern);
+
+		if (canExpandLegacyCommandPattern(pattern, prefix)) {
+			expanded.add(`commands/${prefix}/${pattern.slice("commands/".length)}`);
+		}
+	}
+
+	return [...expanded];
+}

--- a/tests/integration/prefix-cleanup-global-upgrade.test.ts
+++ b/tests/integration/prefix-cleanup-global-upgrade.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const isCI = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
+const runCliIntegration = /^(1|true)$/i.test(process.env.CK_RUN_CLI_INTEGRATION ?? "");
+const shouldRunIntegration = !isCI && runCliIntegration;
+const integrationDescribe = shouldRunIntegration ? describe : describe.skip;
+
+function createLegacyMetadata() {
+	return JSON.stringify(
+		{
+			version: "2.10.1",
+			name: "claudekit-engineer",
+			description: "legacy prefixed install",
+			kits: {
+				engineer: {
+					version: "2.10.1",
+					installedAt: "2026-04-06T15:07:00.000Z",
+					files: [
+						{
+							path: "commands/ck/ask.md",
+							checksum: "a".repeat(64),
+							ownership: "ck",
+							installedVersion: "2.10.1",
+						},
+						{
+							path: "commands/ck/coding-level.md",
+							checksum: "b".repeat(64),
+							ownership: "ck",
+							installedVersion: "2.10.1",
+						},
+					],
+				},
+			},
+		},
+		null,
+		2,
+	);
+}
+
+function createUpgradeKitMetadata() {
+	return JSON.stringify(
+		{
+			version: "2.16.0",
+			name: "claudekit-engineer",
+			description: "reproduction fixture",
+			deletions: ["commands/ask.md", "commands/coding-level.md"],
+		},
+		null,
+		2,
+	);
+}
+
+integrationDescribe("global prefixed upgrade cleanup", () => {
+	let tempRoot: string;
+	let homeDir: string;
+	let kitDir: string;
+	const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+	const cliPath = join(repoRoot, "dist", "index.js");
+
+	beforeAll(() => {
+		if (!existsSync(cliPath)) {
+			execSync("bun run build", { cwd: repoRoot, stdio: "pipe" });
+		}
+	});
+
+	afterEach(async () => {
+		if (tempRoot) {
+			await rm(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	async function seedLegacyInstall() {
+		tempRoot = await mkdtemp(join(tmpdir(), "ck-prefix-upgrade-"));
+		homeDir = join(tempRoot, "home");
+		kitDir = join(tempRoot, "kit-v2.16.0");
+
+		await mkdir(join(homeDir, ".claude", "commands", "ck"), { recursive: true });
+		await mkdir(join(kitDir, ".claude", "skills", "ask"), { recursive: true });
+		await mkdir(join(kitDir, ".claude", "skills", "coding-level"), { recursive: true });
+
+		await writeFile(join(homeDir, ".claude", "commands", "ck", "ask.md"), "# Old ask command");
+		await writeFile(
+			join(homeDir, ".claude", "commands", "ck", "coding-level.md"),
+			"# Old coding-level command",
+		);
+		await writeFile(join(homeDir, ".claude", "metadata.json"), createLegacyMetadata());
+
+		await writeFile(join(kitDir, "CLAUDE.md"), "# Test kit");
+		await writeFile(join(kitDir, ".claude", "metadata.json"), createUpgradeKitMetadata());
+		await writeFile(join(kitDir, ".claude", "skills", "ask", "SKILL.md"), "# Ask");
+		await writeFile(
+			join(kitDir, ".claude", "skills", "coding-level", "SKILL.md"),
+			"# Coding Level",
+		);
+	}
+
+	function runCli(args: string): string {
+		return execSync(`node ${cliPath} ${args}`, {
+			cwd: repoRoot,
+			encoding: "utf-8",
+			stdio: "pipe",
+			timeout: 120000,
+			env: {
+				...process.env,
+				CI: "true",
+				HOME: homeDir,
+				GH_NO_UPDATE_NOTIFIER: "1",
+				NO_UPDATE_NOTIFIER: "1",
+			},
+		});
+	}
+
+	test("removes legacy prefixed commands during the exact global upgrade path", async () => {
+		await seedLegacyInstall();
+
+		const beforeVersion = runCli("--version");
+		expect(beforeVersion).toContain("CLI Version:");
+		expect(beforeVersion).toContain("Global Kit Version: engineer@2.10.1");
+
+		runCli(`init -g --kit engineer --kit-path ${kitDir} --yes --install-skills`);
+
+		expect(existsSync(join(homeDir, ".claude", "commands", "ck", "ask.md"))).toBe(false);
+		expect(existsSync(join(homeDir, ".claude", "commands", "ck", "coding-level.md"))).toBe(false);
+		expect(existsSync(join(homeDir, ".claude", "skills", "ask", "SKILL.md"))).toBe(true);
+		expect(existsSync(join(homeDir, ".claude", "skills", "coding-level", "SKILL.md"))).toBe(true);
+
+		const afterVersion = runCli("--version");
+		expect(afterVersion).toContain("Global Kit Version: engineer@local");
+	});
+});


### PR DESCRIPTION
Closes #612

## Problem
Older global engineer installs created with `--prefix` can keep deprecated files under `~/.claude/commands/ck/` after upgrade.

When the user upgrades from a legacy install such as:
- CLI Version: `3.34.0`
- Global Kit Version: `engineer@v2.10.1`

and then reaches the modern upgrade path:
```bash
ck update -y
# internally runs:
ck init -g --kit engineer --yes --install-skills
```

the new skill directories install successfully, but old prefixed command files can survive. Claude then surfaces duplicate `/ck:*` entries for the same capability names.

## Reproduction
I reproduced this in an isolated temp HOME using the exact global upgrade path.

Seeded old install:
- `~/.claude/metadata.json` with `engineer@2.10.1`
- `~/.claude/commands/ck/ask.md`
- `~/.claude/commands/ck/coding-level.md`

Seeded new kit fixture:
- metadata version `2.16.0`
- deletions: `commands/ask.md`, `commands/coding-level.md`
- new skills: `skills/ask/SKILL.md`, `skills/coding-level/SKILL.md`

Executed on unmodified `main` baseline:
```bash
CI=true HOME="$TMP_HOME" bun run src/index.ts init -g --kit engineer --kit-path "$KIT_DIR" --yes --install-skills
```

Baseline result:
```text
[after]
/home/.claude/CLAUDE.md
/home/.claude/commands/ck/ask.md
/home/.claude/commands/ck/coding-level.md
/home/.claude/metadata.json
/home/.claude/skills/ask/SKILL.md
/home/.claude/skills/coding-level/SKILL.md

[checks]
legacy ask: PRESENT
legacy coding-level: PRESENT
new ask skill: PRESENT
new coding-level skill: PRESENT
```

Executed same fixture on this hotfix branch:
```bash
CI=true HOME="$TMP_HOME" bun run src/index.ts init -g --kit engineer --kit-path "$KIT_DIR" --yes --install-skills
```

Fixed result:
```text
[after]
/home/.claude/CLAUDE.md
/home/.claude/metadata.json
/home/.claude/skills/ask/SKILL.md
/home/.claude/skills/coding-level/SKILL.md

[checks]
legacy ask: REMOVED
legacy coding-level: REMOVED
new ask skill: PRESENT
new coding-level skill: PRESENT
```

## Root Cause
Deletion metadata now lists deprecated command paths as unprefixed source paths such as:
- `commands/ask.md`
- `commands/coding-level.md`

But old `--prefix` installs stored those same files as:
- `commands/ck/ask.md`
- `commands/ck/coding-level.md`

Before this fix:
1. merge preserved the old `commands/ck/*` files because the new kit no longer ships commands
2. deletion cleanup only matched unprefixed `commands/*` paths
3. stale prefixed command files survived the upgrade
4. new skill directories installed alongside them

## What Changed
| Area | Change |
| --- | --- |
| Deletion expansion | Added kit-scoped expansion so deprecated `commands/foo` paths also match legacy prefixed installs like `commands/ck/foo` for engineer and `commands/mkt/foo` for marketing |
| Install cleanup | Applied the expansion in the deletion handler during `ck init` upgrades |
| Sync cleanup | Applied the same expansion in sync filtering so stale prefixed tracked files do not linger in sync plans |
| Migrate cleanup | Inferred kit type from source metadata so `ck migrate` cleanup gets the same behavior |
| Coverage | Added focused unit tests plus an opt-in CLI integration test that reproduces the exact global upgrade path in an isolated temp HOME |

## Validation
- `bun run validate`
- `CK_RUN_CLI_INTEGRATION=1 bun test tests/integration/prefix-cleanup-global-upgrade.test.ts`

Note: the deterministic CLI integration repro uses `--kit-path`, so the resulting installed version is tracked as `engineer@local`. The bug signal being validated is stale prefixed command-file survival vs cleanup during the exact upgrade flow.