### PR TITLE
fix: respect CLAUDE_CONFIG_DIR in global path rewrites

### DIFF
--- a/src/__tests__/domains/installation/merger/settings-processor.test.ts
+++ b/src/__tests__/domains/installation/merger/settings-processor.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SettingsProcessor } from "@/domains/installation/merger/settings-processor.js";
+
+function toPosix(path: string): string {
+	return path.replace(/\\/g, "/");
+}
+
+describe("SettingsProcessor custom global dir support", () => {
+	const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+	let testDir: string;
+	let customClaudeDir: string;
+	let sourceFile: string;
+	let destFile: string;
+
+	beforeEach(async () => {
+		testDir = await mkdtemp(join(tmpdir(), "settings-processor-"));
+		customClaudeDir = join(testDir, "persisted-claude-config");
+		sourceFile = join(testDir, "source-settings.json");
+		destFile = join(customClaudeDir, "settings.json");
+		await mkdir(customClaudeDir, { recursive: true });
+		process.env.CLAUDE_CONFIG_DIR = customClaudeDir;
+	});
+
+	afterEach(async () => {
+		await rm(testDir, { recursive: true, force: true });
+		process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+	});
+
+	function createProcessor(): SettingsProcessor {
+		const processor = new SettingsProcessor();
+		processor.setGlobalFlag(true);
+		processor.setProjectDir(customClaudeDir);
+		processor.setKitName("engineer");
+		return processor;
+	}
+
+	it("writes fresh global hook commands to the active CLAUDE_CONFIG_DIR path", async () => {
+		await writeFile(
+			sourceFile,
+			JSON.stringify(
+				{
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: "node .claude/hooks/task-completed-handler.cjs",
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const processor = createProcessor();
+		await processor.processSettingsJson(sourceFile, destFile);
+
+		const writtenSettings = JSON.parse(await readFile(destFile, "utf-8")) as {
+			hooks: { UserPromptSubmit: Array<{ hooks: Array<{ command: string }> }> };
+		};
+
+		expect(writtenSettings.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+			`node "${toPosix(customClaudeDir)}/hooks/task-completed-handler.cjs"`,
+		);
+	});
+
+	it("deduplicates legacy $HOME hooks against the custom global path on merge", async () => {
+		await writeFile(
+			sourceFile,
+			JSON.stringify(
+				{
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: "node .claude/hooks/task-completed-handler.cjs",
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+		await writeFile(
+			destFile,
+			JSON.stringify(
+				{
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: 'node "$HOME/.claude/hooks/task-completed-handler.cjs"',
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const processor = createProcessor();
+		await processor.processSettingsJson(sourceFile, destFile);
+
+		const mergedSettings = JSON.parse(await readFile(destFile, "utf-8")) as {
+			hooks: { UserPromptSubmit: Array<{ hooks: Array<{ command: string }> }> };
+		};
+
+		expect(mergedSettings.hooks.UserPromptSubmit).toHaveLength(1);
+		expect(mergedSettings.hooks.UserPromptSubmit[0].hooks).toHaveLength(1);
+		expect(mergedSettings.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+			`node "${toPosix(customClaudeDir)}/hooks/task-completed-handler.cjs"`,
+		);
+	});
+});

--- a/src/__tests__/domains/installation/merger/settings-processor.test.ts
+++ b/src/__tests__/domains/installation/merger/settings-processor.test.ts
@@ -24,7 +24,9 @@ describe("SettingsProcessor custom global dir support", () => {
 		await mkdir(customClaudeDir, { recursive: true });
 		// CK_TEST_HOME takes priority over CLAUDE_CONFIG_DIR in PathResolver.getGlobalKitDir(),
 		// so clear it to prevent env leakage from other tests running in the same Bun process.
-		process.env.CK_TEST_HOME = undefined;
+		// Must use delete — Node.js coerces `= undefined` to the string "undefined".
+		// biome-ignore lint/performance/noDelete: process.env requires delete to actually unset
+		delete process.env.CK_TEST_HOME;
 		process.env.CLAUDE_CONFIG_DIR = customClaudeDir;
 	});
 
@@ -34,7 +36,8 @@ describe("SettingsProcessor custom global dir support", () => {
 		if (originalCkTestHome !== undefined) {
 			process.env.CK_TEST_HOME = originalCkTestHome;
 		} else {
-			process.env.CK_TEST_HOME = undefined;
+			// biome-ignore lint/performance/noDelete: process.env requires delete to actually unset
+			delete process.env.CK_TEST_HOME;
 		}
 	});
 

--- a/src/__tests__/domains/installation/merger/settings-processor.test.ts
+++ b/src/__tests__/domains/installation/merger/settings-processor.test.ts
@@ -32,7 +32,12 @@ describe("SettingsProcessor custom global dir support", () => {
 
 	afterEach(async () => {
 		await rm(testDir, { recursive: true, force: true });
-		process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+		if (originalClaudeConfigDir !== undefined) {
+			process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+		} else {
+			// biome-ignore lint/performance/noDelete: process.env requires delete to actually unset
+			delete process.env.CLAUDE_CONFIG_DIR;
+		}
 		if (originalCkTestHome !== undefined) {
 			process.env.CK_TEST_HOME = originalCkTestHome;
 		} else {

--- a/src/__tests__/domains/installation/merger/settings-processor.test.ts
+++ b/src/__tests__/domains/installation/merger/settings-processor.test.ts
@@ -10,6 +10,7 @@ function toPosix(path: string): string {
 
 describe("SettingsProcessor custom global dir support", () => {
 	const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+	const originalCkTestHome = process.env.CK_TEST_HOME;
 	let testDir: string;
 	let customClaudeDir: string;
 	let sourceFile: string;
@@ -21,12 +22,20 @@ describe("SettingsProcessor custom global dir support", () => {
 		sourceFile = join(testDir, "source-settings.json");
 		destFile = join(customClaudeDir, "settings.json");
 		await mkdir(customClaudeDir, { recursive: true });
+		// CK_TEST_HOME takes priority over CLAUDE_CONFIG_DIR in PathResolver.getGlobalKitDir(),
+		// so clear it to prevent env leakage from other tests running in the same Bun process.
+		process.env.CK_TEST_HOME = undefined;
 		process.env.CLAUDE_CONFIG_DIR = customClaudeDir;
 	});
 
 	afterEach(async () => {
 		await rm(testDir, { recursive: true, force: true });
 		process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+		if (originalCkTestHome !== undefined) {
+			process.env.CK_TEST_HOME = originalCkTestHome;
+		} else {
+			process.env.CK_TEST_HOME = undefined;
+		}
 	});
 
 	function createProcessor(): SettingsProcessor {

--- a/src/__tests__/shared/command-normalizer.test.ts
+++ b/src/__tests__/shared/command-normalizer.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { normalizeCommand } from "@/shared/command-normalizer.js";
+
+describe("normalizeCommand", () => {
+	const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+	afterEach(() => {
+		process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+	});
+
+	it("treats custom global dir commands as equivalent to legacy $HOME global commands", () => {
+		process.env.CLAUDE_CONFIG_DIR = "/custom/claude-config";
+
+		const customCommand = 'node "/custom/claude-config/hooks/task-completed-handler.cjs"';
+		const legacyCommand = 'node "$HOME/.claude/hooks/task-completed-handler.cjs"';
+
+		expect(normalizeCommand(customCommand)).toBe(normalizeCommand(legacyCommand));
+	});
+});

--- a/src/__tests__/shared/command-normalizer.test.ts
+++ b/src/__tests__/shared/command-normalizer.test.ts
@@ -5,7 +5,12 @@ describe("normalizeCommand", () => {
 	const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
 
 	afterEach(() => {
-		process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+		if (originalClaudeConfigDir !== undefined) {
+			process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+		} else {
+			// biome-ignore lint/performance/noDelete: process.env requires delete to actually unset
+			delete process.env.CLAUDE_CONFIG_DIR;
+		}
 	});
 
 	it("treats custom global dir commands as equivalent to legacy $HOME global commands", () => {

--- a/src/commands/init/phases/transform-handler.ts
+++ b/src/commands/init/phases/transform-handler.ts
@@ -30,6 +30,7 @@ export async function handleTransforms(ctx: InitContext): Promise<InitContext> {
 	if (ctx.options.global) {
 		logger.info("Transforming paths for global installation...");
 		const transformResult = await transformPathsForGlobalInstall(ctx.extractDir, {
+			targetClaudeDir: ctx.resolvedDir,
 			verbose: logger.isVerbose(),
 		});
 		logger.success(

--- a/src/domains/installation/merger/settings-processor.ts
+++ b/src/domains/installation/merger/settings-processor.ts
@@ -460,6 +460,7 @@ export class SettingsProcessor {
 	/**
 	 * Read settings file and normalize $CLAUDE_PROJECT_DIR paths to $HOME for global installs.
 	 * This ensures deduplication works correctly when merging into global settings.
+	 * NOTE: Mutations are in-memory only — callers must persist the result via writeSettingsFile.
 	 */
 	private async readAndNormalizeGlobalSettings(destFile: string): Promise<SettingsJson | null> {
 		try {
@@ -498,6 +499,10 @@ export class SettingsProcessor {
 		// Pattern 1: node .claude/... or node ./.claude/... in settings JSON.
 		// Global: node \"$HOME/.claude/hooks/foo.cjs\"
 		// Local:  node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/foo.cjs
+		// NOTE: formatCommandPath returns plain output with literal " chars.
+		// The .replace(/"/g, '\\"') is needed here because this regex operates on raw JSON text,
+		// so quotes must be escaped. fixSingleCommandPath does NOT apply this escape because it
+		// works on parsed command strings (post-JSON-decode).
 		transformed = transformed.replace(
 			/(node\s+)(?:\.\/)?(\.claude\/[^\s"\\]+)([^"\\]*)/g,
 			(_match, nodePrefix: string, relativePath: string, suffix: string) => {
@@ -674,6 +679,11 @@ export class SettingsProcessor {
 
 	private usesCustomGlobalInstallPath(): boolean {
 		if (!this.isGlobal || !this.projectDir) {
+			if (this.isGlobal && !this.projectDir) {
+				logger.debug(
+					"usesCustomGlobalInstallPath: global mode but projectDir not set — defaulting to $HOME",
+				);
+			}
 			return false;
 		}
 

--- a/src/domains/installation/merger/settings-processor.ts
+++ b/src/domains/installation/merger/settings-processor.ts
@@ -1,8 +1,11 @@
 import { execSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { InstalledSettingsTracker } from "@/domains/config/installed-settings-tracker.js";
 import { type SettingsJson, SettingsMerger } from "@/domains/config/settings-merger.js";
 import { normalizeCommand } from "@/shared/command-normalizer.js";
 import { logger } from "@/shared/logger.js";
+import { PathResolver } from "@/shared/path-resolver.js";
 import type { InstalledSettings } from "@/types";
 import { copy, pathExists, readFile, writeFile } from "fs-extra";
 import semver from "semver";
@@ -100,19 +103,18 @@ export class SettingsProcessor {
 			// Transform paths in source content first
 			let transformedSource = sourceContent;
 			if (this.isGlobal) {
-				const homeVar = '"$HOME"';
-				transformedSource = this.transformClaudePaths(sourceContent, homeVar);
+				const globalRoot = this.getCanonicalGlobalCommandRoot();
+				transformedSource = this.transformClaudePaths(sourceContent, globalRoot);
 				if (transformedSource !== sourceContent) {
 					logger.debug(
-						`Transformed .claude/ paths to ${homeVar}/.claude/ in settings.json for global installation`,
+						`Transformed .claude/ paths to ${globalRoot} in settings.json for global installation`,
 					);
 				}
 			} else {
-				const projectDirVar = '"$CLAUDE_PROJECT_DIR"';
-				transformedSource = this.transformClaudePaths(sourceContent, projectDirVar);
+				transformedSource = this.transformClaudePaths(sourceContent, "$CLAUDE_PROJECT_DIR");
 				if (transformedSource !== sourceContent) {
 					logger.debug(
-						`Transformed .claude/ paths to ${projectDirVar}/.claude/ in settings.json for local installation`,
+						'Transformed .claude/ paths to "$CLAUDE_PROJECT_DIR"/.claude/ in settings.json for local installation',
 					);
 				}
 			}
@@ -463,28 +465,9 @@ export class SettingsProcessor {
 		try {
 			const content = await readFile(destFile, "utf-8");
 			if (!content.trim()) return null;
-
-			// Replace $CLAUDE_PROJECT_DIR (and Windows variants) with $HOME (universal)
-			const homeVar = "$HOME";
-			let normalized = content;
-
-			// Unix: $CLAUDE_PROJECT_DIR → $HOME (handle both quoted and unquoted)
-			normalized = normalized.replace(/"\$CLAUDE_PROJECT_DIR"/g, `"${homeVar}"`);
-			normalized = normalized.replace(/\$CLAUDE_PROJECT_DIR/g, homeVar);
-
-			// Windows: %CLAUDE_PROJECT_DIR% → $HOME
-			normalized = normalized.replace(/"%CLAUDE_PROJECT_DIR%"/g, `"${homeVar}"`);
-			normalized = normalized.replace(/%CLAUDE_PROJECT_DIR%/g, homeVar);
-
-			// Windows: %USERPROFILE% → $HOME (migration for pre-existing files)
-			normalized = normalized.replace(/"%USERPROFILE%"/g, `"${homeVar}"`);
-			normalized = normalized.replace(/%USERPROFILE%/g, homeVar);
-
-			if (normalized !== content) {
-				logger.debug("Normalized $CLAUDE_PROJECT_DIR paths to $HOME in existing global settings");
-			}
-
-			return JSON.parse(normalized) as SettingsJson;
+			const parsedSettings = JSON.parse(content) as SettingsJson;
+			this.fixHookCommandPaths(parsedSettings);
+			return parsedSettings;
 		} catch {
 			return null;
 		}
@@ -499,10 +482,10 @@ export class SettingsProcessor {
 	 * Claude Code resolves `project/.claude/...` as `project.claude/...`.
 	 *
 	 * @param content - The file content to transform (raw JSON)
-	 * @param prefix - The environment variable prefix (e.g., '"$HOME"', '"%USERPROFILE%"')
+	 * @param root - The path root (e.g., "$HOME", "$CLAUDE_PROJECT_DIR", "/custom/claude")
 	 * @returns Transformed content with the appropriate quoting strategy per scope
 	 */
-	private transformClaudePaths(content: string, prefix: string): string {
+	private transformClaudePaths(content: string, root: string): string {
 		// Security: Validate that .claude/ paths don't contain shell injection attempts
 		// Matches dangerous chars after .claude/ but before whitespace or quote
 		if (/\.claude\/[^\s"']*[;`$&|><]/.test(content)) {
@@ -512,27 +495,22 @@ export class SettingsProcessor {
 
 		let transformed = content;
 
-		// Extract raw env var (without quotes) for all replacements
-		const rawPrefix = prefix.replace(/"/g, "");
-
 		// Pattern 1: node .claude/... or node ./.claude/... in settings JSON.
 		// Global: node \"$HOME/.claude/hooks/foo.cjs\"
 		// Local:  node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/foo.cjs
 		transformed = transformed.replace(
 			/(node\s+)(?:\.\/)?(\.claude\/[^\s"\\]+)([^"\\]*)/g,
 			(_match, nodePrefix: string, relativePath: string, suffix: string) => {
-				const normalizedRelativePath = relativePath.replace(/\\/g, "/");
-				return rawPrefix === "$CLAUDE_PROJECT_DIR"
-					? `${nodePrefix}\\"${rawPrefix}\\"/${normalizedRelativePath}${suffix}`
-					: `${nodePrefix}\\"${rawPrefix}/${normalizedRelativePath}\\"${suffix}`;
+				return this.formatCommandPath(nodePrefix, root, relativePath, suffix).replace(/"/g, '\\"');
 			},
 		);
 
 		// Pattern 2: Already has $CLAUDE_PROJECT_DIR - replace with appropriate prefix
-		if (rawPrefix.includes("HOME") || rawPrefix.includes("USERPROFILE")) {
-			// Global mode: $CLAUDE_PROJECT_DIR → $HOME or %USERPROFILE%
-			transformed = transformed.replace(/\$CLAUDE_PROJECT_DIR/g, rawPrefix);
-			transformed = transformed.replace(/%CLAUDE_PROJECT_DIR%/g, rawPrefix);
+		if (this.isGlobal) {
+			transformed = transformed.replace(/"\$CLAUDE_PROJECT_DIR"/g, `"${root}"`);
+			transformed = transformed.replace(/\$CLAUDE_PROJECT_DIR/g, root);
+			transformed = transformed.replace(/"%CLAUDE_PROJECT_DIR%"/g, `"${root}"`);
+			transformed = transformed.replace(/%CLAUDE_PROJECT_DIR%/g, root);
 		}
 
 		return transformed;
@@ -606,7 +584,7 @@ export class SettingsProcessor {
 			const [, nodePrefix, relativePath, suffix] = bareRelativeMatch;
 			return this.formatCommandPath(
 				nodePrefix,
-				this.isGlobal ? "$HOME" : "$CLAUDE_PROJECT_DIR",
+				this.isGlobal ? this.getCanonicalGlobalCommandRoot() : "$CLAUDE_PROJECT_DIR",
 				relativePath,
 				suffix,
 			);
@@ -651,11 +629,11 @@ export class SettingsProcessor {
 		relativePath: string,
 		suffix = "",
 	): string {
-		const canonicalVar = this.canonicalizePathVar(capturedVar);
-		const normalizedRelativePath = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
-		return canonicalVar === "$CLAUDE_PROJECT_DIR"
-			? `${nodePrefix}"${canonicalVar}"/${normalizedRelativePath}${suffix}`
-			: `${nodePrefix}"${canonicalVar}/${normalizedRelativePath}"${suffix}`;
+		const canonicalRoot = this.canonicalizePathRoot(capturedVar);
+		const normalizedRelativePath = this.normalizeRelativePath(canonicalRoot, relativePath);
+		return canonicalRoot === "$CLAUDE_PROJECT_DIR"
+			? `${nodePrefix}"${canonicalRoot}"/${normalizedRelativePath}${suffix}`
+			: `${nodePrefix}"${canonicalRoot}/${normalizedRelativePath}"${suffix}`;
 	}
 
 	/**
@@ -663,15 +641,47 @@ export class SettingsProcessor {
 	 * - %USERPROFILE% → $HOME (universal across all shells)
 	 * - %CLAUDE_PROJECT_DIR% → $CLAUDE_PROJECT_DIR (CC expands both, prefer Unix-style)
 	 */
-	private canonicalizePathVar(capturedVar: string): string {
+	private canonicalizePathRoot(capturedVar: string): string {
 		switch (capturedVar) {
 			case "%USERPROFILE%":
-				return "$HOME";
+			case "$HOME":
+				return this.isGlobal ? this.getCanonicalGlobalCommandRoot() : "$HOME";
 			case "%CLAUDE_PROJECT_DIR%":
-				return "$CLAUDE_PROJECT_DIR";
+			case "$CLAUDE_PROJECT_DIR":
+				return this.isGlobal ? this.getCanonicalGlobalCommandRoot() : "$CLAUDE_PROJECT_DIR";
 			default:
-				return capturedVar;
+				return capturedVar.replace(/\\/g, "/").replace(/\/+$/, "");
 		}
+	}
+
+	private normalizeRelativePath(root: string, relativePath: string): string {
+		const normalizedRelativePath = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
+
+		if (root !== "$CLAUDE_PROJECT_DIR" && this.usesCustomGlobalInstallPath()) {
+			return normalizedRelativePath.replace(/^\.claude\//, "");
+		}
+
+		return normalizedRelativePath;
+	}
+
+	private getCanonicalGlobalCommandRoot(): string {
+		if (this.usesCustomGlobalInstallPath()) {
+			return PathResolver.getGlobalKitDir().replace(/\\/g, "/").replace(/\/+$/, "");
+		}
+
+		return "$HOME";
+	}
+
+	private usesCustomGlobalInstallPath(): boolean {
+		if (!this.isGlobal || !this.projectDir) {
+			return false;
+		}
+
+		const configuredGlobalDir = PathResolver.getGlobalKitDir()
+			.replace(/\\/g, "/")
+			.replace(/\/+$/, "");
+		const defaultGlobalDir = join(homedir(), ".claude").replace(/\\/g, "/");
+		return configuredGlobalDir !== defaultGlobalDir;
 	}
 
 	/**
@@ -757,7 +767,7 @@ export class SettingsProcessor {
 		for (const { event, handler } of teamHooks) {
 			const hookCommand = this.formatCommandPath(
 				"node ",
-				this.isGlobal ? "$HOME" : "$CLAUDE_PROJECT_DIR",
+				this.isGlobal ? this.getCanonicalGlobalCommandRoot() : "$CLAUDE_PROJECT_DIR",
 				`.claude/hooks/${handler}`,
 			);
 			const eventHooks = settings.hooks[event];

--- a/src/services/transformers/global-path-transformer.ts
+++ b/src/services/transformers/global-path-transformer.ts
@@ -12,7 +12,7 @@
  */
 
 import { readFile, readdir, writeFile } from "node:fs/promises";
-import { platform } from "node:os";
+import { homedir, platform } from "node:os";
 import { extname, join } from "node:path";
 import { logger } from "@/shared/logger.js";
 
@@ -45,6 +45,44 @@ export function getHomeDirPrefix(): string {
 	return HOME_PREFIX;
 }
 
+function normalizeInstallPath(path: string): string {
+	return path.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function getDefaultGlobalClaudeDir(): string {
+	return normalizeInstallPath(join(homedir(), ".claude"));
+}
+
+function getCustomGlobalClaudeDir(targetClaudeDir?: string): string | null {
+	if (!targetClaudeDir) return null;
+
+	const normalizedTargetDir = normalizeInstallPath(targetClaudeDir);
+	return normalizedTargetDir === getDefaultGlobalClaudeDir() ? null : normalizedTargetDir;
+}
+
+function getGlobalClaudePath(targetClaudeDir?: string): string {
+	const customGlobalClaudeDir = getCustomGlobalClaudeDir(targetClaudeDir);
+	if (customGlobalClaudeDir) {
+		return `${customGlobalClaudeDir}/`;
+	}
+
+	return `${getHomeDirPrefix()}/.claude/`;
+}
+
+function replaceTracked(
+	content: string,
+	pattern: RegExp,
+	replacement: string,
+): { content: string; changes: number } {
+	let changes = 0;
+	const updated = content.replace(pattern, () => {
+		changes++;
+		return replacement;
+	});
+
+	return { content: updated, changes };
+}
+
 /**
  * Convert Unix-style path separators to Windows-style when on Windows
  * @internal Exported for testing purposes
@@ -65,6 +103,7 @@ export const TRANSFORMABLE_EXTENSIONS = new Set([
 	".cjs",
 	".mjs",
 	".ts",
+	".py",
 	".json",
 	".sh",
 	".ps1",
@@ -93,86 +132,100 @@ export const ALWAYS_TRANSFORM_FILES = new Set(["CLAUDE.md", "claude.md"]);
  *
  * @internal Exported for testing purposes
  */
-export function transformContent(content: string): { transformed: string; changes: number } {
+export function transformContent(
+	content: string,
+	options: { targetClaudeDir?: string } = {},
+): { transformed: string; changes: number } {
 	let changes = 0;
 	let transformed = content;
 	const homePrefix = getHomeDirPrefix();
-	// Always use forward slashes - they work on all platforms (Windows, Linux, macOS)
-	// This ensures consistent path format across all environments
-	const claudePath = `${homePrefix}/.claude/`;
+	const customGlobalClaudeDir = getCustomGlobalClaudeDir(options.targetClaudeDir);
+	const claudePath = getGlobalClaudePath(options.targetClaudeDir);
 
 	// Windows-specific: Convert $HOME → %USERPROFILE% (handles content with Unix env vars)
 	if (IS_WINDOWS) {
 		// Pattern W1: $HOME/.claude/ → %USERPROFILE%/.claude/
-		transformed = transformed.replace(/\$HOME\/\.claude\//g, () => {
-			changes++;
-			return claudePath;
-		});
+		const homePathResult = replaceTracked(transformed, /\$HOME\/\.claude\//g, claudePath);
+		transformed = homePathResult.content;
+		changes += homePathResult.changes;
 
 		// Pattern W2: ${HOME}/.claude/ → %USERPROFILE%/.claude/
-		transformed = transformed.replace(/\$\{HOME\}\/\.claude\//g, () => {
-			changes++;
-			return claudePath;
-		});
+		const braceHomePathResult = replaceTracked(transformed, /\$\{HOME\}\/\.claude\//g, claudePath);
+		transformed = braceHomePathResult.content;
+		changes += braceHomePathResult.changes;
 
 		// Pattern W3: Standalone $HOME → %USERPROFILE% (only when followed by path separator)
-		transformed = transformed.replace(/\$HOME(?=\/|\\)/g, () => {
-			changes++;
-			return homePrefix;
-		});
+		const homePrefixResult = replaceTracked(transformed, /\$HOME(?=\/|\\)/g, homePrefix);
+		transformed = homePrefixResult.content;
+		changes += homePrefixResult.changes;
 
 		// Pattern W4: ${HOME} → %USERPROFILE% (only when followed by path separator)
-		transformed = transformed.replace(/\$\{HOME\}(?=\/|\\)/g, () => {
-			changes++;
-			return homePrefix;
-		});
+		const braceHomePrefixResult = replaceTracked(transformed, /\$\{HOME\}(?=\/|\\)/g, homePrefix);
+		transformed = braceHomePrefixResult.content;
+		changes += braceHomePrefixResult.changes;
 	}
 
 	// Convert $CLAUDE_PROJECT_DIR to home prefix (for global install transformation)
 	// Pattern P1: $CLAUDE_PROJECT_DIR/.claude/ → $HOME/.claude/
-	transformed = transformed.replace(/\$CLAUDE_PROJECT_DIR\/\.claude\//g, () => {
-		changes++;
-		return claudePath;
-	});
+	const projectDirPathResult = replaceTracked(
+		transformed,
+		/\$CLAUDE_PROJECT_DIR\/\.claude\//g,
+		claudePath,
+	);
+	transformed = projectDirPathResult.content;
+	changes += projectDirPathResult.changes;
 
 	// Pattern P2: "$CLAUDE_PROJECT_DIR"/.claude/ → "$HOME"/.claude/ (quoted)
-	transformed = transformed.replace(/"\$CLAUDE_PROJECT_DIR"\/\.claude\//g, () => {
-		changes++;
-		return `"${homePrefix}"/.claude/`;
-	});
+	const quotedProjectDirPath = customGlobalClaudeDir
+		? `${customGlobalClaudeDir}/`
+		: `"${homePrefix}"/.claude/`;
+	const quotedProjectDirPathResult = replaceTracked(
+		transformed,
+		/"\$CLAUDE_PROJECT_DIR"\/\.claude\//g,
+		quotedProjectDirPath,
+	);
+	transformed = quotedProjectDirPathResult.content;
+	changes += quotedProjectDirPathResult.changes;
 
 	// Pattern P3: ${CLAUDE_PROJECT_DIR}/.claude/ → ${HOME}/.claude/ (curly brace)
-	transformed = transformed.replace(/\$\{CLAUDE_PROJECT_DIR\}\/\.claude\//g, () => {
-		changes++;
-		return claudePath;
-	});
+	const braceProjectDirPathResult = replaceTracked(
+		transformed,
+		/\$\{CLAUDE_PROJECT_DIR\}\/\.claude\//g,
+		claudePath,
+	);
+	transformed = braceProjectDirPathResult.content;
+	changes += braceProjectDirPathResult.changes;
 
 	// Windows: %CLAUDE_PROJECT_DIR% → platform-appropriate prefix
 	if (IS_WINDOWS) {
 		// Pattern W5: %CLAUDE_PROJECT_DIR%/.claude/ → %USERPROFILE%/.claude/
-		transformed = transformed.replace(/%CLAUDE_PROJECT_DIR%\/\.claude\//g, () => {
-			changes++;
-			return claudePath;
-		});
+		const windowsProjectDirPathResult = replaceTracked(
+			transformed,
+			/%CLAUDE_PROJECT_DIR%\/\.claude\//g,
+			claudePath,
+		);
+		transformed = windowsProjectDirPathResult.content;
+		changes += windowsProjectDirPathResult.changes;
 	}
 
 	// Pattern 1: ./.claude/ → $HOME/.claude/ (remove ./ prefix entirely)
-	transformed = transformed.replace(/\.\/\.claude\//g, () => {
-		changes++;
-		return claudePath;
-	});
+	const relativeClaudePathResult = replaceTracked(transformed, /\.\/\.claude\//g, claudePath);
+	transformed = relativeClaudePathResult.content;
+	changes += relativeClaudePathResult.changes;
 
 	// Pattern 1b: @./.claude/ → @$HOME/.claude/ (@ with relative path)
-	transformed = transformed.replace(/@\.\/\.claude\//g, () => {
-		changes++;
-		return `@${claudePath}`;
-	});
+	const atRelativeClaudePathResult = replaceTracked(
+		transformed,
+		/@\.\/\.claude\//g,
+		`@${claudePath}`,
+	);
+	transformed = atRelativeClaudePathResult.content;
+	changes += atRelativeClaudePathResult.changes;
 
 	// Pattern 2: @.claude/ → @$HOME/.claude/ (keep @ prefix)
-	transformed = transformed.replace(/@\.claude\//g, () => {
-		changes++;
-		return `@${claudePath}`;
-	});
+	const atClaudePathResult = replaceTracked(transformed, /@\.claude\//g, `@${claudePath}`);
+	transformed = atClaudePathResult.content;
+	changes += atClaudePathResult.changes;
 
 	// Pattern 3: Quoted paths ".claude/ or '.claude/ or `.claude/
 	transformed = transformed.replace(/(["'`])\.claude\//g, (_match, quote) => {
@@ -181,32 +234,58 @@ export function transformContent(content: string): { transformed: string; change
 	});
 
 	// Pattern 4: Parentheses (.claude/ for markdown links
-	transformed = transformed.replace(/\(\.claude\//g, () => {
-		changes++;
-		return `(${claudePath}`;
-	});
+	const markdownClaudePathResult = replaceTracked(transformed, /\(\.claude\//g, `(${claudePath}`);
+	transformed = markdownClaudePathResult.content;
+	changes += markdownClaudePathResult.changes;
 
 	// Pattern 5: Space prefix " .claude/" (but not already handled)
-	transformed = transformed.replace(/ \.claude\//g, () => {
-		changes++;
-		return ` ${claudePath}`;
-	});
+	const spacedClaudePathResult = replaceTracked(transformed, / \.claude\//g, ` ${claudePath}`);
+	transformed = spacedClaudePathResult.content;
+	changes += spacedClaudePathResult.changes;
 
 	// Pattern 6: Start of line ^.claude/
-	transformed = transformed.replace(/^\.claude\//gm, () => {
-		changes++;
-		return claudePath;
-	});
+	const lineStartClaudePathResult = replaceTracked(transformed, /^\.claude\//gm, claudePath);
+	transformed = lineStartClaudePathResult.content;
+	changes += lineStartClaudePathResult.changes;
 
 	// Pattern 7: After colon (YAML/JSON) : .claude/ or :.claude/
-	transformed = transformed.replace(/: \.claude\//g, () => {
-		changes++;
-		return `: ${claudePath}`;
-	});
-	transformed = transformed.replace(/:\.claude\//g, () => {
-		changes++;
-		return `:${claudePath}`;
-	});
+	const colonClaudePathResult = replaceTracked(transformed, /: \.claude\//g, `: ${claudePath}`);
+	transformed = colonClaudePathResult.content;
+	changes += colonClaudePathResult.changes;
+	const compactColonClaudePathResult = replaceTracked(
+		transformed,
+		/:\.claude\//g,
+		`:${claudePath}`,
+	);
+	transformed = compactColonClaudePathResult.content;
+	changes += compactColonClaudePathResult.changes;
+
+	if (customGlobalClaudeDir) {
+		const customPatterns = [
+			{ pattern: /~\/\.claude\//g, replacement: `${customGlobalClaudeDir}/` },
+			{ pattern: /~\/\.claude\b/g, replacement: customGlobalClaudeDir },
+			{ pattern: /\$HOME\/\.claude\//g, replacement: `${customGlobalClaudeDir}/` },
+			{ pattern: /\$HOME\/\.claude\b/g, replacement: customGlobalClaudeDir },
+			{ pattern: /\$\{HOME\}\/\.claude\//g, replacement: `${customGlobalClaudeDir}/` },
+			{ pattern: /\$\{HOME\}\/\.claude\b/g, replacement: customGlobalClaudeDir },
+			{ pattern: /%USERPROFILE%[\\/]\.claude[\\/]/g, replacement: `${customGlobalClaudeDir}/` },
+			{ pattern: /%USERPROFILE%[\\/]\.claude\b/g, replacement: customGlobalClaudeDir },
+			{
+				pattern: /(?:os\.)?homedir\(\)\s*,\s*(["'])\.claude\1/g,
+				replacement: `"${customGlobalClaudeDir}"`,
+			},
+			{
+				pattern: /\b(?:homeDir|homedir)\b\s*,\s*(["'])\.claude\1/g,
+				replacement: `"${customGlobalClaudeDir}"`,
+			},
+		];
+
+		for (const { pattern, replacement } of customPatterns) {
+			const customPatternResult = replaceTracked(transformed, pattern, replacement);
+			transformed = customPatternResult.content;
+			changes += customPatternResult.changes;
+		}
+	}
 
 	return { transformed, changes };
 }
@@ -231,7 +310,7 @@ export function shouldTransformFile(filename: string): boolean {
  */
 export async function transformPathsForGlobalInstall(
 	directory: string,
-	options: { verbose?: boolean } = {},
+	options: { targetClaudeDir?: string; verbose?: boolean } = {},
 ): Promise<{
 	filesTransformed: number;
 	totalChanges: number;
@@ -265,7 +344,9 @@ export async function transformPathsForGlobalInstall(
 			} else if (entry.isFile() && shouldTransformFile(entry.name)) {
 				try {
 					const content = await readFile(fullPath, "utf-8");
-					const { transformed, changes } = transformContent(content);
+					const { transformed, changes } = transformContent(content, {
+						targetClaudeDir: options.targetClaudeDir,
+					});
 
 					if (changes > 0) {
 						await writeFile(fullPath, transformed, "utf-8");
@@ -308,10 +389,11 @@ export async function transformPathsForGlobalInstall(
  */
 export async function transformFile(
 	filePath: string,
+	options: { targetClaudeDir?: string } = {},
 ): Promise<{ success: boolean; changes: number }> {
 	try {
 		const content = await readFile(filePath, "utf-8");
-		const { transformed, changes } = transformContent(content);
+		const { transformed, changes } = transformContent(content, options);
 
 		if (changes > 0) {
 			await writeFile(filePath, transformed, "utf-8");

--- a/src/services/transformers/global-path-transformer.ts
+++ b/src/services/transformers/global-path-transformer.ts
@@ -270,6 +270,8 @@ export function transformContent(
 			{ pattern: /\$\{HOME\}\/\.claude\b/g, replacement: customGlobalClaudeDir },
 			{ pattern: /%USERPROFILE%[\\/]\.claude[\\/]/g, replacement: `${customGlobalClaudeDir}/` },
 			{ pattern: /%USERPROFILE%[\\/]\.claude\b/g, replacement: customGlobalClaudeDir },
+			// Template-specific patterns: exhaustive for current kit templates.
+			// Update if new templates use different variable names (e.g., baseDir, userHome).
 			{
 				pattern: /(?:os\.)?homedir\(\)\s*,\s*(["'])\.claude\1/g,
 				replacement: `"${customGlobalClaudeDir}"`,

--- a/src/shared/command-normalizer.ts
+++ b/src/shared/command-normalizer.ts
@@ -1,3 +1,11 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { PathResolver } from "@/shared/path-resolver.js";
+
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /**
  * Normalize hook command strings for consistent comparison.
  * Canonicalizes path variables and quoting styles to enable matching across formats.
@@ -13,6 +21,8 @@
 export function normalizeCommand(cmd: string | null | undefined): string {
 	if (!cmd) return "";
 	let normalized = cmd;
+	const globalKitDir = PathResolver.getGlobalKitDir().replace(/\\/g, "/").replace(/\/+$/, "");
+	const defaultGlobalKitDir = join(homedir(), ".claude").replace(/\\/g, "/");
 
 	// Strip all double quotes first — quoting is only meaningful for shell execution, not comparison
 	normalized = normalized.replace(/"/g, "");
@@ -33,6 +43,13 @@ export function normalizeCommand(cmd: string | null | undefined): string {
 
 	// Normalize path separators (Windows backslashes → forward slashes)
 	normalized = normalized.replace(/\\/g, "/");
+
+	// Normalize absolute global install paths to canonical $HOME/.claude form
+	for (const absoluteGlobalPath of [globalKitDir, defaultGlobalKitDir]) {
+		if (!absoluteGlobalPath) continue;
+		const absoluteGlobalPathPattern = new RegExp(escapeRegex(absoluteGlobalPath), "g");
+		normalized = normalized.replace(absoluteGlobalPathPattern, "$HOME/.claude");
+	}
 
 	// Normalize whitespace
 	normalized = normalized.replace(/\s+/g, " ").trim();

--- a/src/shared/command-normalizer.ts
+++ b/src/shared/command-normalizer.ts
@@ -45,8 +45,9 @@ export function normalizeCommand(cmd: string | null | undefined): string {
 	normalized = normalized.replace(/\\/g, "/");
 
 	// Normalize absolute global install paths to canonical $HOME/.claude form
-	for (const absoluteGlobalPath of [globalKitDir, defaultGlobalKitDir]) {
-		if (!absoluteGlobalPath) continue;
+	// Deduplicate to avoid redundant regex when CLAUDE_CONFIG_DIR is not set
+	const globalPaths = [...new Set([globalKitDir, defaultGlobalKitDir].filter(Boolean))];
+	for (const absoluteGlobalPath of globalPaths) {
 		const absoluteGlobalPathPattern = new RegExp(escapeRegex(absoluteGlobalPath), "g");
 		normalized = normalized.replace(absoluteGlobalPathPattern, "$HOME/.claude");
 	}

--- a/tests/lib/global-path-transformer.test.ts
+++ b/tests/lib/global-path-transformer.test.ts
@@ -192,6 +192,31 @@ describe("global-path-transformer", () => {
 			expect(transformed).toContain(`${expectedPrefix}/.claude/hooks/scout-block.js`);
 			expect(changes).toBe(2);
 		});
+
+		it("rewrites legacy global references to a custom CLAUDE_CONFIG_DIR target", () => {
+			const input = "Use ~/.claude/skills/install.sh and $HOME/.claude/hooks/test.js";
+			const { transformed, changes } = transformContent(input, {
+				targetClaudeDir: "/custom/claude-config",
+			});
+
+			expect(transformed).toContain("/custom/claude-config/skills/install.sh");
+			expect(transformed).toContain("/custom/claude-config/hooks/test.js");
+			expect(changes).toBe(2);
+		});
+
+		it("rewrites os.homedir-based global path joins to a custom CLAUDE_CONFIG_DIR target", () => {
+			const input = [
+				"const teamsDir = path.join(os.homedir(), '.claude', 'teams');",
+				"const tasksDir = path.join(homeDir, '.claude', 'tasks');",
+			].join("\n");
+			const { transformed, changes } = transformContent(input, {
+				targetClaudeDir: "/custom/claude-config",
+			});
+
+			expect(transformed).toContain("path.join(\"/custom/claude-config\", 'teams')");
+			expect(transformed).toContain("path.join(\"/custom/claude-config\", 'tasks')");
+			expect(changes).toBe(2);
+		});
 	});
 
 	describe("transformFile", () => {
@@ -298,7 +323,7 @@ describe("global-path-transformer", () => {
 		});
 
 		it("only transforms files with eligible extensions", async () => {
-			// Eligible: .json, .md, .js, .ts, .sh, .ps1, .yaml, .yml, .toml
+			// Eligible: .json, .md, .js, .ts, .py, .sh, .ps1, .yaml, .yml, .toml
 			await writeFile(join(testDir, ".claude", "test.json"), '"path": ".claude/test"');
 			await writeFile(join(testDir, ".claude", "test.txt"), "path: .claude/test"); // Not eligible
 
@@ -324,6 +349,36 @@ describe("global-path-transformer", () => {
 			expect(result).toHaveProperty("filesSkipped");
 			expect(result).toHaveProperty("skippedFiles");
 			expect(Array.isArray(result.skippedFiles)).toBe(true);
+		});
+
+		it("uses the active global target for runtime scripts and docs", async () => {
+			await writeFile(
+				join(testDir, ".claude", "hooks", "team-hook.cjs"),
+				"const tasksDir = path.join(os.homedir(), '.claude', 'tasks');",
+			);
+			await writeFile(
+				join(testDir, ".claude", "hooks", "helper.py"),
+				'print("cd ~/.claude/skills/excalidraw/references")',
+			);
+			await writeFile(join(testDir, ".claude", "CLAUDE.md"), "Run ~/.claude/skills/install.sh");
+
+			const result = await transformPathsForGlobalInstall(testDir, {
+				targetClaudeDir: "/custom/claude-config",
+			});
+
+			expect(result.filesTransformed).toBe(3);
+
+			const hookContent = await readFile(
+				join(testDir, ".claude", "hooks", "team-hook.cjs"),
+				"utf-8",
+			);
+			expect(hookContent).toContain("path.join(\"/custom/claude-config\", 'tasks')");
+
+			const pythonContent = await readFile(join(testDir, ".claude", "hooks", "helper.py"), "utf-8");
+			expect(pythonContent).toContain("/custom/claude-config/skills/excalidraw/references");
+
+			const claudeContent = await readFile(join(testDir, ".claude", "CLAUDE.md"), "utf-8");
+			expect(claudeContent).toContain("/custom/claude-config/skills/install.sh");
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- pass the resolved global Claude config root into the init-time global path transformer
- rewrite generated hooks, scripts, and instructions to the active global install dir when `CLAUDE_CONFIG_DIR` is set
- keep settings.json merge/dedup logic compatible with legacy `$HOME/.claude` hook commands while canonicalizing custom-dir installs
- add regression tests for transformer behavior, settings processing, and command normalization

## Validation
- `bun run validate`
- manual repro: `CLAUDE_CONFIG_DIR=/tmp/... bun run src/index.ts init -g -y --skip-setup --kit engineer --kit-path /Users/kaitran/claudekit/claudekit-engineer`

Closes #618
