### PR TITLE
fix(init): normalize wrapped offline kit sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ ck new --prefix
 # Offline installation (from local archive or directory)
 ck new --archive ~/downloads/engineer-v1.16.0.zip
 ck new --kit-path ~/extracted-kit/
+
+# Direct repo downloads are also supported
+ck new --archive ~/downloads/claudekit-engineer-main.zip
+ck new --kit-path ~/downloads/claudekit-engineer-main/
 ```
 
 **Flags:**
@@ -157,6 +161,8 @@ ck new --kit-path ~/extracted-kit/
 - `--opencode/--gemini`: Install optional packages
 - `--archive <path>`: Use local archive (zip/tar.gz) instead of downloading
 - `--kit-path <path>`: Use local kit directory instead of downloading
+
+`--archive` and `--kit-path` both accept direct repo downloads with a single wrapper directory, including GitHub "Download ZIP" archives and extracted repo folders that still contain `claudekit-engineer-main/` or similar at the top level.
 
 ### Initialize or Update Project
 
@@ -188,6 +194,10 @@ ck init --exclude "*.local" --prefix
 # Offline installation (from local archive or directory)
 ck init --archive ~/downloads/engineer-v1.16.0.zip
 ck init --kit-path ~/extracted-kit/
+
+# Direct repo downloads are also supported
+ck init --archive ~/downloads/claudekit-engineer-main.zip
+ck init --kit-path ~/downloads/claudekit-engineer-main/
 ```
 
 **Flags:**
@@ -198,6 +208,8 @@ ck init --kit-path ~/extracted-kit/
 - `--prefix`: Apply /ck: namespace to commands
 - `--archive <path>`: Use local archive (zip/tar.gz) instead of downloading
 - `--kit-path <path>`: Use local kit directory instead of downloading
+
+`--archive` and `--kit-path` both accept direct repo downloads with a single wrapper directory, including GitHub "Download ZIP" archives and extracted repo folders that still contain `claudekit-engineer-main/` or similar at the top level.
 
 **Default Behavior with `-y` Flag:**
 

--- a/src/__tests__/domains/installation/download-extractor.test.ts
+++ b/src/__tests__/domains/installation/download-extractor.test.ts
@@ -3,10 +3,41 @@ import * as fs from "node:fs";
 import os from "node:os";
 import * as path from "node:path";
 import { downloadAndExtract } from "@/domains/installation/download-extractor.js";
+import {
+	getHomeDirPrefix,
+	transformPathsForGlobalInstall,
+} from "@/services/transformers/global-path-transformer.js";
 import { AVAILABLE_KITS } from "@/types";
+import * as tar from "tar";
 
 const TEST_DIR = path.join(os.tmpdir(), "ck-test-offline");
 const mockKit = AVAILABLE_KITS.engineer;
+
+async function createWrappedSourceLayoutKit(baseDir: string, wrapperName: string): Promise<string> {
+	const wrapperDir = path.join(baseDir, wrapperName);
+	await fs.promises.mkdir(path.join(wrapperDir, "claude", "agents"), { recursive: true });
+	await fs.promises.mkdir(path.join(wrapperDir, "claude", "skills", "demo"), { recursive: true });
+	await fs.promises.writeFile(
+		path.join(wrapperDir, "package.json"),
+		JSON.stringify({
+			claudekit: {
+				sourceDir: "claude",
+				runtimeDir: ".claude",
+			},
+		}),
+	);
+	await fs.promises.writeFile(path.join(wrapperDir, "CLAUDE.md"), "# Kit");
+	await fs.promises.writeFile(
+		path.join(wrapperDir, "claude", "agents", "planner.md"),
+		'node .claude/scripts/set-active-plan.cjs "plans/demo"',
+	);
+	await fs.promises.writeFile(
+		path.join(wrapperDir, "claude", "skills", "demo", "SKILL.md"),
+		"# Demo skill",
+	);
+
+	return wrapperDir;
+}
 
 describe("downloadAndExtract - offline options", () => {
 	const tempDirsToCleanup: string[] = [];
@@ -73,6 +104,26 @@ describe("downloadAndExtract - offline options", () => {
 			});
 		});
 
+		test("should resolve wrapped local repo directories before materializing runtime layout", async () => {
+			const downloadDir = path.join(TEST_DIR, "downloaded-kit");
+			await fs.promises.mkdir(downloadDir, { recursive: true });
+			await createWrappedSourceLayoutKit(downloadDir, "claudekit-engineer-main");
+
+			const result = await downloadAndExtract({
+				kit: mockKit,
+				kitPath: downloadDir,
+			});
+
+			tempDirsToCleanup.push(result.tempDir);
+			expect(result.extractDir).not.toBe(path.resolve(downloadDir));
+			await expect(
+				fs.promises.stat(path.join(result.extractDir, ".claude", "skills", "demo", "SKILL.md")),
+			).resolves.toBeDefined();
+			await expect(
+				fs.promises.stat(path.join(result.extractDir, ".claude", "agents", "planner.md")),
+			).resolves.toBeDefined();
+		});
+
 		test("should warn but proceed when .claude missing", async () => {
 			// Setup: create kit dir WITHOUT .claude
 			const kitDir = path.join(TEST_DIR, "no-claude-kit");
@@ -111,6 +162,43 @@ describe("downloadAndExtract - offline options", () => {
 	});
 
 	describe("--archive option", () => {
+		test("should resolve wrapped repo archives and keep global path transforms working", async () => {
+			const archiveSourceDir = path.join(TEST_DIR, "archive-source");
+			await fs.promises.mkdir(archiveSourceDir, { recursive: true });
+			const wrapperName = "claudekit-engineer-main";
+			await createWrappedSourceLayoutKit(archiveSourceDir, wrapperName);
+
+			const archivePath = path.join(TEST_DIR, "claudekit-engineer-main.tar.gz");
+			await tar.create(
+				{
+					cwd: archiveSourceDir,
+					file: archivePath,
+					gzip: true,
+				},
+				[wrapperName],
+			);
+
+			const result = await downloadAndExtract({
+				kit: mockKit,
+				archive: archivePath,
+			});
+
+			tempDirsToCleanup.push(result.tempDir);
+			await expect(
+				fs.promises.stat(path.join(result.extractDir, ".claude", "skills", "demo", "SKILL.md")),
+			).resolves.toBeDefined();
+			await expect(fs.promises.stat(path.join(result.extractDir, "claude"))).rejects.toMatchObject({
+				code: "ENOENT",
+			});
+
+			await transformPathsForGlobalInstall(result.extractDir);
+			const plannerContent = await fs.promises.readFile(
+				path.join(result.extractDir, ".claude", "agents", "planner.md"),
+				"utf-8",
+			);
+			expect(plannerContent).toContain(`${getHomeDirPrefix()}/.claude/scripts/set-active-plan.cjs`);
+		});
+
 		test("should reject non-file paths (directories)", async () => {
 			// Use a directory instead of file with valid extension to bypass format check
 			const dirPath = path.join(TEST_DIR, "not-a-file.zip");

--- a/src/__tests__/domains/installation/download-extractor.test.ts
+++ b/src/__tests__/domains/installation/download-extractor.test.ts
@@ -124,6 +124,28 @@ describe("downloadAndExtract - offline options", () => {
 			).resolves.toBeDefined();
 		});
 
+		test("should ignore top-level metadata noise when resolving wrapped local repo directories", async () => {
+			const downloadDir = path.join(TEST_DIR, "downloaded-kit-with-noise");
+			await fs.promises.mkdir(downloadDir, { recursive: true });
+			await createWrappedSourceLayoutKit(downloadDir, "claudekit-engineer-main");
+			await fs.promises.writeFile(path.join(downloadDir, "._claudekit-engineer-main"), "noise");
+			await fs.promises.writeFile(path.join(downloadDir, "Thumbs.db"), "noise");
+
+			const result = await downloadAndExtract({
+				kit: mockKit,
+				kitPath: downloadDir,
+			});
+
+			tempDirsToCleanup.push(result.tempDir);
+			expect(result.extractDir).not.toBe(path.resolve(downloadDir));
+			await expect(
+				fs.promises.stat(path.join(result.extractDir, ".claude", "skills", "demo", "SKILL.md")),
+			).resolves.toBeDefined();
+			await expect(fs.promises.stat(path.join(result.extractDir, "claude"))).rejects.toMatchObject({
+				code: "ENOENT",
+			});
+		});
+
 		test("should warn but proceed when .claude missing", async () => {
 			// Setup: create kit dir WITHOUT .claude
 			const kitDir = path.join(TEST_DIR, "no-claude-kit");
@@ -197,6 +219,41 @@ describe("downloadAndExtract - offline options", () => {
 				"utf-8",
 			);
 			expect(plannerContent).toContain(`${getHomeDirPrefix()}/.claude/scripts/set-active-plan.cjs`);
+		});
+
+		test("should ignore top-level metadata noise when resolving wrapped repo archives", async () => {
+			const archiveSourceDir = path.join(TEST_DIR, "archive-source-with-noise");
+			await fs.promises.mkdir(archiveSourceDir, { recursive: true });
+			const wrapperName = "claudekit-engineer-main";
+			await createWrappedSourceLayoutKit(archiveSourceDir, wrapperName);
+			await fs.promises.writeFile(
+				path.join(archiveSourceDir, "._claudekit-engineer-main"),
+				"noise",
+			);
+			await fs.promises.writeFile(path.join(archiveSourceDir, "desktop.ini"), "noise");
+
+			const archivePath = path.join(TEST_DIR, "claudekit-engineer-main-with-noise.tar.gz");
+			await tar.create(
+				{
+					cwd: archiveSourceDir,
+					file: archivePath,
+					gzip: true,
+				},
+				["._claudekit-engineer-main", "desktop.ini", wrapperName],
+			);
+
+			const result = await downloadAndExtract({
+				kit: mockKit,
+				archive: archivePath,
+			});
+
+			tempDirsToCleanup.push(result.tempDir);
+			await expect(
+				fs.promises.stat(path.join(result.extractDir, ".claude", "skills", "demo", "SKILL.md")),
+			).resolves.toBeDefined();
+			await expect(fs.promises.stat(path.join(result.extractDir, "claude"))).rejects.toMatchObject({
+				code: "ENOENT",
+			});
 		});
 
 		test("should reject non-file paths (directories)", async () => {

--- a/src/domains/installation/download-extractor.ts
+++ b/src/domains/installation/download-extractor.ts
@@ -13,7 +13,7 @@ import { GitCloneManager } from "@/domains/installation/git-clone-manager.js";
 import { resolveKitLayout } from "@/shared/kit-layout.js";
 import { logger } from "@/shared/logger.js";
 import { output } from "@/shared/output-manager.js";
-import { DEFAULT_KIT_LAYOUT, type GitHubRelease, type KitConfig, type KitLayout } from "@/types";
+import type { GitHubRelease, KitConfig, KitLayout } from "@/types";
 
 /**
  * Files/directories to KEEP from git clone (matches release package contents)
@@ -29,6 +29,9 @@ const RELEASE_ROOT_ALLOWLIST = [
 	".opencode",
 	"release-manifest.json",
 ];
+
+const NESTED_KIT_ROOT_MAX_DEPTH = 4;
+const IGNORED_WRAPPER_ENTRIES = new Set([".DS_Store", "__MACOSX"]);
 
 function buildReleaseAllowlist(layout: KitLayout): string[] {
 	return [...new Set([layout.sourceDir, ...RELEASE_ROOT_ALLOWLIST])];
@@ -79,6 +82,45 @@ async function materializeRuntimeLayoutInPlace(
 	const runtimeDir = path.join(projectRoot, layout.runtimeDir);
 	await fs.promises.rm(runtimeDir, { recursive: true, force: true });
 	await fs.promises.rename(sourceDir, runtimeDir);
+}
+
+async function isLikelyKitRoot(projectRoot: string): Promise<boolean> {
+	const entries = (await fs.promises.readdir(projectRoot)).filter(
+		(entry) => !IGNORED_WRAPPER_ENTRIES.has(entry),
+	);
+	const entrySet = new Set(entries);
+	const layout = resolveKitLayout(projectRoot);
+
+	return (
+		entrySet.has("CLAUDE.md") ||
+		entrySet.has(layout.runtimeDir) ||
+		entrySet.has(layout.sourceDir) ||
+		entrySet.has("claude") ||
+		entrySet.has(".claude")
+	);
+}
+
+async function resolveOfflineKitRoot(rootDir: string): Promise<string> {
+	let currentDir = rootDir;
+
+	for (let depth = 0; depth <= NESTED_KIT_ROOT_MAX_DEPTH; depth++) {
+		if (await isLikelyKitRoot(currentDir)) {
+			return currentDir;
+		}
+
+		const entries = (await fs.promises.readdir(currentDir, { withFileTypes: true })).filter(
+			(entry) => !IGNORED_WRAPPER_ENTRIES.has(entry.name),
+		);
+		const childDirectories = entries.filter((entry) => entry.isDirectory());
+
+		if (entries.length !== 1 || childDirectories.length !== 1) {
+			break;
+		}
+
+		currentDir = path.join(currentDir, childDirectories[0].name);
+	}
+
+	return rootDir;
 }
 
 async function stageLocalKitPathForRuntimeLayout(
@@ -362,11 +404,16 @@ async function useLocalKitPath(kitPath: string): Promise<DownloadExtractResult> 
 		throw error;
 	}
 
-	const layout = resolveKitLayout(absolutePath);
+	const kitRoot = await resolveOfflineKitRoot(absolutePath);
+	if (kitRoot !== absolutePath) {
+		logger.info(`Detected nested kit root: ${kitRoot}`);
+	}
+
+	const layout = resolveKitLayout(kitRoot);
 	if (layout.sourceDir !== layout.runtimeDir) {
-		const stagedKit = await stageLocalKitPathForRuntimeLayout(absolutePath, layout);
+		const stagedKit = await stageLocalKitPathForRuntimeLayout(kitRoot, layout);
 		if (stagedKit) {
-			logger.info(`Using kit from: ${absolutePath}`);
+			logger.info(`Using kit from: ${kitRoot}`);
 			return {
 				tempDir: stagedKit.tempDir,
 				archivePath: "",
@@ -376,7 +423,7 @@ async function useLocalKitPath(kitPath: string): Promise<DownloadExtractResult> 
 	}
 
 	// Check for .claude directory (warn if missing, don't block)
-	const claudeDir = path.join(absolutePath, DEFAULT_KIT_LAYOUT.runtimeDir);
+	const claudeDir = path.join(kitRoot, layout.runtimeDir);
 	try {
 		const stat = await fs.promises.stat(claudeDir);
 		if (!stat.isDirectory()) {
@@ -387,17 +434,17 @@ async function useLocalKitPath(kitPath: string): Promise<DownloadExtractResult> 
 	} catch (error: unknown) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
 			logger.warning(
-				`Warning: No .claude directory found in ${absolutePath}\nThis may not be a valid ClaudeKit installation. Proceeding anyway...`,
+				`Warning: No ${layout.runtimeDir} directory found in ${kitRoot}\nThis may not be a valid ClaudeKit installation. Proceeding anyway...`,
 			);
 		}
 	}
 
-	logger.info(`Using kit from: ${absolutePath}`);
+	logger.info(`Using kit from: ${kitRoot}`);
 
 	return {
 		tempDir: absolutePath,
 		archivePath: "", // No archive for local path
-		extractDir: absolutePath,
+		extractDir: kitRoot,
 	};
 }
 
@@ -474,15 +521,28 @@ async function extractLocalArchive(
 	logger.verbose("Extraction", { archivePath: absolutePath, extractDir });
 	await downloadManager.extractArchive(absolutePath, extractDir);
 
+	const kitRoot = await resolveOfflineKitRoot(extractDir);
+	if (kitRoot !== extractDir) {
+		logger.info(`Detected nested kit root in archive: ${kitRoot}`);
+	}
+
+	const layout = resolveKitLayout(kitRoot);
+	if (
+		layout.sourceDir !== layout.runtimeDir &&
+		(await ensureLayoutSourceDir(kitRoot, layout, false))
+	) {
+		await materializeRuntimeLayoutInPlace(kitRoot, layout);
+	}
+
 	// Validate extraction
-	await downloadManager.validateExtraction(extractDir);
+	await downloadManager.validateExtraction(kitRoot);
 
 	logger.info(`Extracted from: ${absolutePath}`);
 
 	return {
 		tempDir,
 		archivePath: absolutePath,
-		extractDir,
+		extractDir: kitRoot,
 	};
 }
 

--- a/src/domains/installation/download-extractor.ts
+++ b/src/domains/installation/download-extractor.ts
@@ -30,8 +30,8 @@ const RELEASE_ROOT_ALLOWLIST = [
 	"release-manifest.json",
 ];
 
-const NESTED_KIT_ROOT_MAX_DEPTH = 4;
-const IGNORED_WRAPPER_ENTRIES = new Set([".DS_Store", "__MACOSX"]);
+const NESTED_KIT_ROOT_MAX_LEVELS = 5;
+const IGNORED_WRAPPER_ENTRY_NAMES = new Set([".DS_Store", "__MACOSX"]);
 
 function buildReleaseAllowlist(layout: KitLayout): string[] {
 	return [...new Set([layout.sourceDir, ...RELEASE_ROOT_ALLOWLIST])];
@@ -84,33 +84,43 @@ async function materializeRuntimeLayoutInPlace(
 	await fs.promises.rename(sourceDir, runtimeDir);
 }
 
-async function isLikelyKitRoot(projectRoot: string): Promise<boolean> {
-	const entries = (await fs.promises.readdir(projectRoot)).filter(
-		(entry) => !IGNORED_WRAPPER_ENTRIES.has(entry),
+function isIgnoredWrapperEntry(entryName: string): boolean {
+	const normalizedName = entryName.toLowerCase();
+	return (
+		IGNORED_WRAPPER_ENTRY_NAMES.has(entryName) ||
+		normalizedName === "thumbs.db" ||
+		normalizedName === "desktop.ini" ||
+		entryName.startsWith("._")
 	);
-	const entrySet = new Set(entries);
+}
+
+async function listVisibleEntries(projectRoot: string): Promise<fs.Dirent[]> {
+	return (await fs.promises.readdir(projectRoot, { withFileTypes: true })).filter(
+		(entry) => !isIgnoredWrapperEntry(entry.name),
+	);
+}
+
+function isLikelyKitRoot(projectRoot: string, entries: fs.Dirent[]): boolean {
+	const entrySet = new Set(entries.map((entry) => entry.name));
 	const layout = resolveKitLayout(projectRoot);
 
 	return (
 		entrySet.has("CLAUDE.md") ||
 		entrySet.has(layout.runtimeDir) ||
 		entrySet.has(layout.sourceDir) ||
-		entrySet.has("claude") ||
-		entrySet.has(".claude")
+		entrySet.has("claude")
 	);
 }
 
 async function resolveOfflineKitRoot(rootDir: string): Promise<string> {
 	let currentDir = rootDir;
 
-	for (let depth = 0; depth <= NESTED_KIT_ROOT_MAX_DEPTH; depth++) {
-		if (await isLikelyKitRoot(currentDir)) {
+	for (let level = 0; level < NESTED_KIT_ROOT_MAX_LEVELS; level++) {
+		const entries = await listVisibleEntries(currentDir);
+		if (isLikelyKitRoot(currentDir, entries)) {
 			return currentDir;
 		}
 
-		const entries = (await fs.promises.readdir(currentDir, { withFileTypes: true })).filter(
-			(entry) => !IGNORED_WRAPPER_ENTRIES.has(entry.name),
-		);
 		const childDirectories = entries.filter((entry) => entry.isDirectory());
 
 		if (entries.length !== 1 || childDirectories.length !== 1) {


### PR DESCRIPTION
## Summary
- detect nested offline kit roots for `--archive` and `--kit-path`
- ignore common top-level wrapper noise files when descending into wrapped offline kits
- materialize `claude -> .claude` before init continues when the kit uses source layout metadata
- add regressions for wrapped repo archives, wrapped extracted repo directories, and noisy wrapper roots
- clarify README examples for direct repo ZIP and extracted repo folder installs

## Validation
- `bun run validate`
- remote Windows e2e on `ssh i9-bootcamp`
  - built the PR branch
  - ran `init -g --archive <wrapped repo zip>` with isolated `CK_TEST_HOME`
  - ran `init -g --kit-path <expanded wrapped repo zip>` with isolated `CK_TEST_HOME`
  - verified installed global planner/script paths and removed the remote temp tree after completion

## Notes
- fixes the offline install path where direct GitHub/repo ZIP downloads were not normalized to the real kit root
- also covers noisy wrapper roots such as AppleDouble / Windows metadata sidecars
- keeps global path transformation working after offline archive extraction

Docs impact: minor
Action: updated README only; no claudekit-docs changes required