### PR TITLE
hotfix(hooks): self-heal stale Claude hook command paths

### DIFF
--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
@@ -3,6 +3,7 @@ import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	checkHookCommandPaths,
 	checkHookConfig,
 	checkHookDeps,
 	checkHookLogs,
@@ -402,6 +403,151 @@ describe("checkHookConfig", () => {
 
 		expect(result.status).toBe("pass");
 		expect(result.message).toBe("No hooks configured");
+	});
+});
+
+describe("checkHookCommandPaths", () => {
+	let tempDir: string;
+	let projectDir: string;
+	let originalCkTestHome: string | undefined;
+
+	beforeEach(async () => {
+		tempDir = join(
+			tmpdir(),
+			`hook-health-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		projectDir = join(tempDir, "project");
+		await mkdir(projectDir, { recursive: true });
+
+		originalCkTestHome = process.env.CK_TEST_HOME;
+		process.env.CK_TEST_HOME = tempDir;
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+
+		if (originalCkTestHome === undefined) {
+			process.env.CK_TEST_HOME = undefined;
+		} else {
+			process.env.CK_TEST_HOME = originalCkTestHome;
+		}
+	});
+
+	test("returns fail for raw relative hook commands in settings.local.json", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		await writeFile(
+			join(projectDir, ".claude", "settings.local.json"),
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Read",
+							hooks: [{ type: "command", command: "node .claude/hooks/scout-block.cjs" }],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookCommandPaths(projectDir);
+
+		expect(result.status).toBe("fail");
+		expect(result.message).toBe("1 stale hook command path(s)");
+		expect(result.details).toContain("project settings.local.json");
+		expect(result.details).toContain("raw-relative");
+		expect(result.autoFixable).toBe(true);
+	});
+
+	test("returns pass when hook commands are already canonical", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		await writeFile(
+			join(projectDir, ".claude", "settings.json"),
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Read",
+							hooks: [
+								{
+									type: "command",
+									command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/scout-block.cjs',
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookCommandPaths(projectDir);
+
+		expect(result.status).toBe("pass");
+		expect(result.message).toBe("1 settings file(s) canonical");
+	});
+
+	test("returns fail for invalid embedded-quoted hook commands", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		await writeFile(
+			join(projectDir, ".claude", "settings.json"),
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Read",
+							hooks: [
+								{
+									type: "command",
+									command: 'node "$CLAUDE_PROJECT_DIR/.claude/hooks/scout-block.cjs"',
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookCommandPaths(projectDir);
+
+		expect(result.status).toBe("fail");
+		expect(result.details).toContain("invalid-format");
+		expect(result.autoFixable).toBe(true);
+	});
+
+	test("auto-fix rewrites stale hook commands but leaves non-node commands untouched", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		const settingsPath = join(projectDir, ".claude", "settings.local.json");
+		await writeFile(
+			settingsPath,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Read",
+							hooks: [
+								{ type: "command", command: "node .claude/hooks/scout-block.cjs" },
+								{ type: "command", command: "bash .claude/hooks/scout-block.cjs" },
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookCommandPaths(projectDir);
+		expect(result.fix).toBeDefined();
+
+		const fixResult = await result.fix?.execute();
+		expect(fixResult?.success).toBe(true);
+
+		const repaired = JSON.parse(await Bun.file(settingsPath).text()) as {
+			hooks: { PreToolUse: Array<{ hooks: Array<{ command: string }> }> };
+		};
+		expect(repaired.hooks.PreToolUse[0].hooks[0].command).toBe(
+			'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/scout-block.cjs',
+		);
+		expect(repaired.hooks.PreToolUse[0].hooks[1].command).toBe(
+			"bash .claude/hooks/scout-block.cjs",
+		);
 	});
 });
 

--- a/src/__tests__/domains/installation/merger/settings-processor.test.ts
+++ b/src/__tests__/domains/installation/merger/settings-processor.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SettingsProcessor } from "@/domains/installation/merger/settings-processor.js";
+
+function toPosix(path: string): string {
+	return path.replace(/\\/g, "/");
+}
+
+describe("SettingsProcessor custom global dir support", () => {
+	const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+	const originalCkTestHome = process.env.CK_TEST_HOME;
+	let testDir: string;
+	let customClaudeDir: string;
+	let sourceFile: string;
+	let destFile: string;
+
+	beforeEach(async () => {
+		testDir = await mkdtemp(join(tmpdir(), "settings-processor-"));
+		customClaudeDir = join(testDir, "persisted-claude-config");
+		sourceFile = join(testDir, "source-settings.json");
+		destFile = join(customClaudeDir, "settings.json");
+		await mkdir(customClaudeDir, { recursive: true });
+		// CK_TEST_HOME takes priority over CLAUDE_CONFIG_DIR in PathResolver.getGlobalKitDir(),
+		// so clear it to prevent env leakage from other tests running in the same Bun process.
+		// Must use delete — Node.js coerces `= undefined` to the string "undefined".
+		// biome-ignore lint/performance/noDelete: process.env requires delete to actually unset
+		delete process.env.CK_TEST_HOME;
+		process.env.CLAUDE_CONFIG_DIR = customClaudeDir;
+	});
+
+	afterEach(async () => {
+		await rm(testDir, { recursive: true, force: true });
+		if (originalClaudeConfigDir !== undefined) {
+			process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+		} else {
+			// biome-ignore lint/performance/noDelete: process.env requires delete to actually unset
+			delete process.env.CLAUDE_CONFIG_DIR;
+		}
+		if (originalCkTestHome !== undefined) {
+			process.env.CK_TEST_HOME = originalCkTestHome;
+		} else {
+			// biome-ignore lint/performance/noDelete: process.env requires delete to actually unset
+			delete process.env.CK_TEST_HOME;
+		}
+	});
+
+	function createProcessor(): SettingsProcessor {
+		const processor = new SettingsProcessor();
+		processor.setGlobalFlag(true);
+		processor.setProjectDir(customClaudeDir);
+		processor.setKitName("engineer");
+		return processor;
+	}
+
+	it("writes fresh global hook commands to the active CLAUDE_CONFIG_DIR path", async () => {
+		await writeFile(
+			sourceFile,
+			JSON.stringify(
+				{
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: "node .claude/hooks/task-completed-handler.cjs",
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const processor = createProcessor();
+		await processor.processSettingsJson(sourceFile, destFile);
+
+		const writtenSettings = JSON.parse(await readFile(destFile, "utf-8")) as {
+			hooks: { UserPromptSubmit: Array<{ hooks: Array<{ command: string }> }> };
+		};
+
+		expect(writtenSettings.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+			`node "${toPosix(customClaudeDir)}/hooks/task-completed-handler.cjs"`,
+		);
+	});
+
+	it("deduplicates legacy $HOME hooks against the custom global path on merge", async () => {
+		await writeFile(
+			sourceFile,
+			JSON.stringify(
+				{
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: "node .claude/hooks/task-completed-handler.cjs",
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+		await writeFile(
+			destFile,
+			JSON.stringify(
+				{
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: 'node "$HOME/.claude/hooks/task-completed-handler.cjs"',
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const processor = createProcessor();
+		await processor.processSettingsJson(sourceFile, destFile);
+
+		const mergedSettings = JSON.parse(await readFile(destFile, "utf-8")) as {
+			hooks: { UserPromptSubmit: Array<{ hooks: Array<{ command: string }> }> };
+		};
+
+		expect(mergedSettings.hooks.UserPromptSubmit).toHaveLength(1);
+		expect(mergedSettings.hooks.UserPromptSubmit[0].hooks).toHaveLength(1);
+		expect(mergedSettings.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+			`node "${toPosix(customClaudeDir)}/hooks/task-completed-handler.cjs"`,
+		);
+	});
+
+	it("repairs stale sibling settings.local.json hook paths without touching non-node commands", async () => {
+		await writeFile(
+			sourceFile,
+			JSON.stringify(
+				{
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: "node .claude/hooks/task-completed-handler.cjs",
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+		await writeFile(destFile, JSON.stringify({ hooks: {} }, null, 2));
+		const settingsLocalPath = join(customClaudeDir, "settings.local.json");
+		await writeFile(
+			settingsLocalPath,
+			JSON.stringify(
+				{
+					hooks: {
+						PreToolUse: [
+							{
+								matcher: "Read",
+								hooks: [
+									{
+										type: "command",
+										command: "node .claude/hooks/scout-block.cjs",
+									},
+									{
+										type: "command",
+										command: "bash .claude/hooks/scout-block.cjs",
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const processor = createProcessor();
+		await processor.processSettingsJson(sourceFile, destFile);
+
+		const settingsLocal = JSON.parse(await readFile(settingsLocalPath, "utf-8")) as {
+			hooks: { PreToolUse: Array<{ hooks: Array<{ command: string }> }> };
+		};
+
+		expect(settingsLocal.hooks.PreToolUse[0].hooks[0].command).toBe(
+			`node "${toPosix(customClaudeDir)}/hooks/scout-block.cjs"`,
+		);
+		expect(settingsLocal.hooks.PreToolUse[0].hooks[1].command).toBe(
+			"bash .claude/hooks/scout-block.cjs",
+		);
+	});
+});

--- a/src/__tests__/shared/command-normalizer.test.ts
+++ b/src/__tests__/shared/command-normalizer.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { normalizeCommand, repairClaudeNodeCommandPath } from "@/shared/command-normalizer.js";
+
+describe("normalizeCommand", () => {
+	const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+	afterEach(() => {
+		if (originalClaudeConfigDir !== undefined) {
+			process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+		} else {
+			// biome-ignore lint/performance/noDelete: process.env requires delete to actually unset
+			delete process.env.CLAUDE_CONFIG_DIR;
+		}
+	});
+
+	it("treats custom global dir commands as equivalent to legacy $HOME global commands", () => {
+		process.env.CLAUDE_CONFIG_DIR = "/custom/claude-config";
+
+		const customCommand = 'node "/custom/claude-config/hooks/task-completed-handler.cjs"';
+		const legacyCommand = 'node "$HOME/.claude/hooks/task-completed-handler.cjs"';
+
+		expect(normalizeCommand(customCommand)).toBe(normalizeCommand(legacyCommand));
+	});
+
+	it("repairs raw relative project commands to the canonical CLAUDE_PROJECT_DIR form", () => {
+		const result = repairClaudeNodeCommandPath(
+			"node .claude/hooks/scout-block.cjs",
+			"$CLAUDE_PROJECT_DIR",
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.issue).toBe("raw-relative");
+		expect(result.command).toBe('node "$CLAUDE_PROJECT_DIR"/.claude/hooks/scout-block.cjs');
+	});
+
+	it("ignores non-node commands even when they mention .claude", () => {
+		const command = "bash .claude/hooks/scout-block.cjs";
+		const result = repairClaudeNodeCommandPath(command, "$CLAUDE_PROJECT_DIR");
+
+		expect(result.changed).toBe(false);
+		expect(result.issue).toBeNull();
+		expect(result.command).toBe(command);
+	});
+
+	it("repairs invalid embedded-quoted project commands to the canonical CLAUDE_PROJECT_DIR form", () => {
+		const result = repairClaudeNodeCommandPath(
+			'node "$CLAUDE_PROJECT_DIR/.claude/hooks/scout-block.cjs"',
+			"$CLAUDE_PROJECT_DIR",
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.issue).toBe("invalid-format");
+		expect(result.command).toBe('node "$CLAUDE_PROJECT_DIR"/.claude/hooks/scout-block.cjs');
+	});
+});

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -1,9 +1,11 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { readdir } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { type SettingsJson, SettingsMerger } from "@/domains/config/settings-merger.js";
 import { CLAUDEKIT_CLI_NPM_PACKAGE_NAME } from "@/shared/claudekit-constants.js";
+import { repairClaudeNodeCommandPath } from "@/shared/command-normalizer.js";
 import { logger } from "@/shared/logger.js";
 import { PathResolver } from "@/shared/path-resolver.js";
 import type { CheckResult } from "../types.js";
@@ -12,6 +14,22 @@ import { HOOK_EXTENSIONS } from "./shared.js";
 const HOOK_CHECK_TIMEOUT_MS = 5000;
 const PYTHON_CHECK_TIMEOUT_MS = 3000;
 const MAX_LOG_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
+interface ClaudeSettingsFile {
+	path: string;
+	label: string;
+	root: string;
+}
+
+interface HookCommandFinding {
+	path: string;
+	label: string;
+	eventName: string;
+	matcher?: string;
+	command: string;
+	expected: string;
+	issue: "raw-relative" | "invalid-format";
+}
 
 /**
  * Get the hooks directory to check (prefer project, fallback to global)
@@ -30,6 +48,139 @@ function getHooksDir(projectDir: string): string | null {
  */
 function isPathWithin(filePath: string, parentDir: string): boolean {
 	return resolve(filePath).startsWith(resolve(parentDir));
+}
+
+function getCanonicalGlobalCommandRoot(): string {
+	const configuredGlobalDir = PathResolver.getGlobalKitDir()
+		.replace(/\\/g, "/")
+		.replace(/\/+$/, "");
+	const defaultGlobalDir = join(homedir(), ".claude").replace(/\\/g, "/");
+	return configuredGlobalDir === defaultGlobalDir ? "$HOME" : configuredGlobalDir;
+}
+
+function getClaudeSettingsFiles(projectDir: string): ClaudeSettingsFile[] {
+	const globalClaudeDir = PathResolver.getGlobalKitDir();
+	const candidates: ClaudeSettingsFile[] = [
+		{
+			path: resolve(projectDir, ".claude", "settings.json"),
+			label: "project settings.json",
+			root: "$CLAUDE_PROJECT_DIR",
+		},
+		{
+			path: resolve(projectDir, ".claude", "settings.local.json"),
+			label: "project settings.local.json",
+			root: "$CLAUDE_PROJECT_DIR",
+		},
+		{
+			path: resolve(globalClaudeDir, "settings.json"),
+			label: "global settings.json",
+			root: getCanonicalGlobalCommandRoot(),
+		},
+		{
+			path: resolve(globalClaudeDir, "settings.local.json"),
+			label: "global settings.local.json",
+			root: getCanonicalGlobalCommandRoot(),
+		},
+	];
+
+	return candidates.filter((candidate) => existsSync(candidate.path));
+}
+
+function collectHookCommandFindings(
+	settings: SettingsJson,
+	settingsFile: ClaudeSettingsFile,
+): HookCommandFinding[] {
+	if (!settings.hooks) {
+		return [];
+	}
+
+	const findings: HookCommandFinding[] = [];
+	for (const [eventName, entries] of Object.entries(settings.hooks)) {
+		for (const entry of entries) {
+			if ("command" in entry && typeof entry.command === "string") {
+				const repair = repairClaudeNodeCommandPath(entry.command, settingsFile.root);
+				if (repair.changed && repair.issue) {
+					findings.push({
+						path: settingsFile.path,
+						label: settingsFile.label,
+						eventName,
+						command: entry.command,
+						expected: repair.command,
+						issue: repair.issue,
+					});
+				}
+			}
+
+			if (!("hooks" in entry) || !entry.hooks) {
+				continue;
+			}
+
+			for (const hook of entry.hooks) {
+				if (!hook.command) {
+					continue;
+				}
+
+				const repair = repairClaudeNodeCommandPath(hook.command, settingsFile.root);
+				if (!repair.changed || !repair.issue) {
+					continue;
+				}
+
+				findings.push({
+					path: settingsFile.path,
+					label: settingsFile.label,
+					eventName,
+					matcher: "matcher" in entry ? entry.matcher : undefined,
+					command: hook.command,
+					expected: repair.command,
+					issue: repair.issue,
+				});
+			}
+		}
+	}
+
+	return findings;
+}
+
+async function repairHookCommandsInSettingsFile(settingsFile: ClaudeSettingsFile): Promise<number> {
+	const settings = await SettingsMerger.readSettingsFile(settingsFile.path);
+	if (!settings?.hooks) {
+		return 0;
+	}
+
+	let repaired = 0;
+	for (const entries of Object.values(settings.hooks)) {
+		for (const entry of entries) {
+			if ("command" in entry && typeof entry.command === "string") {
+				const repair = repairClaudeNodeCommandPath(entry.command, settingsFile.root);
+				if (repair.changed) {
+					entry.command = repair.command;
+					repaired++;
+				}
+			}
+
+			if (!("hooks" in entry) || !entry.hooks) {
+				continue;
+			}
+
+			for (const hook of entry.hooks) {
+				if (!hook.command) {
+					continue;
+				}
+
+				const repair = repairClaudeNodeCommandPath(hook.command, settingsFile.root);
+				if (repair.changed) {
+					hook.command = repair.command;
+					repaired++;
+				}
+			}
+		}
+	}
+
+	if (repaired > 0) {
+		await SettingsMerger.writeSettingsFile(settingsFile.path, settings);
+	}
+
+	return repaired;
 }
 
 /**
@@ -388,6 +539,94 @@ export async function checkHookRuntime(projectDir: string): Promise<CheckResult>
 			autoFixable: false,
 		};
 	}
+}
+
+/**
+ * Validate configured hook commands in Claude settings files.
+ * Unlike checkHookRuntime, this inspects the actual command strings Claude executes.
+ */
+export async function checkHookCommandPaths(projectDir: string): Promise<CheckResult> {
+	const settingsFiles = getClaudeSettingsFiles(projectDir);
+
+	if (settingsFiles.length === 0) {
+		return {
+			id: "hook-command-paths",
+			name: "Hook Command Paths",
+			group: "claudekit",
+			priority: "standard",
+			status: "info",
+			message: "No Claude settings files",
+			autoFixable: false,
+		};
+	}
+
+	const findings: HookCommandFinding[] = [];
+	for (const settingsFile of settingsFiles) {
+		const settings = await SettingsMerger.readSettingsFile(settingsFile.path);
+		if (!settings) {
+			continue;
+		}
+		findings.push(...collectHookCommandFindings(settings, settingsFile));
+	}
+
+	if (findings.length === 0) {
+		return {
+			id: "hook-command-paths",
+			name: "Hook Command Paths",
+			group: "claudekit",
+			priority: "standard",
+			status: "pass",
+			message: `${settingsFiles.length} settings file(s) canonical`,
+			autoFixable: false,
+		};
+	}
+
+	const details = findings
+		.slice(0, 5)
+		.map((finding) => {
+			const matcher = finding.matcher ? ` [${finding.matcher}]` : "";
+			return `${finding.label} :: ${finding.eventName}${matcher} :: ${finding.issue} :: ${finding.command}`;
+		})
+		.join("\n");
+
+	return {
+		id: "hook-command-paths",
+		name: "Hook Command Paths",
+		group: "claudekit",
+		priority: "standard",
+		status: "fail",
+		message: `${findings.length} stale hook command path(s)`,
+		details,
+		suggestion: "Run: ck doctor --fix",
+		autoFixable: true,
+		fix: {
+			id: "fix-hook-command-paths",
+			description: "Canonicalize stale .claude hook command paths in settings files",
+			execute: async () => {
+				try {
+					let repaired = 0;
+					for (const settingsFile of settingsFiles) {
+						repaired += await repairHookCommandsInSettingsFile(settingsFile);
+					}
+					if (repaired === 0) {
+						return {
+							success: true,
+							message: "No stale hook command paths needed repair",
+						};
+					}
+					return {
+						success: true,
+						message: `Repaired ${repaired} stale hook command path(s)`,
+					};
+				} catch (error) {
+					return {
+						success: false,
+						message: `Failed to repair hook command paths: ${error}`,
+					};
+				}
+			},
+		},
+	};
 }
 
 /**

--- a/src/domains/health-checks/checkers/index.ts
+++ b/src/domains/health-checks/checkers/index.ts
@@ -19,6 +19,7 @@ export {
 	checkHookSyntax,
 	checkHookDeps,
 	checkHookRuntime,
+	checkHookCommandPaths,
 	checkHookConfig,
 	checkHookLogs,
 	checkCliVersion,

--- a/src/domains/health-checks/claudekit-checker.ts
+++ b/src/domains/health-checks/claudekit-checker.ts
@@ -10,6 +10,7 @@ import {
 	checkGlobalDirReadable,
 	checkGlobalDirWritable,
 	checkGlobalInstall,
+	checkHookCommandPaths,
 	checkHookConfig,
 	checkHookDeps,
 	checkHookLogs,
@@ -94,6 +95,8 @@ export class ClaudekitChecker implements Checker {
 		results.push(await checkHookDeps(this.projectDir));
 		logger.verbose("ClaudekitChecker: Checking hook runtime");
 		results.push(await checkHookRuntime(this.projectDir));
+		logger.verbose("ClaudekitChecker: Checking hook command paths");
+		results.push(await checkHookCommandPaths(this.projectDir));
 		logger.verbose("ClaudekitChecker: Checking hook config");
 		results.push(await checkHookConfig(this.projectDir));
 		logger.verbose("ClaudekitChecker: Checking hook crash logs");

--- a/src/domains/installation/merger/settings-processor.ts
+++ b/src/domains/installation/merger/settings-processor.ts
@@ -1,8 +1,11 @@
 import { execSync } from "node:child_process";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import { InstalledSettingsTracker } from "@/domains/config/installed-settings-tracker.js";
 import { type SettingsJson, SettingsMerger } from "@/domains/config/settings-merger.js";
-import { normalizeCommand } from "@/shared/command-normalizer.js";
+import { normalizeCommand, repairClaudeNodeCommandPath } from "@/shared/command-normalizer.js";
 import { logger } from "@/shared/logger.js";
+import { PathResolver } from "@/shared/path-resolver.js";
 import type { InstalledSettings } from "@/types";
 import { copy, pathExists, readFile, writeFile } from "fs-extra";
 import semver from "semver";
@@ -100,19 +103,18 @@ export class SettingsProcessor {
 			// Transform paths in source content first
 			let transformedSource = sourceContent;
 			if (this.isGlobal) {
-				const homeVar = '"$HOME"';
-				transformedSource = this.transformClaudePaths(sourceContent, homeVar);
+				const globalRoot = this.getCanonicalGlobalCommandRoot();
+				transformedSource = this.transformClaudePaths(sourceContent, globalRoot);
 				if (transformedSource !== sourceContent) {
 					logger.debug(
-						`Transformed .claude/ paths to ${homeVar}/.claude/ in settings.json for global installation`,
+						`Transformed .claude/ paths to ${globalRoot} in settings.json for global installation`,
 					);
 				}
 			} else {
-				const projectDirVar = '"$CLAUDE_PROJECT_DIR"';
-				transformedSource = this.transformClaudePaths(sourceContent, projectDirVar);
+				transformedSource = this.transformClaudePaths(sourceContent, "$CLAUDE_PROJECT_DIR");
 				if (transformedSource !== sourceContent) {
 					logger.debug(
-						`Transformed .claude/ paths to ${projectDirVar}/.claude/ in settings.json for local installation`,
+						'Transformed .claude/ paths to "$CLAUDE_PROJECT_DIR"/.claude/ in settings.json for local installation',
 					);
 				}
 			}
@@ -154,6 +156,8 @@ export class SettingsProcessor {
 				// Inject team hooks if supported
 				await this.injectTeamHooksIfSupported(destFile);
 			}
+
+			await this.repairSiblingSettingsLocal(destFile);
 		} catch (error) {
 			logger.error(`Failed to process settings.json: ${error}`);
 			// Fallback to direct copy if processing fails
@@ -458,33 +462,15 @@ export class SettingsProcessor {
 	/**
 	 * Read settings file and normalize $CLAUDE_PROJECT_DIR paths to $HOME for global installs.
 	 * This ensures deduplication works correctly when merging into global settings.
+	 * NOTE: Mutations are in-memory only — callers must persist the result via writeSettingsFile.
 	 */
 	private async readAndNormalizeGlobalSettings(destFile: string): Promise<SettingsJson | null> {
 		try {
 			const content = await readFile(destFile, "utf-8");
 			if (!content.trim()) return null;
-
-			// Replace $CLAUDE_PROJECT_DIR (and Windows variants) with $HOME (universal)
-			const homeVar = "$HOME";
-			let normalized = content;
-
-			// Unix: $CLAUDE_PROJECT_DIR → $HOME (handle both quoted and unquoted)
-			normalized = normalized.replace(/"\$CLAUDE_PROJECT_DIR"/g, `"${homeVar}"`);
-			normalized = normalized.replace(/\$CLAUDE_PROJECT_DIR/g, homeVar);
-
-			// Windows: %CLAUDE_PROJECT_DIR% → $HOME
-			normalized = normalized.replace(/"%CLAUDE_PROJECT_DIR%"/g, `"${homeVar}"`);
-			normalized = normalized.replace(/%CLAUDE_PROJECT_DIR%/g, homeVar);
-
-			// Windows: %USERPROFILE% → $HOME (migration for pre-existing files)
-			normalized = normalized.replace(/"%USERPROFILE%"/g, `"${homeVar}"`);
-			normalized = normalized.replace(/%USERPROFILE%/g, homeVar);
-
-			if (normalized !== content) {
-				logger.debug("Normalized $CLAUDE_PROJECT_DIR paths to $HOME in existing global settings");
-			}
-
-			return JSON.parse(normalized) as SettingsJson;
+			const parsedSettings = JSON.parse(content) as SettingsJson;
+			this.fixHookCommandPaths(parsedSettings);
+			return parsedSettings;
 		} catch {
 			return null;
 		}
@@ -499,10 +485,10 @@ export class SettingsProcessor {
 	 * Claude Code resolves `project/.claude/...` as `project.claude/...`.
 	 *
 	 * @param content - The file content to transform (raw JSON)
-	 * @param prefix - The environment variable prefix (e.g., '"$HOME"', '"%USERPROFILE%"')
+	 * @param root - The path root (e.g., "$HOME", "$CLAUDE_PROJECT_DIR", "/custom/claude")
 	 * @returns Transformed content with the appropriate quoting strategy per scope
 	 */
-	private transformClaudePaths(content: string, prefix: string): string {
+	private transformClaudePaths(content: string, root: string): string {
 		// Security: Validate that .claude/ paths don't contain shell injection attempts
 		// Matches dangerous chars after .claude/ but before whitespace or quote
 		if (/\.claude\/[^\s"']*[;`$&|><]/.test(content)) {
@@ -512,27 +498,26 @@ export class SettingsProcessor {
 
 		let transformed = content;
 
-		// Extract raw env var (without quotes) for all replacements
-		const rawPrefix = prefix.replace(/"/g, "");
-
 		// Pattern 1: node .claude/... or node ./.claude/... in settings JSON.
 		// Global: node \"$HOME/.claude/hooks/foo.cjs\"
 		// Local:  node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/foo.cjs
+		// NOTE: formatCommandPath returns plain output with literal " chars.
+		// The .replace(/"/g, '\\"') is needed here because this regex operates on raw JSON text,
+		// so quotes must be escaped. fixSingleCommandPath does NOT apply this escape because it
+		// works on parsed command strings (post-JSON-decode).
 		transformed = transformed.replace(
 			/(node\s+)(?:\.\/)?(\.claude\/[^\s"\\]+)([^"\\]*)/g,
 			(_match, nodePrefix: string, relativePath: string, suffix: string) => {
-				const normalizedRelativePath = relativePath.replace(/\\/g, "/");
-				return rawPrefix === "$CLAUDE_PROJECT_DIR"
-					? `${nodePrefix}\\"${rawPrefix}\\"/${normalizedRelativePath}${suffix}`
-					: `${nodePrefix}\\"${rawPrefix}/${normalizedRelativePath}\\"${suffix}`;
+				return this.formatCommandPath(nodePrefix, root, relativePath, suffix).replace(/"/g, '\\"');
 			},
 		);
 
 		// Pattern 2: Already has $CLAUDE_PROJECT_DIR - replace with appropriate prefix
-		if (rawPrefix.includes("HOME") || rawPrefix.includes("USERPROFILE")) {
-			// Global mode: $CLAUDE_PROJECT_DIR → $HOME or %USERPROFILE%
-			transformed = transformed.replace(/\$CLAUDE_PROJECT_DIR/g, rawPrefix);
-			transformed = transformed.replace(/%CLAUDE_PROJECT_DIR%/g, rawPrefix);
+		if (this.isGlobal) {
+			transformed = transformed.replace(/"\$CLAUDE_PROJECT_DIR"/g, `"${root}"`);
+			transformed = transformed.replace(/\$CLAUDE_PROJECT_DIR/g, root);
+			transformed = transformed.replace(/"%CLAUDE_PROJECT_DIR%"/g, `"${root}"`);
+			transformed = transformed.replace(/%CLAUDE_PROJECT_DIR%/g, root);
 		}
 
 		return transformed;
@@ -598,51 +583,7 @@ export class SettingsProcessor {
 	 * Only processes paths containing .claude/ — leaves other commands untouched.
 	 */
 	private fixSingleCommandPath(cmd: string): string {
-		// Only fix node commands targeting .claude/ paths
-		if (!cmd.includes(".claude/") && !cmd.includes(".claude\\")) return cmd;
-
-		const bareRelativeMatch = cmd.match(/^(node\s+)(?:\.\/)?(\.claude[/\\][^\s"]+)(.*)$/);
-		if (bareRelativeMatch) {
-			const [, nodePrefix, relativePath, suffix] = bareRelativeMatch;
-			return this.formatCommandPath(
-				nodePrefix,
-				this.isGlobal ? "$HOME" : "$CLAUDE_PROJECT_DIR",
-				relativePath,
-				suffix,
-			);
-		}
-
-		const embeddedQuotedMatch = cmd.match(
-			/^(node\s+)"(\$HOME|\$CLAUDE_PROJECT_DIR|%USERPROFILE%|%CLAUDE_PROJECT_DIR%)[/\\](\.claude[/\\][^"]+)"(.*)$/,
-		);
-		if (embeddedQuotedMatch) {
-			const [, nodePrefix, capturedVar, relativePath, suffix] = embeddedQuotedMatch;
-			return this.formatCommandPath(nodePrefix, capturedVar, relativePath, suffix);
-		}
-
-		const varOnlyQuotedMatch = cmd.match(
-			/^(node\s+)"(\$HOME|\$CLAUDE_PROJECT_DIR|%USERPROFILE%|%CLAUDE_PROJECT_DIR%)"[/\\](\.claude[/\\][^\s"]+)(.*)$/,
-		);
-		if (varOnlyQuotedMatch) {
-			const [, nodePrefix, capturedVar, relativePath, suffix] = varOnlyQuotedMatch;
-			return this.formatCommandPath(nodePrefix, capturedVar, relativePath, suffix);
-		}
-
-		const tildeMatch = cmd.match(/^(node\s+)~[/\\](\.claude[/\\][^\s"]+)(.*)$/);
-		if (tildeMatch) {
-			const [, nodePrefix, relativePath, suffix] = tildeMatch;
-			return this.formatCommandPath(nodePrefix, "$HOME", relativePath, suffix);
-		}
-
-		const unquotedMatch = cmd.match(
-			/^(node\s+)(\$HOME|\$CLAUDE_PROJECT_DIR|%USERPROFILE%|%CLAUDE_PROJECT_DIR%)[/\\](\.claude[/\\][^\s"]+)(.*)$/,
-		);
-		if (unquotedMatch) {
-			const [, nodePrefix, capturedVar, relativePath, suffix] = unquotedMatch;
-			return this.formatCommandPath(nodePrefix, capturedVar, relativePath, suffix);
-		}
-
-		return cmd;
+		return repairClaudeNodeCommandPath(cmd, this.getClaudeCommandRoot()).command;
 	}
 
 	private formatCommandPath(
@@ -651,11 +592,11 @@ export class SettingsProcessor {
 		relativePath: string,
 		suffix = "",
 	): string {
-		const canonicalVar = this.canonicalizePathVar(capturedVar);
-		const normalizedRelativePath = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
-		return canonicalVar === "$CLAUDE_PROJECT_DIR"
-			? `${nodePrefix}"${canonicalVar}"/${normalizedRelativePath}${suffix}`
-			: `${nodePrefix}"${canonicalVar}/${normalizedRelativePath}"${suffix}`;
+		const canonicalRoot = this.canonicalizePathRoot(capturedVar);
+		const normalizedRelativePath = this.normalizeRelativePath(canonicalRoot, relativePath);
+		return canonicalRoot === "$CLAUDE_PROJECT_DIR"
+			? `${nodePrefix}"${canonicalRoot}"/${normalizedRelativePath}${suffix}`
+			: `${nodePrefix}"${canonicalRoot}/${normalizedRelativePath}"${suffix}`;
 	}
 
 	/**
@@ -663,14 +604,81 @@ export class SettingsProcessor {
 	 * - %USERPROFILE% → $HOME (universal across all shells)
 	 * - %CLAUDE_PROJECT_DIR% → $CLAUDE_PROJECT_DIR (CC expands both, prefer Unix-style)
 	 */
-	private canonicalizePathVar(capturedVar: string): string {
+	private canonicalizePathRoot(capturedVar: string): string {
 		switch (capturedVar) {
 			case "%USERPROFILE%":
-				return "$HOME";
+			case "$HOME":
+				return this.isGlobal ? this.getCanonicalGlobalCommandRoot() : "$HOME";
 			case "%CLAUDE_PROJECT_DIR%":
-				return "$CLAUDE_PROJECT_DIR";
+			case "$CLAUDE_PROJECT_DIR":
+				return this.isGlobal ? this.getCanonicalGlobalCommandRoot() : "$CLAUDE_PROJECT_DIR";
 			default:
-				return capturedVar;
+				return capturedVar.replace(/\\/g, "/").replace(/\/+$/, "");
+		}
+	}
+
+	private normalizeRelativePath(root: string, relativePath: string): string {
+		const normalizedRelativePath = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
+
+		if (root !== "$CLAUDE_PROJECT_DIR" && this.usesCustomGlobalInstallPath()) {
+			return normalizedRelativePath.replace(/^\.claude\//, "");
+		}
+
+		return normalizedRelativePath;
+	}
+
+	private getCanonicalGlobalCommandRoot(): string {
+		if (this.usesCustomGlobalInstallPath()) {
+			return PathResolver.getGlobalKitDir().replace(/\\/g, "/").replace(/\/+$/, "");
+		}
+
+		return "$HOME";
+	}
+
+	private usesCustomGlobalInstallPath(): boolean {
+		if (!this.isGlobal || !this.projectDir) {
+			if (this.isGlobal && !this.projectDir) {
+				logger.debug(
+					"usesCustomGlobalInstallPath: global mode but projectDir not set — defaulting to $HOME",
+				);
+			}
+			return false;
+		}
+
+		const configuredGlobalDir = PathResolver.getGlobalKitDir()
+			.replace(/\\/g, "/")
+			.replace(/\/+$/, "");
+		const defaultGlobalDir = join(homedir(), ".claude").replace(/\\/g, "/");
+		return configuredGlobalDir !== defaultGlobalDir;
+	}
+
+	private getClaudeCommandRoot(): string {
+		return this.isGlobal ? this.getCanonicalGlobalCommandRoot() : "$CLAUDE_PROJECT_DIR";
+	}
+
+	private async repairSettingsFile(filePath: string): Promise<boolean> {
+		const settings = await SettingsMerger.readSettingsFile(filePath);
+		if (!settings) {
+			return false;
+		}
+
+		const pathsFixed = this.fixHookCommandPaths(settings);
+		if (!pathsFixed) {
+			return false;
+		}
+
+		await SettingsMerger.writeSettingsFile(filePath, settings);
+		return true;
+	}
+
+	private async repairSiblingSettingsLocal(destFile: string): Promise<void> {
+		const settingsLocalPath = join(dirname(destFile), "settings.local.json");
+		if (settingsLocalPath === destFile || !(await pathExists(settingsLocalPath))) {
+			return;
+		}
+
+		if (await this.repairSettingsFile(settingsLocalPath)) {
+			logger.info(`Repaired stale .claude command paths in ${settingsLocalPath}`);
 		}
 	}
 
@@ -757,7 +765,7 @@ export class SettingsProcessor {
 		for (const { event, handler } of teamHooks) {
 			const hookCommand = this.formatCommandPath(
 				"node ",
-				this.isGlobal ? "$HOME" : "$CLAUDE_PROJECT_DIR",
+				this.isGlobal ? this.getCanonicalGlobalCommandRoot() : "$CLAUDE_PROJECT_DIR",
 				`.claude/hooks/${handler}`,
 			);
 			const eventHooks = settings.hooks[event];

--- a/src/shared/command-normalizer.ts
+++ b/src/shared/command-normalizer.ts
@@ -1,3 +1,110 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { PathResolver } from "@/shared/path-resolver.js";
+
+export type ClaudeNodeCommandIssue = "raw-relative" | "invalid-format";
+
+export interface ClaudeNodeCommandRepairResult {
+	command: string;
+	changed: boolean;
+	issue: ClaudeNodeCommandIssue | null;
+}
+
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function normalizeCommandRoot(root: string): string {
+	return root.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function formatCanonicalClaudeCommand(
+	nodePrefix: string,
+	root: string,
+	relativePath: string,
+	suffix = "",
+): string {
+	const normalizedRoot = normalizeCommandRoot(root);
+	let normalizedRelativePath = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
+
+	if (normalizedRoot !== "$HOME" && normalizedRoot !== "$CLAUDE_PROJECT_DIR") {
+		normalizedRelativePath = normalizedRelativePath.replace(/^\.claude\//, "");
+	}
+
+	return normalizedRoot === "$CLAUDE_PROJECT_DIR"
+		? `${nodePrefix}"${normalizedRoot}"/${normalizedRelativePath}${suffix}`
+		: `${nodePrefix}"${normalizedRoot}/${normalizedRelativePath}"${suffix}`;
+}
+
+/**
+ * Returns true for `node` commands targeting `.claude/...` paths.
+ * Non-node commands are intentionally ignored so user-managed commands are untouched.
+ */
+export function isNodeClaudeCommand(cmd: string | null | undefined): boolean {
+	if (!cmd) return false;
+	return /^\s*node\s+/.test(cmd) && (cmd.includes(".claude/") || cmd.includes(".claude\\"));
+}
+
+/**
+ * Canonicalize a `node` command targeting `.claude/...` into the expected scope-aware form.
+ *
+ * Accepted target roots:
+ * - `$CLAUDE_PROJECT_DIR` for project-local settings
+ * - `$HOME` for default global settings
+ * - `/custom/claude-dir` for custom global install roots
+ */
+export function repairClaudeNodeCommandPath(
+	cmd: string | null | undefined,
+	root: string,
+): ClaudeNodeCommandRepairResult {
+	if (!cmd || !isNodeClaudeCommand(cmd)) {
+		return { command: cmd ?? "", changed: false, issue: null };
+	}
+
+	const bareRelativeMatch = cmd.match(/^(node\s+)(?:\.\/)?(\.claude[/\\][^\s"]+)(.*)$/);
+	if (bareRelativeMatch) {
+		const [, nodePrefix, relativePath, suffix] = bareRelativeMatch;
+		const command = formatCanonicalClaudeCommand(nodePrefix, root, relativePath, suffix);
+		return { command, changed: command !== cmd, issue: "raw-relative" };
+	}
+
+	const embeddedQuotedMatch = cmd.match(
+		/^(node\s+)"(?:\$HOME|\$CLAUDE_PROJECT_DIR|%USERPROFILE%|%CLAUDE_PROJECT_DIR%)[/\\](\.claude[/\\][^"]+)"(.*)$/,
+	);
+	if (embeddedQuotedMatch) {
+		const [, nodePrefix, relativePath, suffix] = embeddedQuotedMatch;
+		const command = formatCanonicalClaudeCommand(nodePrefix, root, relativePath, suffix);
+		return { command, changed: command !== cmd, issue: "invalid-format" };
+	}
+
+	const varOnlyQuotedMatch = cmd.match(
+		/^(node\s+)"(?:\$HOME|\$CLAUDE_PROJECT_DIR|%USERPROFILE%|%CLAUDE_PROJECT_DIR%)"[/\\](\.claude[/\\][^\s"]+)(.*)$/,
+	);
+	if (varOnlyQuotedMatch) {
+		const [, nodePrefix, relativePath, suffix] = varOnlyQuotedMatch;
+		const command = formatCanonicalClaudeCommand(nodePrefix, root, relativePath, suffix);
+		return { command, changed: command !== cmd, issue: "invalid-format" };
+	}
+
+	const tildeMatch = cmd.match(/^(node\s+)~[/\\](\.claude[/\\][^\s"]+)(.*)$/);
+	if (tildeMatch) {
+		const [, nodePrefix, relativePath, suffix] = tildeMatch;
+		const command = formatCanonicalClaudeCommand(nodePrefix, root, relativePath, suffix);
+		return { command, changed: command !== cmd, issue: "invalid-format" };
+	}
+
+	const unquotedMatch = cmd.match(
+		/^(node\s+)(?:\$HOME|\$CLAUDE_PROJECT_DIR|%USERPROFILE%|%CLAUDE_PROJECT_DIR%)[/\\](\.claude[/\\][^\s"]+)(.*)$/,
+	);
+	if (unquotedMatch) {
+		const [, nodePrefix, relativePath, suffix] = unquotedMatch;
+		const command = formatCanonicalClaudeCommand(nodePrefix, root, relativePath, suffix);
+		return { command, changed: command !== cmd, issue: "invalid-format" };
+	}
+
+	return { command: cmd, changed: false, issue: null };
+}
+
 /**
  * Normalize hook command strings for consistent comparison.
  * Canonicalizes path variables and quoting styles to enable matching across formats.
@@ -13,6 +120,8 @@
 export function normalizeCommand(cmd: string | null | undefined): string {
 	if (!cmd) return "";
 	let normalized = cmd;
+	const globalKitDir = PathResolver.getGlobalKitDir().replace(/\\/g, "/").replace(/\/+$/, "");
+	const defaultGlobalKitDir = join(homedir(), ".claude").replace(/\\/g, "/");
 
 	// Strip all double quotes first — quoting is only meaningful for shell execution, not comparison
 	normalized = normalized.replace(/"/g, "");
@@ -33,6 +142,14 @@ export function normalizeCommand(cmd: string | null | undefined): string {
 
 	// Normalize path separators (Windows backslashes → forward slashes)
 	normalized = normalized.replace(/\\/g, "/");
+
+	// Normalize absolute global install paths to canonical $HOME/.claude form
+	// Deduplicate to avoid redundant regex when CLAUDE_CONFIG_DIR is not set
+	const globalPaths = [...new Set([globalKitDir, defaultGlobalKitDir].filter(Boolean))];
+	for (const absoluteGlobalPath of globalPaths) {
+		const absoluteGlobalPathPattern = new RegExp(escapeRegex(absoluteGlobalPath), "g");
+		normalized = normalized.replace(absoluteGlobalPathPattern, "$HOME/.claude");
+	}
 
 	// Normalize whitespace
 	normalized = normalized.replace(/\s+/g, " ").trim();

--- a/tests/lib/health-checks/claudekit-checker-enhanced.test.ts
+++ b/tests/lib/health-checks/claudekit-checker-enhanced.test.ts
@@ -812,6 +812,36 @@ describe("ClaudeKitChecker - Enhanced Checks", () => {
 		});
 	});
 
+	describe("ClaudekitChecker.run", () => {
+		test("includes hook-command-path findings from settings.local.json in the aggregate run", async () => {
+			const projectClaudeDir = join(mockProjectDir, ".claude");
+			mkdirSync(projectClaudeDir, { recursive: true });
+			await writeFile(
+				join(projectClaudeDir, "settings.local.json"),
+				JSON.stringify({
+					hooks: {
+						PreToolUse: [
+							{
+								matcher: "Read",
+								hooks: [{ type: "command", command: "node .claude/hooks/scout-block.cjs" }],
+							},
+						],
+					},
+				}),
+			);
+
+			const { ClaudekitChecker } = await import(
+				"../../../src/domains/health-checks/claudekit-checker.js"
+			);
+			const results = await new ClaudekitChecker(mockProjectDir).run();
+			const hookCommandPaths = results.find((result) => result.id === "hook-command-paths");
+
+			expect(hookCommandPaths).toBeDefined();
+			expect(hookCommandPaths?.status).toBe("fail");
+			expect(hookCommandPaths?.details).toContain("project settings.local.json");
+		});
+	});
+
 	describe("Edge Cases", () => {
 		test("handles special characters in paths", async () => {
 			const globalHooksDir = join(testPaths.claudeDir, "hooks");

--- a/tests/lib/merge.test.ts
+++ b/tests/lib/merge.test.ts
@@ -1747,6 +1747,61 @@ describe("FileMerger", () => {
 			}
 		});
 
+		test("should self-heal stale raw relative hook commands already present in destination settings", async () => {
+			const sourceSettings = JSON.stringify(
+				{
+					hooks: {
+						PreToolUse: [
+							{
+								matcher: "Read",
+								hooks: [
+									{
+										type: "command",
+										command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/scout-block.cjs',
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			);
+			const destSettings = JSON.stringify(
+				{
+					hooks: {
+						PreToolUse: [
+							{
+								matcher: "Read",
+								hooks: [
+									{
+										type: "command",
+										command: "node .claude/hooks/scout-block.cjs",
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			);
+
+			await writeFile(join(testSourceDir, "settings.json"), sourceSettings);
+			await writeFile(join(testDestDir, "settings.json"), destSettings);
+
+			await merger.merge(testSourceDir, testDestDir, true);
+
+			const destContent = await Bun.file(join(testDestDir, "settings.json")).text();
+			const destJson = JSON.parse(destContent);
+
+			expect(destJson.hooks.PreToolUse).toHaveLength(1);
+			expect(destJson.hooks.PreToolUse[0].hooks).toHaveLength(1);
+			expect(destJson.hooks.PreToolUse[0].hooks[0].command).toBe(
+				'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/scout-block.cjs',
+			);
+		});
+
 		test("should transform to $HOME in global mode (Windows)", async () => {
 			// $HOME is universal — works in PowerShell, cmd, Git Bash, and Unix
 			const settingsContent = JSON.stringify(


### PR DESCRIPTION
## Summary
- self-heal stale `.claude` node hook command paths during settings merge
- repair existing sibling `settings.local.json` overrides without touching non-node commands
- add `ck doctor` diagnostics and auto-fix for stale configured hook commands
- add regression coverage for raw-relative and invalid-format hook command cases

## Validation
- `bun run validate`
- Targeted regression suites:
  - `bun test src/__tests__/shared/command-normalizer.test.ts src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts src/__tests__/domains/installation/merger/settings-processor.test.ts tests/lib/merge.test.ts tests/lib/health-checks/claudekit-checker-enhanced.test.ts`
- Actual Windows host verification:
  - checked out this PR branch on a real Windows host
  - ran `bun install --ignore-scripts`
  - ran the 5 changed suites above: `169 pass, 0 fail`
  - ran a CLI-level `doctor` repro/fix cycle against an isolated temp Claude home with stale `settings.local.json`
    - before fix: `hook-command-paths = fail` with `2 stale hook command path(s)`
    - after `doctor --fix`: `hook-command-paths = pass` with `1 settings file(s) canonical`
- Full Windows host `bun run validate` was also executed for signal. It exposed 2 unrelated failures outside this patch surface:
  - `PackageManagerDetector > edge cases > handles cache boundary - exactly 30 days old`
  - `Package Installer Tests > Google Gemini CLI > should get version if @google/gemini-cli is installed` (timeout)

## Notes
- This hotfix is branched from `main` to avoid leaking dev-only history into production.
- Windows host details are intentionally anonymized in this PR body.
- Docs impact: none. Action: no update needed — internal self-heal and diagnostic improvement only.