### PR TITLE
fix(opencode): reuse Claude-compatible skill roots

### DIFF
--- a/src/commands/portable/__tests__/provider-registry.test.ts
+++ b/src/commands/portable/__tests__/provider-registry.test.ts
@@ -188,6 +188,16 @@ describe("provider-registry", () => {
 	});
 
 	describe("skills path consolidation to .agents/skills", () => {
+		it("opencode skills projectPath is .claude/skills for native Claude compatibility", () => {
+			expect(providers.opencode.skills?.projectPath).toBe(".claude/skills");
+		});
+
+		it("opencode skills globalPath points to .claude/skills to avoid duplicate shadows", () => {
+			const globalPath = providers.opencode.skills?.globalPath?.replace(/\\/g, "/") ?? "";
+			expect(globalPath).toContain(".claude/skills");
+			expect(globalPath).not.toContain(".config/opencode/skills");
+		});
+
 		it("gemini-cli skills projectPath is .agents/skills", () => {
 			expect(providers["gemini-cli"].skills?.projectPath).toBe(".agents/skills");
 		});
@@ -223,6 +233,17 @@ describe("provider-registry", () => {
 	});
 
 	describe("detectProviderPathCollisions", () => {
+		it("detects claude-code+opencode skills path collision in project scope", () => {
+			const collisions = detectProviderPathCollisions(["claude-code", "opencode"], {
+				global: false,
+			});
+			const skillCollisions = collisions.filter((c) => c.portableType === "skills");
+			expect(skillCollisions).toHaveLength(1);
+			expect(skillCollisions[0].path).toBe(".claude/skills");
+			expect(skillCollisions[0].providers).toContain("claude-code");
+			expect(skillCollisions[0].providers).toContain("opencode");
+		});
+
 		it("detects codex+amp skills path collision in project scope", () => {
 			const collisions = detectProviderPathCollisions(["codex", "amp"], { global: false });
 			const skillCollisions = collisions.filter((c) => c.portableType === "skills");

--- a/src/commands/portable/provider-registry.ts
+++ b/src/commands/portable/provider-registry.ts
@@ -3,12 +3,13 @@
  * path configurations for agents, commands, and skills.
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import type { ProviderConfig, ProviderType } from "./types.js";
 
 const home = homedir();
 const cwd = process.cwd();
+const OPENCODE_BINARY_NAME = platform() === "win32" ? "opencode.exe" : "opencode";
 
 function hasInstallSignal(path: string | null | undefined): boolean {
 	if (!path || !existsSync(path)) {
@@ -31,6 +32,19 @@ function hasInstallSignal(path: string | null | undefined): boolean {
 
 function hasAnyInstallSignal(paths: Array<string | null | undefined>): boolean {
 	return paths.some((path) => hasInstallSignal(path));
+}
+
+function hasOpenCodeInstallSignal(): boolean {
+	return hasAnyInstallSignal([
+		join(cwd, "opencode.json"),
+		join(cwd, "opencode.jsonc"),
+		join(cwd, ".opencode/agents"),
+		join(cwd, ".opencode/commands"),
+		join(home, ".config/opencode/AGENTS.md"),
+		join(home, ".config/opencode/agents"),
+		join(home, ".config/opencode/commands"),
+		join(home, ".opencode/bin", OPENCODE_BINARY_NAME),
+	]);
 }
 
 /**
@@ -122,8 +136,11 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			fileExtension: ".md",
 		},
 		skills: {
-			projectPath: ".opencode/skills",
-			globalPath: join(home, ".config/opencode/skills"),
+			// OpenCode reads Claude-compatible skill roots natively.
+			// Writing duplicate copies to .opencode/skills can shadow .claude/skills
+			// and make OpenCode load the wrong version of a skill.
+			projectPath: ".claude/skills",
+			globalPath: join(home, ".claude/skills"),
 			format: "direct-copy",
 			writeStrategy: "per-file",
 			fileExtension: ".md",
@@ -144,18 +161,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 		},
 		hooks: null,
 		settingsJsonPath: null,
-		detect: async () =>
-			hasAnyInstallSignal([
-				join(cwd, "opencode.json"),
-				join(cwd, "opencode.jsonc"),
-				join(cwd, ".opencode/agents"),
-				join(cwd, ".opencode/commands"),
-				join(cwd, ".opencode/skills"),
-				join(home, ".config/opencode/AGENTS.md"),
-				join(home, ".config/opencode/agents"),
-				join(home, ".config/opencode/commands"),
-				join(home, ".config/opencode/skills"),
-			]),
+		detect: async () => hasOpenCodeInstallSignal(),
 	},
 	"github-copilot": {
 		name: "github-copilot",

--- a/src/commands/skills/__tests__/agents.test.ts
+++ b/src/commands/skills/__tests__/agents.test.ts
@@ -54,6 +54,13 @@ describe("agents", () => {
 			expect(cursor.projectPath).toBe(".cursor/skills");
 			expect(cursor.globalPath).toBe(join(home, ".cursor/skills"));
 		});
+
+		it("should have opencode agent reusing Claude-compatible skill paths", () => {
+			const opencode = agents.opencode;
+			expect(opencode.displayName).toBe("OpenCode");
+			expect(opencode.projectPath).toBe(".claude/skills");
+			expect(opencode.globalPath).toBe(join(home, ".claude/skills"));
+		});
 	});
 
 	describe("detectInstalledAgents", () => {

--- a/src/commands/skills/__tests__/skills-installer.test.ts
+++ b/src/commands/skills/__tests__/skills-installer.test.ts
@@ -118,6 +118,36 @@ description: Test skill at source location
 			}
 		});
 
+		it("should skip OpenCode installation when skill already lives in Claude root", async () => {
+			const samePathSkillDir = join(home, ".claude/skills/opencode-native-skill");
+			mkdirSync(samePathSkillDir, { recursive: true });
+			writeFileSync(
+				join(samePathSkillDir, "SKILL.md"),
+				`---
+name: opencode-native-skill
+description: OpenCode native Claude-compatible skill
+---
+# OpenCode Native Skill
+`,
+			);
+
+			const samePathSkill: SkillInfo = {
+				name: "opencode-native-skill",
+				description: "OpenCode native Claude-compatible skill",
+				path: samePathSkillDir,
+			};
+
+			try {
+				const result = await installSkillForAgent(samePathSkill, "opencode", { global: true });
+
+				expect(result.success).toBe(true);
+				expect(result.skipped).toBe(true);
+				expect(result.skipReason).toContain("already exists at source");
+			} finally {
+				rmSync(samePathSkillDir, { recursive: true, force: true });
+			}
+		});
+
 		it("should not skip when source and target are different paths", async () => {
 			// Skill source is in test directory, target is in .claude/skills
 			const result = await installSkillForAgent(testSkill, "claude-code", { global: true });

--- a/src/commands/skills/__tests__/skills-uninstaller.test.ts
+++ b/src/commands/skills/__tests__/skills-uninstaller.test.ts
@@ -129,6 +129,26 @@ describe("skill-uninstaller", () => {
 			const installed = await getInstalledSkills("claude-code", true);
 			expect(installed.find((i) => i.skill === "force-with-registry")).toBeUndefined();
 		});
+
+		it("preserves shared skill directory when another agent uses the same path", async () => {
+			const skillPath = join(claudeSkillsPath, "force-shared-opencode-test");
+			mkdirSync(skillPath, { recursive: true });
+			writeFileSync(join(skillPath, "SKILL.md"), "# Force Shared Test");
+			await addInstallation("force-shared-opencode-test", "claude-code", true, skillPath, "/src");
+			await addInstallation("force-shared-opencode-test", "opencode", true, skillPath, "/src");
+
+			try {
+				const result = await forceUninstallSkill("force-shared-opencode-test", "opencode", true);
+
+				expect(result.success).toBe(true);
+				expect(existsSync(skillPath)).toBe(true);
+
+				const installed = await getInstalledSkills("claude-code", true);
+				expect(installed.find((i) => i.skill === "force-shared-opencode-test")).toBeDefined();
+			} finally {
+				await uninstallSkillFromAgent("force-shared-opencode-test", "claude-code", true);
+			}
+		});
 	});
 
 	describe("getInstalledSkills", () => {

--- a/src/commands/skills/__tests__/skills-uninstaller.test.ts
+++ b/src/commands/skills/__tests__/skills-uninstaller.test.ts
@@ -72,6 +72,26 @@ describe("skill-uninstaller", () => {
 			expect(result.success).toBe(true);
 			expect(result.wasOrphaned).toBe(true);
 		});
+
+		it("preserves shared skill directory when another agent uses the same path", async () => {
+			const skillPath = join(claudeSkillsPath, "shared-opencode-test");
+			mkdirSync(skillPath, { recursive: true });
+			writeFileSync(join(skillPath, "SKILL.md"), "# Shared Test");
+			await addInstallation("shared-opencode-test", "claude-code", true, skillPath, "/src");
+			await addInstallation("shared-opencode-test", "opencode", true, skillPath, "/src");
+
+			try {
+				const result = await uninstallSkillFromAgent("shared-opencode-test", "opencode", true);
+
+				expect(result.success).toBe(true);
+				expect(existsSync(skillPath)).toBe(true);
+
+				const installed = await getInstalledSkills("claude-code", true);
+				expect(installed.find((i) => i.skill === "shared-opencode-test")).toBeDefined();
+			} finally {
+				await uninstallSkillFromAgent("shared-opencode-test", "claude-code", true);
+			}
+		});
 	});
 
 	describe("forceUninstallSkill", () => {

--- a/src/commands/skills/agents.ts
+++ b/src/commands/skills/agents.ts
@@ -2,11 +2,22 @@
  * Agent registry - defines supported coding agents and their skill paths
  */
 import { existsSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import type { AgentConfig, AgentType } from "./types.js";
 
 const home = homedir();
+const OPENCODE_BINARY_NAME = platform() === "win32" ? "opencode.exe" : "opencode";
+
+function hasOpenCodeInstallSignal(): boolean {
+	return (
+		existsSync(join(process.cwd(), "opencode.json")) ||
+		existsSync(join(process.cwd(), "opencode.jsonc")) ||
+		existsSync(join(process.cwd(), ".opencode")) ||
+		existsSync(join(home, ".config/opencode")) ||
+		existsSync(join(home, ".opencode", "bin", OPENCODE_BINARY_NAME))
+	);
+}
 
 /**
  * Registry of supported coding agents with their skill directory paths
@@ -37,9 +48,11 @@ export const agents: Record<AgentType, AgentConfig> = {
 	opencode: {
 		name: "opencode",
 		displayName: "OpenCode",
-		projectPath: ".opencode/skills",
-		globalPath: join(home, ".config/opencode/skills"),
-		detect: async () => existsSync(join(home, ".config/opencode")),
+		// OpenCode discovers Claude-compatible skill roots automatically.
+		// Reusing .claude/skills avoids redundant shadow copies in .opencode/skills.
+		projectPath: ".claude/skills",
+		globalPath: join(home, ".claude/skills"),
+		detect: async () => hasOpenCodeInstallSignal(),
 	},
 	goose: {
 		name: "goose",

--- a/src/commands/skills/agents.ts
+++ b/src/commands/skills/agents.ts
@@ -1,7 +1,7 @@
 /**
  * Agent registry - defines supported coding agents and their skill paths
  */
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import type { AgentConfig, AgentType } from "./types.js";
@@ -9,14 +9,40 @@ import type { AgentConfig, AgentType } from "./types.js";
 const home = homedir();
 const OPENCODE_BINARY_NAME = platform() === "win32" ? "opencode.exe" : "opencode";
 
+function hasInstallSignal(path: string | null | undefined): boolean {
+	if (!path || !existsSync(path)) {
+		return false;
+	}
+
+	try {
+		const stat = statSync(path);
+		if (stat.isDirectory()) {
+			return readdirSync(path).length > 0;
+		}
+		if (stat.isFile()) {
+			return true;
+		}
+		return false;
+	} catch {
+		return false;
+	}
+}
+
+function hasAnyInstallSignal(paths: Array<string | null | undefined>): boolean {
+	return paths.some((path) => hasInstallSignal(path));
+}
+
 function hasOpenCodeInstallSignal(): boolean {
-	return (
-		existsSync(join(process.cwd(), "opencode.json")) ||
-		existsSync(join(process.cwd(), "opencode.jsonc")) ||
-		existsSync(join(process.cwd(), ".opencode")) ||
-		existsSync(join(home, ".config/opencode")) ||
-		existsSync(join(home, ".opencode", "bin", OPENCODE_BINARY_NAME))
-	);
+	return hasAnyInstallSignal([
+		join(process.cwd(), "opencode.json"),
+		join(process.cwd(), "opencode.jsonc"),
+		join(process.cwd(), ".opencode/agents"),
+		join(process.cwd(), ".opencode/commands"),
+		join(home, ".config/opencode/AGENTS.md"),
+		join(home, ".config/opencode/agents"),
+		join(home, ".config/opencode/commands"),
+		join(home, ".opencode", "bin", OPENCODE_BINARY_NAME),
+	]);
 }
 
 /**

--- a/src/commands/skills/skills-uninstaller.ts
+++ b/src/commands/skills/skills-uninstaller.ts
@@ -3,7 +3,7 @@
  */
 import { existsSync } from "node:fs";
 import { rm } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { agents } from "./agents.js";
 import { findInstallation, readRegistry, removeInstallation } from "./skills-registry.js";
 import type { AgentType, SkillInstallation } from "./types.js";
@@ -17,6 +17,14 @@ export interface UninstallResult {
 	success: boolean;
 	error?: string;
 	wasOrphaned?: boolean; // Entry existed in registry but file was already gone
+}
+
+function isSamePath(path1: string, path2: string): boolean {
+	try {
+		return resolve(path1) === resolve(path2);
+	} catch {
+		return false;
+	}
 }
 
 /**
@@ -49,7 +57,7 @@ export async function uninstallSkillFromAgent(
 	const path = installation.path;
 	const sharedInstallations = registry.installations.filter(
 		(i) =>
-			i.path === path &&
+			isSamePath(i.path, path) &&
 			!(
 				i.skill === installation.skill &&
 				i.agent === installation.agent &&
@@ -103,6 +111,7 @@ export async function forceUninstallSkill(
 	const agentConfig = agents[agent];
 	const basePath = global ? agentConfig.globalPath : agentConfig.projectPath;
 	const path = join(basePath, skill);
+	const registry = await readRegistry();
 
 	if (!existsSync(path)) {
 		return {
@@ -117,7 +126,15 @@ export async function forceUninstallSkill(
 	}
 
 	try {
-		await rm(path, { recursive: true, force: true });
+		const sharedInstallations = registry.installations.filter(
+			(i) =>
+				isSamePath(i.path, path) &&
+				!(i.skill === skill && i.agent === agent && i.global === global),
+		);
+
+		if (sharedInstallations.length === 0) {
+			await rm(path, { recursive: true, force: true });
+		}
 
 		// Also try to remove from registry if it exists there
 		await removeInstallation(skill, agent, global);

--- a/src/commands/skills/skills-uninstaller.ts
+++ b/src/commands/skills/skills-uninstaller.ts
@@ -47,13 +47,23 @@ export async function uninstallSkillFromAgent(
 
 	const installation = installations[0];
 	const path = installation.path;
+	const sharedInstallations = registry.installations.filter(
+		(i) =>
+			i.path === path &&
+			!(
+				i.skill === installation.skill &&
+				i.agent === installation.agent &&
+				i.global === installation.global
+			),
+	);
 
 	// Check if file actually exists
 	const fileExists = existsSync(path);
 
 	try {
-		// Remove from filesystem if exists
-		if (fileExists) {
+		// Shared skill roots (for example Claude Code + OpenCode) must remain on disk
+		// until the last registry entry referencing that path is removed.
+		if (fileExists && sharedInstallations.length === 0) {
 			await rm(path, { recursive: true, force: true });
 		}
 

--- a/src/domains/help/commands/migrate-command-help.ts
+++ b/src/domains/help/commands/migrate-command-help.ts
@@ -12,8 +12,8 @@ export const migrateCommandHelp: CommandHelp = {
 	usage: "ck migrate [options]",
 	examples: [
 		{
-			command: "ck migrate --agent droid --agent codex",
-			description: "Migrate to specific providers",
+			command: "ck migrate --agent opencode",
+			description: "Migrate OpenCode-native items while reusing Claude-compatible skill roots",
 		},
 		{
 			command: "ck migrate --all --global",

--- a/src/domains/help/commands/migrate-command-help.ts
+++ b/src/domains/help/commands/migrate-command-help.ts
@@ -16,8 +16,8 @@ export const migrateCommandHelp: CommandHelp = {
 			description: "Migrate OpenCode-native items while reusing Claude-compatible skill roots",
 		},
 		{
-			command: "ck migrate --all --global",
-			description: "Migrate globally to all supported providers",
+			command: "ck migrate --agent droid --agent codex",
+			description: "Migrate to specific providers",
 		},
 		{
 			command: "ck migrate --dry-run",

--- a/src/domains/help/commands/skills-command-help.ts
+++ b/src/domains/help/commands/skills-command-help.ts
@@ -100,8 +100,9 @@ export const skillsCommandHelp: CommandHelp = {
 		{
 			title: "Notes",
 			content: `  • Skills are installed from ~/.claude/skills (ClaudeKit Engineer source)
+  • OpenCode reuses Claude-compatible skill roots (.claude/skills, ~/.claude/skills), so installs may be a no-op
   • Registry stored at ~/.claudekit/skill-registry.json
-  • Project installs go to ./<agent>/skills, global to ~/<agent>/skills`,
+  • Target paths vary by agent; some agents intentionally share a common skills directory`,
 		},
 	],
 };


### PR DESCRIPTION
## Summary
- reuse Claude-compatible skill roots for OpenCode skills instead of duplicating them into `.opencode/skills`
- tighten OpenCode detection around real install signals instead of stale skill-directory assumptions
- preserve shared skill directories during uninstall and cover the behavior with regression tests

## Verification
- `bun run validate`
- verified behavior against `opencode debug skill` with isolated temp homes

## Notes
- OpenCode-native agents, commands, config, and rules still migrate normally
- built-in CLI help was updated to reflect the shared-skill-root behavior
- Docs impact: none for `claudekit-docs`; the public migrate page does not currently document OpenCode skill path precedence
