### PR TITLE
feat: support provider-aware CLI onboarding

### DIFF
--- a/docs/ck-command-flow-guide.md
+++ b/docs/ck-command-flow-guide.md
@@ -108,7 +108,7 @@ flowchart TD
 - Optional: Install skills
 - Optional: Install Gemini MCP
 - Optional: Open in code editor
-- Setup wizard: Prompts for required env keys for `ai-multimodal` image generation if missing (for example, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, or `MINIMAX_API_KEY`)
+- Setup wizard: Prompts for required env keys for `ai-multimodal` image generation if missing (for example, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, or `MINIMAX_API_KEY`) and can persist `IMAGE_GEN_PROVIDER` when multiple providers are configured
 
 ---
 
@@ -218,7 +218,7 @@ flowchart TD
 - Skill components and dependencies
 - Slash command hooks present
 - Active CLAUDE.md file
-- Required environment keys for image generation (for example, one of `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, or `MINIMAX_API_KEY`) in `.env`
+- Required environment keys for image generation (for example, one of `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, or `MINIMAX_API_KEY`) in `.env`, plus optional `IMAGE_GEN_PROVIDER` when users want an explicit default path
 
 ---
 

--- a/docs/ck-command-flow-guide.md
+++ b/docs/ck-command-flow-guide.md
@@ -108,7 +108,7 @@ flowchart TD
 - Optional: Install skills
 - Optional: Install Gemini MCP
 - Optional: Open in code editor
-- Setup wizard: Prompts for required env keys (e.g., `GEMINI_API_KEY`) if missing
+- Setup wizard: Prompts for required env keys for `ai-multimodal` image generation if missing (for example, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, or `MINIMAX_API_KEY`)
 
 ---
 
@@ -218,7 +218,7 @@ flowchart TD
 - Skill components and dependencies
 - Slash command hooks present
 - Active CLAUDE.md file
-- Required environment keys (e.g., `GEMINI_API_KEY`) in `.env`
+- Required environment keys for image generation (for example, one of `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, or `MINIMAX_API_KEY`) in `.env`
 
 ---
 

--- a/src/__tests__/domains/health-checks/checkers/env-keys-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/env-keys-checker.test.ts
@@ -79,7 +79,7 @@ describe("checkEnvKeys", () => {
 
 		expect(results.length).toBe(1);
 		expect(results[0].status).toBe("pass");
-		expect(results[0].message).toBe("One supported image-generation provider key configured");
+		expect(results[0].message).toBe("Configured image providers: Gemini");
 	});
 
 	test("returns pass status when global .env has OpenRouter key only", async () => {
@@ -92,7 +92,23 @@ describe("checkEnvKeys", () => {
 
 		expect(results.length).toBe(1);
 		expect(results[0].status).toBe("pass");
-		expect(results[0].message).toBe("One supported image-generation provider key configured");
+		expect(results[0].message).toBe("Configured image providers: OpenRouter");
+	});
+
+	test("returns pass status when multiple image providers are configured", async () => {
+		await writeFile(
+			join(globalDir, ".env"),
+			[
+				"GEMINI_API_KEY=AIzaSyTestKey12345678901234567890123",
+				"OPENROUTER_API_KEY=sk-or-v1-abcdefghijklmnopqrstuvwxyz123456",
+			].join("\n"),
+		);
+		const setup = createSetup({ hasGlobal: true, hasProjectMetadata: false });
+		const results = await checkEnvKeys(setup);
+
+		expect(results.length).toBe(1);
+		expect(results[0].status).toBe("pass");
+		expect(results[0].message).toBe("Configured image providers: Gemini, OpenRouter");
 	});
 
 	test("returns warn status when project .env is missing", async () => {

--- a/src/__tests__/domains/health-checks/checkers/env-keys-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/env-keys-checker.test.ts
@@ -57,7 +57,9 @@ describe("checkEnvKeys", () => {
 		expect(results[0].id).toBe("ck-global-env-keys");
 		expect(results[0].status).toBe("warn");
 		expect(results[0].message).toBe(".env file not found");
-		expect(results[0].suggestion).toBe("Run: ck init --global");
+		expect(results[0].suggestion).toBe(
+			"Run: ck init --global (configure Gemini, OpenRouter, or MiniMax)",
+		);
 	});
 
 	test("returns warn status when global .env missing required key", async () => {
@@ -67,7 +69,7 @@ describe("checkEnvKeys", () => {
 
 		expect(results.length).toBe(1);
 		expect(results[0].status).toBe("warn");
-		expect(results[0].message).toBe("Missing: Gemini API Key");
+		expect(results[0].message).toBe("Missing: Image generation provider API key");
 	});
 
 	test("returns pass status when global .env has required key", async () => {
@@ -77,7 +79,20 @@ describe("checkEnvKeys", () => {
 
 		expect(results.length).toBe(1);
 		expect(results[0].status).toBe("pass");
-		expect(results[0].message).toBe("1 required key(s) configured");
+		expect(results[0].message).toBe("One supported image-generation provider key configured");
+	});
+
+	test("returns pass status when global .env has OpenRouter key only", async () => {
+		await writeFile(
+			join(globalDir, ".env"),
+			"OPENROUTER_API_KEY=sk-or-v1-abcdefghijklmnopqrstuvwxyz123456",
+		);
+		const setup = createSetup({ hasGlobal: true, hasProjectMetadata: false });
+		const results = await checkEnvKeys(setup);
+
+		expect(results.length).toBe(1);
+		expect(results[0].status).toBe("pass");
+		expect(results[0].message).toBe("One supported image-generation provider key configured");
 	});
 
 	test("returns warn status when project .env is missing", async () => {
@@ -88,7 +103,7 @@ describe("checkEnvKeys", () => {
 		expect(results[0].id).toBe("ck-project-env-keys");
 		expect(results[0].status).toBe("warn");
 		expect(results[0].message).toBe(".env file not found");
-		expect(results[0].suggestion).toBe("Run: ck init");
+		expect(results[0].suggestion).toBe("Run: ck init (configure Gemini, OpenRouter, or MiniMax)");
 	});
 
 	test("returns pass status when project .env has required key", async () => {

--- a/src/__tests__/domains/health-checks/checkers/env-keys-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/env-keys-checker.test.ts
@@ -5,6 +5,9 @@ import { join } from "node:path";
 import { checkEnvKeys } from "@/domains/health-checks/checkers/env-keys-checker.js";
 import type { ClaudeKitSetup } from "@/types";
 
+const VALID_GEMINI_KEY = `AIza${"A".repeat(35)}`;
+const VALID_OPENROUTER_KEY = "sk-or-v1-abcdefghijklmnopqrstuvwxyz123456";
+
 describe("checkEnvKeys", () => {
 	let tempDir: string;
 	let globalDir: string;
@@ -73,7 +76,7 @@ describe("checkEnvKeys", () => {
 	});
 
 	test("returns pass status when global .env has required key", async () => {
-		await writeFile(join(globalDir, ".env"), "GEMINI_API_KEY=AIzaSyTestKey12345678901234567890123");
+		await writeFile(join(globalDir, ".env"), `GEMINI_API_KEY=${VALID_GEMINI_KEY}`);
 		const setup = createSetup({ hasGlobal: true, hasProjectMetadata: false });
 		const results = await checkEnvKeys(setup);
 
@@ -83,10 +86,7 @@ describe("checkEnvKeys", () => {
 	});
 
 	test("returns pass status when global .env has OpenRouter key only", async () => {
-		await writeFile(
-			join(globalDir, ".env"),
-			"OPENROUTER_API_KEY=sk-or-v1-abcdefghijklmnopqrstuvwxyz123456",
-		);
+		await writeFile(join(globalDir, ".env"), `OPENROUTER_API_KEY=${VALID_OPENROUTER_KEY}`);
 		const setup = createSetup({ hasGlobal: true, hasProjectMetadata: false });
 		const results = await checkEnvKeys(setup);
 
@@ -98,10 +98,9 @@ describe("checkEnvKeys", () => {
 	test("returns pass status when multiple image providers are configured", async () => {
 		await writeFile(
 			join(globalDir, ".env"),
-			[
-				"GEMINI_API_KEY=AIzaSyTestKey12345678901234567890123",
-				"OPENROUTER_API_KEY=sk-or-v1-abcdefghijklmnopqrstuvwxyz123456",
-			].join("\n"),
+			[`GEMINI_API_KEY=${VALID_GEMINI_KEY}`, `OPENROUTER_API_KEY=${VALID_OPENROUTER_KEY}`].join(
+				"\n",
+			),
 		);
 		const setup = createSetup({ hasGlobal: true, hasProjectMetadata: false });
 		const results = await checkEnvKeys(setup);
@@ -123,10 +122,7 @@ describe("checkEnvKeys", () => {
 	});
 
 	test("returns pass status when project .env has required key", async () => {
-		await writeFile(
-			join(projectDir, ".env"),
-			"GEMINI_API_KEY=AIzaSyTestKey12345678901234567890123",
-		);
+		await writeFile(join(projectDir, ".env"), `GEMINI_API_KEY=${VALID_GEMINI_KEY}`);
 		const setup = createSetup({ hasGlobal: false, hasProjectMetadata: true });
 		const results = await checkEnvKeys(setup);
 
@@ -135,7 +131,7 @@ describe("checkEnvKeys", () => {
 	});
 
 	test("checks both global and project when both exist", async () => {
-		await writeFile(join(globalDir, ".env"), "GEMINI_API_KEY=AIzaSyTestKey12345678901234567890123");
+		await writeFile(join(globalDir, ".env"), `GEMINI_API_KEY=${VALID_GEMINI_KEY}`);
 		await writeFile(join(projectDir, ".env"), "OTHER_KEY=value");
 		const setup = createSetup({ hasGlobal: true, hasProjectMetadata: true });
 		const results = await checkEnvKeys(setup);

--- a/src/__tests__/domains/installation/setup-wizard.test.ts
+++ b/src/__tests__/domains/installation/setup-wizard.test.ts
@@ -61,6 +61,28 @@ describe("checkRequiredKeysExist", () => {
 		expect(result.missing).toEqual([]);
 	});
 
+	test("returns allPresent: true when OPENROUTER_API_KEY exists", async () => {
+		const envPath = join(tempDir, ".env");
+		await writeFile(envPath, "OPENROUTER_API_KEY=sk-or-v1-abcdefghijklmnopqrstuvwxyz123456");
+
+		const result = await checkRequiredKeysExist(envPath);
+
+		expect(result.envExists).toBe(true);
+		expect(result.allPresent).toBe(true);
+		expect(result.missing).toEqual([]);
+	});
+
+	test("returns allPresent: true when MINIMAX_API_KEY exists", async () => {
+		const envPath = join(tempDir, ".env");
+		await writeFile(envPath, "MINIMAX_API_KEY=minimax_test_key_1234567890");
+
+		const result = await checkRequiredKeysExist(envPath);
+
+		expect(result.envExists).toBe(true);
+		expect(result.allPresent).toBe(true);
+		expect(result.missing).toEqual([]);
+	});
+
 	test("handles quoted values correctly", async () => {
 		const envPath = join(tempDir, ".env");
 		await writeFile(envPath, 'GEMINI_API_KEY="AIzaSyTestKey12345678901234567890123"');
@@ -154,6 +176,6 @@ describe("checkRequiredKeysExist", () => {
 		expect(result.envExists).toBe(true);
 		expect(result.allPresent).toBe(false);
 		expect(result.missing.length).toBe(1);
-		expect(result.missing[0].key).toBe("GEMINI_API_KEY");
+		expect(result.missing[0].key).toBe("IMAGE_PROVIDER_API_KEY");
 	});
 });

--- a/src/__tests__/domains/installation/setup-wizard.test.ts
+++ b/src/__tests__/domains/installation/setup-wizard.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { REQUIRED_ENV_KEYS, checkRequiredKeysExist } from "@/domains/installation/setup-wizard.js";
+import {
+	REQUIRED_ENV_KEYS,
+	checkRequiredKeysExist,
+	getConfiguredImageProviders,
+	getDefaultImageProviderSelection,
+} from "@/domains/installation/setup-wizard.js";
 
 describe("checkRequiredKeysExist", () => {
 	let tempDir: string;
@@ -70,6 +75,7 @@ describe("checkRequiredKeysExist", () => {
 		expect(result.envExists).toBe(true);
 		expect(result.allPresent).toBe(true);
 		expect(result.missing).toEqual([]);
+		expect(result.configuredProviders).toEqual(["openrouter"]);
 	});
 
 	test("returns allPresent: true when MINIMAX_API_KEY exists", async () => {
@@ -162,6 +168,7 @@ describe("checkRequiredKeysExist", () => {
 
 		expect(result.allPresent).toBe(true);
 		expect(result.missing).toEqual([]);
+		expect(result.configuredProviders).toEqual(["google"]);
 	});
 
 	test("handles multiple env vars with key missing", async () => {
@@ -177,5 +184,31 @@ describe("checkRequiredKeysExist", () => {
 		expect(result.allPresent).toBe(false);
 		expect(result.missing.length).toBe(1);
 		expect(result.missing[0].key).toBe("IMAGE_PROVIDER_API_KEY");
+	});
+});
+
+describe("image provider helpers", () => {
+	test("getConfiguredImageProviders returns all configured provider paths", () => {
+		expect(
+			getConfiguredImageProviders({
+				GEMINI_API_KEY: "gemini",
+				OPENROUTER_API_KEY: "openrouter",
+				MINIMAX_API_KEY: "",
+			}),
+		).toEqual(["google", "openrouter"]);
+	});
+
+	test("getDefaultImageProviderSelection prefers existing supported choice", () => {
+		expect(getDefaultImageProviderSelection(["google", "openrouter"], "openrouter")).toBe(
+			"openrouter",
+		);
+	});
+
+	test("getDefaultImageProviderSelection falls back to auto when Gemini is configured", () => {
+		expect(getDefaultImageProviderSelection(["google", "openrouter"])).toBe("auto");
+	});
+
+	test("getDefaultImageProviderSelection falls back to first configured non-Google provider", () => {
+		expect(getDefaultImageProviderSelection(["openrouter", "minimax"])).toBe("openrouter");
 	});
 });

--- a/src/__tests__/domains/installation/setup-wizard.test.ts
+++ b/src/__tests__/domains/installation/setup-wizard.test.ts
@@ -9,6 +9,10 @@ import {
 	getDefaultImageProviderSelection,
 } from "@/domains/installation/setup-wizard.js";
 
+const VALID_GEMINI_KEY = `AIza${"A".repeat(35)}`;
+const VALID_OPENROUTER_KEY = "sk-or-v1-abcdefghijklmnopqrstuvwxyz123456";
+const VALID_MINIMAX_KEY = "minimax_test_key_1234567890";
+
 describe("checkRequiredKeysExist", () => {
 	let tempDir: string;
 
@@ -57,7 +61,7 @@ describe("checkRequiredKeysExist", () => {
 
 	test("returns allPresent: true when GEMINI_API_KEY exists", async () => {
 		const envPath = join(tempDir, ".env");
-		await writeFile(envPath, "GEMINI_API_KEY=AIzaSyTestKey12345678901234567890123");
+		await writeFile(envPath, `GEMINI_API_KEY=${VALID_GEMINI_KEY}`);
 
 		const result = await checkRequiredKeysExist(envPath);
 
@@ -68,7 +72,7 @@ describe("checkRequiredKeysExist", () => {
 
 	test("returns allPresent: true when OPENROUTER_API_KEY exists", async () => {
 		const envPath = join(tempDir, ".env");
-		await writeFile(envPath, "OPENROUTER_API_KEY=sk-or-v1-abcdefghijklmnopqrstuvwxyz123456");
+		await writeFile(envPath, `OPENROUTER_API_KEY=${VALID_OPENROUTER_KEY}`);
 
 		const result = await checkRequiredKeysExist(envPath);
 
@@ -80,18 +84,31 @@ describe("checkRequiredKeysExist", () => {
 
 	test("returns allPresent: true when MINIMAX_API_KEY exists", async () => {
 		const envPath = join(tempDir, ".env");
-		await writeFile(envPath, "MINIMAX_API_KEY=minimax_test_key_1234567890");
+		await writeFile(envPath, `MINIMAX_API_KEY=${VALID_MINIMAX_KEY}`);
 
 		const result = await checkRequiredKeysExist(envPath);
 
 		expect(result.envExists).toBe(true);
 		expect(result.allPresent).toBe(true);
 		expect(result.missing).toEqual([]);
+		expect(result.configuredProviders).toEqual(["minimax"]);
+	});
+
+	test("treats invalid provider keys as missing", async () => {
+		const envPath = join(tempDir, ".env");
+		await writeFile(envPath, "GEMINI_API_KEY=invalid");
+
+		const result = await checkRequiredKeysExist(envPath);
+
+		expect(result.envExists).toBe(true);
+		expect(result.allPresent).toBe(false);
+		expect(result.missing).toEqual(REQUIRED_ENV_KEYS);
+		expect(result.configuredProviders).toEqual([]);
 	});
 
 	test("handles quoted values correctly", async () => {
 		const envPath = join(tempDir, ".env");
-		await writeFile(envPath, 'GEMINI_API_KEY="AIzaSyTestKey12345678901234567890123"');
+		await writeFile(envPath, `GEMINI_API_KEY="${VALID_GEMINI_KEY}"`);
 
 		const result = await checkRequiredKeysExist(envPath);
 
@@ -101,7 +118,7 @@ describe("checkRequiredKeysExist", () => {
 
 	test("handles single-quoted values correctly", async () => {
 		const envPath = join(tempDir, ".env");
-		await writeFile(envPath, "GEMINI_API_KEY='AIzaSyTestKey12345678901234567890123'");
+		await writeFile(envPath, `GEMINI_API_KEY='${VALID_GEMINI_KEY}'`);
 
 		const result = await checkRequiredKeysExist(envPath);
 
@@ -111,7 +128,7 @@ describe("checkRequiredKeysExist", () => {
 
 	test("handles export prefix correctly", async () => {
 		const envPath = join(tempDir, ".env");
-		await writeFile(envPath, "export GEMINI_API_KEY=AIzaSyTestKey12345678901234567890123");
+		await writeFile(envPath, `export GEMINI_API_KEY=${VALID_GEMINI_KEY}`);
 
 		const result = await checkRequiredKeysExist(envPath);
 
@@ -159,7 +176,7 @@ describe("checkRequiredKeysExist", () => {
 			[
 				"# Config file",
 				"OTHER_KEY=value",
-				"GEMINI_API_KEY=AIzaSyTestKey12345678901234567890123",
+				`GEMINI_API_KEY=${VALID_GEMINI_KEY}`,
 				"DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/123",
 			].join("\n"),
 		);
@@ -191,11 +208,21 @@ describe("image provider helpers", () => {
 	test("getConfiguredImageProviders returns all configured provider paths", () => {
 		expect(
 			getConfiguredImageProviders({
-				GEMINI_API_KEY: "gemini",
-				OPENROUTER_API_KEY: "openrouter",
+				GEMINI_API_KEY: VALID_GEMINI_KEY,
+				OPENROUTER_API_KEY: VALID_OPENROUTER_KEY,
 				MINIMAX_API_KEY: "",
 			}),
 		).toEqual(["google", "openrouter"]);
+	});
+
+	test("getConfiguredImageProviders ignores invalid provider values", () => {
+		expect(
+			getConfiguredImageProviders({
+				GEMINI_API_KEY: "invalid",
+				OPENROUTER_API_KEY: VALID_OPENROUTER_KEY,
+				MINIMAX_API_KEY: "short",
+			}),
+		).toEqual(["openrouter"]);
 	});
 
 	test("getDefaultImageProviderSelection prefers existing supported choice", () => {
@@ -206,6 +233,19 @@ describe("image provider helpers", () => {
 
 	test("getDefaultImageProviderSelection preserves explicit auto preference", () => {
 		expect(getDefaultImageProviderSelection(["google", "openrouter"], "auto")).toBe("auto");
+	});
+
+	test("getDefaultImageProviderSelection does not preserve auto without Gemini", () => {
+		expect(getDefaultImageProviderSelection(["openrouter", "minimax"], "auto")).toBe("openrouter");
+	});
+
+	test("getDefaultImageProviderSelection ignores stale auto when Gemini key is invalid", () => {
+		const configuredProviders = getConfiguredImageProviders({
+			GEMINI_API_KEY: "invalid",
+			OPENROUTER_API_KEY: VALID_OPENROUTER_KEY,
+		});
+
+		expect(getDefaultImageProviderSelection(configuredProviders, "auto")).toBe("openrouter");
 	});
 
 	test("getDefaultImageProviderSelection falls back to auto when Gemini is configured", () => {

--- a/src/__tests__/domains/installation/setup-wizard.test.ts
+++ b/src/__tests__/domains/installation/setup-wizard.test.ts
@@ -204,11 +204,19 @@ describe("image provider helpers", () => {
 		);
 	});
 
+	test("getDefaultImageProviderSelection preserves explicit auto preference", () => {
+		expect(getDefaultImageProviderSelection(["google", "openrouter"], "auto")).toBe("auto");
+	});
+
 	test("getDefaultImageProviderSelection falls back to auto when Gemini is configured", () => {
 		expect(getDefaultImageProviderSelection(["google", "openrouter"])).toBe("auto");
 	});
 
 	test("getDefaultImageProviderSelection falls back to first configured non-Google provider", () => {
 		expect(getDefaultImageProviderSelection(["openrouter", "minimax"])).toBe("openrouter");
+	});
+
+	test("getDefaultImageProviderSelection ignores unsupported existing preference", () => {
+		expect(getDefaultImageProviderSelection(["minimax"], "openrouter")).toBe("minimax");
 	});
 });

--- a/src/__tests__/types/skills-dependencies.test.ts
+++ b/src/__tests__/types/skills-dependencies.test.ts
@@ -26,7 +26,12 @@ describe("skills-dependencies", () => {
 		it("includes google-genai in python deps", () => {
 			const googleGenai = SKILLS_DEPENDENCIES.python.find((d) => d.name.includes("google-genai"));
 			expect(googleGenai).toBeDefined();
-			expect(googleGenai?.description).toContain("ai-multimodal");
+			expect(googleGenai?.description).toContain("Gemini provider");
+		});
+
+		it("includes requests in python dependency messaging", () => {
+			const requestsLine = SKILLS_DEPENDENCIES.python.find((d) => d.name.includes("requests"));
+			expect(requestsLine).toBeDefined();
 		});
 
 		it("includes ffmpeg in system deps", () => {

--- a/src/domains/config/config-validator.ts
+++ b/src/domains/config/config-validator.ts
@@ -5,6 +5,7 @@ export const VALIDATION_PATTERNS = {
 	// Gemini API keys are exactly 39 chars: "AIza" prefix (4) + 35 base64url chars
 	GEMINI_API_KEY: /^AIza[0-9A-Za-z_-]{35}$/,
 	OPENROUTER_API_KEY: /^sk-or-v1-[A-Za-z0-9_-]+$/,
+	// MiniMax keys do not appear to expose a stable public prefix; use a length/charset guard only.
 	MINIMAX_API_KEY: /^[A-Za-z0-9_-]{16,}$/,
 	IMAGE_GEN_PROVIDER: /^(auto|google|openrouter|minimax)$/,
 	DISCORD_WEBHOOK_URL: /^https:\/\/discord\.com\/api\/webhooks\//,

--- a/src/domains/config/config-validator.ts
+++ b/src/domains/config/config-validator.ts
@@ -4,6 +4,9 @@
 export const VALIDATION_PATTERNS = {
 	// Gemini API keys are exactly 39 chars: "AIza" prefix (4) + 35 base64url chars
 	GEMINI_API_KEY: /^AIza[0-9A-Za-z_-]{35}$/,
+	OPENROUTER_API_KEY: /^sk-or-v1-[A-Za-z0-9_-]+$/,
+	MINIMAX_API_KEY: /^[A-Za-z0-9_-]{16,}$/,
+	IMAGE_GEN_PROVIDER: /^(auto|google|openrouter|minimax)$/,
 	DISCORD_WEBHOOK_URL: /^https:\/\/discord\.com\/api\/webhooks\//,
 	TELEGRAM_BOT_TOKEN: /^\d+:[A-Za-z0-9_-]{35}$/,
 };

--- a/src/domains/health-checks/checkers/env-keys-checker.ts
+++ b/src/domains/health-checks/checkers/env-keys-checker.ts
@@ -8,8 +8,28 @@ import { checkRequiredKeysExist } from "@/domains/installation/setup-wizard.js";
 import type { ClaudeKitSetup } from "@/types";
 import type { CheckResult } from "../types.js";
 
-const PROVIDER_REQUIREMENT_MESSAGE = "One supported image-generation provider key configured";
 const PROVIDER_SETUP_SUGGESTION = "Run: ck init (configure Gemini, OpenRouter, or MiniMax)";
+
+function formatConfiguredProviderMessage(providers: string[]): string {
+	if (providers.length === 0) {
+		return "No supported image-generation provider keys configured";
+	}
+
+	const labels = providers.map((provider) => {
+		switch (provider) {
+			case "google":
+				return "Gemini";
+			case "openrouter":
+				return "OpenRouter";
+			case "minimax":
+				return "MiniMax";
+			default:
+				return provider;
+		}
+	});
+
+	return `Configured image providers: ${labels.join(", ")}`;
+}
 
 /**
  * Check required environment keys in .env files
@@ -43,7 +63,7 @@ export async function checkEnvKeys(setup: ClaudeKitSetup): Promise<CheckResult[]
 				group: "claudekit",
 				priority: "standard",
 				status: "pass",
-				message: PROVIDER_REQUIREMENT_MESSAGE,
+				message: formatConfiguredProviderMessage(globalCheck.configuredProviders),
 				details: globalEnvPath,
 				autoFixable: false,
 			});
@@ -75,7 +95,7 @@ export async function checkEnvKeys(setup: ClaudeKitSetup): Promise<CheckResult[]
 				group: "claudekit",
 				priority: "standard",
 				status: "pass",
-				message: PROVIDER_REQUIREMENT_MESSAGE,
+				message: formatConfiguredProviderMessage(projectCheck.configuredProviders),
 				details: projectEnvPath,
 				autoFixable: false,
 			});

--- a/src/domains/health-checks/checkers/env-keys-checker.ts
+++ b/src/domains/health-checks/checkers/env-keys-checker.ts
@@ -4,9 +4,12 @@
  */
 
 import { join } from "node:path";
-import { REQUIRED_ENV_KEYS, checkRequiredKeysExist } from "@/domains/installation/setup-wizard.js";
+import { checkRequiredKeysExist } from "@/domains/installation/setup-wizard.js";
 import type { ClaudeKitSetup } from "@/types";
 import type { CheckResult } from "../types.js";
+
+const PROVIDER_REQUIREMENT_MESSAGE = "One supported image-generation provider key configured";
+const PROVIDER_SETUP_SUGGESTION = "Run: ck init (configure Gemini, OpenRouter, or MiniMax)";
 
 /**
  * Check required environment keys in .env files
@@ -30,7 +33,7 @@ export async function checkEnvKeys(setup: ClaudeKitSetup): Promise<CheckResult[]
 				status: "warn",
 				message: globalCheck.envExists ? `Missing: ${missingKeys}` : ".env file not found",
 				details: globalEnvPath,
-				suggestion: "Run: ck init --global",
+				suggestion: "Run: ck init --global (configure Gemini, OpenRouter, or MiniMax)",
 				autoFixable: false,
 			});
 		} else {
@@ -40,7 +43,7 @@ export async function checkEnvKeys(setup: ClaudeKitSetup): Promise<CheckResult[]
 				group: "claudekit",
 				priority: "standard",
 				status: "pass",
-				message: `${REQUIRED_ENV_KEYS.length} required key(s) configured`,
+				message: PROVIDER_REQUIREMENT_MESSAGE,
 				details: globalEnvPath,
 				autoFixable: false,
 			});
@@ -62,7 +65,7 @@ export async function checkEnvKeys(setup: ClaudeKitSetup): Promise<CheckResult[]
 				status: "warn",
 				message: projectCheck.envExists ? `Missing: ${missingKeys}` : ".env file not found",
 				details: projectEnvPath,
-				suggestion: "Run: ck init",
+				suggestion: PROVIDER_SETUP_SUGGESTION,
 				autoFixable: false,
 			});
 		} else {
@@ -72,7 +75,7 @@ export async function checkEnvKeys(setup: ClaudeKitSetup): Promise<CheckResult[]
 				group: "claudekit",
 				priority: "standard",
 				status: "pass",
-				message: `${REQUIRED_ENV_KEYS.length} required key(s) configured`,
+				message: PROVIDER_REQUIREMENT_MESSAGE,
 				details: projectEnvPath,
 				autoFixable: false,
 			});

--- a/src/domains/health-checks/checkers/env-keys-checker.ts
+++ b/src/domains/health-checks/checkers/env-keys-checker.ts
@@ -8,6 +8,8 @@ import { checkRequiredKeysExist } from "@/domains/installation/setup-wizard.js";
 import type { ClaudeKitSetup } from "@/types";
 import type { CheckResult } from "../types.js";
 
+const GLOBAL_PROVIDER_SETUP_SUGGESTION =
+	"Run: ck init --global (configure Gemini, OpenRouter, or MiniMax)";
 const PROVIDER_SETUP_SUGGESTION = "Run: ck init (configure Gemini, OpenRouter, or MiniMax)";
 
 function formatConfiguredProviderMessage(providers: string[]): string {
@@ -53,7 +55,7 @@ export async function checkEnvKeys(setup: ClaudeKitSetup): Promise<CheckResult[]
 				status: "warn",
 				message: globalCheck.envExists ? `Missing: ${missingKeys}` : ".env file not found",
 				details: globalEnvPath,
-				suggestion: "Run: ck init --global (configure Gemini, OpenRouter, or MiniMax)",
+				suggestion: GLOBAL_PROVIDER_SETUP_SUGGESTION,
 				autoFixable: false,
 			});
 		} else {

--- a/src/domains/help/commands/setup-command-help.ts
+++ b/src/domains/help/commands/setup-command-help.ts
@@ -8,12 +8,16 @@ import type { CommandHelp } from "../help-types.js";
 
 export const setupCommandHelp: CommandHelp = {
 	name: "setup",
-	description: "Run guided setup for API keys and optional packages",
+	description: "Run guided setup for provider API keys and optional packages",
 	usage: "ck setup [options]",
 	examples: [
 		{
 			command: "ck setup",
 			description: "Run setup wizard in current project",
+		},
+		{
+			command: "ck setup --global",
+			description: "Configure a global provider path for Gemini, OpenRouter, or MiniMax",
 		},
 		{
 			command: "ck setup --global --skip-packages",

--- a/src/domains/help/commands/setup-command-help.ts
+++ b/src/domains/help/commands/setup-command-help.ts
@@ -8,7 +8,8 @@ import type { CommandHelp } from "../help-types.js";
 
 export const setupCommandHelp: CommandHelp = {
 	name: "setup",
-	description: "Run guided setup for provider API keys and optional packages",
+	description:
+		"Run guided setup for provider API keys, preferred image provider, and optional packages",
 	usage: "ck setup [options]",
 	examples: [
 		{
@@ -17,7 +18,7 @@ export const setupCommandHelp: CommandHelp = {
 		},
 		{
 			command: "ck setup --global",
-			description: "Configure a global provider path for Gemini, OpenRouter, or MiniMax",
+			description: "Configure global provider keys and a preferred image-generation path",
 		},
 		{
 			command: "ck setup --global --skip-packages",

--- a/src/domains/installation/setup-wizard.ts
+++ b/src/domains/installation/setup-wizard.ts
@@ -41,7 +41,7 @@ const IMAGE_PROVIDER_KEY_MAP = {
 const IMAGE_PROVIDER_META: Record<ImageGenProvider, { label: string; hint: string }> = {
 	auto: {
 		label: "Auto-detect provider",
-		hint: "Use ClaudeKit defaults and runtime fallbacks across your configured providers",
+		hint: "Prefer Gemini when configured; otherwise fall back through your remaining provider path",
 	},
 	google: {
 		label: "Google Gemini",
@@ -147,7 +147,6 @@ interface ConfigPrompt {
 	key: string;
 	label: string;
 	hint: string;
-	required?: boolean;
 	validate?: RegExp;
 	mask?: boolean;
 }
@@ -178,7 +177,6 @@ const ESSENTIAL_CONFIGS: ConfigPrompt[] = [
 		key: "DISCORD_WEBHOOK_URL",
 		label: "Discord Webhook URL (optional)",
 		hint: "For Discord notifications. Leave empty to skip.",
-		required: false,
 		validate: VALIDATION_PATTERNS.DISCORD_WEBHOOK_URL,
 		mask: false,
 	},
@@ -186,7 +184,6 @@ const ESSENTIAL_CONFIGS: ConfigPrompt[] = [
 		key: "TELEGRAM_BOT_TOKEN",
 		label: "Telegram Bot Token (optional)",
 		hint: "For Telegram notifications. Leave empty to skip.",
-		required: false,
 		validate: VALIDATION_PATTERNS.TELEGRAM_BOT_TOKEN,
 		mask: true,
 	},
@@ -361,6 +358,8 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<boole
 			clack.log.info(
 				`Set IMAGE_GEN_PROVIDER=${onlyProvider} to match your configured provider path`,
 			);
+		} else {
+			clack.log.info("Using auto mode for Gemini (default; no IMAGE_GEN_PROVIDER needed)");
 		}
 	} else {
 		const selectedProvider = await clack.select<

--- a/src/domains/installation/setup-wizard.ts
+++ b/src/domains/installation/setup-wizard.ts
@@ -21,11 +21,41 @@ export interface RequiredEnvKey {
 	alternativeKeys?: string[];
 }
 
+export type ImageGenProvider = "auto" | "google" | "openrouter" | "minimax";
+
 export const IMAGE_PROVIDER_ENV_KEYS = [
 	"GEMINI_API_KEY",
 	"OPENROUTER_API_KEY",
 	"MINIMAX_API_KEY",
 ] as const;
+
+const IMAGE_PROVIDER_KEY_MAP = {
+	GEMINI_API_KEY: "google",
+	OPENROUTER_API_KEY: "openrouter",
+	MINIMAX_API_KEY: "minimax",
+} as const satisfies Record<
+	(typeof IMAGE_PROVIDER_ENV_KEYS)[number],
+	Exclude<ImageGenProvider, "auto">
+>;
+
+const IMAGE_PROVIDER_META: Record<ImageGenProvider, { label: string; hint: string }> = {
+	auto: {
+		label: "Auto-detect provider",
+		hint: "Use ClaudeKit defaults and runtime fallbacks across your configured providers",
+	},
+	google: {
+		label: "Google Gemini",
+		hint: "Best fit when you want Gemini analysis plus Google image generation",
+	},
+	openrouter: {
+		label: "OpenRouter",
+		hint: "Use routed image models through OpenRouter",
+	},
+	minimax: {
+		label: "MiniMax",
+		hint: "Use MiniMax as the default image/media provider path",
+	},
+};
 
 export const REQUIRED_ENV_KEYS: RequiredEnvKey[] = [
 	{
@@ -39,6 +69,7 @@ export interface RequiredKeysCheckResult {
 	allPresent: boolean;
 	missing: RequiredEnvKey[];
 	envExists: boolean;
+	configuredProviders: Exclude<ImageGenProvider, "auto">[];
 }
 
 /**
@@ -49,10 +80,16 @@ export async function checkRequiredKeysExist(envPath: string): Promise<RequiredK
 	const envExists = await pathExists(envPath);
 
 	if (!envExists) {
-		return { allPresent: false, missing: REQUIRED_ENV_KEYS, envExists: false };
+		return {
+			allPresent: false,
+			missing: REQUIRED_ENV_KEYS,
+			envExists: false,
+			configuredProviders: [],
+		};
 	}
 
 	const env = await parseEnvFile(envPath);
+	const configuredProviders = getConfiguredImageProviders(env);
 	const missing: RequiredEnvKey[] = [];
 
 	for (const required of REQUIRED_ENV_KEYS) {
@@ -70,7 +107,40 @@ export async function checkRequiredKeysExist(envPath: string): Promise<RequiredK
 		allPresent: missing.length === 0,
 		missing,
 		envExists: true,
+		configuredProviders,
 	};
+}
+
+export function getConfiguredImageProviders(
+	env: Record<string, string>,
+): Exclude<ImageGenProvider, "auto">[] {
+	return IMAGE_PROVIDER_ENV_KEYS.filter((key) => {
+		const value = env[key];
+		return !!value && value.trim() !== "";
+	}).map((key) => IMAGE_PROVIDER_KEY_MAP[key]);
+}
+
+export function getDefaultImageProviderSelection(
+	configuredProviders: readonly Exclude<ImageGenProvider, "auto">[],
+	existingPreference?: string,
+): ImageGenProvider {
+	if (
+		existingPreference &&
+		validateApiKey(existingPreference, VALIDATION_PATTERNS.IMAGE_GEN_PROVIDER)
+	) {
+		if (existingPreference === "auto") {
+			return "auto";
+		}
+		if (configuredProviders.includes(existingPreference as Exclude<ImageGenProvider, "auto">)) {
+			return existingPreference as Exclude<ImageGenProvider, "auto">;
+		}
+	}
+
+	if (configuredProviders.includes("google")) {
+		return "auto";
+	}
+
+	return configuredProviders[0] ?? "auto";
 }
 
 interface ConfigPrompt {
@@ -203,6 +273,10 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<boole
 		clack.log.success("Global config detected - values will be inherited automatically");
 	}
 
+	clack.log.info(
+		"Configure at least one image-generation provider. Leave unused provider fields blank.",
+	);
+
 	// Collect values
 	const values: Record<string, string> = {};
 
@@ -257,11 +331,8 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<boole
 		}
 	}
 
-	const configuredProviderKeys = IMAGE_PROVIDER_ENV_KEYS.filter((key) => {
-		const value = values[key];
-		return !!value && value.trim() !== "";
-	});
-	if (configuredProviderKeys.length === 0) {
+	const configuredProviders = getConfiguredImageProviders(values);
+	if (configuredProviders.length === 0) {
 		clack.log.error(
 			"At least one image-generation provider key is required: GEMINI_API_KEY, OPENROUTER_API_KEY, or MINIMAX_API_KEY.",
 		);
@@ -283,16 +354,45 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<boole
 		}
 	}
 
-	if (!values.IMAGE_GEN_PROVIDER) {
-		const hasNonGoogleProvider = !!values.OPENROUTER_API_KEY || !!values.MINIMAX_API_KEY;
-		const onlyNonGoogleProvider = hasNonGoogleProvider && !values.GEMINI_API_KEY;
-		if (onlyNonGoogleProvider) {
-			const preferredProvider = values.OPENROUTER_API_KEY ? "openrouter" : "minimax";
-			values.IMAGE_GEN_PROVIDER = preferredProvider;
+	if (configuredProviders.length === 1) {
+		const [onlyProvider] = configuredProviders;
+		if (onlyProvider !== "google") {
+			values.IMAGE_GEN_PROVIDER = onlyProvider;
 			clack.log.info(
-				`Set IMAGE_GEN_PROVIDER=${preferredProvider} to match your configured provider path`,
+				`Set IMAGE_GEN_PROVIDER=${onlyProvider} to match your configured provider path`,
 			);
 		}
+	} else {
+		const selectedProvider = await clack.select<
+			{ value: ImageGenProvider; label: string; hint: string }[],
+			ImageGenProvider
+		>({
+			message: "Which image-generation provider should ClaudeKit prefer by default?",
+			options: [
+				{
+					value: "auto",
+					label: IMAGE_PROVIDER_META.auto.label,
+					hint: IMAGE_PROVIDER_META.auto.hint,
+				},
+				...configuredProviders.map((provider) => ({
+					value: provider,
+					label: IMAGE_PROVIDER_META[provider].label,
+					hint: IMAGE_PROVIDER_META[provider].hint,
+				})),
+			],
+			initialValue: getDefaultImageProviderSelection(
+				configuredProviders,
+				globalEnv.IMAGE_GEN_PROVIDER,
+			),
+		});
+
+		if (clack.isCancel(selectedProvider)) {
+			clack.log.warning("Setup cancelled");
+			return false;
+		}
+
+		values.IMAGE_GEN_PROVIDER = selectedProvider;
+		clack.log.info(`Set IMAGE_GEN_PROVIDER=${selectedProvider}`);
 	}
 
 	// Generate .env file
@@ -400,7 +500,7 @@ export async function promptSetupWizardIfNeeded(options: PromptSetupWizardOption
 	const missingKeys = missing.map((m) => m.label).join(", ");
 	const promptMessage = envExists
 		? `Missing required: ${missingKeys}. Set up now?`
-		: "Set up API keys now? (Choose Gemini, OpenRouter, or MiniMax for ai-multimodal image generation; webhooks optional)";
+		: "Set up API keys now? (Choose Gemini, OpenRouter, or MiniMax for ai-multimodal image generation, then optionally set a preferred provider; webhooks optional)";
 
 	const shouldSetup = await prompts.confirm(promptMessage);
 	if (shouldSetup) {

--- a/src/domains/installation/setup-wizard.ts
+++ b/src/domains/installation/setup-wizard.ts
@@ -29,14 +29,19 @@ export const IMAGE_PROVIDER_ENV_KEYS = [
 	"MINIMAX_API_KEY",
 ] as const;
 
+type ImageProviderEnvKey = (typeof IMAGE_PROVIDER_ENV_KEYS)[number];
+
 const IMAGE_PROVIDER_KEY_MAP = {
 	GEMINI_API_KEY: "google",
 	OPENROUTER_API_KEY: "openrouter",
 	MINIMAX_API_KEY: "minimax",
-} as const satisfies Record<
-	(typeof IMAGE_PROVIDER_ENV_KEYS)[number],
-	Exclude<ImageGenProvider, "auto">
->;
+} as const satisfies Record<ImageProviderEnvKey, Exclude<ImageGenProvider, "auto">>;
+
+const IMAGE_PROVIDER_VALIDATION_PATTERNS = {
+	GEMINI_API_KEY: VALIDATION_PATTERNS.GEMINI_API_KEY,
+	OPENROUTER_API_KEY: VALIDATION_PATTERNS.OPENROUTER_API_KEY,
+	MINIMAX_API_KEY: VALIDATION_PATTERNS.MINIMAX_API_KEY,
+} as const satisfies Record<ImageProviderEnvKey, RegExp>;
 
 const IMAGE_PROVIDER_META: Record<ImageGenProvider, { label: string; hint: string }> = {
 	auto: {
@@ -72,6 +77,18 @@ export interface RequiredKeysCheckResult {
 	configuredProviders: Exclude<ImageGenProvider, "auto">[];
 }
 
+function isImageProviderEnvKey(key: string): key is ImageProviderEnvKey {
+	return (IMAGE_PROVIDER_ENV_KEYS as readonly string[]).includes(key);
+}
+
+function hasValidImageProviderValue(key: ImageProviderEnvKey, value?: string): boolean {
+	if (!value || value.trim() === "") {
+		return false;
+	}
+
+	return validateApiKey(value.trim(), IMAGE_PROVIDER_VALIDATION_PATTERNS[key]);
+}
+
 /**
  * Check if required environment keys exist in .env file
  * Returns which keys are missing (if any)
@@ -95,6 +112,10 @@ export async function checkRequiredKeysExist(envPath: string): Promise<RequiredK
 	for (const required of REQUIRED_ENV_KEYS) {
 		const candidateKeys = required.alternativeKeys ?? [required.key];
 		const hasConfiguredValue = candidateKeys.some((candidateKey) => {
+			if (isImageProviderEnvKey(candidateKey)) {
+				return hasValidImageProviderValue(candidateKey, env[candidateKey]);
+			}
+
 			const value = env[candidateKey];
 			return !!value && value.trim() !== "";
 		});
@@ -114,10 +135,9 @@ export async function checkRequiredKeysExist(envPath: string): Promise<RequiredK
 export function getConfiguredImageProviders(
 	env: Record<string, string>,
 ): Exclude<ImageGenProvider, "auto">[] {
-	return IMAGE_PROVIDER_ENV_KEYS.filter((key) => {
-		const value = env[key];
-		return !!value && value.trim() !== "";
-	}).map((key) => IMAGE_PROVIDER_KEY_MAP[key]);
+	return IMAGE_PROVIDER_ENV_KEYS.filter((key) => hasValidImageProviderValue(key, env[key])).map(
+		(key) => IMAGE_PROVIDER_KEY_MAP[key],
+	);
 }
 
 export function getDefaultImageProviderSelection(
@@ -128,7 +148,7 @@ export function getDefaultImageProviderSelection(
 		existingPreference &&
 		validateApiKey(existingPreference, VALIDATION_PATTERNS.IMAGE_GEN_PROVIDER)
 	) {
-		if (existingPreference === "auto") {
+		if (existingPreference === "auto" && configuredProviders.includes("google")) {
 			return "auto";
 		}
 		if (configuredProviders.includes(existingPreference as Exclude<ImageGenProvider, "auto">)) {

--- a/src/domains/installation/setup-wizard.ts
+++ b/src/domains/installation/setup-wizard.ts
@@ -18,10 +18,21 @@ export interface SetupWizardOptions {
 export interface RequiredEnvKey {
 	key: string;
 	label: string;
+	alternativeKeys?: string[];
 }
 
+export const IMAGE_PROVIDER_ENV_KEYS = [
+	"GEMINI_API_KEY",
+	"OPENROUTER_API_KEY",
+	"MINIMAX_API_KEY",
+] as const;
+
 export const REQUIRED_ENV_KEYS: RequiredEnvKey[] = [
-	{ key: "GEMINI_API_KEY", label: "Gemini API Key" },
+	{
+		key: "IMAGE_PROVIDER_API_KEY",
+		label: "Image generation provider API key",
+		alternativeKeys: [...IMAGE_PROVIDER_ENV_KEYS],
+	},
 ];
 
 export interface RequiredKeysCheckResult {
@@ -45,9 +56,12 @@ export async function checkRequiredKeysExist(envPath: string): Promise<RequiredK
 	const missing: RequiredEnvKey[] = [];
 
 	for (const required of REQUIRED_ENV_KEYS) {
-		const value = env[required.key];
-		// Check if key exists and has a non-empty value
-		if (!value || value.trim() === "") {
+		const candidateKeys = required.alternativeKeys ?? [required.key];
+		const hasConfiguredValue = candidateKeys.some((candidateKey) => {
+			const value = env[candidateKey];
+			return !!value && value.trim() !== "";
+		});
+		if (!hasConfiguredValue) {
 			missing.push(required);
 		}
 	}
@@ -63,7 +77,7 @@ interface ConfigPrompt {
 	key: string;
 	label: string;
 	hint: string;
-	required: boolean;
+	required?: boolean;
 	validate?: RegExp;
 	mask?: boolean;
 }
@@ -72,9 +86,22 @@ const ESSENTIAL_CONFIGS: ConfigPrompt[] = [
 	{
 		key: "GEMINI_API_KEY",
 		label: "Google Gemini API Key",
-		hint: "Required for ai-multimodal skill. Get from: https://aistudio.google.com/apikey",
-		required: true,
+		hint: "Optional. Recommended for full ai-multimodal analysis and Google image generation.",
 		validate: VALIDATION_PATTERNS.GEMINI_API_KEY,
+		mask: true,
+	},
+	{
+		key: "OPENROUTER_API_KEY",
+		label: "OpenRouter API Key",
+		hint: "Optional. Alternative image-generation provider. Get from: https://openrouter.ai/settings/keys",
+		validate: VALIDATION_PATTERNS.OPENROUTER_API_KEY,
+		mask: true,
+	},
+	{
+		key: "MINIMAX_API_KEY",
+		label: "MiniMax API Key",
+		hint: "Optional. Alternative image/video/speech/music provider.",
+		validate: VALIDATION_PATTERNS.MINIMAX_API_KEY,
 		mask: true,
 	},
 	{
@@ -208,13 +235,9 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<boole
 		const result = await clack.text({
 			message: config.label,
 			placeholder: config.hint,
-			validate: (value) => {
-				// Skip validation for optional fields with empty input
-				if (!value && !config.required) {
+			validate: (value: string) => {
+				if (!value) {
 					return;
-				}
-				if (!value && config.required) {
-					return "This field is required";
 				}
 				if (value && config.validate && !validateApiKey(value, config.validate)) {
 					return "Invalid format. Please check and try again.";
@@ -234,6 +257,17 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<boole
 		}
 	}
 
+	const configuredProviderKeys = IMAGE_PROVIDER_ENV_KEYS.filter((key) => {
+		const value = values[key];
+		return !!value && value.trim() !== "";
+	});
+	if (configuredProviderKeys.length === 0) {
+		clack.log.error(
+			"At least one image-generation provider key is required: GEMINI_API_KEY, OPENROUTER_API_KEY, or MINIMAX_API_KEY.",
+		);
+		return false;
+	}
+
 	// Prompt for additional Gemini API keys if primary key was set
 	if (values.GEMINI_API_KEY) {
 		const additionalKeys = await promptForAdditionalGeminiKeys(values.GEMINI_API_KEY);
@@ -246,6 +280,18 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<boole
 		const totalKeys = 1 + additionalKeys.length;
 		if (totalKeys > 1) {
 			clack.log.success(`✓ Configured ${totalKeys} Gemini API keys for rotation`);
+		}
+	}
+
+	if (!values.IMAGE_GEN_PROVIDER) {
+		const hasNonGoogleProvider = !!values.OPENROUTER_API_KEY || !!values.MINIMAX_API_KEY;
+		const onlyNonGoogleProvider = hasNonGoogleProvider && !values.GEMINI_API_KEY;
+		if (onlyNonGoogleProvider) {
+			const preferredProvider = values.OPENROUTER_API_KEY ? "openrouter" : "minimax";
+			values.IMAGE_GEN_PROVIDER = preferredProvider;
+			clack.log.info(
+				`Set IMAGE_GEN_PROVIDER=${preferredProvider} to match your configured provider path`,
+			);
 		}
 	}
 
@@ -282,7 +328,7 @@ async function promptForAdditionalGeminiKeys(primaryKey: string): Promise<string
 		const result = await clack.text({
 			message: `Gemini API Key #${keyNumber} (press Enter to finish)`,
 			placeholder: "AIza... or leave empty to finish",
-			validate: (value) => {
+			validate: (value: string) => {
 				// Empty = done adding keys
 				if (!value) return;
 				// Trim whitespace (handles copy-paste issues)
@@ -354,7 +400,7 @@ export async function promptSetupWizardIfNeeded(options: PromptSetupWizardOption
 	const missingKeys = missing.map((m) => m.label).join(", ");
 	const promptMessage = envExists
 		? `Missing required: ${missingKeys}. Set up now?`
-		: "Set up API keys now? (Gemini API key for ai-multimodal skill, optional webhooks)";
+		: "Set up API keys now? (Choose Gemini, OpenRouter, or MiniMax for ai-multimodal image generation; webhooks optional)";
 
 	const shouldSetup = await prompts.confirm(promptMessage);
 	if (shouldSetup) {
@@ -364,7 +410,7 @@ export async function promptSetupWizardIfNeeded(options: PromptSetupWizardOption
 		});
 	} else {
 		prompts.note(
-			`Create ${envPath} manually or run 'ck init' again.\nRequired: GEMINI_API_KEY\nOptional: DISCORD_WEBHOOK_URL, TELEGRAM_BOT_TOKEN`,
+			`Create ${envPath} manually or run 'ck init' again.\nRequired: one of GEMINI_API_KEY, OPENROUTER_API_KEY, MINIMAX_API_KEY\nOptional: IMAGE_GEN_PROVIDER, DISCORD_WEBHOOK_URL, TELEGRAM_BOT_TOKEN`,
 			"Configuration skipped",
 		);
 	}

--- a/src/types/skills-dependencies.ts
+++ b/src/types/skills-dependencies.ts
@@ -21,8 +21,11 @@ export interface SkillsDependenciesConfig {
  */
 export const SKILLS_DEPENDENCIES: SkillsDependenciesConfig = {
 	python: [
-		{ name: "google-genai", description: "Required for ai-multimodal skill (Gemini API)" },
-		{ name: "pillow, pypdf", description: "Image/PDF processing" },
+		{ name: "google-genai", description: "Required for ai-multimodal Gemini provider support" },
+		{
+			name: "pillow, pypdf, requests",
+			description: "Image/PDF processing and provider HTTP clients",
+		},
 		{ name: "python-dotenv", description: "Environment variable management" },
 	],
 	system: [

--- a/tests/lib/config-validator.test.ts
+++ b/tests/lib/config-validator.test.ts
@@ -14,6 +14,47 @@ describe("config-validator", () => {
 		});
 	});
 
+	describe("OPENROUTER_API_KEY validation", () => {
+		test("should accept valid OpenRouter API key", () => {
+			const validKey = "sk-or-v1-abcdefghijklmnopqrstuvwxyz123456";
+			expect(validateApiKey(validKey, VALIDATION_PATTERNS.OPENROUTER_API_KEY)).toBe(true);
+		});
+
+		test("should accept valid OpenRouter API key with url-safe separators", () => {
+			const validKey = "sk-or-v1-abc_DEF-123456";
+			expect(validateApiKey(validKey, VALIDATION_PATTERNS.OPENROUTER_API_KEY)).toBe(true);
+		});
+
+		test("should reject invalid OpenRouter API key", () => {
+			expect(validateApiKey("invalid", VALIDATION_PATTERNS.OPENROUTER_API_KEY)).toBe(false);
+		});
+	});
+
+	describe("MINIMAX_API_KEY validation", () => {
+		test("should accept valid MiniMax API key", () => {
+			const validKey = "minimax_test_key_1234567890";
+			expect(validateApiKey(validKey, VALIDATION_PATTERNS.MINIMAX_API_KEY)).toBe(true);
+		});
+
+		test("should reject invalid MiniMax API key", () => {
+			expect(validateApiKey("short", VALIDATION_PATTERNS.MINIMAX_API_KEY)).toBe(false);
+		});
+	});
+
+	describe("IMAGE_GEN_PROVIDER validation", () => {
+		test("should accept supported image provider values", () => {
+			expect(validateApiKey("auto", VALIDATION_PATTERNS.IMAGE_GEN_PROVIDER)).toBe(true);
+			expect(validateApiKey("google", VALIDATION_PATTERNS.IMAGE_GEN_PROVIDER)).toBe(true);
+			expect(validateApiKey("openrouter", VALIDATION_PATTERNS.IMAGE_GEN_PROVIDER)).toBe(true);
+			expect(validateApiKey("minimax", VALIDATION_PATTERNS.IMAGE_GEN_PROVIDER)).toBe(true);
+		});
+
+		test("should reject unsupported image provider values", () => {
+			expect(validateApiKey("gemini", VALIDATION_PATTERNS.IMAGE_GEN_PROVIDER)).toBe(false);
+			expect(validateApiKey("", VALIDATION_PATTERNS.IMAGE_GEN_PROVIDER)).toBe(false);
+		});
+	});
+
 	describe("DISCORD_WEBHOOK_URL validation", () => {
 		test("should accept valid Discord webhook", () => {
 			const validUrl = "https://discord.com/api/webhooks/123/abc";

--- a/tests/lib/setup-wizard.test.ts
+++ b/tests/lib/setup-wizard.test.ts
@@ -49,6 +49,20 @@ describe("setup-wizard", () => {
 			expect(content).toContain("DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/test");
 		});
 
+		test("should preserve alternative provider keys and image provider selection", async () => {
+			const values = {
+				OPENROUTER_API_KEY: "sk-or-v1-abcdefghijklmnopqrstuvwxyz123456",
+				MINIMAX_API_KEY: "minimax_test_key_1234567890",
+				IMAGE_GEN_PROVIDER: "openrouter",
+			};
+			await generateEnvFile(tempDir, values);
+
+			const content = await readFile(join(tempDir, ".env"), "utf-8");
+			expect(content).toContain("OPENROUTER_API_KEY=sk-or-v1-abcdefghijklmnopqrstuvwxyz123456");
+			expect(content).toContain("MINIMAX_API_KEY=minimax_test_key_1234567890");
+			expect(content).toContain("IMAGE_GEN_PROVIDER=openrouter");
+		});
+
 		test("should skip empty values", async () => {
 			const values = {
 				GEMINI_API_KEY: "test-key",

--- a/tests/lib/skills-customization-scanner.test.ts
+++ b/tests/lib/skills-customization-scanner.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { SkillsCustomizationScanner } from "@/domains/skills/skills-customization-scanner.js";
 import { SkillsManifestManager } from "@/domains/skills/skills-manifest.js";
 
-describe("SkillsCustomizationScanner", () => {
+describe.serial("SkillsCustomizationScanner", () => {
 	let testDir: string;
 	let currentSkillsDir: string;
 	let baselineSkillsDir: string;
@@ -423,7 +423,7 @@ describe("SkillsCustomizationScanner", () => {
 			);
 
 			expect(customizations[0].isCustomized).toBe(true);
-		});
+		}, 15000);
 	});
 
 	describe("scanCustomizations - file change details", () => {

--- a/tests/lib/skills-customization-scanner.test.ts
+++ b/tests/lib/skills-customization-scanner.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SkillsCustomizationScanner } from "@/domains/skills/skills-customization-scanner.js";
@@ -11,9 +11,7 @@ describe.serial("SkillsCustomizationScanner", () => {
 	let baselineSkillsDir: string;
 
 	beforeEach(async () => {
-		// Create temp test directory
-		const timestamp = Date.now();
-		testDir = join(tmpdir(), `test-skills-customization-${timestamp}`);
+		testDir = await mkdtemp(join(tmpdir(), "test-skills-customization-"));
 		currentSkillsDir = join(testDir, "current");
 		baselineSkillsDir = join(testDir, "baseline");
 		await mkdir(testDir, { recursive: true });


### PR DESCRIPTION
## Summary
- make setup wizard and env checks accept Gemini, OpenRouter, or MiniMax provider keys for ai-multimodal image generation
- update validation and dependency/help text to reflect provider-aware onboarding
- refresh CLI onboarding docs and stabilize an unrelated flaky test blocking the repo gate

Closes #634

## Validation
- bun test src/__tests__/domains/installation/setup-wizard.test.ts src/__tests__/domains/health-checks/checkers/env-keys-checker.test.ts src/__tests__/types/skills-dependencies.test.ts tests/lib/setup-wizard.test.ts tests/lib/config-validator.test.ts
- bun run validate
