### PR TITLE
hotfix: retain metadata for preserved tracked files

### DIFF
--- a/src/commands/uninstall/analysis-handler.ts
+++ b/src/commands/uninstall/analysis-handler.ts
@@ -12,6 +12,7 @@ import { OwnershipChecker } from "@/services/file-operations/ownership-checker.j
 import { logger } from "@/shared/logger.js";
 import { log } from "@/shared/safe-prompts.js";
 import type { KitType } from "@/types";
+import { pathExists } from "fs-extra";
 import pc from "picocolors";
 import type { Installation } from "./installation-detector.js";
 
@@ -31,6 +32,10 @@ export interface UninstallAnalysis {
 interface FileClassification {
 	action: "delete" | "preserve";
 	reason: string;
+}
+
+function normalizeTrackedPath(relativePath: string): string {
+	return relativePath.replace(/\\/g, "/");
 }
 
 /**
@@ -108,19 +113,30 @@ export async function analyzeInstallation(
 
 	// Multi-kit format with kit-scoped uninstall
 	if (uninstallManifest.isMultiKit && kit && metadata?.kits?.[kit]) {
+		const preservedPaths = new Set(
+			uninstallManifest.filesToPreserve.map((filePath) => normalizeTrackedPath(filePath)),
+		);
+
 		for (const remainingKit of result.remainingKits) {
 			const remainingFiles = metadata.kits?.[remainingKit]?.files || [];
-			result.retainedManifestPaths.push(...remainingFiles.map((file) => file.path));
+			for (const file of remainingFiles) {
+				const relativePath = normalizeTrackedPath(file.path);
+				if (await pathExists(join(installation.path, relativePath))) {
+					result.retainedManifestPaths.push(relativePath);
+				}
+			}
 		}
 
 		const kitFiles = metadata.kits[kit].files || [];
 
 		for (const trackedFile of kitFiles) {
-			const filePath = join(installation.path, trackedFile.path);
+			const relativePath = normalizeTrackedPath(trackedFile.path);
+			const filePath = join(installation.path, relativePath);
 
 			// Check if file is shared with other kits
-			if (uninstallManifest.filesToPreserve.includes(trackedFile.path)) {
-				result.toPreserve.push({ path: trackedFile.path, reason: "shared with other kit" });
+			if (preservedPaths.has(relativePath)) {
+				result.toPreserve.push({ path: relativePath, reason: "shared with other kit" });
+				result.retainedManifestPaths.push(relativePath);
 				continue;
 			}
 
@@ -138,11 +154,11 @@ export async function analyzeInstallation(
 				`${kit} kit (pristine)`,
 			);
 			if (classification.action === "delete") {
-				result.toDelete.push({ path: trackedFile.path, reason: classification.reason });
+				result.toDelete.push({ path: relativePath, reason: classification.reason });
 			} else {
-				result.toPreserve.push({ path: trackedFile.path, reason: classification.reason });
-				result.protectedTrackedPaths.push(trackedFile.path);
-				result.retainedManifestPaths.push(trackedFile.path);
+				result.toPreserve.push({ path: relativePath, reason: classification.reason });
+				result.protectedTrackedPaths.push(relativePath);
+				result.retainedManifestPaths.push(relativePath);
 			}
 		}
 
@@ -169,7 +185,8 @@ export async function analyzeInstallation(
 
 	// Ownership-aware analysis for all files
 	for (const trackedFile of allTrackedFiles) {
-		const filePath = join(installation.path, trackedFile.path);
+		const relativePath = normalizeTrackedPath(trackedFile.path);
+		const filePath = join(installation.path, relativePath);
 		const ownershipResult = await OwnershipChecker.checkOwnership(
 			filePath,
 			metadata,
@@ -184,11 +201,11 @@ export async function analyzeInstallation(
 			"CK-owned (pristine)",
 		);
 		if (classification.action === "delete") {
-			result.toDelete.push({ path: trackedFile.path, reason: classification.reason });
+			result.toDelete.push({ path: relativePath, reason: classification.reason });
 		} else {
-			result.toPreserve.push({ path: trackedFile.path, reason: classification.reason });
-			result.protectedTrackedPaths.push(trackedFile.path);
-			result.retainedManifestPaths.push(trackedFile.path);
+			result.toPreserve.push({ path: relativePath, reason: classification.reason });
+			result.protectedTrackedPaths.push(relativePath);
+			result.retainedManifestPaths.push(relativePath);
 		}
 	}
 

--- a/src/commands/uninstall/analysis-handler.ts
+++ b/src/commands/uninstall/analysis-handler.ts
@@ -21,6 +21,8 @@ import type { Installation } from "./installation-detector.js";
 export interface UninstallAnalysis {
 	toDelete: { path: string; reason: string }[];
 	toPreserve: { path: string; reason: string }[];
+	retainedManifestPaths: string[];
+	protectedTrackedPaths: string[];
 }
 
 /**
@@ -94,6 +96,8 @@ export async function analyzeInstallation(
 	const result: UninstallAnalysis & { remainingKits: KitType[] } = {
 		toDelete: [],
 		toPreserve: [],
+		retainedManifestPaths: [],
+		protectedTrackedPaths: [],
 		remainingKits: [],
 	};
 	const metadata = await ManifestWriter.readManifest(installation.path);
@@ -104,6 +108,11 @@ export async function analyzeInstallation(
 
 	// Multi-kit format with kit-scoped uninstall
 	if (uninstallManifest.isMultiKit && kit && metadata?.kits?.[kit]) {
+		for (const remainingKit of result.remainingKits) {
+			const remainingFiles = metadata.kits?.[remainingKit]?.files || [];
+			result.retainedManifestPaths.push(...remainingFiles.map((file) => file.path));
+		}
+
 		const kitFiles = metadata.kits[kit].files || [];
 
 		for (const trackedFile of kitFiles) {
@@ -132,11 +141,12 @@ export async function analyzeInstallation(
 				result.toDelete.push({ path: trackedFile.path, reason: classification.reason });
 			} else {
 				result.toPreserve.push({ path: trackedFile.path, reason: classification.reason });
+				result.protectedTrackedPaths.push(trackedFile.path);
+				result.retainedManifestPaths.push(trackedFile.path);
 			}
 		}
 
-		// Don't delete metadata.json if other kits remain
-		if (result.remainingKits.length === 0) {
+		if (result.retainedManifestPaths.length === 0) {
 			result.toDelete.push({ path: "metadata.json", reason: "metadata file" });
 		}
 
@@ -177,11 +187,14 @@ export async function analyzeInstallation(
 			result.toDelete.push({ path: trackedFile.path, reason: classification.reason });
 		} else {
 			result.toPreserve.push({ path: trackedFile.path, reason: classification.reason });
+			result.protectedTrackedPaths.push(trackedFile.path);
+			result.retainedManifestPaths.push(trackedFile.path);
 		}
 	}
 
-	// Always delete metadata.json for full uninstall
-	result.toDelete.push({ path: "metadata.json", reason: "metadata file" });
+	if (result.retainedManifestPaths.length === 0) {
+		result.toDelete.push({ path: "metadata.json", reason: "metadata file" });
+	}
 
 	return result;
 }

--- a/src/commands/uninstall/analysis-handler.ts
+++ b/src/commands/uninstall/analysis-handler.ts
@@ -136,7 +136,6 @@ export async function analyzeInstallation(
 			// Check if file is shared with other kits
 			if (preservedPaths.has(relativePath)) {
 				result.toPreserve.push({ path: relativePath, reason: "shared with other kit" });
-				result.retainedManifestPaths.push(relativePath);
 				continue;
 			}
 

--- a/src/commands/uninstall/removal-handler.ts
+++ b/src/commands/uninstall/removal-handler.ts
@@ -20,6 +20,12 @@ import {
 } from "./analysis-handler.js";
 import type { Installation } from "./installation-detector.js";
 
+export interface UninstallExecutionSummary {
+	path: string;
+	preservedCustomizations: number;
+	protectedTrackedPaths: string[];
+}
+
 /**
  * Check if a path is a directory (async, handles errors gracefully)
  */
@@ -73,7 +79,9 @@ async function isPathSafeToRemove(filePath: string, baseDir: string): Promise<bo
 export async function removeInstallations(
 	installations: Installation[],
 	options: { dryRun: boolean; forceOverwrite: boolean; kit?: KitType },
-): Promise<void> {
+): Promise<UninstallExecutionSummary[]> {
+	const summaries: UninstallExecutionSummary[] = [];
+
 	for (const installation of installations) {
 		// Analyze what would be removed
 		const analysis = await analyzeInstallation(installation, options.forceOverwrite, options.kit);
@@ -125,9 +133,13 @@ export async function removeInstallations(
 				}
 			}
 
-			// Update metadata.json to remove kit (for kit-scoped uninstall)
-			if (options.kit && analysis.remainingKits.length > 0) {
-				await ManifestWriter.removeKitFromManifest(installation.path, options.kit);
+			if (analysis.retainedManifestPaths.length > 0) {
+				const retained = await ManifestWriter.retainTrackedFilesInManifest(installation.path, [
+					...new Set(analysis.retainedManifestPaths),
+				]);
+				if (!retained) {
+					throw new Error("Failed to update metadata.json after partial uninstall");
+				}
 			}
 
 			// Check if installation directory is now empty, remove it
@@ -156,6 +168,19 @@ export async function removeInstallations(
 					log.message(`  ... and ${analysis.toPreserve.length - 5} more`);
 				}
 			}
+
+			if (analysis.protectedTrackedPaths.length > 0) {
+				log.warn(
+					"Protected ClaudeKit files were preserved. Metadata was retained so this installation does not fall back to legacy detection.",
+				);
+				log.info("Use --force-overwrite to remove those files on the next uninstall run.");
+			}
+
+			summaries.push({
+				path: installation.path,
+				preservedCustomizations: analysis.toPreserve.length,
+				protectedTrackedPaths: [...analysis.protectedTrackedPaths],
+			});
 		} catch (error) {
 			spinner.fail(`Failed to remove ${installation.type} installation`);
 			throw new Error(
@@ -163,4 +188,6 @@ export async function removeInstallations(
 			);
 		}
 	}
+
+	return summaries;
 }

--- a/src/commands/uninstall/removal-handler.ts
+++ b/src/commands/uninstall/removal-handler.ts
@@ -134,9 +134,13 @@ export async function removeInstallations(
 			}
 
 			if (analysis.retainedManifestPaths.length > 0) {
-				const retained = await ManifestWriter.retainTrackedFilesInManifest(installation.path, [
-					...new Set(analysis.retainedManifestPaths),
-				]);
+				const retained = await ManifestWriter.retainTrackedFilesInManifest(
+					installation.path,
+					[...new Set(analysis.retainedManifestPaths)],
+					options.kit && analysis.protectedTrackedPaths.length === 0
+						? { excludeKit: options.kit }
+						: undefined,
+				);
 				if (!retained) {
 					throw new Error("Failed to update metadata.json after partial uninstall");
 				}

--- a/src/commands/uninstall/uninstall-command.ts
+++ b/src/commands/uninstall/uninstall-command.ts
@@ -215,14 +215,23 @@ export async function uninstallCommand(options: UninstallCommandOptions): Promis
 		}
 
 		// 13. Remove files using manifest
-		await removeInstallations(installations, {
+		const results = await removeInstallations(installations, {
 			dryRun: false,
 			forceOverwrite: validOptions.forceOverwrite,
 			kit: validOptions.kit,
 		});
 
+		const hasProtectedFiles = results.some((result) => result.protectedTrackedPaths.length > 0);
+
 		// 14. Success message
 		const kitMsg = validOptions.kit ? ` (${validOptions.kit} kit)` : "";
+		if (hasProtectedFiles) {
+			prompts.outro(
+				`ClaudeKit${kitMsg} uninstall completed with preserved customizations. Use --force-overwrite for full removal.`,
+			);
+			return;
+		}
+
 		prompts.outro(`ClaudeKit${kitMsg} uninstalled successfully!`);
 	} catch (error) {
 		logger.error(error instanceof Error ? error.message : "Unknown error");

--- a/src/services/file-operations/manifest-writer.ts
+++ b/src/services/file-operations/manifest-writer.ts
@@ -154,7 +154,8 @@ export class ManifestWriter {
 	static async retainTrackedFilesInManifest(
 		claudeDir: string,
 		retainedPaths: string[],
+		options?: { excludeKit?: KitType },
 	): Promise<boolean> {
-		return retainTrackedFilesInManifest(claudeDir, retainedPaths);
+		return retainTrackedFilesInManifest(claudeDir, retainedPaths, options);
 	}
 }

--- a/src/services/file-operations/manifest-writer.ts
+++ b/src/services/file-operations/manifest-writer.ts
@@ -18,6 +18,7 @@ import {
 	readKitManifest,
 	readManifest,
 	removeKitFromManifest,
+	retainTrackedFilesInManifest,
 	writeManifest,
 } from "./manifest/index.js";
 
@@ -145,5 +146,15 @@ export class ManifestWriter {
 	 */
 	static async removeKitFromManifest(claudeDir: string, kit: KitType): Promise<boolean> {
 		return removeKitFromManifest(claudeDir, kit);
+	}
+
+	/**
+	 * Rewrite metadata.json so only retained tracked files remain.
+	 */
+	static async retainTrackedFilesInManifest(
+		claudeDir: string,
+		retainedPaths: string[],
+	): Promise<boolean> {
+		return retainTrackedFilesInManifest(claudeDir, retainedPaths);
 	}
 }

--- a/src/services/file-operations/manifest/index.ts
+++ b/src/services/file-operations/manifest/index.ts
@@ -19,4 +19,8 @@ export {
 	trackFilesWithProgress,
 } from "./manifest-tracker.js";
 
-export { writeManifest, removeKitFromManifest } from "./manifest-updater.js";
+export {
+	writeManifest,
+	removeKitFromManifest,
+	retainTrackedFilesInManifest,
+} from "./manifest-updater.js";

--- a/src/services/file-operations/manifest/manifest-reader.ts
+++ b/src/services/file-operations/manifest/manifest-reader.ts
@@ -132,6 +132,7 @@ export async function getUninstallManifest(
 	claudeDir: string,
 	kit?: KitType,
 ): Promise<UninstallManifestResult> {
+	const normalizeTrackedPath = (relativePath: string): string => relativePath.replace(/\\/g, "/");
 	const detection = await detectMetadataFormat(claudeDir);
 
 	// Multi-kit format
@@ -152,7 +153,7 @@ export async function getUninstallManifest(
 			}
 
 			// Get files for this kit only
-			const kitFiles = kitMeta.files.map((f) => f.path);
+			const kitFiles = kitMeta.files.map((f) => normalizeTrackedPath(f.path));
 
 			// Check for shared files with other kits (preserve them)
 			const sharedFiles = new Set<string>();
@@ -161,7 +162,7 @@ export async function getUninstallManifest(
 					const otherMeta = detection.metadata.kits[otherKit];
 					if (otherMeta?.files) {
 						for (const f of otherMeta.files) {
-							sharedFiles.add(f.path);
+							sharedFiles.add(normalizeTrackedPath(f.path));
 						}
 					}
 				}
@@ -185,7 +186,7 @@ export async function getUninstallManifest(
 		// Full uninstall - all kits
 		const allFiles = getAllTrackedFiles(detection.metadata);
 		return {
-			filesToRemove: allFiles.map((f) => f.path),
+			filesToRemove: allFiles.map((f) => normalizeTrackedPath(f.path)),
 			filesToPreserve: USER_CONFIG_PATTERNS,
 			hasManifest: true,
 			isMultiKit: true,
@@ -195,8 +196,10 @@ export async function getUninstallManifest(
 
 	// Legacy format
 	if (detection.format === "legacy" && detection.metadata) {
-		const legacyFiles = detection.metadata.files?.map((f) => f.path) || [];
-		const installedFiles = detection.metadata.installedFiles || [];
+		const legacyFiles = detection.metadata.files?.map((f) => normalizeTrackedPath(f.path)) || [];
+		const installedFiles = (detection.metadata.installedFiles || []).map((path) =>
+			normalizeTrackedPath(path),
+		);
 		const hasFiles = legacyFiles.length > 0 || installedFiles.length > 0;
 
 		// If no files tracked, fall through to legacy hardcoded directories

--- a/src/services/file-operations/manifest/manifest-updater.ts
+++ b/src/services/file-operations/manifest/manifest-updater.ts
@@ -166,3 +166,82 @@ export async function removeKitFromManifest(claudeDir: string, kit: KitType): Pr
 		}
 	}
 }
+
+/**
+ * Rewrite metadata.json so it only retains a subset of tracked files.
+ * Used after partial uninstalls that preserve protected tracked files or other kits.
+ */
+export async function retainTrackedFilesInManifest(
+	claudeDir: string,
+	retainedPaths: string[],
+): Promise<boolean> {
+	const metadataPath = join(claudeDir, "metadata.json");
+
+	if (!(await pathExists(metadataPath))) return false;
+
+	const normalizedPaths = new Set(retainedPaths.map((path) => path.replace(/\\/g, "/")));
+	if (normalizedPaths.size === 0) return false;
+
+	let release: (() => Promise<void>) | null = null;
+	try {
+		release = await lock(metadataPath, {
+			retries: { retries: 5, minTimeout: 100, maxTimeout: 1000 },
+			stale: 60000,
+		});
+		logger.debug(`Acquired lock on ${metadataPath} for retained metadata update`);
+
+		const metadata = await readManifest(claudeDir);
+		if (!metadata) return false;
+
+		if (metadata.kits) {
+			const retainedKits = Object.entries(metadata.kits).reduce<NonNullable<Metadata["kits"]>>(
+				(acc, [kitName, kitMeta]) => {
+					const keptFiles = (kitMeta.files || []).filter((file) => normalizedPaths.has(file.path));
+
+					if (keptFiles.length > 0) {
+						acc[kitName as KitType] = {
+							...kitMeta,
+							files: keptFiles,
+						};
+					}
+
+					return acc;
+				},
+				{},
+			);
+
+			if (Object.keys(retainedKits).length === 0) {
+				return false;
+			}
+
+			const updated = MetadataSchema.parse({
+				...metadata,
+				kits: retainedKits,
+			});
+			await writeFile(metadataPath, JSON.stringify(updated, null, 2), "utf-8");
+			return true;
+		}
+
+		const retainedFiles = (metadata.files || []).filter((file) => normalizedPaths.has(file.path));
+		const retainedInstalledFiles = (metadata.installedFiles || []).filter((path) =>
+			normalizedPaths.has(path.replace(/\\/g, "/")),
+		);
+
+		if (retainedFiles.length === 0 && retainedInstalledFiles.length === 0) {
+			return false;
+		}
+
+		const updated = MetadataSchema.parse({
+			...metadata,
+			files: retainedFiles.length > 0 ? retainedFiles : undefined,
+			installedFiles: retainedInstalledFiles.length > 0 ? retainedInstalledFiles : undefined,
+		});
+		await writeFile(metadataPath, JSON.stringify(updated, null, 2), "utf-8");
+		return true;
+	} finally {
+		if (release) {
+			await release();
+			logger.debug(`Released lock on ${metadataPath}`);
+		}
+	}
+}

--- a/src/services/file-operations/manifest/manifest-updater.ts
+++ b/src/services/file-operations/manifest/manifest-updater.ts
@@ -196,7 +196,19 @@ export async function retainTrackedFilesInManifest(
 		if (metadata.kits) {
 			const retainedKits = Object.entries(metadata.kits).reduce<NonNullable<Metadata["kits"]>>(
 				(acc, [kitName, kitMeta]) => {
-					const keptFiles = (kitMeta.files || []).filter((file) => normalizedPaths.has(file.path));
+					const keptFiles = (kitMeta.files || []).flatMap((file) => {
+						const normalizedPath = file.path.replace(/\\/g, "/");
+						if (!normalizedPaths.has(normalizedPath)) {
+							return [];
+						}
+
+						return [
+							{
+								...file,
+								path: normalizedPath,
+							},
+						];
+					});
 
 					if (keptFiles.length > 0) {
 						acc[kitName as KitType] = {
@@ -214,15 +226,31 @@ export async function retainTrackedFilesInManifest(
 				return false;
 			}
 
+			const retainedFiles = Object.values(retainedKits).flatMap((kitMeta) => kitMeta.files || []);
+			const retainedInstalledFiles = retainedFiles.map((file) => file.path);
 			const updated = MetadataSchema.parse({
 				...metadata,
 				kits: retainedKits,
+				files: retainedFiles.length > 0 ? retainedFiles : undefined,
+				installedFiles: retainedInstalledFiles.length > 0 ? retainedInstalledFiles : undefined,
 			});
 			await writeFile(metadataPath, JSON.stringify(updated, null, 2), "utf-8");
 			return true;
 		}
 
-		const retainedFiles = (metadata.files || []).filter((file) => normalizedPaths.has(file.path));
+		const retainedFiles = (metadata.files || []).flatMap((file) => {
+			const normalizedPath = file.path.replace(/\\/g, "/");
+			if (!normalizedPaths.has(normalizedPath)) {
+				return [];
+			}
+
+			return [
+				{
+					...file,
+					path: normalizedPath,
+				},
+			];
+		});
 		const retainedInstalledFiles = (metadata.installedFiles || []).filter((path) =>
 			normalizedPaths.has(path.replace(/\\/g, "/")),
 		);

--- a/src/services/file-operations/manifest/manifest-updater.ts
+++ b/src/services/file-operations/manifest/manifest-updater.ts
@@ -174,6 +174,7 @@ export async function removeKitFromManifest(claudeDir: string, kit: KitType): Pr
 export async function retainTrackedFilesInManifest(
 	claudeDir: string,
 	retainedPaths: string[],
+	options?: { excludeKit?: KitType },
 ): Promise<boolean> {
 	const metadataPath = join(claudeDir, "metadata.json");
 
@@ -196,6 +197,10 @@ export async function retainTrackedFilesInManifest(
 		if (metadata.kits) {
 			const retainedKits = Object.entries(metadata.kits).reduce<NonNullable<Metadata["kits"]>>(
 				(acc, [kitName, kitMeta]) => {
+					if (kitName === options?.excludeKit) {
+						return acc;
+					}
+
 					const keptFiles = (kitMeta.files || []).flatMap((file) => {
 						const normalizedPath = file.path.replace(/\\/g, "/");
 						if (!normalizedPaths.has(normalizedPath)) {

--- a/src/services/file-operations/ownership-checker.ts
+++ b/src/services/file-operations/ownership-checker.ts
@@ -90,7 +90,7 @@ export class OwnershipChecker {
 		const relativePath = relative(claudeDir, filePath).replace(/\\/g, "/");
 
 		// Find file in tracked files (works with both kits[kit].files and legacy metadata.files)
-		const tracked = allTrackedFiles.find((f) => f.path === relativePath);
+		const tracked = allTrackedFiles.find((f) => f.path.replace(/\\/g, "/") === relativePath);
 		if (!tracked) {
 			// File not in metadata → user-created
 			return { path: filePath, ownership: "user", exists: true };

--- a/tests/commands/uninstall.test.ts
+++ b/tests/commands/uninstall.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, realpathSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { ManifestWriter } from "@/services/file-operations/manifest-writer.js";
 import type { Metadata } from "@/types";
 import { type TestPaths, setupTestPaths } from "../helpers/test-paths.js";
 
@@ -125,6 +126,72 @@ describe("uninstall command integration", () => {
 
 			// Verify custom config was preserved
 			expect(existsSync(join(testLocalClaudeDir, "my-custom-config.json"))).toBe(true);
+		});
+
+		test("should retain pruned metadata when protected tracked files remain", async () => {
+			await mkdir(join(testLocalClaudeDir, "skills", "customized-skill"), { recursive: true });
+
+			const skillFile = join(testLocalClaudeDir, "skills", "customized-skill", "SKILL.md");
+			await writeFile(skillFile, "original skill content");
+
+			const { OwnershipChecker } = await import(
+				"../../src/services/file-operations/ownership-checker.js"
+			);
+			const checksum = await OwnershipChecker.calculateChecksum(skillFile);
+			await writeFile(skillFile, "modified skill content");
+
+			await writeFile(
+				join(testLocalClaudeDir, "metadata.json"),
+				JSON.stringify(
+					{
+						kits: {
+							engineer: {
+								version: "1.0.0",
+								installedAt: "2025-01-01T00:00:00.000Z",
+								files: [
+									{
+										path: "skills/customized-skill/SKILL.md",
+										checksum,
+										ownership: "ck",
+										installedVersion: "1.0.0",
+									},
+								],
+							},
+						},
+						scope: "local",
+					},
+					null,
+					2,
+				),
+			);
+
+			const { uninstallCommand, detectInstallations } = await import(
+				"../../src/commands/uninstall/index.js"
+			);
+
+			await uninstallCommand({
+				yes: true,
+				json: false,
+				verbose: false,
+				local: true,
+				global: false,
+				all: false,
+				dryRun: false,
+				forceOverwrite: false,
+			});
+
+			expect(existsSync(skillFile)).toBe(true);
+			expect(existsSync(join(testLocalClaudeDir, "metadata.json"))).toBe(true);
+
+			const metadata = await ManifestWriter.readManifest(testLocalClaudeDir);
+			expect(metadata?.kits?.engineer?.files?.map((file) => file.path)).toEqual([
+				"skills/customized-skill/SKILL.md",
+			]);
+
+			const installations = await detectInstallations();
+			const localInstall = installations.find((install) => install.type === "local");
+			expect(localInstall?.hasMetadata).toBe(true);
+			expect(localInstall?.components.skills).toBe(1);
 		});
 	});
 

--- a/tests/commands/uninstall.test.ts
+++ b/tests/commands/uninstall.test.ts
@@ -260,6 +260,64 @@ describe("uninstall command integration", () => {
 			expect(localInstall?.components.skills).toBe(1);
 		});
 
+		test("should remove pristine Windows-style tracked files with force-overwrite", async () => {
+			await mkdir(join(testLocalClaudeDir, "skills", "windows-force"), { recursive: true });
+
+			const skillFile = join(testLocalClaudeDir, "skills", "windows-force", "SKILL.md");
+			await writeFile(skillFile, "original skill content");
+
+			const { OwnershipChecker } = await import(
+				"../../src/services/file-operations/ownership-checker.js"
+			);
+			const checksum = await OwnershipChecker.calculateChecksum(skillFile);
+
+			await writeFile(
+				join(testLocalClaudeDir, "metadata.json"),
+				JSON.stringify(
+					{
+						kits: {
+							engineer: {
+								version: "1.0.0",
+								installedAt: "2025-01-01T00:00:00.000Z",
+								files: [
+									{
+										path: "skills\\windows-force\\SKILL.md",
+										checksum,
+										ownership: "ck",
+										installedVersion: "1.0.0",
+									},
+								],
+							},
+						},
+						scope: "local",
+					},
+					null,
+					2,
+				),
+			);
+
+			const { uninstallCommand, detectInstallations } = await import(
+				"../../src/commands/uninstall/index.js"
+			);
+
+			await uninstallCommand({
+				yes: true,
+				json: false,
+				verbose: false,
+				local: true,
+				global: false,
+				all: false,
+				dryRun: false,
+				forceOverwrite: true,
+			});
+
+			expect(existsSync(skillFile)).toBe(false);
+			expect(existsSync(join(testLocalClaudeDir, "metadata.json"))).toBe(false);
+
+			const installations = await detectInstallations();
+			expect(installations.find((install) => install.type === "local")).toBeUndefined();
+		});
+
 		test("should drop stale remaining-kit metadata during kit-scoped uninstall", async () => {
 			await mkdir(join(testLocalClaudeDir, "commands"), { recursive: true });
 			const engineerFile = join(testLocalClaudeDir, "commands", "engineer.md");
@@ -342,6 +400,92 @@ describe("uninstall command integration", () => {
 
 			const installations = await detectInstallations();
 			expect(installations.find((install) => install.type === "local")).toBeUndefined();
+		});
+
+		test("should preserve shared mixed-separator files for remaining kits only", async () => {
+			await mkdir(join(testLocalClaudeDir, "commands"), { recursive: true });
+			const sharedFile = join(testLocalClaudeDir, "commands", "shared.md");
+			await writeFile(sharedFile, "shared");
+
+			const { OwnershipChecker } = await import(
+				"../../src/services/file-operations/ownership-checker.js"
+			);
+			const sharedChecksum = await OwnershipChecker.calculateChecksum(sharedFile);
+
+			await writeFile(
+				join(testLocalClaudeDir, "metadata.json"),
+				JSON.stringify(
+					{
+						kits: {
+							engineer: {
+								version: "1.0.0",
+								installedAt: "2025-01-01T00:00:00.000Z",
+								files: [
+									{
+										path: "commands\\shared.md",
+										checksum: sharedChecksum,
+										ownership: "ck",
+										installedVersion: "1.0.0",
+									},
+								],
+							},
+							marketing: {
+								version: "1.0.0",
+								installedAt: "2025-01-01T00:00:00.000Z",
+								files: [
+									{
+										path: "commands/shared.md",
+										checksum: sharedChecksum,
+										ownership: "ck",
+										installedVersion: "1.0.0",
+									},
+								],
+							},
+						},
+						scope: "local",
+						files: [
+							{
+								path: "commands\\shared.md",
+								checksum: sharedChecksum,
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+							{
+								path: "commands/shared.md",
+								checksum: sharedChecksum,
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+						],
+						installedFiles: ["commands\\shared.md", "commands/shared.md"],
+					},
+					null,
+					2,
+				),
+			);
+
+			const { uninstallCommand } = await import("../../src/commands/uninstall/index.js");
+
+			await uninstallCommand({
+				yes: true,
+				json: false,
+				verbose: false,
+				local: true,
+				global: false,
+				all: false,
+				dryRun: false,
+				forceOverwrite: false,
+				kit: "engineer",
+			});
+
+			expect(existsSync(sharedFile)).toBe(true);
+
+			const metadata = await ManifestWriter.readManifest(testLocalClaudeDir);
+			expect(Object.keys(metadata?.kits || {})).toEqual(["marketing"]);
+			expect(metadata?.kits?.marketing?.files?.map((file) => file.path)).toEqual([
+				"commands/shared.md",
+			]);
+			expect(metadata?.installedFiles).toEqual(["commands/shared.md"]);
 		});
 	});
 

--- a/tests/commands/uninstall.test.ts
+++ b/tests/commands/uninstall.test.ts
@@ -193,6 +193,156 @@ describe("uninstall command integration", () => {
 			expect(localInstall?.hasMetadata).toBe(true);
 			expect(localInstall?.components.skills).toBe(1);
 		});
+
+		test("should retain metadata for protected tracked files with Windows-style paths", async () => {
+			await mkdir(join(testLocalClaudeDir, "skills", "windows-skill"), { recursive: true });
+
+			const skillFile = join(testLocalClaudeDir, "skills", "windows-skill", "SKILL.md");
+			await writeFile(skillFile, "original skill content");
+
+			const { OwnershipChecker } = await import(
+				"../../src/services/file-operations/ownership-checker.js"
+			);
+			const checksum = await OwnershipChecker.calculateChecksum(skillFile);
+			await writeFile(skillFile, "modified skill content");
+
+			await writeFile(
+				join(testLocalClaudeDir, "metadata.json"),
+				JSON.stringify(
+					{
+						kits: {
+							engineer: {
+								version: "1.0.0",
+								installedAt: "2025-01-01T00:00:00.000Z",
+								files: [
+									{
+										path: "skills\\windows-skill\\SKILL.md",
+										checksum,
+										ownership: "ck",
+										installedVersion: "1.0.0",
+									},
+								],
+							},
+						},
+						scope: "local",
+					},
+					null,
+					2,
+				),
+			);
+
+			const { uninstallCommand, detectInstallations } = await import(
+				"../../src/commands/uninstall/index.js"
+			);
+
+			await uninstallCommand({
+				yes: true,
+				json: false,
+				verbose: false,
+				local: true,
+				global: false,
+				all: false,
+				dryRun: false,
+				forceOverwrite: false,
+			});
+
+			expect(existsSync(skillFile)).toBe(true);
+			expect(existsSync(join(testLocalClaudeDir, "metadata.json"))).toBe(true);
+
+			const metadata = await ManifestWriter.readManifest(testLocalClaudeDir);
+			expect(metadata?.kits?.engineer?.files?.map((file) => file.path)).toEqual([
+				"skills/windows-skill/SKILL.md",
+			]);
+
+			const installations = await detectInstallations();
+			const localInstall = installations.find((install) => install.type === "local");
+			expect(localInstall?.hasMetadata).toBe(true);
+			expect(localInstall?.components.skills).toBe(1);
+		});
+
+		test("should drop stale remaining-kit metadata during kit-scoped uninstall", async () => {
+			await mkdir(join(testLocalClaudeDir, "commands"), { recursive: true });
+			const engineerFile = join(testLocalClaudeDir, "commands", "engineer.md");
+			await writeFile(engineerFile, "engineer");
+
+			const { OwnershipChecker } = await import(
+				"../../src/services/file-operations/ownership-checker.js"
+			);
+			const engineerChecksum = await OwnershipChecker.calculateChecksum(engineerFile);
+
+			await writeFile(
+				join(testLocalClaudeDir, "metadata.json"),
+				JSON.stringify(
+					{
+						kits: {
+							engineer: {
+								version: "1.0.0",
+								installedAt: "2025-01-01T00:00:00.000Z",
+								files: [
+									{
+										path: "commands/engineer.md",
+										checksum: engineerChecksum,
+										ownership: "ck",
+										installedVersion: "1.0.0",
+									},
+								],
+							},
+							marketing: {
+								version: "1.0.0",
+								installedAt: "2025-01-01T00:00:00.000Z",
+								files: [
+									{
+										path: "skills/missing-skill/SKILL.md",
+										checksum: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+										ownership: "ck",
+										installedVersion: "1.0.0",
+									},
+								],
+							},
+						},
+						scope: "local",
+						files: [
+							{
+								path: "commands/engineer.md",
+								checksum: engineerChecksum,
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+							{
+								path: "skills/missing-skill/SKILL.md",
+								checksum: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+								ownership: "ck",
+								installedVersion: "1.0.0",
+							},
+						],
+						installedFiles: ["commands/engineer.md", "skills/missing-skill/SKILL.md"],
+					},
+					null,
+					2,
+				),
+			);
+
+			const { uninstallCommand, detectInstallations } = await import(
+				"../../src/commands/uninstall/index.js"
+			);
+
+			await uninstallCommand({
+				yes: true,
+				json: false,
+				verbose: false,
+				local: true,
+				global: false,
+				all: false,
+				dryRun: false,
+				forceOverwrite: false,
+				kit: "engineer",
+			});
+
+			expect(existsSync(join(testLocalClaudeDir, "metadata.json"))).toBe(false);
+
+			const installations = await detectInstallations();
+			expect(installations.find((install) => install.type === "local")).toBeUndefined();
+		});
 	});
 
 	describe("legacy uninstall fallback", () => {


### PR DESCRIPTION
## Problem
`ck uninstall` preserved user-modified tracked files but still removed `metadata.json`, which made the remaining `.claude` tree look like a legacy install on the next run.

## Root Cause
Full uninstall always removed `metadata.json` when no other kits remained, even if protected tracked files were preserved.

## What changed
- retain metadata when protected tracked files survive uninstall
- prune manifest entries down to the protected tracked files
- surface a clearer CLI outro and warning for the partial-uninstall case
- add a regression test for the single-run uninstall path

## Validation
- `bun test tests/commands/uninstall.test.ts`
- `bun run validate`

Closes #619
