### PR TITLE
fix: back up destructive fresh and uninstall operations

### DIFF
--- a/__tests__/domains/help/help-commands.test.ts
+++ b/__tests__/domains/help/help-commands.test.ts
@@ -25,6 +25,7 @@ describe("help-commands", () => {
 		"uninstall",
 		"skills",
 		"agents",
+		"backups",
 		"commands",
 		"migrate",
 		"watch",

--- a/src/__tests__/services/file-operations/destructive-operation-backup-atomicity.test.ts
+++ b/src/__tests__/services/file-operations/destructive-operation-backup-atomicity.test.ts
@@ -65,4 +65,27 @@ describe("destructive operation backup atomicity", () => {
 			"second-current",
 		);
 	});
+
+	test("keeps the original content when the first source rename fails", async () => {
+		const backup = await createDestructiveOperationBackup({
+			operation: "fresh-install",
+			sourceRoot,
+			deletePaths: ["commands/first.md"],
+		});
+
+		await writeFile(join(sourceRoot, "commands", "first.md"), "first-current");
+
+		renameMock.mockImplementation(async (from, to) => {
+			if (String(from).endsWith("first.md") && String(to).includes(".ck-current-first.md-")) {
+				throw new Error("forced current staging failure");
+			}
+
+			return realRename(from, to);
+		});
+
+		await expect(restoreDestructiveOperationBackup(backup)).rejects.toThrow(
+			"forced current staging failure",
+		);
+		expect(await readFile(join(sourceRoot, "commands", "first.md"), "utf8")).toBe("first-current");
+	});
 });

--- a/src/__tests__/services/file-operations/destructive-operation-backup-atomicity.test.ts
+++ b/src/__tests__/services/file-operations/destructive-operation-backup-atomicity.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { type TestPaths, setupTestPaths } from "../../../../tests/helpers/test-paths.js";
+
+const actualFsPromises = await import("node:fs/promises");
+const realRename = actualFsPromises.rename.bind(actualFsPromises);
+const renameMock = mock(realRename);
+
+mock.module("node:fs/promises", () => ({
+	...actualFsPromises,
+	rename: renameMock,
+}));
+
+const { createDestructiveOperationBackup, restoreDestructiveOperationBackup } = await import(
+	"@/services/file-operations/destructive-operation-backup.js"
+);
+
+afterAll(() => {
+	mock.restore();
+});
+
+describe("destructive operation backup atomicity", () => {
+	let testPaths: TestPaths;
+	let sourceRoot: string;
+
+	beforeEach(async () => {
+		testPaths = setupTestPaths();
+		sourceRoot = join(testPaths.testHome, "installation", ".claude");
+		await mkdir(join(sourceRoot, "commands"), { recursive: true });
+		await writeFile(join(sourceRoot, "commands", "first.md"), "first-original");
+		await writeFile(join(sourceRoot, "commands", "second.md"), "second-original");
+		renameMock.mockReset();
+		renameMock.mockImplementation(realRename);
+	});
+
+	afterEach(async () => {
+		await rm(join(testPaths.testHome, "installation"), { recursive: true, force: true });
+		testPaths.cleanup();
+	});
+
+	test("rolls back earlier restored items when a later swap fails", async () => {
+		const backup = await createDestructiveOperationBackup({
+			operation: "fresh-install",
+			sourceRoot,
+			deletePaths: ["commands/first.md", "commands/second.md"],
+		});
+
+		await writeFile(join(sourceRoot, "commands", "first.md"), "first-current");
+		await writeFile(join(sourceRoot, "commands", "second.md"), "second-current");
+
+		renameMock.mockImplementation(async (from, to) => {
+			if (String(from).includes(".ck-restore-") && String(to).endsWith("second.md")) {
+				throw new Error("forced second restore swap failure");
+			}
+
+			return realRename(from, to);
+		});
+
+		await expect(restoreDestructiveOperationBackup(backup)).rejects.toThrow(
+			"forced second restore swap failure",
+		);
+		expect(await readFile(join(sourceRoot, "commands", "first.md"), "utf8")).toBe("first-current");
+		expect(await readFile(join(sourceRoot, "commands", "second.md"), "utf8")).toBe(
+			"second-current",
+		);
+	});
+});

--- a/src/__tests__/services/file-operations/destructive-operation-backup-manager.test.ts
+++ b/src/__tests__/services/file-operations/destructive-operation-backup-manager.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+	DEFAULT_DESTRUCTIVE_BACKUP_KEEP_COUNT,
+	cleanupOldDestructiveOperationBackups,
+	deleteDestructiveOperationBackup,
+	getDestructiveOperationBackupDir,
+	listDestructiveOperationBackups,
+	pruneDestructiveOperationBackups,
+} from "@/services/file-operations/destructive-operation-backup-manager.js";
+import { type TestPaths, setupTestPaths } from "../../../../tests/helpers/test-paths.js";
+
+describe("destructive operation backup manager", () => {
+	let testPaths: TestPaths;
+	let backupsRoot: string;
+
+	beforeEach(async () => {
+		testPaths = setupTestPaths();
+		backupsRoot = join(testPaths.testHome, ".claudekit", "backups");
+		await mkdir(backupsRoot, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(backupsRoot, { recursive: true, force: true });
+		testPaths.cleanup();
+	});
+
+	async function createBackupDir(
+		id: string,
+		manifest: Record<string, unknown>,
+		extraFile = "snapshot/file.txt",
+	): Promise<string> {
+		const backupDir = join(backupsRoot, id);
+		await mkdir(join(backupDir, "snapshot"), { recursive: true });
+		await writeFile(join(backupDir, "manifest.json"), JSON.stringify(manifest, null, 2));
+		await writeFile(join(backupDir, extraFile), "payload");
+		return backupDir;
+	}
+
+	test("lists valid and invalid backups newest first", async () => {
+		await createBackupDir("2026-04-06T10-00-00-000-abcd", {
+			version: 1,
+			operation: "fresh-install",
+			createdAt: "2026-04-06T10:00:00.000Z",
+			sourceRoot: join(testPaths.testHome, "project-a", ".claude"),
+			items: [],
+			restoreNotes: [],
+		});
+		await createBackupDir("2026-04-05T09-00-00-000-bad1", {
+			version: 999,
+			broken: true,
+		});
+
+		const backups = await listDestructiveOperationBackups();
+
+		expect(backups.map((backup) => backup.id)).toEqual([
+			"2026-04-06T10-00-00-000-abcd",
+			"2026-04-05T09-00-00-000-bad1",
+		]);
+		expect(backups[0].valid).toBe(true);
+		expect(backups[1].valid).toBe(false);
+	});
+
+	test("prunes old backups while keeping the newest N", async () => {
+		await createBackupDir("2026-04-06T10-00-00-000-a001", {
+			version: 1,
+			operation: "fresh-install",
+			createdAt: "2026-04-06T10:00:00.000Z",
+			sourceRoot: join(testPaths.testHome, "project-a", ".claude"),
+			items: [],
+			restoreNotes: [],
+		});
+		await createBackupDir("2026-04-06T11-00-00-000-a002", {
+			version: 1,
+			operation: "uninstall",
+			createdAt: "2026-04-06T11:00:00.000Z",
+			sourceRoot: join(testPaths.testHome, "project-b", ".claude"),
+			items: [],
+			restoreNotes: [],
+		});
+		await createBackupDir("2026-04-06T12-00-00-000-a003", {
+			version: 1,
+			operation: "uninstall",
+			createdAt: "2026-04-06T12:00:00.000Z",
+			sourceRoot: join(testPaths.testHome, "project-c", ".claude"),
+			items: [],
+			restoreNotes: [],
+		});
+
+		const result = await pruneDestructiveOperationBackups({ keepCount: 2 });
+
+		expect(result.deletedIds).toEqual(["2026-04-06T10-00-00-000-a001"]);
+		expect(await listDestructiveOperationBackups()).toHaveLength(2);
+	});
+
+	test("resolves and deletes a specific backup id safely", async () => {
+		await createBackupDir("2026-04-06T10-00-00-000-safe", {
+			version: 1,
+			operation: "fresh-install",
+			createdAt: "2026-04-06T10:00:00.000Z",
+			sourceRoot: join(testPaths.testHome, "project-a", ".claude"),
+			items: [],
+			restoreNotes: [],
+		});
+
+		expect(await getDestructiveOperationBackupDir("2026-04-06T10-00-00-000-safe")).toContain(
+			"2026-04-06T10-00-00-000-safe",
+		);
+
+		await deleteDestructiveOperationBackup("2026-04-06T10-00-00-000-safe");
+		expect(await listDestructiveOperationBackups()).toHaveLength(0);
+	});
+
+	test("cleanup keeps the configured total count when excluding the newest current backup", async () => {
+		for (let index = 0; index < DEFAULT_DESTRUCTIVE_BACKUP_KEEP_COUNT + 1; index++) {
+			const hour = String(index).padStart(2, "0");
+			await createBackupDir(`2026-04-06T${hour}-00-00-000-a${index}`, {
+				version: 1,
+				operation: "fresh-install",
+				createdAt: `2026-04-06T${hour}:00:00.000Z`,
+				sourceRoot: join(testPaths.testHome, `project-${index}`, ".claude"),
+				items: [],
+				restoreNotes: [],
+			});
+		}
+
+		await cleanupOldDestructiveOperationBackups(
+			DEFAULT_DESTRUCTIVE_BACKUP_KEEP_COUNT,
+			"2026-04-06T10-00-00-000-a10",
+		);
+
+		expect(await listDestructiveOperationBackups()).toHaveLength(
+			DEFAULT_DESTRUCTIVE_BACKUP_KEEP_COUNT,
+		);
+	});
+
+	test("prune keeps the newest valid backups instead of lexically-high invalid directories", async () => {
+		await createBackupDir("zz-invalid-dir", {
+			version: 999,
+			createdAt: "bad",
+		});
+		await createBackupDir("2026-04-06T10-00-00-000-a001", {
+			version: 1,
+			operation: "fresh-install",
+			createdAt: "2026-04-06T10:00:00.000Z",
+			sourceRoot: join(testPaths.testHome, "project-a", ".claude"),
+			items: [],
+			restoreNotes: [],
+		});
+		await createBackupDir("2026-04-06T11-00-00-000-a002", {
+			version: 1,
+			operation: "uninstall",
+			createdAt: "2026-04-06T11:00:00.000Z",
+			sourceRoot: join(testPaths.testHome, "project-b", ".claude"),
+			items: [],
+			restoreNotes: [],
+		});
+
+		const result = await pruneDestructiveOperationBackups({ keepCount: 1 });
+
+		expect(result.deletedIds).toContain("zz-invalid-dir");
+		expect((await listDestructiveOperationBackups()).map((backup) => backup.id)).toContain(
+			"2026-04-06T11-00-00-000-a002",
+		);
+	});
+});

--- a/src/__tests__/services/file-operations/destructive-operation-backup.test.ts
+++ b/src/__tests__/services/file-operations/destructive-operation-backup.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+	createDestructiveOperationBackup,
+	restoreDestructiveOperationBackup,
+} from "@/services/file-operations/destructive-operation-backup.js";
+import { type TestPaths, setupTestPaths } from "../../../../tests/helpers/test-paths.js";
+
+describe("destructive operation backup", () => {
+	let testPaths: TestPaths;
+	let sourceRoot: string;
+
+	beforeEach(async () => {
+		testPaths = setupTestPaths();
+		sourceRoot = join(testPaths.testHome, "installation", ".claude");
+		await mkdir(sourceRoot, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(join(testPaths.testHome, "installation"), { recursive: true, force: true });
+		testPaths.cleanup();
+	});
+
+	test("creates snapshots and a manifest under CK-owned backup storage", async () => {
+		await mkdir(join(sourceRoot, "commands"), { recursive: true });
+		await mkdir(join(sourceRoot, "rules", "nested"), { recursive: true });
+		await writeFile(join(sourceRoot, "commands", "test.md"), "command");
+		await writeFile(join(sourceRoot, "rules", "nested", "rule.md"), "rule");
+		await writeFile(join(sourceRoot, "metadata.json"), '{"version":"1.0.0"}');
+
+		const backup = await createDestructiveOperationBackup({
+			operation: "fresh-install",
+			sourceRoot,
+			deletePaths: ["commands/test.md", "rules"],
+			mutatePaths: ["metadata.json"],
+			scope: "claude",
+		});
+
+		expect(backup.backupDir).toStartWith(join(testPaths.testHome, ".claudekit", "backups"));
+		expect(backup.manifest.operation).toBe("fresh-install");
+		expect(backup.manifest.items.map((item) => item.path).sort()).toEqual([
+			"commands/test.md",
+			"metadata.json",
+			"rules",
+		]);
+		expect(existsSync(join(backup.backupDir, "snapshot", "commands", "test.md"))).toBe(true);
+		expect(existsSync(join(backup.backupDir, "snapshot", "rules", "nested", "rule.md"))).toBe(true);
+		expect(existsSync(join(backup.backupDir, "snapshot", "metadata.json"))).toBe(true);
+	});
+
+	test("restores deleted and mutated paths from backup", async () => {
+		await mkdir(join(sourceRoot, "commands"), { recursive: true });
+		await writeFile(join(sourceRoot, "commands", "test.md"), "original command");
+		await writeFile(join(sourceRoot, "metadata.json"), '{"version":"1.0.0"}');
+
+		const backup = await createDestructiveOperationBackup({
+			operation: "uninstall",
+			sourceRoot,
+			deletePaths: ["commands"],
+			mutatePaths: ["metadata.json"],
+			scope: "local",
+		});
+
+		await rm(join(sourceRoot, "commands"), { recursive: true, force: true });
+		await writeFile(join(sourceRoot, "metadata.json"), '{"version":"broken"}');
+
+		await restoreDestructiveOperationBackup(backup);
+
+		expect(await readFile(join(sourceRoot, "commands", "test.md"), "utf8")).toBe(
+			"original command",
+		);
+		expect(await readFile(join(sourceRoot, "metadata.json"), "utf8")).toBe('{"version":"1.0.0"}');
+	});
+
+	test("rejects unsafe paths that escape the installation root", async () => {
+		await expect(
+			createDestructiveOperationBackup({
+				operation: "fresh-install",
+				sourceRoot,
+				deletePaths: ["../outside.txt"],
+			}),
+		).rejects.toThrow("Path escapes installation root");
+	});
+
+	test("collapses nested targets when a parent directory is already being backed up", async () => {
+		await mkdir(join(sourceRoot, "commands"), { recursive: true });
+		await writeFile(join(sourceRoot, "commands", "test.md"), "command");
+
+		const backup = await createDestructiveOperationBackup({
+			operation: "uninstall",
+			sourceRoot,
+			deletePaths: ["commands", "commands/test.md"],
+		});
+
+		expect(backup.manifest.items.map((item) => item.path)).toEqual(["commands"]);
+	});
+
+	test("keeps the current destination intact when rollback staging copy fails", async () => {
+		if (process.platform === "win32") {
+			return;
+		}
+
+		await mkdir(join(sourceRoot, "commands"), { recursive: true });
+		await writeFile(join(sourceRoot, "commands", "test.md"), "original");
+
+		const backup = await createDestructiveOperationBackup({
+			operation: "fresh-install",
+			sourceRoot,
+			deletePaths: ["commands/test.md"],
+		});
+
+		await writeFile(join(sourceRoot, "commands", "test.md"), "current-state");
+		await chmod(join(sourceRoot, "commands"), 0o555);
+
+		try {
+			await expect(restoreDestructiveOperationBackup(backup)).rejects.toThrow();
+			expect(await readFile(join(sourceRoot, "commands", "test.md"), "utf8")).toBe("current-state");
+		} finally {
+			await chmod(join(sourceRoot, "commands"), 0o755);
+		}
+	});
+});

--- a/src/__tests__/services/file-operations/destructive-operation-backup.test.ts
+++ b/src/__tests__/services/file-operations/destructive-operation-backup.test.ts
@@ -111,6 +111,26 @@ describe("destructive operation backup", () => {
 		await expect(loadDestructiveOperationBackup(backupDir)).rejects.toThrow();
 	});
 
+	test("rejects relative sourceRoot values when loading a backup", async () => {
+		const backupDir = join(testPaths.testHome, ".claudekit", "backups", "manual-relative-root");
+		await mkdir(backupDir, { recursive: true });
+		await writeFile(
+			join(backupDir, "manifest.json"),
+			JSON.stringify({
+				version: 1,
+				operation: "fresh-install",
+				createdAt: new Date().toISOString(),
+				sourceRoot: ".",
+				items: [],
+				restoreNotes: [],
+			}),
+		);
+
+		await expect(loadDestructiveOperationBackup(backupDir)).rejects.toThrow(
+			"source root must be absolute",
+		);
+	});
+
 	test("backs up and restores safe in-tree symlinks", async () => {
 		if (process.platform === "win32") {
 			return;
@@ -227,5 +247,55 @@ describe("destructive operation backup", () => {
 		await expect(restoreDestructiveOperationBackup(backup)).rejects.toThrow(
 			"symlinked parent directory",
 		);
+	});
+
+	test("rejects backup directories that are symlinks outside CK-managed storage", async () => {
+		if (process.platform === "win32") {
+			return;
+		}
+
+		const outsideDir = join(testPaths.testHome, "outside-backup");
+		await mkdir(outsideDir, { recursive: true });
+		await writeFile(
+			join(outsideDir, "manifest.json"),
+			JSON.stringify({
+				version: 1,
+				operation: "fresh-install",
+				createdAt: new Date().toISOString(),
+				sourceRoot,
+				items: [],
+				restoreNotes: [],
+			}),
+		);
+
+		await mkdir(join(testPaths.testHome, ".claudekit", "backups"), { recursive: true });
+		const symlinkDir = join(testPaths.testHome, ".claudekit", "backups", "linked-outside");
+		await symlink(outsideDir, symlinkDir);
+
+		await expect(loadDestructiveOperationBackup(symlinkDir)).rejects.toThrow(
+			"outside ClaudeKit-managed storage",
+		);
+	});
+
+	test("rejects nested directory symlinks that escape the installation root", async () => {
+		if (process.platform === "win32") {
+			return;
+		}
+
+		await mkdir(join(sourceRoot, "commands", "nested"), { recursive: true });
+		await writeFile(join(sourceRoot, "commands", "nested", "ok.md"), "ok");
+		await writeFile(join(testPaths.testHome, "outside.md"), "outside");
+		await symlink(
+			join(testPaths.testHome, "outside.md"),
+			join(sourceRoot, "commands", "nested", "link.md"),
+		);
+
+		await expect(
+			createDestructiveOperationBackup({
+				operation: "uninstall",
+				sourceRoot,
+				deletePaths: ["commands"],
+			}),
+		).rejects.toThrow("Nested symlink target escapes installation root");
 	});
 });

--- a/src/__tests__/services/file-operations/destructive-operation-backup.test.ts
+++ b/src/__tests__/services/file-operations/destructive-operation-backup.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync } from "node:fs";
-import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync, readdirSync } from "node:fs";
+import { chmod, mkdir, readFile, readlink, rm, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
 	createDestructiveOperationBackup,
+	loadDestructiveOperationBackup,
 	restoreDestructiveOperationBackup,
 } from "@/services/file-operations/destructive-operation-backup.js";
 import { type TestPaths, setupTestPaths } from "../../../../tests/helpers/test-paths.js";
@@ -74,6 +75,65 @@ describe("destructive operation backup", () => {
 		expect(await readFile(join(sourceRoot, "metadata.json"), "utf8")).toBe('{"version":"1.0.0"}');
 	});
 
+	test("loads a valid manifest from CK-managed backup storage", async () => {
+		await mkdir(join(sourceRoot, "commands"), { recursive: true });
+		await writeFile(join(sourceRoot, "commands", "test.md"), "command");
+
+		const backup = await createDestructiveOperationBackup({
+			operation: "fresh-install",
+			sourceRoot,
+			deletePaths: ["commands/test.md"],
+		});
+
+		const loaded = await loadDestructiveOperationBackup(backup.backupDir);
+
+		expect(loaded.manifest.operation).toBe("fresh-install");
+		expect(loaded.manifest.items.map((item) => item.path)).toEqual(["commands/test.md"]);
+	});
+
+	test("rejects malformed manifests when loading a backup", async () => {
+		const backupDir = join(testPaths.testHome, ".claudekit", "backups", "manual-invalid");
+		await mkdir(backupDir, { recursive: true });
+		await writeFile(
+			join(backupDir, "manifest.json"),
+			JSON.stringify({
+				version: 1,
+				operation: "fresh-install",
+				createdAt: new Date().toISOString(),
+				sourceRoot: "/tmp/unsafe",
+				items: [
+					{ path: "../escape", mode: "delete", kind: "file", snapshotPath: "snapshot/../escape" },
+				],
+				restoreNotes: [],
+			}),
+		);
+
+		await expect(loadDestructiveOperationBackup(backupDir)).rejects.toThrow();
+	});
+
+	test("backs up and restores safe in-tree symlinks", async () => {
+		if (process.platform === "win32") {
+			return;
+		}
+
+		await mkdir(join(sourceRoot, "commands"), { recursive: true });
+		await writeFile(join(sourceRoot, "commands", "target.md"), "target");
+		await symlink("target.md", join(sourceRoot, "commands", "alias.md"));
+
+		const backup = await createDestructiveOperationBackup({
+			operation: "uninstall",
+			sourceRoot,
+			deletePaths: ["commands/alias.md"],
+		});
+
+		await rm(join(sourceRoot, "commands", "alias.md"));
+		await restoreDestructiveOperationBackup(backup);
+
+		expect((await readlink(join(sourceRoot, "commands", "alias.md"))).replaceAll("\\", "/")).toBe(
+			"target.md",
+		);
+	});
+
 	test("rejects unsafe paths that escape the installation root", async () => {
 		await expect(
 			createDestructiveOperationBackup({
@@ -120,5 +180,52 @@ describe("destructive operation backup", () => {
 		} finally {
 			await chmod(join(sourceRoot, "commands"), 0o755);
 		}
+	});
+
+	test("removes the backup directory if snapshot creation fails partway through", async () => {
+		if (process.platform === "win32") {
+			return;
+		}
+
+		await mkdir(join(sourceRoot, "commands"), { recursive: true });
+		await writeFile(join(sourceRoot, "commands", "ok.md"), "ok");
+		await writeFile(join(testPaths.testHome, "outside.md"), "outside");
+		await symlink(join(testPaths.testHome, "outside.md"), join(sourceRoot, "commands", "link.md"));
+
+		const backupRoot = join(testPaths.testHome, ".claudekit", "backups");
+		const before = existsSync(backupRoot) ? readdirSync(backupRoot).length : 0;
+
+		await expect(
+			createDestructiveOperationBackup({
+				operation: "uninstall",
+				sourceRoot,
+				deletePaths: ["commands/ok.md", "commands/link.md"],
+			}),
+		).rejects.toThrow("Symlink target escapes installation root");
+
+		const after = existsSync(backupRoot) ? readdirSync(backupRoot).length : 0;
+		expect(after).toBe(before);
+	});
+
+	test("rejects restores that would traverse a symlinked parent directory", async () => {
+		if (process.platform === "win32") {
+			return;
+		}
+
+		await mkdir(join(sourceRoot, "commands"), { recursive: true });
+		await writeFile(join(sourceRoot, "commands", "test.md"), "original");
+		const backup = await createDestructiveOperationBackup({
+			operation: "fresh-install",
+			sourceRoot,
+			deletePaths: ["commands/test.md"],
+		});
+
+		await rm(join(sourceRoot, "commands"), { recursive: true, force: true });
+		await mkdir(join(testPaths.testHome, "escaped"), { recursive: true });
+		await symlink(join(testPaths.testHome, "escaped"), join(sourceRoot, "commands"));
+
+		await expect(restoreDestructiveOperationBackup(backup)).rejects.toThrow(
+			"symlinked parent directory",
+		);
 	});
 });

--- a/src/__tests__/services/file-operations/installation-state-lock.test.ts
+++ b/src/__tests__/services/file-operations/installation-state-lock.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { acquireInstallationStateLock } from "@/services/file-operations/installation-state-lock.js";
+
+describe("installation state lock", () => {
+	let rootDir: string;
+
+	beforeEach(async () => {
+		rootDir = join(tmpdir(), `installation-lock-${Date.now()}`);
+		await mkdir(rootDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(rootDir, { recursive: true, force: true });
+	});
+
+	test("canonicalizes symlinked installation paths to the same lock", async () => {
+		if (process.platform === "win32") {
+			return;
+		}
+
+		const actualDir = join(rootDir, "actual");
+		const aliasDir = join(rootDir, "alias");
+		await mkdir(actualDir, { recursive: true });
+		await symlink(actualDir, aliasDir);
+
+		const release = await acquireInstallationStateLock(actualDir);
+
+		try {
+			await expect(acquireInstallationStateLock(aliasDir)).rejects.toThrow(
+				"Lock file is already being held",
+			);
+		} finally {
+			await release();
+		}
+	});
+});

--- a/src/__tests__/services/file-operations/manifest-writer-multikit.test.ts
+++ b/src/__tests__/services/file-operations/manifest-writer-multikit.test.ts
@@ -5,8 +5,10 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { acquireInstallationStateLock } from "@/services/file-operations/installation-state-lock.js";
 import { ManifestWriter } from "@/services/file-operations/manifest-writer.js";
 import type { Metadata, TrackedFile } from "@/types";
+import { pathExists } from "fs-extra";
 
 describe("ManifestWriter multi-kit", () => {
 	let testDir: string;
@@ -136,6 +138,25 @@ describe("ManifestWriter multi-kit", () => {
 			const metadata = JSON.parse(content) as Metadata;
 
 			expect(metadata.kits?.engineer?.version).toBe("v1.0.0");
+		});
+
+		it("waits for the shared installation lock before writing metadata", async () => {
+			const writer = new ManifestWriter();
+			const release = await acquireInstallationStateLock(testDir);
+
+			let settled = false;
+			const run = writer
+				.writeManifest(testDir, "ClaudeKit Engineer", "v1.2.3", "local", "engineer")
+				.finally(() => {
+					settled = true;
+				});
+
+			await Bun.sleep(50);
+			expect(settled).toBe(false);
+
+			await release();
+			await run;
+			expect(settled).toBe(true);
 		});
 	});
 
@@ -425,7 +446,7 @@ describe("ManifestWriter multi-kit", () => {
 			expect(updated.kits?.marketing?.version).toBe("v0.1.0");
 		});
 
-		it("returns true even when removing last kit (metadata.json cleanup handled separately)", async () => {
+		it("removes metadata.json when the last kit is removed", async () => {
 			const metadata: Metadata = {
 				kits: {
 					engineer: {
@@ -439,6 +460,7 @@ describe("ManifestWriter multi-kit", () => {
 			const result = await ManifestWriter.removeKitFromManifest(testDir, "engineer");
 
 			expect(result).toBe(true);
+			expect(await pathExists(join(testDir, "metadata.json"))).toBe(false);
 		});
 
 		it("returns false for non-existent kit", async () => {

--- a/src/cli/command-registry.ts
+++ b/src/cli/command-registry.ts
@@ -7,6 +7,7 @@
 import type { cac } from "cac";
 import { agentsCommand } from "../commands/agents/index.js";
 import { apiCommand } from "../commands/api/index.js";
+import { registerBackupsCommand } from "../commands/backups/index.js";
 import { commandsCommand } from "../commands/commands/index.js";
 import { configCommand } from "../commands/config/index.js";
 import { doctorCommand } from "../commands/doctor.js";
@@ -205,6 +206,9 @@ export function registerCommands(cli: ReturnType<typeof cac>): void {
 		.action(async (options) => {
 			await uninstallCommand(options);
 		});
+
+	// Backups command
+	registerBackupsCommand(cli);
 
 	// Easter Egg command (Code Hunt 2025)
 	cli

--- a/src/commands/backups/backups-command.ts
+++ b/src/commands/backups/backups-command.ts
@@ -1,0 +1,68 @@
+import type { cac } from "cac";
+import { handleBackupsList } from "./list-handler.js";
+import { handleBackupsPrune } from "./prune-handler.js";
+import { handleBackupsRestore } from "./restore-handler.js";
+import type { BackupsListOptions, BackupsPruneOptions, BackupsRestoreOptions } from "./types.js";
+
+type BackupAction = "list" | "restore" | "prune";
+type BackupsCommandOptions = BackupsListOptions & BackupsRestoreOptions & BackupsPruneOptions;
+
+function emitJsonError(message: string): void {
+	console.log(
+		JSON.stringify(
+			{
+				ok: false,
+				error: message,
+			},
+			null,
+			2,
+		),
+	);
+}
+
+async function runBackupsCommand(
+	action: string | undefined,
+	id: string | undefined,
+	options: BackupsCommandOptions,
+): Promise<void> {
+	const resolvedAction: BackupAction = (action ?? "list") as BackupAction;
+
+	switch (resolvedAction) {
+		case "list":
+			await handleBackupsList(options);
+			return;
+		case "restore":
+			if (!id) {
+				throw new Error("Usage: ck backups restore <id>");
+			}
+			await handleBackupsRestore(id, options);
+			return;
+		case "prune":
+			await handleBackupsPrune(id, options);
+			return;
+		default:
+			throw new Error(`Unknown backups action: ${action}`);
+	}
+}
+
+export function registerBackupsCommand(cli: ReturnType<typeof cac>): void {
+	cli
+		.command("backups [action] [id]", "List, restore, and prune ClaudeKit recovery backups")
+		.option("--json", "Output in JSON format")
+		.option("--limit <limit>", "Limit the number of backups shown")
+		.option("-y, --yes", "Skip confirmation prompt")
+		.option("--all", "Delete all recovery backups")
+		.option("--keep <count>", "Keep the newest N backups and prune the rest")
+		.action(async (action: string | undefined, id: string | undefined, options) => {
+			try {
+				await runBackupsCommand(action, id, options);
+			} catch (error) {
+				if (options.json) {
+					emitJsonError(error instanceof Error ? error.message : "Unknown error");
+					process.exitCode = 1;
+					return;
+				}
+				throw error;
+			}
+		});
+}

--- a/src/commands/backups/formatters.ts
+++ b/src/commands/backups/formatters.ts
@@ -1,0 +1,25 @@
+import type { DestructiveOperationBackupSummary } from "@/services/file-operations/destructive-operation-backup-manager.js";
+
+export function formatBytes(sizeBytes: number): string {
+	const units = ["B", "KB", "MB", "GB", "TB"];
+	let size = sizeBytes;
+	let unitIndex = 0;
+
+	while (size >= 1024 && unitIndex < units.length - 1) {
+		size /= 1024;
+		unitIndex++;
+	}
+
+	return `${size.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+export function formatBackupRow(summary: DestructiveOperationBackupSummary): string[] {
+	return [
+		summary.id,
+		summary.valid ? (summary.operation ?? "-") : "invalid",
+		summary.valid ? new Date(summary.createdAt as string).toLocaleString() : "-",
+		summary.valid ? String(summary.itemCount ?? 0) : "-",
+		formatBytes(summary.sizeBytes),
+		summary.valid ? "ok" : "invalid",
+	];
+}

--- a/src/commands/backups/index.ts
+++ b/src/commands/backups/index.ts
@@ -1,0 +1,4 @@
+export { registerBackupsCommand } from "./backups-command.js";
+export { handleBackupsList } from "./list-handler.js";
+export { handleBackupsRestore } from "./restore-handler.js";
+export { handleBackupsPrune } from "./prune-handler.js";

--- a/src/commands/backups/list-handler.ts
+++ b/src/commands/backups/list-handler.ts
@@ -1,0 +1,60 @@
+import { listDestructiveOperationBackups } from "@/services/file-operations/destructive-operation-backup-manager.js";
+import pc from "picocolors";
+import { formatBackupRow } from "./formatters.js";
+import type { BackupsListOptions } from "./types.js";
+
+function parseLimit(limit?: string): number | undefined {
+	if (!limit) return undefined;
+	if (!/^\d+$/.test(limit)) {
+		throw new Error(`Invalid backup limit: ${limit}`);
+	}
+	const parsed = Number.parseInt(limit, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		throw new Error(`Invalid backup limit: ${limit}`);
+	}
+	return parsed;
+}
+
+export async function handleBackupsList(options: BackupsListOptions): Promise<void> {
+	const backups = await listDestructiveOperationBackups(parseLimit(options.limit));
+
+	if (options.json) {
+		console.log(JSON.stringify(backups, null, 2));
+		return;
+	}
+
+	if (backups.length === 0) {
+		console.log();
+		console.log(pc.yellow("No ClaudeKit recovery backups found."));
+		console.log();
+		console.log(pc.dim("  Backups are stored under: ~/.claudekit/backups/"));
+		console.log();
+		return;
+	}
+
+	const rows = backups.map(formatBackupRow);
+	const headers = ["ID", "OPERATION", "CREATED", "ITEMS", "SIZE", "STATUS"];
+	const widths = headers.map((header, index) =>
+		Math.max(header.length, ...rows.map((row) => row[index].length)),
+	);
+
+	console.log();
+	console.log(pc.bold(`ClaudeKit Recovery Backups (${backups.length})`));
+	console.log();
+	console.log(pc.dim(headers.map((header, index) => header.padEnd(widths[index])).join("  ")));
+	console.log(pc.dim(widths.map((width) => "-".repeat(width)).join("  ")));
+
+	for (const row of rows) {
+		console.log(
+			row
+				.map((column, index) => {
+					if (index === 0) return pc.cyan(column.padEnd(widths[index]));
+					if (index === 5 && column === "invalid") return pc.red(column.padEnd(widths[index]));
+					return column.padEnd(widths[index]);
+				})
+				.join("  "),
+		);
+	}
+
+	console.log();
+}

--- a/src/commands/backups/prune-handler.ts
+++ b/src/commands/backups/prune-handler.ts
@@ -1,0 +1,95 @@
+import {
+	DEFAULT_DESTRUCTIVE_BACKUP_KEEP_COUNT,
+	getDestructiveOperationBackupSummary,
+	pruneDestructiveOperationBackups,
+} from "@/services/file-operations/destructive-operation-backup-manager.js";
+import { withProcessLock } from "@/shared/process-lock.js";
+import { confirm, isCancel, log } from "@/shared/safe-prompts.js";
+import type { BackupsPruneOptions } from "./types.js";
+
+function parseKeepCount(keep?: string): number {
+	if (!keep) return DEFAULT_DESTRUCTIVE_BACKUP_KEEP_COUNT;
+	if (!/^\d+$/.test(keep)) {
+		throw new Error(`Invalid keep count: ${keep}`);
+	}
+	const parsed = Number.parseInt(keep, 10);
+	if (!Number.isFinite(parsed) || parsed < 0) {
+		throw new Error(`Invalid keep count: ${keep}`);
+	}
+	return parsed;
+}
+
+export async function handleBackupsPrune(
+	backupId: string | undefined,
+	options: BackupsPruneOptions,
+	deps?: { confirmFn?: typeof confirm },
+): Promise<void> {
+	if (backupId && options.all) {
+		throw new Error("Cannot combine a backup id with --all.");
+	}
+	if (backupId && options.keep) {
+		throw new Error("Cannot combine a backup id with --keep.");
+	}
+	if (options.all && options.keep) {
+		throw new Error("Cannot combine --all with --keep.");
+	}
+
+	let promptMessage: string;
+	if (backupId) {
+		const summary = await getDestructiveOperationBackupSummary(backupId);
+		promptMessage = `Delete backup ${summary.id}?`;
+	} else if (options.all) {
+		promptMessage = "Delete all ClaudeKit recovery backups?";
+	} else {
+		const keepCount = parseKeepCount(options.keep);
+		promptMessage = `Prune old ClaudeKit recovery backups and keep the newest ${keepCount}?`;
+	}
+
+	const confirmed =
+		options.yes === true
+			? true
+			: await (deps?.confirmFn ?? confirm)({
+					message: promptMessage,
+					initialValue: false,
+				});
+
+	if (isCancel(confirmed) || confirmed !== true) {
+		if (options.json) {
+			console.log(
+				JSON.stringify(
+					{
+						ok: true,
+						cancelled: true,
+					},
+					null,
+					2,
+				),
+			);
+			return;
+		}
+		log.info("Backup prune cancelled.");
+		return;
+	}
+
+	const result = await withProcessLock("destructive-backups", async () => {
+		return pruneDestructiveOperationBackups({
+			all: options.all,
+			backupIds: backupId ? [backupId] : undefined,
+			keepCount: backupId || options.all ? undefined : parseKeepCount(options.keep),
+		});
+	});
+
+	if (options.json) {
+		console.log(JSON.stringify(result, null, 2));
+		return;
+	}
+
+	if (result.deletedIds.length === 0) {
+		log.info("No recovery backups were deleted.");
+		return;
+	}
+
+	log.info(
+		`Deleted ${result.deletedIds.length} recovery backup(s): ${result.deletedIds.join(", ")}`,
+	);
+}

--- a/src/commands/backups/prune-handler.ts
+++ b/src/commands/backups/prune-handler.ts
@@ -80,7 +80,16 @@ export async function handleBackupsPrune(
 	});
 
 	if (options.json) {
-		console.log(JSON.stringify(result, null, 2));
+		console.log(
+			JSON.stringify(
+				{
+					ok: true,
+					...result,
+				},
+				null,
+				2,
+			),
+		);
 		return;
 	}
 

--- a/src/commands/backups/restore-handler.ts
+++ b/src/commands/backups/restore-handler.ts
@@ -1,7 +1,4 @@
-import {
-	getDestructiveOperationBackupDir,
-	getDestructiveOperationBackupSummary,
-} from "@/services/file-operations/destructive-operation-backup-manager.js";
+import { getDestructiveOperationBackupDir } from "@/services/file-operations/destructive-operation-backup-manager.js";
 import {
 	loadDestructiveOperationBackup,
 	restoreDestructiveOperationBackup,
@@ -16,10 +13,8 @@ export async function handleBackupsRestore(
 	options: BackupsRestoreOptions,
 	deps?: { confirmFn?: typeof confirm },
 ): Promise<void> {
-	const summary = await getDestructiveOperationBackupSummary(backupId);
-	if (!summary.valid) {
-		throw new Error(`Backup ${backupId} is invalid and cannot be restored.`);
-	}
+	const backupDir = await getDestructiveOperationBackupDir(backupId);
+	const backup = await loadDestructiveOperationBackup(backupDir);
 
 	const restored = await withProcessLock("kit-install", async () => {
 		const confirmFn = deps?.confirmFn ?? confirm;
@@ -27,7 +22,7 @@ export async function handleBackupsRestore(
 			options.yes === true
 				? true
 				: await confirmFn({
-						message: `Restore backup ${backupId} to ${summary.sourceRoot}?`,
+						message: `Restore backup ${backupId} to ${backup.manifest.sourceRoot}?`,
 						initialValue: false,
 					});
 
@@ -38,8 +33,6 @@ export async function handleBackupsRestore(
 			return false;
 		}
 
-		const backupDir = await getDestructiveOperationBackupDir(backupId);
-		const backup = await loadDestructiveOperationBackup(backupDir);
 		const release = await acquireInstallationStateLock(backup.manifest.sourceRoot);
 
 		try {
@@ -73,10 +66,11 @@ export async function handleBackupsRestore(
 		console.log(
 			JSON.stringify(
 				{
+					ok: true,
 					restored: true,
 					backupId,
-					sourceRoot: summary.sourceRoot,
-					itemCount: summary.itemCount,
+					sourceRoot: backup.manifest.sourceRoot,
+					itemCount: backup.manifest.items.length,
 				},
 				null,
 				2,
@@ -85,5 +79,5 @@ export async function handleBackupsRestore(
 		return;
 	}
 
-	log.info(`Restored backup ${backupId} to ${summary.sourceRoot}`);
+	log.info(`Restored backup ${backupId} to ${backup.manifest.sourceRoot}`);
 }

--- a/src/commands/backups/restore-handler.ts
+++ b/src/commands/backups/restore-handler.ts
@@ -1,0 +1,89 @@
+import {
+	getDestructiveOperationBackupDir,
+	getDestructiveOperationBackupSummary,
+} from "@/services/file-operations/destructive-operation-backup-manager.js";
+import {
+	loadDestructiveOperationBackup,
+	restoreDestructiveOperationBackup,
+} from "@/services/file-operations/destructive-operation-backup.js";
+import { acquireInstallationStateLock } from "@/services/file-operations/installation-state-lock.js";
+import { withProcessLock } from "@/shared/process-lock.js";
+import { confirm, isCancel, log } from "@/shared/safe-prompts.js";
+import type { BackupsRestoreOptions } from "./types.js";
+
+export async function handleBackupsRestore(
+	backupId: string,
+	options: BackupsRestoreOptions,
+	deps?: { confirmFn?: typeof confirm },
+): Promise<void> {
+	const summary = await getDestructiveOperationBackupSummary(backupId);
+	if (!summary.valid) {
+		throw new Error(`Backup ${backupId} is invalid and cannot be restored.`);
+	}
+
+	const restored = await withProcessLock("kit-install", async () => {
+		const confirmFn = deps?.confirmFn ?? confirm;
+		const confirmed =
+			options.yes === true
+				? true
+				: await confirmFn({
+						message: `Restore backup ${backupId} to ${summary.sourceRoot}?`,
+						initialValue: false,
+					});
+
+		if (isCancel(confirmed) || confirmed !== true) {
+			if (!options.json) {
+				log.info("Backup restore cancelled.");
+			}
+			return false;
+		}
+
+		const backupDir = await getDestructiveOperationBackupDir(backupId);
+		const backup = await loadDestructiveOperationBackup(backupDir);
+		const release = await acquireInstallationStateLock(backup.manifest.sourceRoot);
+
+		try {
+			await restoreDestructiveOperationBackup(backup);
+		} finally {
+			await release();
+		}
+
+		return true;
+	});
+
+	if (!restored) {
+		if (options.json) {
+			console.log(
+				JSON.stringify(
+					{
+						ok: true,
+						restored: false,
+						cancelled: true,
+						backupId,
+					},
+					null,
+					2,
+				),
+			);
+		}
+		return;
+	}
+
+	if (options.json) {
+		console.log(
+			JSON.stringify(
+				{
+					restored: true,
+					backupId,
+					sourceRoot: summary.sourceRoot,
+					itemCount: summary.itemCount,
+				},
+				null,
+				2,
+			),
+		);
+		return;
+	}
+
+	log.info(`Restored backup ${backupId} to ${summary.sourceRoot}`);
+}

--- a/src/commands/backups/types.ts
+++ b/src/commands/backups/types.ts
@@ -1,0 +1,16 @@
+export interface BackupsListOptions {
+	json?: boolean;
+	limit?: string;
+}
+
+export interface BackupsRestoreOptions {
+	json?: boolean;
+	yes?: boolean;
+}
+
+export interface BackupsPruneOptions {
+	json?: boolean;
+	yes?: boolean;
+	all?: boolean;
+	keep?: string;
+}

--- a/src/commands/uninstall/removal-handler.ts
+++ b/src/commands/uninstall/removal-handler.ts
@@ -7,12 +7,18 @@
 
 import { readdirSync, rmSync } from "node:fs";
 import { join, resolve, sep } from "node:path";
+import {
+	type DestructiveOperationBackup,
+	createDestructiveOperationBackup,
+	restoreDestructiveOperationBackup,
+} from "@/services/file-operations/destructive-operation-backup.js";
 import { ManifestWriter } from "@/services/file-operations/manifest-writer.js";
 import { logger } from "@/shared/logger.js";
 import { log } from "@/shared/safe-prompts.js";
 import { createSpinner } from "@/shared/safe-spinner.js";
 import type { KitType } from "@/types";
 import { lstat, pathExists, realpath, remove } from "fs-extra";
+import { lock } from "proper-lockfile";
 import {
 	analyzeInstallation,
 	cleanupEmptyDirectories,
@@ -31,6 +37,41 @@ async function isDirectory(filePath: string): Promise<boolean> {
 		logger.debug(`Failed to check if path is directory: ${filePath}`);
 		return false;
 	}
+}
+
+function getUninstallMutatePaths(options: {
+	kit?: KitType;
+	remainingKits: KitType[];
+}): string[] {
+	if (options.kit && options.remainingKits.length > 0) {
+		return ["metadata.json"];
+	}
+
+	return [];
+}
+
+async function restoreUninstallBackup(backup: DestructiveOperationBackup): Promise<void> {
+	const restoreSpinner = createSpinner("Restoring installation from recovery backup...").start();
+
+	try {
+		await restoreDestructiveOperationBackup(backup);
+		restoreSpinner.succeed(`Restored previous state from ${backup.backupDir}`);
+	} catch (error) {
+		restoreSpinner.fail("Failed to restore installation from recovery backup");
+		throw new Error(
+			`Uninstall rollback failed: ${error instanceof Error ? error.message : "Unknown error"}. Recovery backup retained at ${backup.backupDir}`,
+		);
+	}
+}
+
+async function acquireUninstallMetadataLock(
+	installationPath: string,
+): Promise<() => Promise<void>> {
+	const metadataPath = join(installationPath, "metadata.json");
+	return lock(metadataPath, {
+		retries: { retries: 5, minTimeout: 100, maxTimeout: 1000 },
+		stale: 60000,
+	});
 }
 
 /**
@@ -92,75 +133,121 @@ export async function removeInstallations(
 			continue;
 		}
 
-		const kitLabel = options.kit ? ` ${options.kit} kit` : "";
-		const legacyLabel = !installation.hasMetadata ? " (legacy)" : "";
-		const spinner = createSpinner(
-			`Removing ${installation.type}${kitLabel}${legacyLabel} ClaudeKit files...`,
-		).start();
+		const mutatePaths = getUninstallMutatePaths({
+			kit: options.kit,
+			remainingKits: analysis.remainingKits,
+		});
+		let backup: DestructiveOperationBackup | null = null;
+		let releaseMetadataLock: (() => Promise<void>) | null = null;
 
 		try {
-			let removedCount = 0;
-			let cleanedDirs = 0;
+			if (mutatePaths.includes("metadata.json")) {
+				releaseMetadataLock = await acquireUninstallMetadataLock(installation.path);
+			}
 
-			// Remove files/directories
-			for (const item of analysis.toDelete) {
-				const filePath = join(installation.path, item.path);
-				if (!(await pathExists(filePath))) continue;
+			if (analysis.toDelete.length > 0 || mutatePaths.length > 0) {
+				const backupSpinner = createSpinner("Creating recovery backup...").start();
 
-				// Security: validate path is safe to remove (symlink protection)
-				if (!(await isPathSafeToRemove(filePath, installation.path))) {
-					logger.debug(`Skipping unsafe path: ${item.path}`);
-					continue;
-				}
-
-				// Remove file or directory
-				const isDir = await isDirectory(filePath);
-				await remove(filePath);
-				removedCount++;
-				logger.debug(`Removed ${isDir ? "directory" : "file"}: ${item.path}`);
-
-				// Clean up empty parent directories (only for files, not directories)
-				if (!isDir) {
-					cleanedDirs += await cleanupEmptyDirectories(filePath, installation.path);
+				try {
+					backup = await createDestructiveOperationBackup({
+						operation: "uninstall",
+						sourceRoot: installation.path,
+						deletePaths: analysis.toDelete.map((item) => item.path),
+						mutatePaths,
+						scope: installation.type,
+						kit: options.kit,
+					});
+					backupSpinner.succeed(`Recovery backup saved to ${backup.backupDir}`);
+				} catch (error) {
+					backupSpinner.fail("Failed to create recovery backup");
+					throw new Error(
+						`Uninstall aborted before deletion: ${error instanceof Error ? error.message : "Unknown error"}`,
+					);
 				}
 			}
 
-			// Update metadata.json to remove kit (for kit-scoped uninstall)
-			if (options.kit && analysis.remainingKits.length > 0) {
-				await ManifestWriter.removeKitFromManifest(installation.path, options.kit);
-			}
+			const kitLabel = options.kit ? ` ${options.kit} kit` : "";
+			const legacyLabel = !installation.hasMetadata ? " (legacy)" : "";
+			const spinner = createSpinner(
+				`Removing ${installation.type}${kitLabel}${legacyLabel} ClaudeKit files...`,
+			).start();
 
-			// Check if installation directory is now empty, remove it
 			try {
-				const remaining = readdirSync(installation.path);
-				if (remaining.length === 0) {
-					rmSync(installation.path, { recursive: true });
-					logger.debug(`Removed empty installation directory: ${installation.path}`);
-				}
-			} catch {
-				// Directory might not exist, ignore
-			}
+				let removedCount = 0;
+				let cleanedDirs = 0;
 
-			const kitsInfo =
-				analysis.remainingKits.length > 0
-					? `, ${analysis.remainingKits.join(", ")} kit(s) preserved`
-					: "";
-			spinner.succeed(
-				`Removed ${removedCount} files${cleanedDirs > 0 ? `, cleaned ${cleanedDirs} empty directories` : ""}, preserved ${analysis.toPreserve.length} customizations${kitsInfo}`,
-			);
+				// Remove files/directories
+				for (const item of analysis.toDelete) {
+					const filePath = join(installation.path, item.path);
+					if (!(await pathExists(filePath))) continue;
 
-			if (analysis.toPreserve.length > 0) {
-				log.info("Preserved customizations:");
-				analysis.toPreserve.slice(0, 5).forEach((f) => log.message(`  - ${f.path} (${f.reason})`));
-				if (analysis.toPreserve.length > 5) {
-					log.message(`  ... and ${analysis.toPreserve.length - 5} more`);
+					// Security: validate path is safe to remove (symlink protection)
+					if (!(await isPathSafeToRemove(filePath, installation.path))) {
+						logger.debug(`Skipping unsafe path: ${item.path}`);
+						continue;
+					}
+
+					// Remove file or directory
+					const isDir = await isDirectory(filePath);
+					await remove(filePath);
+					removedCount++;
+					logger.debug(`Removed ${isDir ? "directory" : "file"}: ${item.path}`);
+
+					// Clean up empty parent directories (only for files, not directories)
+					if (!isDir) {
+						cleanedDirs += await cleanupEmptyDirectories(filePath, installation.path);
+					}
 				}
+
+				// Update metadata.json to remove kit (for kit-scoped uninstall)
+				if (options.kit && analysis.remainingKits.length > 0) {
+					await ManifestWriter.removeKitFromManifest(installation.path, options.kit, {
+						lockHeld: mutatePaths.includes("metadata.json"),
+					});
+				}
+
+				// Check if installation directory is now empty, remove it
+				try {
+					const remaining = readdirSync(installation.path);
+					if (remaining.length === 0) {
+						rmSync(installation.path, { recursive: true });
+						logger.debug(`Removed empty installation directory: ${installation.path}`);
+					}
+				} catch {
+					// Directory might not exist, ignore
+				}
+
+				const kitsInfo =
+					analysis.remainingKits.length > 0
+						? `, ${analysis.remainingKits.join(", ")} kit(s) preserved`
+						: "";
+				spinner.succeed(
+					`Removed ${removedCount} files${cleanedDirs > 0 ? `, cleaned ${cleanedDirs} empty directories` : ""}, preserved ${analysis.toPreserve.length} customizations${kitsInfo}`,
+				);
+
+				if (analysis.toPreserve.length > 0) {
+					log.info("Preserved customizations:");
+					analysis.toPreserve
+						.slice(0, 5)
+						.forEach((f) => log.message(`  - ${f.path} (${f.reason})`));
+					if (analysis.toPreserve.length > 5) {
+						log.message(`  ... and ${analysis.toPreserve.length - 5} more`);
+					}
+				}
+			} catch (error) {
+				spinner.fail(`Failed to remove ${installation.type} installation`);
+				if (backup) {
+					await restoreUninstallBackup(backup);
+				}
+
+				throw new Error(
+					`Failed to remove files from ${installation.path}: ${error instanceof Error ? error.message : "Unknown error"}${backup ? `. Recovery backup retained at ${backup.backupDir}` : ""}`,
+				);
 			}
-		} catch (error) {
-			spinner.fail(`Failed to remove ${installation.type} installation`);
-			throw new Error(
-				`Failed to remove files from ${installation.path}: ${error instanceof Error ? error.message : "Unknown error"}`,
-			);
+		} finally {
+			if (releaseMetadataLock) {
+				await releaseMetadataLock();
+			}
 		}
 	}
 }

--- a/src/commands/uninstall/removal-handler.ts
+++ b/src/commands/uninstall/removal-handler.ts
@@ -6,7 +6,8 @@
  */
 
 import { readdirSync, rmSync } from "node:fs";
-import { join, resolve, sep } from "node:path";
+import { basename, join, resolve, sep } from "node:path";
+import { cleanupOldDestructiveOperationBackups } from "@/services/file-operations/destructive-operation-backup-manager.js";
 import {
 	type DestructiveOperationBackup,
 	createDestructiveOperationBackup,
@@ -146,6 +147,7 @@ export async function removeInstallations(
 						scope: installation.type,
 						kit: options.kit,
 					});
+					await cleanupOldDestructiveOperationBackups(undefined, basename(backup.backupDir));
 					backupSpinner.succeed(`Recovery backup saved to ${backup.backupDir}`);
 				} catch (error) {
 					backupSpinner.fail("Failed to create recovery backup");

--- a/src/commands/uninstall/removal-handler.ts
+++ b/src/commands/uninstall/removal-handler.ts
@@ -12,13 +12,13 @@ import {
 	createDestructiveOperationBackup,
 	restoreDestructiveOperationBackup,
 } from "@/services/file-operations/destructive-operation-backup.js";
+import { acquireInstallationStateLock } from "@/services/file-operations/installation-state-lock.js";
 import { ManifestWriter } from "@/services/file-operations/manifest-writer.js";
 import { logger } from "@/shared/logger.js";
 import { log } from "@/shared/safe-prompts.js";
 import { createSpinner } from "@/shared/safe-spinner.js";
 import type { KitType } from "@/types";
 import { lstat, pathExists, realpath, remove } from "fs-extra";
-import { lock } from "proper-lockfile";
 import {
 	analyzeInstallation,
 	cleanupEmptyDirectories,
@@ -64,16 +64,6 @@ async function restoreUninstallBackup(backup: DestructiveOperationBackup): Promi
 	}
 }
 
-async function acquireUninstallMetadataLock(
-	installationPath: string,
-): Promise<() => Promise<void>> {
-	const metadataPath = join(installationPath, "metadata.json");
-	return lock(metadataPath, {
-		retries: { retries: 5, minTimeout: 100, maxTimeout: 1000 },
-		stale: 60000,
-	});
-}
-
 /**
  * Validate that a path is safe to remove (within base directory, not a symlink escape)
  * Prevents symlink attacks that could delete files outside the installation directory
@@ -116,34 +106,33 @@ export async function removeInstallations(
 	options: { dryRun: boolean; forceOverwrite: boolean; kit?: KitType },
 ): Promise<void> {
 	for (const installation of installations) {
-		// Analyze what would be removed
-		const analysis = await analyzeInstallation(installation, options.forceOverwrite, options.kit);
-
-		// Dry-run mode: just show preview
-		if (options.dryRun) {
-			const label = options.kit ? `${installation.type} (${options.kit} kit)` : installation.type;
-			const legacyLabel = !installation.hasMetadata ? " [legacy]" : "";
-			displayDryRunPreview(analysis, `${label}${legacyLabel}`);
-			if (analysis.remainingKits.length > 0) {
-				log.info(`Remaining kits after uninstall: ${analysis.remainingKits.join(", ")}`);
-			}
-			if (!installation.hasMetadata) {
-				log.warn("Legacy installation - directories will be removed recursively");
-			}
-			continue;
-		}
-
-		const mutatePaths = getUninstallMutatePaths({
-			kit: options.kit,
-			remainingKits: analysis.remainingKits,
-		});
-		let backup: DestructiveOperationBackup | null = null;
-		let releaseMetadataLock: (() => Promise<void>) | null = null;
+		let releaseInstallationLock: (() => Promise<void>) | null = null;
 
 		try {
-			if (mutatePaths.includes("metadata.json")) {
-				releaseMetadataLock = await acquireUninstallMetadataLock(installation.path);
+			releaseInstallationLock = await acquireInstallationStateLock(installation.path);
+
+			// Analyze what would be removed
+			const analysis = await analyzeInstallation(installation, options.forceOverwrite, options.kit);
+
+			// Dry-run mode: just show preview
+			if (options.dryRun) {
+				const label = options.kit ? `${installation.type} (${options.kit} kit)` : installation.type;
+				const legacyLabel = !installation.hasMetadata ? " [legacy]" : "";
+				displayDryRunPreview(analysis, `${label}${legacyLabel}`);
+				if (analysis.remainingKits.length > 0) {
+					log.info(`Remaining kits after uninstall: ${analysis.remainingKits.join(", ")}`);
+				}
+				if (!installation.hasMetadata) {
+					log.warn("Legacy installation - directories will be removed recursively");
+				}
+				continue;
 			}
+
+			const mutatePaths = getUninstallMutatePaths({
+				kit: options.kit,
+				remainingKits: analysis.remainingKits,
+			});
+			let backup: DestructiveOperationBackup | null = null;
 
 			if (analysis.toDelete.length > 0 || mutatePaths.length > 0) {
 				const backupSpinner = createSpinner("Creating recovery backup...").start();
@@ -201,9 +190,16 @@ export async function removeInstallations(
 
 				// Update metadata.json to remove kit (for kit-scoped uninstall)
 				if (options.kit && analysis.remainingKits.length > 0) {
-					await ManifestWriter.removeKitFromManifest(installation.path, options.kit, {
-						lockHeld: mutatePaths.includes("metadata.json"),
-					});
+					const removed = await ManifestWriter.removeKitFromManifest(
+						installation.path,
+						options.kit,
+						{
+							lockHeld: true,
+						},
+					);
+					if (!removed) {
+						throw new Error(`Failed to update metadata.json for ${options.kit} kit uninstall`);
+					}
 				}
 
 				// Check if installation directory is now empty, remove it
@@ -245,8 +241,8 @@ export async function removeInstallations(
 				);
 			}
 		} finally {
-			if (releaseMetadataLock) {
-				await releaseMetadataLock();
+			if (releaseInstallationLock) {
+				await releaseInstallationLock();
 			}
 		}
 	}

--- a/src/commands/uninstall/uninstall-command.ts
+++ b/src/commands/uninstall/uninstall-command.ts
@@ -94,7 +94,7 @@ async function confirmUninstall(scope: UninstallScope, kitLabel = ""): Promise<b
 				: "global ClaudeKit installation";
 
 	const confirmed = await confirm({
-		message: `Continue with uninstalling ${scopeText}${kitLabel}?`,
+		message: `Continue with uninstalling ${scopeText}${kitLabel}? A recovery backup will be created first.`,
 		initialValue: false,
 	});
 

--- a/src/commands/uninstall/uninstall-command.ts
+++ b/src/commands/uninstall/uninstall-command.ts
@@ -9,6 +9,7 @@ import { PromptsManager } from "@/domains/ui/prompts.js";
 import { ManifestWriter } from "@/services/file-operations/manifest-writer.js";
 import { logger } from "@/shared/logger.js";
 import { PathResolver } from "@/shared/path-resolver.js";
+import { withProcessLock } from "@/shared/process-lock.js";
 import { confirm, isCancel, log, select } from "@/shared/safe-prompts.js";
 import { type UninstallCommandOptions, UninstallCommandOptionsSchema } from "@/types";
 import pc from "picocolors";
@@ -103,127 +104,131 @@ async function confirmUninstall(scope: UninstallScope, kitLabel = ""): Promise<b
 
 export async function uninstallCommand(options: UninstallCommandOptions): Promise<void> {
 	try {
-		// 1. Validate options
-		const validOptions = UninstallCommandOptionsSchema.parse(options);
+		await withProcessLock("kit-install", async () => {
+			// 1. Validate options
+			const validOptions = UninstallCommandOptionsSchema.parse(options);
 
-		// 2. Detect installations
-		const allInstallations = await detectInstallations();
+			// 2. Detect installations
+			const allInstallations = await detectInstallations();
 
-		// 3. Check if any found
-		if (allInstallations.length === 0) {
-			logger.info("No ClaudeKit installations found.");
-			return;
-		}
+			// 3. Check if any found
+			if (allInstallations.length === 0) {
+				logger.info("No ClaudeKit installations found.");
+				return;
+			}
 
-		// 4. Validate --kit flag if provided
-		if (validOptions.kit) {
-			// Check if kit is installed in any installation
-			let kitFound = false;
-			for (const inst of allInstallations) {
-				const metadata = await ManifestWriter.readManifest(inst.path);
-				if (metadata) {
-					const installedKits = getInstalledKits(metadata);
-					if (installedKits.includes(validOptions.kit)) {
-						kitFound = true;
-						break;
+			// 4. Validate --kit flag if provided
+			if (validOptions.kit) {
+				// Check if kit is installed in any installation
+				let kitFound = false;
+				for (const inst of allInstallations) {
+					const metadata = await ManifestWriter.readManifest(inst.path);
+					if (metadata) {
+						const installedKits = getInstalledKits(metadata);
+						if (installedKits.includes(validOptions.kit)) {
+							kitFound = true;
+							break;
+						}
 					}
 				}
+				if (!kitFound) {
+					logger.info(`Kit "${validOptions.kit}" is not installed.`);
+					return;
+				}
 			}
-			if (!kitFound) {
-				logger.info(`Kit "${validOptions.kit}" is not installed.`);
+
+			// 5. Check if running at HOME directory (local === global)
+			const isAtHome = PathResolver.isLocalSameAsGlobal();
+
+			// 6. Handle --local flag at HOME directory (invalid scenario)
+			if (validOptions.local && !validOptions.global && isAtHome) {
+				log.warn(
+					pc.yellow("Cannot use --local at HOME directory (local path equals global path)."),
+				);
+				log.info("Use -g/--global or run from a project directory.");
 				return;
 			}
-		}
 
-		// 5. Check if running at HOME directory (local === global)
-		const isAtHome = PathResolver.isLocalSameAsGlobal();
+			// 7. Determine scope (from flags or interactive prompt)
+			let scope: UninstallScope;
+			if (validOptions.all || (validOptions.local && validOptions.global)) {
+				scope = "all";
+			} else if (validOptions.local) {
+				scope = "local";
+			} else if (validOptions.global) {
+				scope = "global";
+			} else if (isAtHome) {
+				// At HOME directory: skip scope prompt, auto-select global
+				log.info(pc.cyan("Running at HOME directory - targeting global installation"));
+				scope = "global";
+			} else {
+				// Interactive: prompt user to choose scope
+				const promptedScope = await promptScope(allInstallations);
+				if (!promptedScope) {
+					logger.info("Uninstall cancelled.");
+					return;
+				}
+				scope = promptedScope;
+			}
 
-		// 6. Handle --local flag at HOME directory (invalid scenario)
-		if (validOptions.local && !validOptions.global && isAtHome) {
-			log.warn(pc.yellow("Cannot use --local at HOME directory (local path equals global path)."));
-			log.info("Use -g/--global or run from a project directory.");
-			return;
-		}
+			// 8. Filter installations by scope
+			const installations = allInstallations.filter((i) => {
+				if (scope === "all") return true;
+				return i.type === scope;
+			});
 
-		// 7. Determine scope (from flags or interactive prompt)
-		let scope: UninstallScope;
-		if (validOptions.all || (validOptions.local && validOptions.global)) {
-			scope = "all";
-		} else if (validOptions.local) {
-			scope = "local";
-		} else if (validOptions.global) {
-			scope = "global";
-		} else if (isAtHome) {
-			// At HOME directory: skip scope prompt, auto-select global
-			log.info(pc.cyan("Running at HOME directory - targeting global installation"));
-			scope = "global";
-		} else {
-			// Interactive: prompt user to choose scope
-			const promptedScope = await promptScope(allInstallations);
-			if (!promptedScope) {
-				logger.info("Uninstall cancelled.");
+			if (installations.length === 0) {
+				const scopeLabel = scope === "local" ? "local" : "global";
+				logger.info(`No ${scopeLabel} ClaudeKit installation found.`);
 				return;
 			}
-			scope = promptedScope;
-		}
 
-		// 8. Filter installations by scope
-		const installations = allInstallations.filter((i) => {
-			if (scope === "all") return true;
-			return i.type === scope;
-		});
+			// 9. Display found installations
+			displayInstallations(installations, scope);
+			if (validOptions.kit) {
+				log.info(pc.cyan(`Kit-scoped uninstall: ${validOptions.kit} kit only`));
+			}
 
-		if (installations.length === 0) {
-			const scopeLabel = scope === "local" ? "local" : "global";
-			logger.info(`No ${scopeLabel} ClaudeKit installation found.`);
-			return;
-		}
+			// 10. Dry-run mode - skip confirmation
+			if (validOptions.dryRun) {
+				log.info(pc.yellow("DRY RUN MODE - No files will be deleted"));
+				await removeInstallations(installations, {
+					dryRun: true,
+					forceOverwrite: validOptions.forceOverwrite,
+					kit: validOptions.kit,
+				});
+				prompts.outro("Dry-run complete. No changes were made.");
+				return;
+			}
 
-		// 9. Display found installations
-		displayInstallations(installations, scope);
-		if (validOptions.kit) {
-			log.info(pc.cyan(`Kit-scoped uninstall: ${validOptions.kit} kit only`));
-		}
+			// 11. Force-overwrite warning
+			if (validOptions.forceOverwrite) {
+				log.warn(
+					`${pc.yellow(pc.bold("FORCE MODE ENABLED"))}\n${pc.yellow("User modifications will be permanently deleted!")}`,
+				);
+			}
 
-		// 10. Dry-run mode - skip confirmation
-		if (validOptions.dryRun) {
-			log.info(pc.yellow("DRY RUN MODE - No files will be deleted"));
+			// 12. Confirm deletion
+			if (!validOptions.yes) {
+				const kitLabel = validOptions.kit ? ` (${validOptions.kit} kit only)` : "";
+				const confirmed = await confirmUninstall(scope, kitLabel);
+				if (!confirmed) {
+					logger.info("Uninstall cancelled.");
+					return;
+				}
+			}
+
+			// 13. Remove files using manifest
 			await removeInstallations(installations, {
-				dryRun: true,
+				dryRun: false,
 				forceOverwrite: validOptions.forceOverwrite,
 				kit: validOptions.kit,
 			});
-			prompts.outro("Dry-run complete. No changes were made.");
-			return;
-		}
 
-		// 11. Force-overwrite warning
-		if (validOptions.forceOverwrite) {
-			log.warn(
-				`${pc.yellow(pc.bold("FORCE MODE ENABLED"))}\n${pc.yellow("User modifications will be permanently deleted!")}`,
-			);
-		}
-
-		// 12. Confirm deletion
-		if (!validOptions.yes) {
-			const kitLabel = validOptions.kit ? ` (${validOptions.kit} kit only)` : "";
-			const confirmed = await confirmUninstall(scope, kitLabel);
-			if (!confirmed) {
-				logger.info("Uninstall cancelled.");
-				return;
-			}
-		}
-
-		// 13. Remove files using manifest
-		await removeInstallations(installations, {
-			dryRun: false,
-			forceOverwrite: validOptions.forceOverwrite,
-			kit: validOptions.kit,
+			// 14. Success message
+			const kitMsg = validOptions.kit ? ` (${validOptions.kit} kit)` : "";
+			prompts.outro(`ClaudeKit${kitMsg} uninstalled successfully!`);
 		});
-
-		// 14. Success message
-		const kitMsg = validOptions.kit ? ` (${validOptions.kit} kit)` : "";
-		prompts.outro(`ClaudeKit${kitMsg} uninstalled successfully!`);
 	} catch (error) {
 		logger.error(error instanceof Error ? error.message : "Unknown error");
 		process.exit(1);

--- a/src/domains/help/commands/backups-command-help.ts
+++ b/src/domains/help/commands/backups-command-help.ts
@@ -1,0 +1,58 @@
+import type { CommandHelp } from "../help-types.js";
+
+export const backupsCommandHelp: CommandHelp = {
+	name: "backups",
+	description: "List, restore, and prune ClaudeKit recovery backups",
+	usage: "ck backups <list|restore|prune> [options]",
+	examples: [
+		{
+			command: "ck backups list --limit 5",
+			description: "Show the newest five recovery backups",
+		},
+		{
+			command: "ck backups restore 2026-04-06T21-53-01-706-byrf --yes",
+			description: "Restore a specific recovery backup without prompting",
+		},
+	],
+	optionGroups: [
+		{
+			title: "Subcommands",
+			options: [
+				{
+					flags: "list [--limit <n>] [--json]",
+					description: "List recovery backups under ~/.claudekit/backups/",
+				},
+				{
+					flags: "restore <id> [--yes] [--json]",
+					description: "Restore a specific recovery backup to its original source root",
+				},
+				{
+					flags: "prune [id] [--keep <n> | --all] [--yes] [--json]",
+					description: "Delete one, many, or old recovery backups",
+				},
+			],
+		},
+		{
+			title: "Shared Options",
+			options: [
+				{ flags: "--limit <n>", description: "Show only the newest N backups" },
+				{ flags: "--keep <n>", description: "Keep the newest N backups when pruning" },
+				{ flags: "--all", description: "Delete all recovery backups" },
+				{ flags: "-y, --yes", description: "Skip confirmation prompts" },
+				{ flags: "--json", description: "Output machine-readable JSON" },
+			],
+		},
+	],
+	sections: [
+		{
+			title: "Backup Scope",
+			content:
+				"These backups contain only the ClaudeKit-managed files targeted by destructive operations, not the full ~/.claude/ directory.",
+		},
+		{
+			title: "Automatic Retention",
+			content:
+				"ClaudeKit keeps the newest recovery backups automatically and prunes older ones after successful destructive operations.",
+		},
+	],
+};

--- a/src/domains/help/commands/index.ts
+++ b/src/domains/help/commands/index.ts
@@ -5,6 +5,7 @@
  */
 
 export { newCommandHelp } from "./new-command-help.js";
+export { backupsCommandHelp } from "./backups-command-help.js";
 export { initCommandHelp } from "./init-command-help.js";
 export { doctorCommandHelp } from "./doctor-command-help.js";
 export { uninstallCommandHelp } from "./uninstall-command-help.js";

--- a/src/domains/help/help-commands.ts
+++ b/src/domains/help/help-commands.ts
@@ -7,6 +7,7 @@
 
 import {
 	agentsCommandHelp,
+	backupsCommandHelp,
 	commandsCommandHelp,
 	configCommandHelp,
 	contentCommandHelp,
@@ -29,6 +30,7 @@ import type { CommandHelp, CommandRegistry } from "./help-types.js";
  */
 export const HELP_REGISTRY: CommandRegistry = {
 	new: newCommandHelp,
+	backups: backupsCommandHelp,
 	init: initCommandHelp,
 	config: configCommandHelp,
 	content: contentCommandHelp,
@@ -70,6 +72,7 @@ export function hasCommand(command: string): boolean {
 export type { CommandHelp, CommandRegistry } from "./help-types.js";
 export {
 	agentsCommandHelp,
+	backupsCommandHelp,
 	commandsCommandHelp,
 	configCommandHelp,
 	contentCommandHelp,

--- a/src/domains/installation/fresh-installer.ts
+++ b/src/domains/installation/fresh-installer.ts
@@ -2,11 +2,17 @@ import { existsSync, readdirSync, rmSync, rmdirSync, unlinkSync } from "node:fs"
 import { dirname, join, resolve } from "node:path";
 import { getAllTrackedFiles } from "@/domains/migration/metadata-migration.js";
 import type { PromptsManager } from "@/domains/ui/prompts.js";
+import {
+	type DestructiveOperationBackup,
+	createDestructiveOperationBackup,
+	restoreDestructiveOperationBackup,
+} from "@/services/file-operations/destructive-operation-backup.js";
 import { readManifest } from "@/services/file-operations/manifest/manifest-reader.js";
 import { logger } from "@/shared/logger.js";
 import { createSpinner } from "@/shared/safe-spinner.js";
 import type { KitType, Metadata, TrackedFile } from "@/types";
 import { pathExists, readFile, writeFile } from "fs-extra";
+import { lock } from "proper-lockfile";
 
 /**
  * ClaudeKit-managed subdirectories (fallback when no metadata)
@@ -32,6 +38,11 @@ export interface FreshInstallResult {
 	preservedCount: number;
 	removedFiles: string[];
 	preservedFiles: string[];
+}
+
+interface FreshBackupTargets {
+	deletePaths: string[];
+	mutatePaths: string[];
 }
 
 /**
@@ -137,17 +148,21 @@ async function removeFilesByOwnership(
 	// Remove CK-owned files
 	for (const file of filesToRemove) {
 		const fullPath = join(claudeDir, file.path);
-		try {
-			if (existsSync(fullPath)) {
-				unlinkSync(fullPath);
-				removedFiles.push(file.path);
-				logger.debug(`Removed: ${file.path}`);
+		if (!existsSync(fullPath)) {
+			continue;
+		}
 
-				// Cleanup empty parent directories
-				cleanupEmptyDirectories(fullPath, claudeDir);
-			}
+		try {
+			unlinkSync(fullPath);
+			removedFiles.push(file.path);
+			logger.debug(`Removed: ${file.path}`);
+
+			// Cleanup empty parent directories
+			cleanupEmptyDirectories(fullPath, claudeDir);
 		} catch (error) {
-			logger.debug(`Failed to remove ${file.path}: ${error}`);
+			throw new Error(
+				`Failed to remove ${file.path}: ${error instanceof Error ? error.message : String(error)}`,
+			);
 		}
 	}
 
@@ -157,7 +172,9 @@ async function removeFilesByOwnership(
 	}
 
 	// Update metadata.json to remove tracking for deleted files
-	await updateMetadataAfterFresh(claudeDir, removedFiles);
+	if (removedFiles.length > 0) {
+		await updateMetadataAfterFresh(claudeDir, removedFiles);
+	}
 
 	return {
 		success: true,
@@ -175,7 +192,7 @@ async function updateMetadataAfterFresh(claudeDir: string, removedFiles: string[
 	const metadataPath = join(claudeDir, "metadata.json");
 
 	if (!(await pathExists(metadataPath))) {
-		return;
+		throw new Error("metadata.json is missing during fresh install cleanup");
 	}
 
 	// Read metadata file
@@ -183,10 +200,9 @@ async function updateMetadataAfterFresh(claudeDir: string, removedFiles: string[
 	try {
 		content = await readFile(metadataPath, "utf-8");
 	} catch (readError) {
-		logger.warning(
+		throw new Error(
 			`Failed to read metadata.json: ${readError instanceof Error ? readError.message : String(readError)}`,
 		);
-		return;
 	}
 
 	// Parse metadata JSON
@@ -194,11 +210,9 @@ async function updateMetadataAfterFresh(claudeDir: string, removedFiles: string[
 	try {
 		metadata = JSON.parse(content);
 	} catch (parseError) {
-		logger.warning(
+		throw new Error(
 			`Failed to parse metadata.json: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
 		);
-		logger.info("Recommendation: Run 'ck init' to rebuild metadata");
-		return;
 	}
 
 	const removedSet = new Set(removedFiles);
@@ -223,11 +237,62 @@ async function updateMetadataAfterFresh(claudeDir: string, removedFiles: string[
 		await writeFile(metadataPath, JSON.stringify(metadata, null, 2));
 		logger.debug(`Updated metadata.json, removed ${removedFiles.length} file entries`);
 	} catch (writeError) {
-		logger.warning(
+		throw new Error(
 			`Failed to write metadata.json: ${writeError instanceof Error ? writeError.message : String(writeError)}`,
 		);
-		logger.info("Recommendation: Check file permissions and run 'ck init' to rebuild metadata");
 	}
+}
+
+function getFreshBackupTargets(
+	claudeDir: string,
+	analysis: FreshAnalysisResult,
+	includeModified: boolean,
+): FreshBackupTargets {
+	if (analysis.hasMetadata) {
+		const filesToRemove = includeModified
+			? [...analysis.ckFiles, ...analysis.ckModifiedFiles]
+			: analysis.ckFiles;
+
+		return {
+			deletePaths: filesToRemove.map((file) => file.path),
+			mutatePaths: filesToRemove.length > 0 ? ["metadata.json"] : [],
+		};
+	}
+
+	const deletePaths = CLAUDEKIT_SUBDIRECTORIES.filter((subdir) =>
+		existsSync(join(claudeDir, subdir)),
+	);
+
+	if (existsSync(join(claudeDir, "metadata.json"))) {
+		deletePaths.push("metadata.json");
+	}
+
+	return {
+		deletePaths,
+		mutatePaths: [],
+	};
+}
+
+async function restoreFreshBackup(backup: DestructiveOperationBackup): Promise<void> {
+	const restoreSpinner = createSpinner("Restoring ClaudeKit files from recovery backup...").start();
+
+	try {
+		await restoreDestructiveOperationBackup(backup);
+		restoreSpinner.succeed(`Restored previous state from ${backup.backupDir}`);
+	} catch (error) {
+		restoreSpinner.fail("Failed to restore ClaudeKit files from recovery backup");
+		throw new Error(
+			`Fresh install rollback failed: ${error instanceof Error ? error.message : "Unknown error"}. Recovery backup retained at ${backup.backupDir}`,
+		);
+	}
+}
+
+async function acquireFreshMetadataLock(claudeDir: string): Promise<() => Promise<void>> {
+	const metadataPath = join(claudeDir, "metadata.json");
+	return lock(metadataPath, {
+		retries: { retries: 5, minTimeout: 100, maxTimeout: 1000 },
+		stale: 60000,
+	});
 }
 
 /**
@@ -295,42 +360,77 @@ export async function handleFreshInstallation(
 		return false;
 	}
 
-	// Start removal
-	const spinner = createSpinner("Removing ClaudeKit files...").start();
+	const backupTargets = getFreshBackupTargets(claudeDir, analysis, true);
+	let backup: DestructiveOperationBackup | null = null;
+	let releaseMetadataLock: (() => Promise<void>) | null = null;
 
 	try {
-		let result: FreshInstallResult;
-
-		if (
-			analysis.hasMetadata &&
-			(analysis.ckFiles.length > 0 || analysis.ckModifiedFiles.length > 0)
-		) {
-			// Smart removal: ownership-aware
-			// For now, include ck-modified files in removal (they'll be reinstalled)
-			result = await removeFilesByOwnership(claudeDir, analysis, true);
-
-			spinner.succeed(
-				`Removed ${result.removedCount} CK files, preserved ${result.preservedCount} user files`,
-			);
-		} else {
-			// Fallback: remove entire directories (no metadata to guide us)
-			result = await removeSubdirectoriesFallback(claudeDir);
-
-			spinner.succeed(`Removed ${result.removedCount} ClaudeKit directories`);
+		if (backupTargets.mutatePaths.includes("metadata.json")) {
+			releaseMetadataLock = await acquireFreshMetadataLock(claudeDir);
 		}
 
-		// Log details in verbose mode
-		if (result.preservedCount > 0) {
-			logger.verbose(
-				`Preserved user files: ${result.preservedFiles.slice(0, 5).join(", ")}${result.preservedFiles.length > 5 ? ` and ${result.preservedFiles.length - 5} more` : ""}`,
-			);
+		if (backupTargets.deletePaths.length > 0 || backupTargets.mutatePaths.length > 0) {
+			const backupSpinner = createSpinner("Creating recovery backup...").start();
+
+			try {
+				backup = await createDestructiveOperationBackup({
+					operation: "fresh-install",
+					sourceRoot: claudeDir,
+					deletePaths: backupTargets.deletePaths,
+					mutatePaths: backupTargets.mutatePaths,
+					scope: "claude",
+				});
+				backupSpinner.succeed(`Recovery backup saved to ${backup.backupDir}`);
+			} catch (error) {
+				backupSpinner.fail("Failed to create recovery backup");
+				throw new Error(
+					`Fresh install aborted before deletion: ${error instanceof Error ? error.message : "Unknown error"}`,
+				);
+			}
 		}
 
-		return true;
-	} catch (error) {
-		spinner.fail("Failed to remove ClaudeKit files");
-		throw new Error(
-			`Failed to remove files: ${error instanceof Error ? error.message : "Unknown error"}`,
-		);
+		// Start removal
+		const spinner = createSpinner("Removing ClaudeKit files...").start();
+
+		try {
+			let result: FreshInstallResult;
+
+			if (analysis.hasMetadata) {
+				// Smart removal: ownership-aware
+				// For now, include ck-modified files in removal (they'll be reinstalled)
+				result = await removeFilesByOwnership(claudeDir, analysis, true);
+
+				spinner.succeed(
+					`Removed ${result.removedCount} CK files, preserved ${result.preservedCount} user files`,
+				);
+			} else {
+				// Fallback: remove entire directories (no metadata to guide us)
+				result = await removeSubdirectoriesFallback(claudeDir);
+
+				spinner.succeed(`Removed ${result.removedCount} ClaudeKit directories`);
+			}
+
+			// Log details in verbose mode
+			if (result.preservedCount > 0) {
+				logger.verbose(
+					`Preserved user files: ${result.preservedFiles.slice(0, 5).join(", ")}${result.preservedFiles.length > 5 ? ` and ${result.preservedFiles.length - 5} more` : ""}`,
+				);
+			}
+
+			return true;
+		} catch (error) {
+			spinner.fail("Failed to remove ClaudeKit files");
+			if (backup) {
+				await restoreFreshBackup(backup);
+			}
+
+			throw new Error(
+				`Failed to remove files: ${error instanceof Error ? error.message : "Unknown error"}${backup ? `. Recovery backup retained at ${backup.backupDir}` : ""}`,
+			);
+		}
+	} finally {
+		if (releaseMetadataLock) {
+			await releaseMetadataLock();
+		}
 	}
 }

--- a/src/domains/installation/fresh-installer.ts
+++ b/src/domains/installation/fresh-installer.ts
@@ -187,7 +187,8 @@ async function removeFilesByOwnership(
 }
 
 /**
- * Update metadata.json after fresh install to remove deleted file entries
+ * Update metadata.json after fresh install to remove deleted file entries.
+ * Callers must already hold the installation-state lock for claudeDir.
  */
 async function updateMetadataAfterFresh(claudeDir: string, removedFiles: string[]): Promise<void> {
 	const metadataPath = join(claudeDir, "metadata.json");

--- a/src/domains/installation/fresh-installer.ts
+++ b/src/domains/installation/fresh-installer.ts
@@ -1,7 +1,8 @@
 import { existsSync, readdirSync, rmSync, rmdirSync, unlinkSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { getAllTrackedFiles } from "@/domains/migration/metadata-migration.js";
 import type { PromptsManager } from "@/domains/ui/prompts.js";
+import { cleanupOldDestructiveOperationBackups } from "@/services/file-operations/destructive-operation-backup-manager.js";
 import {
 	type DestructiveOperationBackup,
 	createDestructiveOperationBackup,
@@ -370,6 +371,7 @@ export async function handleFreshInstallation(
 					mutatePaths: backupTargets.mutatePaths,
 					scope: "claude",
 				});
+				await cleanupOldDestructiveOperationBackups(undefined, basename(backup.backupDir));
 				backupSpinner.succeed(`Recovery backup saved to ${backup.backupDir}`);
 			} catch (error) {
 				backupSpinner.fail("Failed to create recovery backup");

--- a/src/domains/installation/fresh-installer.ts
+++ b/src/domains/installation/fresh-installer.ts
@@ -7,12 +7,12 @@ import {
 	createDestructiveOperationBackup,
 	restoreDestructiveOperationBackup,
 } from "@/services/file-operations/destructive-operation-backup.js";
+import { acquireInstallationStateLock } from "@/services/file-operations/installation-state-lock.js";
 import { readManifest } from "@/services/file-operations/manifest/manifest-reader.js";
 import { logger } from "@/shared/logger.js";
 import { createSpinner } from "@/shared/safe-spinner.js";
 import type { KitType, Metadata, TrackedFile } from "@/types";
 import { pathExists, readFile, writeFile } from "fs-extra";
-import { lock } from "proper-lockfile";
 
 /**
  * ClaudeKit-managed subdirectories (fallback when no metadata)
@@ -287,14 +287,6 @@ async function restoreFreshBackup(backup: DestructiveOperationBackup): Promise<v
 	}
 }
 
-async function acquireFreshMetadataLock(claudeDir: string): Promise<() => Promise<void>> {
-	const metadataPath = join(claudeDir, "metadata.json");
-	return lock(metadataPath, {
-		retries: { retries: 5, minTimeout: 100, maxTimeout: 1000 },
-		stale: 60000,
-	});
-}
-
 /**
  * Fallback: Remove entire ClaudeKit subdirectories (legacy behavior)
  */
@@ -362,12 +354,10 @@ export async function handleFreshInstallation(
 
 	const backupTargets = getFreshBackupTargets(claudeDir, analysis, true);
 	let backup: DestructiveOperationBackup | null = null;
-	let releaseMetadataLock: (() => Promise<void>) | null = null;
+	let releaseInstallationLock: (() => Promise<void>) | null = null;
 
 	try {
-		if (backupTargets.mutatePaths.includes("metadata.json")) {
-			releaseMetadataLock = await acquireFreshMetadataLock(claudeDir);
-		}
+		releaseInstallationLock = await acquireInstallationStateLock(claudeDir);
 
 		if (backupTargets.deletePaths.length > 0 || backupTargets.mutatePaths.length > 0) {
 			const backupSpinner = createSpinner("Creating recovery backup...").start();
@@ -429,8 +419,8 @@ export async function handleFreshInstallation(
 			);
 		}
 	} finally {
-		if (releaseMetadataLock) {
-			await releaseMetadataLock();
+		if (releaseInstallationLock) {
+			await releaseInstallationLock();
 		}
 	}
 }

--- a/src/domains/ui/prompts/installation-prompts.ts
+++ b/src/domains/ui/prompts/installation-prompts.ts
@@ -4,6 +4,7 @@
  * Prompts for update modes and directory selection during installation
  */
 
+import { join } from "node:path";
 import type { FreshAnalysisResult } from "@/domains/installation/fresh-installer.js";
 import { logger } from "@/shared/logger.js";
 import { PathResolver } from "@/shared/path-resolver.js";
@@ -75,8 +76,11 @@ export async function promptFreshConfirmation(
 	targetPath: string,
 	analysis?: FreshAnalysisResult,
 ): Promise<boolean> {
+	const backupRoot = join(PathResolver.getConfigDir(false), "backups");
+
 	logger.warning("[!] Fresh installation will remove ClaudeKit files:");
 	logger.info(`Path: ${targetPath}`);
+	logger.info(`Recovery backup: ${backupRoot}`);
 
 	if (analysis?.hasMetadata) {
 		// Smart mode: show ownership-based breakdown

--- a/src/services/file-operations/destructive-operation-backup-manager.ts
+++ b/src/services/file-operations/destructive-operation-backup-manager.ts
@@ -1,0 +1,235 @@
+import { readdir, stat } from "node:fs/promises";
+import { basename, join, resolve, sep } from "node:path";
+import {
+	type DestructiveOperationBackupManifest,
+	loadDestructiveOperationBackup,
+} from "@/services/file-operations/destructive-operation-backup.js";
+import { logger } from "@/shared/logger.js";
+import { PathResolver } from "@/shared/path-resolver.js";
+import type { KitType } from "@/types";
+import { pathExists, remove } from "fs-extra";
+
+export const DEFAULT_DESTRUCTIVE_BACKUP_KEEP_COUNT = 10;
+
+export interface DestructiveOperationBackupSummary {
+	id: string;
+	path: string;
+	sizeBytes: number;
+	valid: boolean;
+	createdAt?: string;
+	operation?: DestructiveOperationBackupManifest["operation"];
+	sourceRoot?: string;
+	scope?: string;
+	kit?: KitType;
+	itemCount?: number;
+	error?: string;
+}
+
+export interface DestructiveOperationBackupPruneResult {
+	deletedIds: string[];
+	keptIds: string[];
+}
+
+function getBackupsRoot(): string {
+	return resolve(PathResolver.getConfigDir(false), "backups");
+}
+
+function validateBackupId(backupId: string): void {
+	if (!backupId || !/^[A-Za-z0-9._:-]+$/.test(backupId) || backupId.includes("..")) {
+		throw new Error(`Invalid backup id: ${backupId}`);
+	}
+}
+
+function resolveBackupDir(backupId: string): string {
+	validateBackupId(backupId);
+	const backupsRoot = getBackupsRoot();
+	const backupDir = resolve(backupsRoot, backupId);
+	if (!backupDir.startsWith(`${backupsRoot}${sep}`) && backupDir !== backupsRoot) {
+		throw new Error(`Backup id escapes backup root: ${backupId}`);
+	}
+	return backupDir;
+}
+
+async function getDirectorySize(dirPath: string): Promise<number> {
+	let size = 0;
+	const entries = await readdir(dirPath, { withFileTypes: true });
+
+	for (const entry of entries) {
+		const fullPath = join(dirPath, entry.name);
+		if (entry.isSymbolicLink()) {
+			continue;
+		}
+
+		if (entry.isDirectory()) {
+			size += await getDirectorySize(fullPath);
+			continue;
+		}
+
+		if (entry.isFile()) {
+			size += (await stat(fullPath)).size;
+		}
+	}
+
+	return size;
+}
+
+async function listBackupDirs(): Promise<string[]> {
+	const backupsRoot = getBackupsRoot();
+	if (!(await pathExists(backupsRoot))) {
+		return [];
+	}
+
+	const entries = await readdir(backupsRoot, { withFileTypes: true });
+	return entries
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => join(backupsRoot, entry.name))
+		.sort((left, right) => basename(right).localeCompare(basename(left)));
+}
+
+function sortBackupSummaries(
+	left: DestructiveOperationBackupSummary,
+	right: DestructiveOperationBackupSummary,
+): number {
+	if (left.valid && right.valid) {
+		return (right.createdAt ?? "").localeCompare(left.createdAt ?? "");
+	}
+	if (left.valid) return -1;
+	if (right.valid) return 1;
+	return right.id.localeCompare(left.id);
+}
+
+async function summarizeBackup(backupDir: string): Promise<DestructiveOperationBackupSummary> {
+	const id = basename(backupDir);
+	const sizeBytes = await getDirectorySize(backupDir).catch(() => 0);
+
+	try {
+		const backup = await loadDestructiveOperationBackup(backupDir);
+		return {
+			id,
+			path: backup.backupDir,
+			sizeBytes,
+			valid: true,
+			createdAt: backup.manifest.createdAt,
+			operation: backup.manifest.operation,
+			sourceRoot: backup.manifest.sourceRoot,
+			scope: backup.manifest.scope,
+			kit: backup.manifest.kit,
+			itemCount: backup.manifest.items.length,
+		};
+	} catch (error) {
+		return {
+			id,
+			path: backupDir,
+			sizeBytes,
+			valid: false,
+			error: error instanceof Error ? error.message : "Unknown error",
+		};
+	}
+}
+
+export async function listDestructiveOperationBackups(
+	limit?: number,
+): Promise<DestructiveOperationBackupSummary[]> {
+	const backupDirs = await listBackupDirs();
+	const summaries: DestructiveOperationBackupSummary[] = [];
+
+	for (const backupDir of backupDirs) {
+		summaries.push(await summarizeBackup(backupDir));
+	}
+
+	summaries.sort(sortBackupSummaries);
+	return limit ? summaries.slice(0, limit) : summaries;
+}
+
+export async function getDestructiveOperationBackupSummary(
+	backupId: string,
+): Promise<DestructiveOperationBackupSummary> {
+	const backupDir = resolveBackupDir(backupId);
+	if (!(await pathExists(backupDir))) {
+		throw new Error(`Backup not found: ${backupId}`);
+	}
+	return summarizeBackup(backupDir);
+}
+
+export async function getDestructiveOperationBackupDir(backupId: string): Promise<string> {
+	const backupDir = resolveBackupDir(backupId);
+	if (!(await pathExists(backupDir))) {
+		throw new Error(`Backup not found: ${backupId}`);
+	}
+	return backupDir;
+}
+
+export async function deleteDestructiveOperationBackup(backupId: string): Promise<void> {
+	const backupDir = await getDestructiveOperationBackupDir(backupId);
+	await remove(backupDir);
+}
+
+export async function pruneDestructiveOperationBackups(options?: {
+	all?: boolean;
+	backupIds?: string[];
+	keepCount?: number;
+	excludeIds?: string[];
+}): Promise<DestructiveOperationBackupPruneResult> {
+	const backupDirs = await listBackupDirs();
+	const exclude = new Set(options?.excludeIds ?? []);
+	const deletedIds: string[] = [];
+	const keptIds: string[] = [];
+
+	let targets: string[];
+	if (options?.all) {
+		targets = backupDirs.filter((backupDir) => !exclude.has(basename(backupDir)));
+	} else if (options?.backupIds?.length) {
+		targets = options.backupIds.map(resolveBackupDir);
+	} else {
+		const keepCount = Math.max(options?.keepCount ?? DEFAULT_DESTRUCTIVE_BACKUP_KEEP_COUNT, 0);
+		const summaries = await listDestructiveOperationBackups();
+		const keepIds = new Set(
+			summaries
+				.filter((summary) => summary.valid && !exclude.has(summary.id))
+				.slice(0, keepCount)
+				.map((summary) => summary.id),
+		);
+		targets = summaries
+			.filter((summary) => !exclude.has(summary.id) && !keepIds.has(summary.id))
+			.map((summary) => summary.path);
+		keptIds.push(...[...keepIds]);
+	}
+
+	for (const backupDir of targets) {
+		const backupId = basename(backupDir);
+		if (!(await pathExists(backupDir))) {
+			continue;
+		}
+
+		await remove(backupDir);
+		deletedIds.push(backupId);
+	}
+
+	if (!options?.all && !options?.backupIds?.length) {
+		const deleted = new Set(deletedIds);
+		for (const backupDir of backupDirs) {
+			const backupId = basename(backupDir);
+			if (!deleted.has(backupId) && !keptIds.includes(backupId)) {
+				keptIds.push(backupId);
+			}
+		}
+	}
+
+	return { deletedIds, keptIds };
+}
+
+export async function cleanupOldDestructiveOperationBackups(
+	keepCount = DEFAULT_DESTRUCTIVE_BACKUP_KEEP_COUNT,
+	currentBackupId?: string,
+): Promise<void> {
+	try {
+		await pruneDestructiveOperationBackups({
+			keepCount: currentBackupId ? Math.max(keepCount - 1, 0) : keepCount,
+			excludeIds: currentBackupId ? [currentBackupId] : [],
+		});
+	} catch (error) {
+		logger.warning(
+			`Failed to prune old destructive backups: ${error instanceof Error ? error.message : "Unknown error"}`,
+		);
+	}
+}

--- a/src/services/file-operations/destructive-operation-backup.ts
+++ b/src/services/file-operations/destructive-operation-backup.ts
@@ -336,11 +336,12 @@ async function applyRestorePlan(plan: RestorePlan): Promise<void> {
 async function rollbackAppliedRestorePlans(plans: RestorePlan[]): Promise<void> {
 	for (const plan of [...plans].reverse()) {
 		if (plan.sourceExists) {
-			if (await pathExists(plan.sourcePath)) {
+			const currentTempExists = await pathExists(plan.currentTempPath);
+			if (currentTempExists && (await pathExists(plan.sourcePath))) {
 				await remove(plan.sourcePath).catch(() => {});
 			}
 
-			if (await pathExists(plan.currentTempPath)) {
+			if (currentTempExists) {
 				await rename(plan.currentTempPath, plan.sourcePath);
 			}
 			continue;

--- a/src/services/file-operations/destructive-operation-backup.ts
+++ b/src/services/file-operations/destructive-operation-backup.ts
@@ -1,12 +1,13 @@
-import { mkdir, rename } from "node:fs/promises";
+import { mkdir, readlink, rename, symlink } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, normalize, resolve, sep } from "node:path";
 import { logger } from "@/shared/logger.js";
 import { PathResolver } from "@/shared/path-resolver.js";
 import type { KitType } from "@/types";
-import { copy, lstat, pathExists, readJson, remove, writeJson } from "fs-extra";
+import { copy, lstat, pathExists, readJson, realpath, remove, writeJson } from "fs-extra";
+import { z } from "zod";
 
 type DestructiveOperationMode = "delete" | "mutate";
-type DestructiveOperationKind = "file" | "directory";
+type DestructiveOperationKind = "file" | "directory" | "symlink";
 type DestructiveOperationType = "fresh-install" | "uninstall";
 
 export interface DestructiveOperationBackupRequest {
@@ -42,17 +43,25 @@ export interface DestructiveOperationBackup {
 	manifest: DestructiveOperationBackupManifest;
 }
 
+interface RestorePlan {
+	sourceExists: boolean;
+	sourcePath: string;
+	snapshotPath: string;
+	restoreTempPath: string;
+	currentTempPath: string;
+}
+
 const SNAPSHOT_DIR = "snapshot";
 const MANIFEST_FILE = "manifest.json";
 
-function normalizeRelativePath(sourceRoot: string, inputPath: string): string {
+function normalizeRelativePath(rootDir: string, inputPath: string): string {
 	if (!inputPath || isAbsolute(inputPath)) {
 		throw new Error(`Unsafe backup path: ${inputPath}`);
 	}
 
 	const normalized = normalize(inputPath).replaceAll("\\", "/");
-	const resolvedRoot = resolve(sourceRoot);
-	const resolvedPath = resolve(sourceRoot, normalized);
+	const resolvedRoot = resolve(rootDir);
+	const resolvedPath = resolve(rootDir, normalized);
 
 	if (
 		normalized === ".." ||
@@ -64,6 +73,50 @@ function normalizeRelativePath(sourceRoot: string, inputPath: string): string {
 
 	return normalized;
 }
+
+function getManagedBackupRoot(): string {
+	return resolve(PathResolver.getConfigDir(false), "backups");
+}
+
+async function getExistingRealpath(pathToResolve: string): Promise<string> {
+	if (await pathExists(pathToResolve)) {
+		return resolve(await realpath(pathToResolve));
+	}
+
+	return resolve(pathToResolve);
+}
+
+function assertManagedBackupDir(backupDir: string): string {
+	const resolvedBackupDir = resolve(backupDir);
+	const managedBackupRoot = getManagedBackupRoot();
+
+	if (
+		!resolvedBackupDir.startsWith(`${managedBackupRoot}${sep}`) &&
+		resolvedBackupDir !== managedBackupRoot
+	) {
+		throw new Error(`Backup directory is outside ClaudeKit-managed storage: ${backupDir}`);
+	}
+
+	return resolvedBackupDir;
+}
+
+const destructiveOperationBackupItemSchema = z.object({
+	path: z.string().min(1),
+	mode: z.enum(["delete", "mutate"]),
+	kind: z.enum(["file", "directory", "symlink"]),
+	snapshotPath: z.string().min(1),
+});
+
+const destructiveOperationBackupManifestSchema = z.object({
+	version: z.literal(1),
+	operation: z.enum(["fresh-install", "uninstall"]),
+	createdAt: z.string().datetime(),
+	sourceRoot: z.string().min(1),
+	scope: z.string().optional(),
+	kit: z.enum(["engineer", "marketing"]).optional(),
+	items: z.array(destructiveOperationBackupItemSchema),
+	restoreNotes: z.array(z.string()),
+});
 
 function buildTargets(
 	sourceRoot: string,
@@ -106,7 +159,28 @@ async function snapshotItem(
 
 	const stats = await lstat(sourcePath);
 	if (stats.isSymbolicLink()) {
-		throw new Error(`Symlink targets are not supported for destructive backups: ${target.path}`);
+		const realTargetPath = resolve(await realpath(sourcePath));
+		const resolvedSourceRoot = await getExistingRealpath(sourceRoot);
+		if (
+			!realTargetPath.startsWith(`${resolvedSourceRoot}${sep}`) &&
+			realTargetPath !== resolvedSourceRoot
+		) {
+			throw new Error(`Symlink target escapes installation root: ${target.path}`);
+		}
+
+		const snapshotPath = join(SNAPSHOT_DIR, target.path);
+		const snapshotFullPath = join(backupDir, snapshotPath);
+		const linkTarget = await readlink(sourcePath);
+
+		await mkdir(dirname(snapshotFullPath), { recursive: true });
+		await symlink(linkTarget, snapshotFullPath);
+
+		return {
+			path: target.path,
+			mode: target.mode,
+			kind: "symlink",
+			snapshotPath,
+		};
 	}
 
 	const kind: DestructiveOperationKind = stats.isDirectory() ? "directory" : "file";
@@ -129,41 +203,82 @@ function buildRestoreTempPath(sourcePath: string, suffix: "current" | "restore")
 	return join(dirname(sourcePath), `.ck-${suffix}-${basename(sourcePath)}-${Date.now()}-${random}`);
 }
 
-async function restoreSnapshotItemAtomically(
-	sourcePath: string,
-	snapshotPath: string,
-): Promise<void> {
-	const restoreTempPath = buildRestoreTempPath(sourcePath, "restore");
-	const currentTempPath = buildRestoreTempPath(sourcePath, "current");
-	const sourceExists = await pathExists(sourcePath);
+async function assertSafeRestoreDestination(targetPath: string, rootDir: string): Promise<void> {
+	const resolvedRoot = await getExistingRealpath(rootDir);
+	const lexicalRoot = resolve(rootDir);
+	let currentPath = dirname(targetPath);
 
-	await mkdir(dirname(restoreTempPath), { recursive: true });
-	await copy(snapshotPath, restoreTempPath, { overwrite: true });
-
-	try {
-		if (sourceExists) {
-			await rename(sourcePath, currentTempPath);
+	while (true) {
+		const resolvedCurrent = resolve(currentPath);
+		if (!resolvedCurrent.startsWith(`${lexicalRoot}${sep}`) && resolvedCurrent !== lexicalRoot) {
+			throw new Error(`Restore target escapes installation root: ${targetPath}`);
 		}
 
-		await rename(restoreTempPath, sourcePath);
-		await remove(currentTempPath).catch(() => {});
-	} catch (error) {
-		await remove(restoreTempPath).catch(() => {});
+		if (await pathExists(currentPath)) {
+			const stats = await lstat(currentPath);
+			if (stats.isSymbolicLink()) {
+				throw new Error(`Restore target uses a symlinked parent directory: ${currentPath}`);
+			}
 
-		if (sourceExists && (await pathExists(currentTempPath)) && !(await pathExists(sourcePath))) {
-			await rename(currentTempPath, sourcePath).catch((restoreError) => {
-				throw new Error(
-					`Failed to roll back restore swap for ${sourcePath}: ${restoreError instanceof Error ? restoreError.message : "Unknown error"}`,
-				);
-			});
+			const resolvedCurrentReal = await getExistingRealpath(currentPath);
+			if (
+				!resolvedCurrentReal.startsWith(`${resolvedRoot}${sep}`) &&
+				resolvedCurrentReal !== resolvedRoot
+			) {
+				throw new Error(`Restore target escapes installation root: ${targetPath}`);
+			}
 		}
 
-		throw new Error(
-			`Failed to restore ${sourcePath}: ${error instanceof Error ? error.message : "Unknown error"}`,
-		);
-	} finally {
-		await remove(restoreTempPath).catch(() => {});
-		await remove(currentTempPath).catch(() => {});
+		if (resolvedCurrent === lexicalRoot) {
+			return;
+		}
+
+		currentPath = dirname(currentPath);
+	}
+}
+
+async function stageRestorePlan(plan: RestorePlan): Promise<void> {
+	await mkdir(dirname(plan.restoreTempPath), { recursive: true });
+	const snapshotStats = await lstat(plan.snapshotPath);
+	if (snapshotStats.isSymbolicLink()) {
+		await symlink(await readlink(plan.snapshotPath), plan.restoreTempPath);
+		return;
+	}
+
+	await copy(plan.snapshotPath, plan.restoreTempPath, { overwrite: true });
+}
+
+async function applyRestorePlan(plan: RestorePlan): Promise<void> {
+	if (plan.sourceExists) {
+		await rename(plan.sourcePath, plan.currentTempPath);
+	}
+
+	await rename(plan.restoreTempPath, plan.sourcePath);
+}
+
+async function rollbackAppliedRestorePlans(plans: RestorePlan[]): Promise<void> {
+	for (const plan of [...plans].reverse()) {
+		if (plan.sourceExists) {
+			if (await pathExists(plan.sourcePath)) {
+				await remove(plan.sourcePath).catch(() => {});
+			}
+
+			if (await pathExists(plan.currentTempPath)) {
+				await rename(plan.currentTempPath, plan.sourcePath);
+			}
+			continue;
+		}
+
+		if (await pathExists(plan.sourcePath)) {
+			await remove(plan.sourcePath).catch(() => {});
+		}
+	}
+}
+
+async function cleanupRestorePlanTemps(plans: RestorePlan[]): Promise<void> {
+	for (const plan of plans) {
+		await remove(plan.restoreTempPath).catch(() => {});
+		await remove(plan.currentTempPath).catch(() => {});
 	}
 }
 
@@ -214,30 +329,93 @@ export async function createDestructiveOperationBackup(
 export async function loadDestructiveOperationBackup(
 	backupDir: string,
 ): Promise<DestructiveOperationBackup> {
-	const manifestPath = join(backupDir, MANIFEST_FILE);
-	const manifest = await readJson(manifestPath);
+	const resolvedBackupDir = assertManagedBackupDir(backupDir);
+	const manifestPath = join(resolvedBackupDir, MANIFEST_FILE);
+	const manifest = destructiveOperationBackupManifestSchema.parse(await readJson(manifestPath));
+	const resolvedSourceRoot = resolve(manifest.sourceRoot);
+
+	if (!isAbsolute(resolvedSourceRoot)) {
+		throw new Error(`Backup manifest source root must be absolute: ${manifest.sourceRoot}`);
+	}
+
+	for (const item of manifest.items) {
+		normalizeRelativePath(resolvedSourceRoot, item.path);
+		const normalizedSnapshotPath = normalizeRelativePath(resolvedBackupDir, item.snapshotPath);
+		if (
+			normalizedSnapshotPath !== SNAPSHOT_DIR &&
+			!normalizedSnapshotPath.startsWith(`${SNAPSHOT_DIR}/`)
+		) {
+			throw new Error(
+				`Backup manifest snapshot path is outside the snapshot payload: ${item.snapshotPath}`,
+			);
+		}
+	}
+
 	return {
-		backupDir,
+		backupDir: resolvedBackupDir,
 		manifestPath,
-		manifest: manifest as DestructiveOperationBackupManifest,
+		manifest: {
+			...manifest,
+			sourceRoot: resolvedSourceRoot,
+		},
 	};
 }
 
 export async function restoreDestructiveOperationBackup(
 	backup: DestructiveOperationBackup,
 ): Promise<void> {
+	const restorePlans: RestorePlan[] = [];
+
 	for (const item of backup.manifest.items) {
 		const sourcePath = resolve(
 			backup.manifest.sourceRoot,
 			normalizeRelativePath(backup.manifest.sourceRoot, item.path),
 		);
-		const snapshotPath = join(backup.backupDir, item.snapshotPath);
+		const snapshotPath = resolve(
+			backup.backupDir,
+			normalizeRelativePath(backup.backupDir, item.snapshotPath),
+		);
 
-		if (!(await pathExists(snapshotPath))) {
+		try {
+			await lstat(snapshotPath);
+		} catch {
 			throw new Error(`Backup snapshot is missing for ${item.path}`);
 		}
 
-		await restoreSnapshotItemAtomically(sourcePath, snapshotPath);
+		await assertSafeRestoreDestination(sourcePath, backup.manifest.sourceRoot);
+		restorePlans.push({
+			sourceExists: await pathExists(sourcePath),
+			sourcePath,
+			snapshotPath,
+			restoreTempPath: buildRestoreTempPath(sourcePath, "restore"),
+			currentTempPath: buildRestoreTempPath(sourcePath, "current"),
+		});
+	}
+
+	try {
+		for (const plan of restorePlans) {
+			await stageRestorePlan(plan);
+		}
+
+		const appliedPlans: RestorePlan[] = [];
+		let currentPlan: RestorePlan | null = null;
+		try {
+			for (const plan of restorePlans) {
+				currentPlan = plan;
+				await applyRestorePlan(plan);
+				appliedPlans.push(plan);
+				currentPlan = null;
+			}
+		} catch (error) {
+			await rollbackAppliedRestorePlans(
+				currentPlan ? [...appliedPlans, currentPlan] : appliedPlans,
+			);
+			throw new Error(
+				`Failed to restore backup payload: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
+	} finally {
+		await cleanupRestorePlanTemps(restorePlans);
 	}
 
 	logger.debug(`Restored destructive backup from: ${backup.backupDir}`);

--- a/src/services/file-operations/destructive-operation-backup.ts
+++ b/src/services/file-operations/destructive-operation-backup.ts
@@ -1,0 +1,244 @@
+import { mkdir, rename } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, normalize, resolve, sep } from "node:path";
+import { logger } from "@/shared/logger.js";
+import { PathResolver } from "@/shared/path-resolver.js";
+import type { KitType } from "@/types";
+import { copy, lstat, pathExists, readJson, remove, writeJson } from "fs-extra";
+
+type DestructiveOperationMode = "delete" | "mutate";
+type DestructiveOperationKind = "file" | "directory";
+type DestructiveOperationType = "fresh-install" | "uninstall";
+
+export interface DestructiveOperationBackupRequest {
+	operation: DestructiveOperationType;
+	sourceRoot: string;
+	deletePaths: string[];
+	mutatePaths?: string[];
+	scope?: string;
+	kit?: KitType;
+}
+
+export interface DestructiveOperationBackupItem {
+	path: string;
+	mode: DestructiveOperationMode;
+	kind: DestructiveOperationKind;
+	snapshotPath: string;
+}
+
+export interface DestructiveOperationBackupManifest {
+	version: 1;
+	operation: DestructiveOperationType;
+	createdAt: string;
+	sourceRoot: string;
+	scope?: string;
+	kit?: KitType;
+	items: DestructiveOperationBackupItem[];
+	restoreNotes: string[];
+}
+
+export interface DestructiveOperationBackup {
+	backupDir: string;
+	manifestPath: string;
+	manifest: DestructiveOperationBackupManifest;
+}
+
+const SNAPSHOT_DIR = "snapshot";
+const MANIFEST_FILE = "manifest.json";
+
+function normalizeRelativePath(sourceRoot: string, inputPath: string): string {
+	if (!inputPath || isAbsolute(inputPath)) {
+		throw new Error(`Unsafe backup path: ${inputPath}`);
+	}
+
+	const normalized = normalize(inputPath).replaceAll("\\", "/");
+	const resolvedRoot = resolve(sourceRoot);
+	const resolvedPath = resolve(sourceRoot, normalized);
+
+	if (
+		normalized === ".." ||
+		normalized.startsWith("../") ||
+		(!resolvedPath.startsWith(`${resolvedRoot}${sep}`) && resolvedPath !== resolvedRoot)
+	) {
+		throw new Error(`Path escapes installation root: ${inputPath}`);
+	}
+
+	return normalized;
+}
+
+function buildTargets(
+	sourceRoot: string,
+	deletePaths: string[],
+	mutatePaths: string[],
+): Array<{ path: string; mode: DestructiveOperationMode }> {
+	const targetModes = new Map<string, DestructiveOperationMode>();
+
+	for (const path of mutatePaths) {
+		targetModes.set(normalizeRelativePath(sourceRoot, path), "mutate");
+	}
+
+	for (const path of deletePaths) {
+		targetModes.set(normalizeRelativePath(sourceRoot, path), "delete");
+	}
+
+	const sortedTargets = [...targetModes.entries()]
+		.map(([path, mode]) => ({ path, mode }))
+		.sort((left, right) => {
+			const depth = left.path.split("/").length - right.path.split("/").length;
+			return depth === 0 ? left.path.localeCompare(right.path) : depth;
+		});
+
+	return sortedTargets.filter((target, index, targets) => {
+		return !targets.slice(0, index).some((parent) => {
+			return parent.path === target.path || target.path.startsWith(`${parent.path}/`);
+		});
+	});
+}
+
+async function snapshotItem(
+	sourceRoot: string,
+	backupDir: string,
+	target: { path: string; mode: DestructiveOperationMode },
+): Promise<DestructiveOperationBackupItem | null> {
+	const sourcePath = resolve(sourceRoot, target.path);
+	if (!(await pathExists(sourcePath))) {
+		return null;
+	}
+
+	const stats = await lstat(sourcePath);
+	if (stats.isSymbolicLink()) {
+		throw new Error(`Symlink targets are not supported for destructive backups: ${target.path}`);
+	}
+
+	const kind: DestructiveOperationKind = stats.isDirectory() ? "directory" : "file";
+	const snapshotPath = join(SNAPSHOT_DIR, target.path);
+	const snapshotFullPath = join(backupDir, snapshotPath);
+
+	await mkdir(dirname(snapshotFullPath), { recursive: true });
+	await copy(sourcePath, snapshotFullPath, { overwrite: true });
+
+	return {
+		path: target.path,
+		mode: target.mode,
+		kind,
+		snapshotPath,
+	};
+}
+
+function buildRestoreTempPath(sourcePath: string, suffix: "current" | "restore"): string {
+	const random = Math.random().toString(36).slice(2, 8);
+	return join(dirname(sourcePath), `.ck-${suffix}-${basename(sourcePath)}-${Date.now()}-${random}`);
+}
+
+async function restoreSnapshotItemAtomically(
+	sourcePath: string,
+	snapshotPath: string,
+): Promise<void> {
+	const restoreTempPath = buildRestoreTempPath(sourcePath, "restore");
+	const currentTempPath = buildRestoreTempPath(sourcePath, "current");
+	const sourceExists = await pathExists(sourcePath);
+
+	await mkdir(dirname(restoreTempPath), { recursive: true });
+	await copy(snapshotPath, restoreTempPath, { overwrite: true });
+
+	try {
+		if (sourceExists) {
+			await rename(sourcePath, currentTempPath);
+		}
+
+		await rename(restoreTempPath, sourcePath);
+		await remove(currentTempPath).catch(() => {});
+	} catch (error) {
+		await remove(restoreTempPath).catch(() => {});
+
+		if (sourceExists && (await pathExists(currentTempPath)) && !(await pathExists(sourcePath))) {
+			await rename(currentTempPath, sourcePath).catch((restoreError) => {
+				throw new Error(
+					`Failed to roll back restore swap for ${sourcePath}: ${restoreError instanceof Error ? restoreError.message : "Unknown error"}`,
+				);
+			});
+		}
+
+		throw new Error(
+			`Failed to restore ${sourcePath}: ${error instanceof Error ? error.message : "Unknown error"}`,
+		);
+	} finally {
+		await remove(restoreTempPath).catch(() => {});
+		await remove(currentTempPath).catch(() => {});
+	}
+}
+
+export async function createDestructiveOperationBackup(
+	request: DestructiveOperationBackupRequest,
+): Promise<DestructiveOperationBackup> {
+	const backupDir = PathResolver.getBackupDir();
+	const manifestPath = join(backupDir, MANIFEST_FILE);
+	const targets = buildTargets(request.sourceRoot, request.deletePaths, request.mutatePaths ?? []);
+
+	try {
+		await mkdir(join(backupDir, SNAPSHOT_DIR), { recursive: true });
+
+		const items: DestructiveOperationBackupItem[] = [];
+		for (const target of targets) {
+			const snapshot = await snapshotItem(request.sourceRoot, backupDir, target);
+			if (snapshot) {
+				items.push(snapshot);
+			}
+		}
+
+		const manifest: DestructiveOperationBackupManifest = {
+			version: 1,
+			operation: request.operation,
+			createdAt: new Date().toISOString(),
+			sourceRoot: resolve(request.sourceRoot),
+			scope: request.scope,
+			kit: request.kit,
+			items,
+			restoreNotes: [
+				"Backup was created before ClaudeKit performed a destructive operation.",
+				"Restore the snapshot paths back into sourceRoot to recover the previous state.",
+			],
+		};
+
+		await writeJson(manifestPath, manifest, { spaces: 2 });
+		logger.debug(`Created destructive backup at: ${backupDir}`);
+
+		return { backupDir, manifestPath, manifest };
+	} catch (error) {
+		await remove(backupDir).catch(() => {});
+		throw new Error(
+			`Failed to create destructive backup: ${error instanceof Error ? error.message : "Unknown error"}`,
+		);
+	}
+}
+
+export async function loadDestructiveOperationBackup(
+	backupDir: string,
+): Promise<DestructiveOperationBackup> {
+	const manifestPath = join(backupDir, MANIFEST_FILE);
+	const manifest = await readJson(manifestPath);
+	return {
+		backupDir,
+		manifestPath,
+		manifest: manifest as DestructiveOperationBackupManifest,
+	};
+}
+
+export async function restoreDestructiveOperationBackup(
+	backup: DestructiveOperationBackup,
+): Promise<void> {
+	for (const item of backup.manifest.items) {
+		const sourcePath = resolve(
+			backup.manifest.sourceRoot,
+			normalizeRelativePath(backup.manifest.sourceRoot, item.path),
+		);
+		const snapshotPath = join(backup.backupDir, item.snapshotPath);
+
+		if (!(await pathExists(snapshotPath))) {
+			throw new Error(`Backup snapshot is missing for ${item.path}`);
+		}
+
+		await restoreSnapshotItemAtomically(sourcePath, snapshotPath);
+	}
+
+	logger.debug(`Restored destructive backup from: ${backup.backupDir}`);
+}

--- a/src/services/file-operations/destructive-operation-backup.ts
+++ b/src/services/file-operations/destructive-operation-backup.ts
@@ -1,4 +1,4 @@
-import { mkdir, readlink, rename, symlink } from "node:fs/promises";
+import { mkdir, readdir, readlink, rename, symlink } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, normalize, resolve, sep } from "node:path";
 import { logger } from "@/shared/logger.js";
 import { PathResolver } from "@/shared/path-resolver.js";
@@ -86,9 +86,9 @@ async function getExistingRealpath(pathToResolve: string): Promise<string> {
 	return resolve(pathToResolve);
 }
 
-function assertManagedBackupDir(backupDir: string): string {
-	const resolvedBackupDir = resolve(backupDir);
-	const managedBackupRoot = getManagedBackupRoot();
+async function assertManagedBackupDir(backupDir: string): Promise<string> {
+	const resolvedBackupDir = await getExistingRealpath(backupDir);
+	const managedBackupRoot = await getExistingRealpath(getManagedBackupRoot());
 
 	if (
 		!resolvedBackupDir.startsWith(`${managedBackupRoot}${sep}`) &&
@@ -188,7 +188,11 @@ async function snapshotItem(
 	const snapshotFullPath = join(backupDir, snapshotPath);
 
 	await mkdir(dirname(snapshotFullPath), { recursive: true });
-	await copy(sourcePath, snapshotFullPath, { overwrite: true });
+	if (kind === "directory") {
+		await copyDirectorySnapshot(sourcePath, snapshotFullPath, sourceRoot);
+	} else {
+		await copy(sourcePath, snapshotFullPath, { overwrite: true });
+	}
 
 	return {
 		path: target.path,
@@ -196,6 +200,40 @@ async function snapshotItem(
 		kind,
 		snapshotPath,
 	};
+}
+
+async function copyDirectorySnapshot(
+	sourceDir: string,
+	destDir: string,
+	rootDir: string,
+): Promise<void> {
+	await mkdir(destDir, { recursive: true });
+	const entries = await readdir(sourceDir, { withFileTypes: true });
+
+	for (const entry of entries) {
+		const sourceEntry = join(sourceDir, entry.name);
+		const destEntry = join(destDir, entry.name);
+
+		if (entry.isSymbolicLink()) {
+			const realTargetPath = resolve(await realpath(sourceEntry));
+			const resolvedRoot = await getExistingRealpath(rootDir);
+			if (!realTargetPath.startsWith(`${resolvedRoot}${sep}`) && realTargetPath !== resolvedRoot) {
+				throw new Error(`Nested symlink target escapes installation root: ${sourceEntry}`);
+			}
+
+			await symlink(await readlink(sourceEntry), destEntry);
+			continue;
+		}
+
+		if (entry.isDirectory()) {
+			await copyDirectorySnapshot(sourceEntry, destEntry, rootDir);
+			continue;
+		}
+
+		if (entry.isFile()) {
+			await copy(sourceEntry, destEntry, { overwrite: true });
+		}
+	}
 }
 
 function buildRestoreTempPath(sourcePath: string, suffix: "current" | "restore"): string {
@@ -237,11 +275,50 @@ async function assertSafeRestoreDestination(targetPath: string, rootDir: string)
 	}
 }
 
-async function stageRestorePlan(plan: RestorePlan): Promise<void> {
+async function copySnapshotDirectoryForRestore(
+	snapshotDir: string,
+	destDir: string,
+	rootDir: string,
+): Promise<void> {
+	await mkdir(destDir, { recursive: true });
+	const entries = await readdir(snapshotDir, { withFileTypes: true });
+
+	for (const entry of entries) {
+		const sourceEntry = join(snapshotDir, entry.name);
+		const destEntry = join(destDir, entry.name);
+
+		if (entry.isSymbolicLink()) {
+			const linkTarget = await readlink(sourceEntry);
+			const resolvedTarget = resolve(dirname(destEntry), linkTarget);
+			const lexicalRoot = resolve(rootDir);
+			if (!resolvedTarget.startsWith(`${lexicalRoot}${sep}`) && resolvedTarget !== lexicalRoot) {
+				throw new Error(`Nested restore symlink escapes installation root: ${destEntry}`);
+			}
+
+			await symlink(linkTarget, destEntry);
+			continue;
+		}
+
+		if (entry.isDirectory()) {
+			await copySnapshotDirectoryForRestore(sourceEntry, destEntry, rootDir);
+			continue;
+		}
+
+		if (entry.isFile()) {
+			await copy(sourceEntry, destEntry, { overwrite: true });
+		}
+	}
+}
+
+async function stageRestorePlan(plan: RestorePlan, rootDir: string): Promise<void> {
 	await mkdir(dirname(plan.restoreTempPath), { recursive: true });
 	const snapshotStats = await lstat(plan.snapshotPath);
 	if (snapshotStats.isSymbolicLink()) {
 		await symlink(await readlink(plan.snapshotPath), plan.restoreTempPath);
+		return;
+	}
+	if (snapshotStats.isDirectory()) {
+		await copySnapshotDirectoryForRestore(plan.snapshotPath, plan.restoreTempPath, rootDir);
 		return;
 	}
 
@@ -329,14 +406,14 @@ export async function createDestructiveOperationBackup(
 export async function loadDestructiveOperationBackup(
 	backupDir: string,
 ): Promise<DestructiveOperationBackup> {
-	const resolvedBackupDir = assertManagedBackupDir(backupDir);
+	const resolvedBackupDir = await assertManagedBackupDir(backupDir);
 	const manifestPath = join(resolvedBackupDir, MANIFEST_FILE);
 	const manifest = destructiveOperationBackupManifestSchema.parse(await readJson(manifestPath));
-	const resolvedSourceRoot = resolve(manifest.sourceRoot);
 
-	if (!isAbsolute(resolvedSourceRoot)) {
+	if (!isAbsolute(manifest.sourceRoot)) {
 		throw new Error(`Backup manifest source root must be absolute: ${manifest.sourceRoot}`);
 	}
+	const resolvedSourceRoot = resolve(manifest.sourceRoot);
 
 	for (const item of manifest.items) {
 		normalizeRelativePath(resolvedSourceRoot, item.path);
@@ -393,15 +470,12 @@ export async function restoreDestructiveOperationBackup(
 	}
 
 	try {
-		for (const plan of restorePlans) {
-			await stageRestorePlan(plan);
-		}
-
 		const appliedPlans: RestorePlan[] = [];
 		let currentPlan: RestorePlan | null = null;
 		try {
 			for (const plan of restorePlans) {
 				currentPlan = plan;
+				await stageRestorePlan(plan, backup.manifest.sourceRoot);
 				await applyRestorePlan(plan);
 				appliedPlans.push(plan);
 				currentPlan = null;

--- a/src/services/file-operations/installation-state-lock.ts
+++ b/src/services/file-operations/installation-state-lock.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { join, resolve } from "node:path";
 import { logger } from "@/shared/logger.js";
 import { PathResolver } from "@/shared/path-resolver.js";
-import { ensureFile } from "fs-extra";
+import { ensureFile, pathExists, realpath } from "fs-extra";
 import lockfile from "proper-lockfile";
 
 const LOCK_OPTIONS = {
@@ -11,8 +11,16 @@ const LOCK_OPTIONS = {
 	stale: 60000,
 };
 
-function getInstallationStateLockPath(installationRoot: string): string {
-	const normalizedRoot = resolve(installationRoot);
+async function getCanonicalInstallationRoot(installationRoot: string): Promise<string> {
+	if (await pathExists(installationRoot)) {
+		return resolve(await realpath(installationRoot));
+	}
+
+	return resolve(installationRoot);
+}
+
+async function getInstallationStateLockPath(installationRoot: string): Promise<string> {
+	const normalizedRoot = await getCanonicalInstallationRoot(installationRoot);
 	const hash = createHash("sha256").update(normalizedRoot).digest("hex").slice(0, 16);
 	return join(PathResolver.getConfigDir(false), "locks", `installation-${hash}.lock`);
 }
@@ -20,7 +28,7 @@ function getInstallationStateLockPath(installationRoot: string): string {
 export async function acquireInstallationStateLock(
 	installationRoot: string,
 ): Promise<() => Promise<void>> {
-	const lockPath = getInstallationStateLockPath(installationRoot);
+	const lockPath = await getInstallationStateLockPath(installationRoot);
 	await ensureFile(lockPath);
 
 	const release = await lockfile.lock(lockPath, LOCK_OPTIONS);

--- a/src/services/file-operations/installation-state-lock.ts
+++ b/src/services/file-operations/installation-state-lock.ts
@@ -1,0 +1,33 @@
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { logger } from "@/shared/logger.js";
+import { PathResolver } from "@/shared/path-resolver.js";
+import { ensureFile } from "fs-extra";
+import lockfile from "proper-lockfile";
+
+const LOCK_OPTIONS = {
+	realpath: false,
+	retries: { retries: 5, minTimeout: 100, maxTimeout: 1000 },
+	stale: 60000,
+};
+
+function getInstallationStateLockPath(installationRoot: string): string {
+	const normalizedRoot = resolve(installationRoot);
+	const hash = createHash("sha256").update(normalizedRoot).digest("hex").slice(0, 16);
+	return join(PathResolver.getConfigDir(false), "locks", `installation-${hash}.lock`);
+}
+
+export async function acquireInstallationStateLock(
+	installationRoot: string,
+): Promise<() => Promise<void>> {
+	const lockPath = getInstallationStateLockPath(installationRoot);
+	await ensureFile(lockPath);
+
+	const release = await lockfile.lock(lockPath, LOCK_OPTIONS);
+	logger.debug(`Acquired installation state lock: ${lockPath}`);
+
+	return async () => {
+		await release();
+		logger.debug(`Released installation state lock: ${lockPath}`);
+	};
+}

--- a/src/services/file-operations/manifest-writer.ts
+++ b/src/services/file-operations/manifest-writer.ts
@@ -143,7 +143,11 @@ export class ManifestWriter {
 	/**
 	 * Remove a kit from metadata.json (for kit-scoped uninstall)
 	 */
-	static async removeKitFromManifest(claudeDir: string, kit: KitType): Promise<boolean> {
-		return removeKitFromManifest(claudeDir, kit);
+	static async removeKitFromManifest(
+		claudeDir: string,
+		kit: KitType,
+		options?: { lockHeld?: boolean },
+	): Promise<boolean> {
+		return removeKitFromManifest(claudeDir, kit, options);
 	}
 }

--- a/src/services/file-operations/manifest/manifest-updater.ts
+++ b/src/services/file-operations/manifest/manifest-updater.ts
@@ -1,10 +1,10 @@
 import { join } from "node:path";
 import { migrateToMultiKit } from "@/domains/migration/metadata-migration.js";
+import { acquireInstallationStateLock } from "@/services/file-operations/installation-state-lock.js";
 import { logger } from "@/shared/logger.js";
 import type { KitMetadata, KitType, Metadata, TrackedFile } from "@/types";
 import { MetadataSchema, USER_CONFIG_PATTERNS } from "@/types";
-import { ensureFile, pathExists, readFile, writeFile } from "fs-extra";
-import { lock } from "proper-lockfile";
+import { ensureFile, pathExists, readFile, remove, writeFile } from "fs-extra";
 import { readManifest } from "./manifest-reader.js";
 
 /**
@@ -38,11 +38,7 @@ export async function writeManifest(
 	// Acquire exclusive lock to prevent concurrent modification
 	let release: (() => Promise<void>) | null = null;
 	try {
-		release = await lock(metadataPath, {
-			retries: { retries: 5, minTimeout: 100, maxTimeout: 1000 },
-			stale: 60000, // Consider lock stale after 60 seconds (allows for slow I/O and migrations)
-		});
-		logger.debug(`Acquired lock on ${metadataPath}`);
+		release = await acquireInstallationStateLock(claudeDir);
 
 		// Migrate legacy metadata if needed (inside lock)
 		const migrationResult = await migrateToMultiKit(claudeDir);
@@ -133,11 +129,7 @@ export async function removeKitFromManifest(
 	let release: (() => Promise<void>) | null = null;
 	try {
 		if (!options?.lockHeld) {
-			release = await lock(metadataPath, {
-				retries: { retries: 5, minTimeout: 100, maxTimeout: 1000 },
-				stale: 60000, // Consider lock stale after 60 seconds (consistent with writeManifest)
-			});
-			logger.debug(`Acquired lock on ${metadataPath} for kit removal`);
+			release = await acquireInstallationStateLock(claudeDir);
 		}
 
 		// Read current metadata inside lock
@@ -147,9 +139,10 @@ export async function removeKitFromManifest(
 		// Remove kit from kits object
 		const { [kit]: _removed, ...remainingKits } = metadata.kits;
 
-		// If no kits remaining, delete metadata.json
+		// If no kits remain, remove metadata.json inside the lock.
 		if (Object.keys(remainingKits).length === 0) {
-			logger.debug("No kits remaining, metadata.json will be cleaned up");
+			await remove(metadataPath);
+			logger.debug("No kits remaining, removed metadata.json");
 			return true;
 		}
 

--- a/src/services/file-operations/manifest/manifest-updater.ts
+++ b/src/services/file-operations/manifest/manifest-updater.ts
@@ -120,7 +120,11 @@ export async function writeManifest(
  * @param kit - Kit to remove
  * @returns true if kit was removed, false if not found
  */
-export async function removeKitFromManifest(claudeDir: string, kit: KitType): Promise<boolean> {
+export async function removeKitFromManifest(
+	claudeDir: string,
+	kit: KitType,
+	options?: { lockHeld?: boolean },
+): Promise<boolean> {
 	const metadataPath = join(claudeDir, "metadata.json");
 
 	if (!(await pathExists(metadataPath))) return false;
@@ -128,11 +132,13 @@ export async function removeKitFromManifest(claudeDir: string, kit: KitType): Pr
 	// Acquire exclusive lock
 	let release: (() => Promise<void>) | null = null;
 	try {
-		release = await lock(metadataPath, {
-			retries: { retries: 5, minTimeout: 100, maxTimeout: 1000 },
-			stale: 60000, // Consider lock stale after 60 seconds (consistent with writeManifest)
-		});
-		logger.debug(`Acquired lock on ${metadataPath} for kit removal`);
+		if (!options?.lockHeld) {
+			release = await lock(metadataPath, {
+				retries: { retries: 5, minTimeout: 100, maxTimeout: 1000 },
+				stale: 60000, // Consider lock stale after 60 seconds (consistent with writeManifest)
+			});
+			logger.debug(`Acquired lock on ${metadataPath} for kit removal`);
+		}
 
 		// Read current metadata inside lock
 		const metadata = await readManifest(claudeDir);

--- a/tests/commands/backups.test.ts
+++ b/tests/commands/backups.test.ts
@@ -127,7 +127,9 @@ describe("backups command handlers", () => {
 
 		const output = (console.log as ReturnType<typeof mock>).mock.calls.at(-1)?.[0];
 		const parsed = JSON.parse(String(output));
+		expect(parsed.ok).toBe(true);
 		expect(parsed.deletedIds).toHaveLength(1);
+		expect(parsed.keptIds).toHaveLength(1);
 	});
 
 	test("returns structured JSON when prune is cancelled", async () => {

--- a/tests/commands/backups.test.ts
+++ b/tests/commands/backups.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createCliInstance } from "@/cli/cli-config.js";
@@ -20,6 +21,7 @@ describe("backups command handlers", () => {
 
 		originalLog = console.log;
 		originalError = console.error;
+		process.exitCode = undefined;
 		console.log = mock(() => {}) as typeof console.log;
 		console.error = mock(() => {}) as typeof console.error;
 	});
@@ -27,6 +29,7 @@ describe("backups command handlers", () => {
 	afterEach(async () => {
 		console.log = originalLog;
 		console.error = originalError;
+		process.exitCode = undefined;
 		await rm(join(testPaths.testHome, "project"), { recursive: true, force: true });
 		testPaths.cleanup();
 	});
@@ -79,6 +82,11 @@ describe("backups command handlers", () => {
 		});
 
 		expect(await Bun.file(join(sourceRoot, "commands", "test.md")).text()).toBe("original");
+		const output = (console.log as ReturnType<typeof mock>).mock.calls.at(-1)?.[0];
+		const parsed = JSON.parse(String(output));
+		expect(parsed.ok).toBe(true);
+		expect(parsed.restored).toBe(true);
+		expect(parsed.itemCount).toBe(1);
 	});
 
 	test("does not report success when restore is cancelled", async () => {
@@ -142,14 +150,20 @@ describe("backups command handlers", () => {
 	});
 
 	test("emits JSON error envelope for invalid CLI input", async () => {
-		const cli = createCliInstance();
-		registerCommands(cli);
-		cli.parse(["node", "ck", "backups", "prune", "--keep", "1abc", "--json", "--yes"]);
-		await cli.runMatchedCommand();
+		const result = spawnSync(
+			"bun",
+			["run", "src/index.ts", "backups", "prune", "--keep", "1abc", "--json", "--yes"],
+			{
+				cwd: process.cwd(),
+				encoding: "utf-8",
+			},
+		);
 
-		const output = (console.log as ReturnType<typeof mock>).mock.calls[0]?.[0];
-		const parsed = JSON.parse(String(output));
+		expect(result.status).toBe(1);
+		expect(result.stdout).toBeTruthy();
+		const parsed = JSON.parse(result.stdout);
 		expect(parsed.ok).toBe(false);
 		expect(parsed.error).toContain("Invalid keep count");
+		expect(result.stderr).toBe("");
 	});
 });

--- a/tests/commands/backups.test.ts
+++ b/tests/commands/backups.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createCliInstance } from "@/cli/cli-config.js";
+import { registerCommands } from "@/cli/command-registry.js";
+import { createDestructiveOperationBackup } from "@/services/file-operations/destructive-operation-backup.js";
+import { type TestPaths, setupTestPaths } from "../helpers/test-paths.js";
+
+describe("backups command handlers", () => {
+	let testPaths: TestPaths;
+	let sourceRoot: string;
+	let originalLog: typeof console.log;
+	let originalError: typeof console.error;
+
+	beforeEach(async () => {
+		testPaths = setupTestPaths();
+		sourceRoot = join(testPaths.testHome, "project", ".claude");
+		await mkdir(join(sourceRoot, "commands"), { recursive: true });
+		await writeFile(join(sourceRoot, "commands", "test.md"), "original");
+
+		originalLog = console.log;
+		originalError = console.error;
+		console.log = mock(() => {}) as typeof console.log;
+		console.error = mock(() => {}) as typeof console.error;
+	});
+
+	afterEach(async () => {
+		console.log = originalLog;
+		console.error = originalError;
+		await rm(join(testPaths.testHome, "project"), { recursive: true, force: true });
+		testPaths.cleanup();
+	});
+
+	test("lists backups in JSON mode", async () => {
+		await createDestructiveOperationBackup({
+			operation: "fresh-install",
+			sourceRoot,
+			deletePaths: ["commands/test.md"],
+		});
+
+		const { handleBackupsList } = await import("../../src/commands/backups/index.js");
+		await handleBackupsList({ json: true });
+
+		const output = (console.log as ReturnType<typeof mock>).mock.calls[0]?.[0];
+		const parsed = JSON.parse(String(output));
+		expect(parsed).toHaveLength(1);
+		expect(parsed[0].operation).toBe("fresh-install");
+	});
+
+	test("dispatches through the real CLI parser", async () => {
+		await createDestructiveOperationBackup({
+			operation: "fresh-install",
+			sourceRoot,
+			deletePaths: ["commands/test.md"],
+		});
+
+		const cli = createCliInstance();
+		registerCommands(cli);
+		cli.parse(["node", "ck", "backups", "list", "--json"]);
+		await cli.runMatchedCommand();
+
+		const output = (console.log as ReturnType<typeof mock>).mock.calls[0]?.[0];
+		const parsed = JSON.parse(String(output));
+		expect(parsed).toHaveLength(1);
+	});
+
+	test("restores a backup by id", async () => {
+		const backup = await createDestructiveOperationBackup({
+			operation: "fresh-install",
+			sourceRoot,
+			deletePaths: ["commands/test.md"],
+		});
+		await rm(join(sourceRoot, "commands", "test.md"));
+
+		const { handleBackupsRestore } = await import("../../src/commands/backups/index.js");
+		await handleBackupsRestore(backup.backupDir.split("/").pop() as string, {
+			yes: true,
+			json: true,
+		});
+
+		expect(await Bun.file(join(sourceRoot, "commands", "test.md")).text()).toBe("original");
+	});
+
+	test("does not report success when restore is cancelled", async () => {
+		const backup = await createDestructiveOperationBackup({
+			operation: "fresh-install",
+			sourceRoot,
+			deletePaths: ["commands/test.md"],
+		});
+
+		const confirmSpy = mock(async () => false);
+		const { handleBackupsRestore } = await import("../../src/commands/backups/index.js");
+		await handleBackupsRestore(
+			backup.backupDir.split("/").pop() as string,
+			{ json: true },
+			{ confirmFn: confirmSpy },
+		);
+		const output = (console.log as ReturnType<typeof mock>).mock.calls[0]?.[0];
+		const parsed = JSON.parse(String(output));
+		expect(parsed.cancelled).toBe(true);
+		expect(parsed.restored).toBe(false);
+	});
+
+	test("prunes backups by keep count", async () => {
+		await createDestructiveOperationBackup({
+			operation: "fresh-install",
+			sourceRoot,
+			deletePaths: ["commands/test.md"],
+		});
+		await writeFile(join(sourceRoot, "commands", "test.md"), "updated");
+		await createDestructiveOperationBackup({
+			operation: "uninstall",
+			sourceRoot,
+			deletePaths: ["commands/test.md"],
+		});
+
+		const { handleBackupsPrune } = await import("../../src/commands/backups/index.js");
+		await handleBackupsPrune(undefined, { yes: true, json: true, keep: "1" });
+
+		const output = (console.log as ReturnType<typeof mock>).mock.calls.at(-1)?.[0];
+		const parsed = JSON.parse(String(output));
+		expect(parsed.deletedIds).toHaveLength(1);
+	});
+
+	test("returns structured JSON when prune is cancelled", async () => {
+		const confirmSpy = mock(async () => false);
+		const { handleBackupsPrune } = await import("../../src/commands/backups/index.js");
+		await handleBackupsPrune(undefined, { json: true, keep: "1" }, { confirmFn: confirmSpy });
+		const output = (console.log as ReturnType<typeof mock>).mock.calls[0]?.[0];
+		const parsed = JSON.parse(String(output));
+		expect(parsed.cancelled).toBe(true);
+	});
+
+	test("rejects malformed numeric input for list and prune", async () => {
+		const { handleBackupsList, handleBackupsPrune } = await import(
+			"../../src/commands/backups/index.js"
+		);
+		await expect(handleBackupsList({ limit: "1abc" })).rejects.toThrow("Invalid backup limit");
+		await expect(handleBackupsPrune(undefined, { keep: "1abc", yes: true })).rejects.toThrow(
+			"Invalid keep count",
+		);
+	});
+
+	test("emits JSON error envelope for invalid CLI input", async () => {
+		const cli = createCliInstance();
+		registerCommands(cli);
+		cli.parse(["node", "ck", "backups", "prune", "--keep", "1abc", "--json", "--yes"]);
+		await cli.runMatchedCommand();
+
+		const output = (console.log as ReturnType<typeof mock>).mock.calls[0]?.[0];
+		const parsed = JSON.parse(String(output));
+		expect(parsed.ok).toBe(false);
+		expect(parsed.error).toContain("Invalid keep count");
+	});
+});

--- a/tests/commands/uninstall.test.ts
+++ b/tests/commands/uninstall.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, realpathSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, readdirSync, realpathSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { ManifestWriter } from "@/services/file-operations/manifest-writer.js";
 import type { Metadata } from "@/types";
 import { type TestPaths, setupTestPaths } from "../helpers/test-paths.js";
 
@@ -38,6 +39,15 @@ describe("uninstall command integration", () => {
 		// Cleanup via test paths helper (also clears CK_TEST_HOME)
 		testPaths.cleanup();
 	});
+
+	function getBackupDirs(): string[] {
+		const backupRoot = join(testPaths.testHome, ".claudekit", "backups");
+		if (!existsSync(backupRoot)) {
+			return [];
+		}
+
+		return readdirSync(backupRoot).map((entry) => join(backupRoot, entry));
+	}
 
 	describe("manifest-based uninstall", () => {
 		test("should use manifest for accurate file removal", async () => {
@@ -78,7 +88,7 @@ describe("uninstall command integration", () => {
 				global: false,
 				all: false,
 				dryRun: false,
-				forceOverwrite: false,
+				forceOverwrite: true,
 			});
 
 			// Verify files were removed
@@ -117,7 +127,7 @@ describe("uninstall command integration", () => {
 				global: false,
 				all: false,
 				dryRun: false,
-				forceOverwrite: false,
+				forceOverwrite: true,
 			});
 
 			// Verify installed file was removed
@@ -125,6 +135,52 @@ describe("uninstall command integration", () => {
 
 			// Verify custom config was preserved
 			expect(existsSync(join(testLocalClaudeDir, "my-custom-config.json"))).toBe(true);
+		});
+
+		test("should create a recovery backup before tracked uninstall", async () => {
+			const metadata = {
+				kits: {
+					engineer: {
+						version: "1.0.0",
+						installedAt: new Date().toISOString(),
+						files: [
+							{
+								path: "commands/test.md",
+								checksum: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+						],
+					},
+				},
+			};
+
+			await writeFile(join(testLocalClaudeDir, "metadata.json"), JSON.stringify(metadata, null, 2));
+			await mkdir(join(testLocalClaudeDir, "commands"), { recursive: true });
+			await writeFile(join(testLocalClaudeDir, "commands", "test.md"), "command");
+
+			const { uninstallCommand } = await import("../../src/commands/uninstall/index.js");
+
+			await uninstallCommand({
+				yes: true,
+				json: false,
+				verbose: false,
+				local: true,
+				global: false,
+				all: false,
+				dryRun: false,
+				forceOverwrite: true,
+			});
+
+			const backups = getBackupDirs();
+			expect(backups.length).toBe(1);
+
+			const manifest = JSON.parse(await Bun.file(join(backups[0], "manifest.json")).text());
+			expect(manifest.operation).toBe("uninstall");
+			expect(manifest.items.map((item: { path: string }) => item.path).sort()).toEqual([
+				"commands/test.md",
+				"metadata.json",
+			]);
 		});
 	});
 
@@ -206,6 +262,31 @@ describe("uninstall command integration", () => {
 			expect(existsSync(join(testLocalClaudeDir, "commands"))).toBe(false);
 		});
 
+		test("should create a recovery backup before legacy uninstall", async () => {
+			await mkdir(join(testLocalClaudeDir, "commands"), { recursive: true });
+			await writeFile(join(testLocalClaudeDir, "commands", "test.md"), "command");
+
+			const { uninstallCommand } = await import("../../src/commands/uninstall/index.js");
+
+			await uninstallCommand({
+				yes: true,
+				json: false,
+				verbose: false,
+				local: true,
+				global: false,
+				all: false,
+				dryRun: false,
+				forceOverwrite: false,
+			});
+
+			const backups = getBackupDirs();
+			expect(backups.length).toBe(1);
+
+			const manifest = JSON.parse(await Bun.file(join(backups[0], "manifest.json")).text());
+			expect(manifest.items.map((item: { path: string }) => item.path)).toContain("commands");
+			expect(existsSync(join(backups[0], "snapshot", "commands", "test.md"))).toBe(true);
+		});
+
 		test("should preserve USER_CONFIG_PATTERNS in legacy mode", async () => {
 			// No metadata at all
 			await mkdir(join(testLocalClaudeDir, "commands"), { recursive: true });
@@ -248,6 +329,145 @@ describe("uninstall command integration", () => {
 
 			// Verify commands were removed
 			expect(existsSync(join(testLocalClaudeDir, "commands"))).toBe(false);
+		});
+	});
+
+	describe("recovery backups", () => {
+		test("should include metadata.json for kit-scoped uninstall", async () => {
+			const metadata = {
+				kits: {
+					engineer: {
+						version: "1.0.0",
+						installedAt: new Date().toISOString(),
+						files: [
+							{
+								path: "commands/engineer.md",
+								checksum: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+						],
+					},
+					marketing: {
+						version: "1.0.0",
+						installedAt: new Date().toISOString(),
+						files: [
+							{
+								path: "skills/marketing.md",
+								checksum: "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+						],
+					},
+				},
+			};
+
+			await writeFile(join(testLocalClaudeDir, "metadata.json"), JSON.stringify(metadata, null, 2));
+			await mkdir(join(testLocalClaudeDir, "commands"), { recursive: true });
+			await mkdir(join(testLocalClaudeDir, "skills"), { recursive: true });
+			await writeFile(join(testLocalClaudeDir, "commands", "engineer.md"), "engineer");
+			await writeFile(join(testLocalClaudeDir, "skills", "marketing.md"), "marketing");
+
+			const { uninstallCommand } = await import("../../src/commands/uninstall/index.js");
+
+			await uninstallCommand({
+				yes: true,
+				json: false,
+				verbose: false,
+				local: true,
+				global: false,
+				all: false,
+				dryRun: false,
+				forceOverwrite: true,
+				kit: "engineer",
+			});
+
+			const backups = getBackupDirs();
+			expect(backups.length).toBe(1);
+
+			const manifest = JSON.parse(await Bun.file(join(backups[0], "manifest.json")).text());
+			expect(manifest.items.map((item: { path: string }) => item.path).sort()).toEqual([
+				"commands/engineer.md",
+				"metadata.json",
+			]);
+		});
+
+		test("should restore files if kit-scoped uninstall fails after backup creation", async () => {
+			const metadata = {
+				kits: {
+					engineer: {
+						version: "1.0.0",
+						installedAt: new Date().toISOString(),
+						files: [
+							{
+								path: "commands/engineer.md",
+								checksum: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+						],
+					},
+					marketing: {
+						version: "1.0.0",
+						installedAt: new Date().toISOString(),
+						files: [
+							{
+								path: "skills/marketing.md",
+								checksum: "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+						],
+					},
+				},
+			};
+
+			await writeFile(join(testLocalClaudeDir, "metadata.json"), JSON.stringify(metadata, null, 2));
+			await mkdir(join(testLocalClaudeDir, "commands"), { recursive: true });
+			await mkdir(join(testLocalClaudeDir, "skills"), { recursive: true });
+			await writeFile(join(testLocalClaudeDir, "commands", "engineer.md"), "engineer");
+			await writeFile(join(testLocalClaudeDir, "skills", "marketing.md"), "marketing");
+
+			const originalRemoveKitFromManifest = ManifestWriter.removeKitFromManifest;
+			ManifestWriter.removeKitFromManifest = mock(async () => {
+				throw new Error("forced metadata write failure");
+			});
+
+			try {
+				const { removeInstallations } = await import(
+					"../../src/commands/uninstall/removal-handler.js"
+				);
+
+				await expect(
+					removeInstallations(
+						[
+							{
+								type: "local",
+								path: testLocalClaudeDir,
+								exists: true,
+								hasMetadata: true,
+								components: {
+									agents: 0,
+									commands: 1,
+									rules: 0,
+									skills: 1,
+								},
+							},
+						],
+						{
+							dryRun: false,
+							forceOverwrite: true,
+							kit: "engineer",
+						},
+					),
+				).rejects.toThrow("Recovery backup retained at");
+
+				expect(existsSync(join(testLocalClaudeDir, "commands", "engineer.md"))).toBe(true);
+				expect(getBackupDirs().length).toBe(1);
+			} finally {
+				ManifestWriter.removeKitFromManifest = originalRemoveKitFromManifest;
+			}
 		});
 	});
 

--- a/tests/commands/uninstall.test.ts
+++ b/tests/commands/uninstall.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { existsSync, readdirSync, realpathSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { acquireInstallationStateLock } from "@/services/file-operations/installation-state-lock.js";
 import { ManifestWriter } from "@/services/file-operations/manifest-writer.js";
 import type { Metadata } from "@/types";
 import { type TestPaths, setupTestPaths } from "../helpers/test-paths.js";
@@ -468,6 +469,100 @@ describe("uninstall command integration", () => {
 			} finally {
 				ManifestWriter.removeKitFromManifest = originalRemoveKitFromManifest;
 			}
+		});
+
+		test("should allow safe in-tree symlinks during uninstall backup", async () => {
+			if (process.platform === "win32") {
+				return;
+			}
+
+			const metadata = {
+				kits: {
+					engineer: {
+						version: "1.0.0",
+						installedAt: new Date().toISOString(),
+						files: [
+							{
+								path: "commands/target.md",
+								checksum: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+							{
+								path: "commands/alias.md",
+								checksum: "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+						],
+					},
+				},
+			};
+			await writeFile(join(testLocalClaudeDir, "metadata.json"), JSON.stringify(metadata, null, 2));
+			await mkdir(join(testLocalClaudeDir, "commands"), { recursive: true });
+			await writeFile(join(testLocalClaudeDir, "commands", "target.md"), "target");
+			await symlink("target.md", join(testLocalClaudeDir, "commands", "alias.md"));
+
+			const { uninstallCommand } = await import("../../src/commands/uninstall/index.js");
+
+			await uninstallCommand({
+				yes: true,
+				json: false,
+				verbose: false,
+				local: true,
+				global: false,
+				all: false,
+				dryRun: false,
+				forceOverwrite: true,
+			});
+
+			expect(existsSync(join(testLocalClaudeDir, "commands", "alias.md"))).toBe(false);
+		});
+	});
+
+	describe("installation state locking", () => {
+		test("acquires the shared installation lock before uninstall analysis", async () => {
+			const metadata: Metadata = {
+				name: "engineer",
+				version: "1.0.0",
+				installedAt: "2025-01-01T00:00:00.000Z",
+				scope: "local",
+				installedFiles: ["commands/test.md"],
+			};
+			await writeFile(join(testLocalClaudeDir, "metadata.json"), JSON.stringify(metadata, null, 2));
+			await mkdir(join(testLocalClaudeDir, "commands"), { recursive: true });
+			await writeFile(join(testLocalClaudeDir, "commands", "test.md"), "command");
+
+			const release = await acquireInstallationStateLock(testLocalClaudeDir);
+			const { removeInstallations } = await import(
+				"../../src/commands/uninstall/removal-handler.js"
+			);
+
+			let settled = false;
+			const run = removeInstallations(
+				[
+					{
+						type: "local",
+						path: testLocalClaudeDir,
+						exists: true,
+						hasMetadata: true,
+						components: { agents: 0, commands: 1, rules: 0, skills: 0 },
+					},
+				],
+				{
+					dryRun: true,
+					forceOverwrite: false,
+				},
+			).finally(() => {
+				settled = true;
+			});
+
+			await Bun.sleep(50);
+			expect(settled).toBe(false);
+
+			await release();
+			await run;
+			expect(settled).toBe(true);
 		});
 	});
 

--- a/tests/domains/help/help-registry.test.ts
+++ b/tests/domains/help/help-registry.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_HELP_OPTIONS, renderGlobalHelp } from "@/domains/help/help-rend
 describe("help registry coverage", () => {
 	const expectedCommands = [
 		"agents",
+		"backups",
 		"commands",
 		"config",
 		"content",

--- a/tests/lib/fresh-installer.test.ts
+++ b/tests/lib/fresh-installer.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
@@ -7,13 +7,17 @@ import {
 	handleFreshInstallation,
 } from "@/domains/installation/fresh-installer.js";
 import { PromptsManager } from "@/domains/ui/prompts.js";
+import { type TestPaths, setupTestPaths } from "../helpers/test-paths.js";
 
 describe("Fresh Installer", () => {
 	let testDir: string;
 	let claudeDir: string;
 	let prompts: PromptsManager;
+	let testPaths: TestPaths;
 
 	beforeEach(async () => {
+		testPaths = setupTestPaths();
+
 		// Create test directory
 		testDir = join(process.cwd(), "test-temp", `fresh-test-${Date.now()}`);
 		claudeDir = join(testDir, ".claude");
@@ -45,7 +49,17 @@ describe("Fresh Installer", () => {
 		if (existsSync(testDir)) {
 			await rm(testDir, { recursive: true, force: true });
 		}
+		testPaths.cleanup();
 	});
+
+	function getBackupDirs(): string[] {
+		const backupRoot = join(testPaths.testHome, ".claudekit", "backups");
+		if (!existsSync(backupRoot)) {
+			return [];
+		}
+
+		return readdirSync(backupRoot).map((entry) => join(backupRoot, entry));
+	}
 
 	// Valid SHA-256 checksums (64 hex characters)
 	const CHECKSUM_1 = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
@@ -285,6 +299,36 @@ describe("Fresh Installer", () => {
 			expect(existsSync(join(claudeDir, "skills"))).toBe(true);
 		});
 
+		test("should not fall back to directory deletion when metadata tracks only user files", async () => {
+			const metadata = {
+				kits: {
+					engineer: {
+						version: "1.0.0",
+						installedAt: new Date().toISOString(),
+						files: [
+							{
+								path: "skills/my-custom-skill.md",
+								checksum: CHECKSUM_1,
+								ownership: "user",
+								installedVersion: "1.0.0",
+							},
+						],
+					},
+				},
+			};
+			await writeFile(join(claudeDir, "metadata.json"), JSON.stringify(metadata));
+			await writeFile(join(claudeDir, "skills", "my-custom-skill.md"), "custom skill content");
+
+			const mockPrompt = mock(() => Promise.resolve(true));
+			prompts.promptFreshConfirmation = mockPrompt;
+
+			const result = await handleFreshInstallation(claudeDir, prompts);
+
+			expect(result).toBe(true);
+			expect(existsSync(join(claudeDir, "skills", "my-custom-skill.md"))).toBe(true);
+			expect(existsSync(join(claudeDir, "commands"))).toBe(true);
+		});
+
 		test("should cleanup empty directories after removing CK files", async () => {
 			// Create nested directory structure
 			await mkdir(join(claudeDir, "skills", "nested"), { recursive: true });
@@ -374,6 +418,111 @@ describe("Fresh Installer", () => {
 			const files = updatedMetadata.kits.engineer.files;
 			expect(files.length).toBe(1);
 			expect(files[0].path).toBe("skills/user-skill.md");
+		});
+	});
+
+	describe("recovery backups", () => {
+		test("should create a recovery backup before fallback removal", async () => {
+			const mockPrompt = mock(() => Promise.resolve(true));
+			prompts.promptFreshConfirmation = mockPrompt;
+
+			const result = await handleFreshInstallation(claudeDir, prompts);
+
+			expect(result).toBe(true);
+			const backups = getBackupDirs();
+			expect(backups.length).toBe(1);
+
+			const manifest = JSON.parse(await Bun.file(join(backups[0], "manifest.json")).text());
+			expect(manifest.operation).toBe("fresh-install");
+			expect(manifest.items.map((item: { path: string }) => item.path)).toContain("commands");
+			expect(existsSync(join(backups[0], "snapshot", "commands", "test.md"))).toBe(true);
+		});
+
+		test("should create a recovery backup that includes metadata mutations", async () => {
+			const metadata = {
+				kits: {
+					engineer: {
+						version: "1.0.0",
+						installedAt: new Date().toISOString(),
+						files: [
+							{
+								path: "commands/test.md",
+								checksum: CHECKSUM_1,
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+							{
+								path: "agents/test.md",
+								checksum: CHECKSUM_2,
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+							{
+								path: "skills/test.md",
+								checksum: CHECKSUM_3,
+								ownership: "user",
+								installedVersion: "1.0.0",
+							},
+						],
+					},
+				},
+			};
+			await writeFile(join(claudeDir, "metadata.json"), JSON.stringify(metadata));
+
+			const mockPrompt = mock(() => Promise.resolve(true));
+			prompts.promptFreshConfirmation = mockPrompt;
+
+			const result = await handleFreshInstallation(claudeDir, prompts);
+
+			expect(result).toBe(true);
+			const backups = getBackupDirs();
+			expect(backups.length).toBe(1);
+
+			const manifest = JSON.parse(await Bun.file(join(backups[0], "manifest.json")).text());
+			expect(manifest.items.map((item: { path: string }) => item.path).sort()).toEqual([
+				"agents/test.md",
+				"commands/test.md",
+				"metadata.json",
+			]);
+			expect(existsSync(join(backups[0], "snapshot", "metadata.json"))).toBe(true);
+		});
+
+		test("should restore deleted files if removal fails after backup creation", async () => {
+			const metadata = {
+				kits: {
+					engineer: {
+						version: "1.0.0",
+						installedAt: new Date().toISOString(),
+						files: [
+							{
+								path: "commands/test.md",
+								checksum: CHECKSUM_1,
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+							{
+								path: "agents/test.md",
+								checksum: CHECKSUM_2,
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+						],
+					},
+				},
+			};
+			await writeFile(join(claudeDir, "metadata.json"), JSON.stringify(metadata));
+			await rm(join(claudeDir, "agents", "test.md"), { force: true });
+			await mkdir(join(claudeDir, "agents", "test.md"), { recursive: true });
+
+			const mockPrompt = mock(() => Promise.resolve(true));
+			prompts.promptFreshConfirmation = mockPrompt;
+
+			await expect(handleFreshInstallation(claudeDir, prompts)).rejects.toThrow(
+				"Recovery backup retained at",
+			);
+			expect(existsSync(join(claudeDir, "commands", "test.md"))).toBe(true);
+			expect(existsSync(join(claudeDir, "agents", "test.md"))).toBe(true);
+			expect(getBackupDirs().length).toBe(1);
 		});
 	});
 

--- a/tests/lib/fresh-installer.test.ts
+++ b/tests/lib/fresh-installer.test.ts
@@ -7,6 +7,7 @@ import {
 	handleFreshInstallation,
 } from "@/domains/installation/fresh-installer.js";
 import { PromptsManager } from "@/domains/ui/prompts.js";
+import { acquireInstallationStateLock } from "@/services/file-operations/installation-state-lock.js";
 import { type TestPaths, setupTestPaths } from "../helpers/test-paths.js";
 
 describe("Fresh Installer", () => {
@@ -523,6 +524,44 @@ describe("Fresh Installer", () => {
 			expect(existsSync(join(claudeDir, "commands", "test.md"))).toBe(true);
 			expect(existsSync(join(claudeDir, "agents", "test.md"))).toBe(true);
 			expect(getBackupDirs().length).toBe(1);
+		});
+	});
+
+	describe("installation state locking", () => {
+		test("waits for the shared installation lock before starting a fresh install", async () => {
+			const metadata = {
+				kits: {
+					engineer: {
+						version: "1.0.0",
+						installedAt: new Date().toISOString(),
+						files: [
+							{
+								path: "commands/test.md",
+								checksum: CHECKSUM_1,
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+						],
+					},
+				},
+			};
+			await writeFile(join(claudeDir, "metadata.json"), JSON.stringify(metadata));
+
+			const mockPrompt = mock(() => Promise.resolve(true));
+			prompts.promptFreshConfirmation = mockPrompt;
+
+			const release = await acquireInstallationStateLock(claudeDir);
+			let settled = false;
+			const run = handleFreshInstallation(claudeDir, prompts).finally(() => {
+				settled = true;
+			});
+
+			await Bun.sleep(50);
+			expect(settled).toBe(false);
+
+			await release();
+			await run;
+			expect(settled).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
Refs #615

## Summary
This fix makes destructive ClaudeKit flows recoverable and user-manageable. Before `ck init --fresh` or `ck uninstall` delete or rewrite anything, the CLI creates a scoped recovery snapshot under `~/.claudekit/backups/...`. This PR also adds bounded retention and a new `ck backups` command group so users can inspect, restore, and prune those recovery points safely.

## Root Cause
Destructive flows previously removed files in place with no CK-managed recovery path. They also had no bounded backup management story once recovery snapshots were introduced, which left users without a first-class way to inspect or restore backups and risked unbounded storage growth over time.

## What Changed
- added a shared destructive-operation backup service for snapshot + manifest generation
- hardened restore validation, symlink handling, and whole-operation rollback behavior
- serialized destructive flows and manifest writes with installation-state locking
- added automatic retention for destructive-operation backups
- added `ck backups list|restore|prune` for user-facing backup management
- expanded tests for restore safety, retention, lock contention, command UX, and JSON behavior

## Validation
- `bun run validate`
- targeted backup command and backup service tests
- lock contention, symlink, malformed manifest, retention, and rollback regression coverage

## Docs
- paired docs PR: claudekit/claudekit-docs#135

## Notes
Backup scope remains intentionally narrow: only files ClaudeKit is going to delete or mutate are snapshotted, not the full `~/.claude/` tree.