### PR TITLE
fix(versioning): correct mixed-kit update detection

### DIFF
--- a/src/__tests__/cli/version-display.test.ts
+++ b/src/__tests__/cli/version-display.test.ts
@@ -1,194 +1,130 @@
-/**
- * Unit tests for version-display helper functions
- */
-import { describe, expect, it } from "bun:test";
-import type { Metadata } from "@/types";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { displayVersion } from "@/cli/version-display.js";
+import { ConfigVersionChecker } from "@/domains/sync/config-version-checker.js";
+import { CliVersionChecker } from "@/domains/versioning/version-checker.js";
 
-// Re-implement helpers for testing (these are private in the module)
-function formatInstalledKits(metadata: Metadata): string | null {
-	if (!metadata.kits || Object.keys(metadata.kits).length === 0) {
-		if (metadata.version) {
-			const kitName = metadata.name || "ClaudeKit";
-			return `${metadata.version} (${kitName})`;
-		}
-		return null;
-	}
+describe("displayVersion", () => {
+	let testHome: string;
+	let projectDir: string;
+	let originalCwd: string;
+	let consoleSpy: ReturnType<typeof spyOn<typeof console, "log">> | null;
+	let cliCheckSpy: ReturnType<typeof spyOn<typeof CliVersionChecker, "check">> | null;
+	let kitCheckSpy: ReturnType<typeof spyOn<typeof ConfigVersionChecker, "checkForUpdates">> | null;
 
-	const kitVersions = Object.entries(metadata.kits)
-		.filter(([_, meta]) => meta.version && meta.version.trim() !== "")
-		.map(([kit, meta]) => `${kit}@${meta.version}`)
-		.sort()
-		.join(", ");
+	beforeEach(async () => {
+		testHome = join(
+			tmpdir(),
+			`version-display-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		projectDir = join(testHome, "project");
+		originalCwd = process.cwd();
+		consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+		cliCheckSpy = spyOn(CliVersionChecker, "check").mockResolvedValue(null);
+		kitCheckSpy = null;
 
-	return kitVersions.length > 0 ? kitVersions : null;
-}
-
-function getInstalledKitTypes(metadata: Metadata): string[] {
-	if (!metadata.kits) return [];
-	return Object.keys(metadata.kits);
-}
-
-describe("version-display helpers", () => {
-	describe("formatInstalledKits", () => {
-		it("formats multiple kits alphabetically", () => {
-			const metadata: Metadata = {
-				kits: {
-					marketing: { version: "v1.0.0", installedAt: "2024-01-01T00:00:00.000Z" },
-					engineer: { version: "v2.2.0", installedAt: "2024-01-01T00:00:00.000Z" },
-				},
-			};
-
-			const result = formatInstalledKits(metadata);
-			expect(result).toBe("engineer@v2.2.0, marketing@v1.0.0");
-		});
-
-		it("formats single kit", () => {
-			const metadata: Metadata = {
-				kits: {
-					engineer: { version: "v2.2.0", installedAt: "2024-01-01T00:00:00.000Z" },
-				},
-			};
-
-			const result = formatInstalledKits(metadata);
-			expect(result).toBe("engineer@v2.2.0");
-		});
-
-		it("filters out kits with undefined versions", () => {
-			const metadata: Metadata = {
-				kits: {
-					engineer: { version: "v2.2.0", installedAt: "2024-01-01T00:00:00.000Z" },
-					marketing: {
-						version: undefined as unknown as string,
-						installedAt: "2024-01-01T00:00:00.000Z",
-					},
-				},
-			};
-
-			const result = formatInstalledKits(metadata);
-			expect(result).toBe("engineer@v2.2.0");
-		});
-
-		it("filters out kits with empty string versions", () => {
-			const metadata: Metadata = {
-				kits: {
-					engineer: { version: "v2.2.0", installedAt: "2024-01-01T00:00:00.000Z" },
-					marketing: { version: "", installedAt: "2024-01-01T00:00:00.000Z" },
-				},
-			};
-
-			const result = formatInstalledKits(metadata);
-			expect(result).toBe("engineer@v2.2.0");
-		});
-
-		it("filters out kits with whitespace-only versions", () => {
-			const metadata: Metadata = {
-				kits: {
-					engineer: { version: "v2.2.0", installedAt: "2024-01-01T00:00:00.000Z" },
-					marketing: { version: "   ", installedAt: "2024-01-01T00:00:00.000Z" },
-				},
-			};
-
-			const result = formatInstalledKits(metadata);
-			expect(result).toBe("engineer@v2.2.0");
-		});
-
-		it("returns null when all kits have invalid versions", () => {
-			const metadata: Metadata = {
-				kits: {
-					engineer: { version: "", installedAt: "2024-01-01T00:00:00.000Z" },
-					marketing: { version: "   ", installedAt: "2024-01-01T00:00:00.000Z" },
-				},
-			};
-
-			const result = formatInstalledKits(metadata);
-			expect(result).toBeNull();
-		});
-
-		it("returns null for empty kits object", () => {
-			const metadata: Metadata = {
-				kits: {},
-			};
-
-			const result = formatInstalledKits(metadata);
-			expect(result).toBeNull();
-		});
-
-		it("returns null for undefined kits", () => {
-			const metadata: Metadata = {};
-
-			const result = formatInstalledKits(metadata);
-			expect(result).toBeNull();
-		});
-
-		it("falls back to legacy format when no kits but has root version", () => {
-			const metadata: Metadata = {
-				name: "ClaudeKit Engineer",
-				version: "v2.0.0",
-			};
-
-			const result = formatInstalledKits(metadata);
-			expect(result).toBe("v2.0.0 (ClaudeKit Engineer)");
-		});
-
-		it("uses default name in legacy fallback when name is undefined", () => {
-			const metadata: Metadata = {
-				version: "v2.0.0",
-			};
-
-			const result = formatInstalledKits(metadata);
-			expect(result).toBe("v2.0.0 (ClaudeKit)");
-		});
-
-		it("returns null when no kits and no root version", () => {
-			const metadata: Metadata = {
-				name: "ClaudeKit Engineer",
-			};
-
-			const result = formatInstalledKits(metadata);
-			expect(result).toBeNull();
-		});
+		process.env.CK_TEST_HOME = testHome;
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		await mkdir(join(testHome, ".claude"), { recursive: true });
+		process.chdir(projectDir);
 	});
 
-	describe("getInstalledKitTypes", () => {
-		it("returns kit types from kits object", () => {
-			const metadata: Metadata = {
+	afterEach(async () => {
+		process.chdir(originalCwd);
+		process.env.CK_TEST_HOME = undefined;
+		consoleSpy?.mockRestore();
+		cliCheckSpy?.mockRestore();
+		kitCheckSpy?.mockRestore();
+		await rm(testHome, { recursive: true, force: true });
+	});
+
+	it("does not show a false cross-kit update prompt for mixed local/global installs", async () => {
+		await writeFile(
+			join(projectDir, ".claude", "metadata.json"),
+			JSON.stringify({
 				kits: {
-					engineer: { version: "v2.2.0", installedAt: "2024-01-01T00:00:00.000Z" },
-					marketing: { version: "v1.0.0", installedAt: "2024-01-01T00:00:00.000Z" },
+					marketing: {
+						version: "1.3.2",
+						installedAt: "2026-04-10T12:00:00.000Z",
+						files: [],
+					},
 				},
-			};
-
-			const result = getInstalledKitTypes(metadata);
-			expect(result).toContain("engineer");
-			expect(result).toContain("marketing");
-			expect(result.length).toBe(2);
-		});
-
-		it("returns empty array when kits is undefined", () => {
-			const metadata: Metadata = {};
-
-			const result = getInstalledKitTypes(metadata);
-			expect(result).toEqual([]);
-		});
-
-		it("returns empty array when kits is empty object", () => {
-			const metadata: Metadata = {
-				kits: {},
-			};
-
-			const result = getInstalledKitTypes(metadata);
-			expect(result).toEqual([]);
-		});
-
-		it("returns single kit type", () => {
-			const metadata: Metadata = {
+			}),
+		);
+		await writeFile(
+			join(testHome, ".claude", "metadata.json"),
+			JSON.stringify({
 				kits: {
-					engineer: { version: "v2.2.0", installedAt: "2024-01-01T00:00:00.000Z" },
+					engineer: {
+						version: "2.16.0-beta.9",
+						installedAt: "2026-04-10T12:00:00.000Z",
+						files: [],
+					},
 				},
-			};
+			}),
+		);
 
-			const result = getInstalledKitTypes(metadata);
-			expect(result).toEqual(["engineer"]);
+		kitCheckSpy = spyOn(ConfigVersionChecker, "checkForUpdates").mockImplementation(
+			async (kitType, currentVersion, globalInstall) => ({
+				hasUpdates: false,
+				currentVersion: String(currentVersion).replace(/^v/, ""),
+				latestVersion: String(currentVersion).replace(/^v/, ""),
+				fromCache: globalInstall || kitType === "marketing",
+			}),
+		);
+
+		const initialLogCount = consoleSpy?.mock.calls.length ?? 0;
+		await displayVersion();
+
+		const output = consoleSpy?.mock.calls
+			.slice(initialLogCount)
+			.flat()
+			.filter((value): value is string => typeof value === "string")
+			.join("\n");
+
+		expect(output).toContain("Local Kit Version: marketing@1.3.2");
+		expect(output).toContain("Global Kit Version: engineer@2.16.0-beta.9");
+		expect(kitCheckSpy).toHaveBeenCalledTimes(2);
+		expect(kitCheckSpy?.mock.calls).toEqual([
+			["marketing", "1.3.2", false],
+			["engineer", "2.16.0-beta.9", true],
+		]);
+	});
+
+	it("shows the matching kit label and scope when a specific installed kit is outdated", async () => {
+		await writeFile(
+			join(testHome, ".claude", "metadata.json"),
+			JSON.stringify({
+				kits: {
+					engineer: {
+						version: "2.16.0-beta.8",
+						installedAt: "2026-04-10T12:00:00.000Z",
+						files: [],
+					},
+				},
+			}),
+		);
+
+		kitCheckSpy = spyOn(ConfigVersionChecker, "checkForUpdates").mockResolvedValue({
+			hasUpdates: true,
+			currentVersion: "2.16.0-beta.8",
+			latestVersion: "2.16.0-beta.9",
+			fromCache: false,
 		});
+
+		const initialLogCount = consoleSpy?.mock.calls.length ?? 0;
+		await displayVersion();
+
+		const output = consoleSpy?.mock.calls
+			.slice(initialLogCount)
+			.flat()
+			.filter((value): value is string => typeof value === "string")
+			.join("\n");
+
+		expect(output).toContain("Kit Update Available");
+		expect(output).toContain("Kit: engineer");
+		expect(output).toContain("Run: ck init -g");
 	});
 });

--- a/src/__tests__/cli/version-display.test.ts
+++ b/src/__tests__/cli/version-display.test.ts
@@ -2,17 +2,23 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { displayVersion } from "@/cli/version-display.js";
+import {
+	displayVersion,
+	getInstalledKitVersions,
+	inferLegacyKitType,
+} from "@/cli/version-display.js";
 import { ConfigVersionChecker } from "@/domains/sync/config-version-checker.js";
-import { CliVersionChecker } from "@/domains/versioning/version-checker.js";
+import { CliVersionChecker, VersionChecker } from "@/domains/versioning/version-checker.js";
 
 describe("displayVersion", () => {
 	let testHome: string;
 	let projectDir: string;
 	let originalCwd: string;
-	let consoleSpy: ReturnType<typeof spyOn<typeof console, "log">> | null;
 	let cliCheckSpy: ReturnType<typeof spyOn<typeof CliVersionChecker, "check">> | null;
 	let kitCheckSpy: ReturnType<typeof spyOn<typeof ConfigVersionChecker, "checkForUpdates">> | null;
+	let displayNotificationSpy: ReturnType<
+		typeof spyOn<typeof VersionChecker, "displayNotification">
+	> | null;
 
 	beforeEach(async () => {
 		testHome = join(
@@ -21,9 +27,11 @@ describe("displayVersion", () => {
 		);
 		projectDir = join(testHome, "project");
 		originalCwd = process.cwd();
-		consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 		cliCheckSpy = spyOn(CliVersionChecker, "check").mockResolvedValue(null);
 		kitCheckSpy = null;
+		displayNotificationSpy = spyOn(VersionChecker, "displayNotification").mockImplementation(
+			() => {},
+		);
 
 		process.env.CK_TEST_HOME = testHome;
 		await mkdir(join(projectDir, ".claude"), { recursive: true });
@@ -34,9 +42,9 @@ describe("displayVersion", () => {
 	afterEach(async () => {
 		process.chdir(originalCwd);
 		process.env.CK_TEST_HOME = undefined;
-		consoleSpy?.mockRestore();
 		cliCheckSpy?.mockRestore();
 		kitCheckSpy?.mockRestore();
+		displayNotificationSpy?.mockRestore();
 		await rm(testHome, { recursive: true, force: true });
 	});
 
@@ -75,22 +83,14 @@ describe("displayVersion", () => {
 			}),
 		);
 
-		const initialLogCount = consoleSpy?.mock.calls.length ?? 0;
 		await displayVersion();
 
-		const output = consoleSpy?.mock.calls
-			.slice(initialLogCount)
-			.flat()
-			.filter((value): value is string => typeof value === "string")
-			.join("\n");
-
-		expect(output).toContain("Local Kit Version: marketing@1.3.2");
-		expect(output).toContain("Global Kit Version: engineer@2.16.0-beta.9");
 		expect(kitCheckSpy).toHaveBeenCalledTimes(2);
 		expect(kitCheckSpy?.mock.calls).toEqual([
 			["marketing", "1.3.2", false],
 			["engineer", "2.16.0-beta.9", true],
 		]);
+		expect(displayNotificationSpy).not.toHaveBeenCalled();
 	});
 
 	it("shows the matching kit label and scope when a specific installed kit is outdated", async () => {
@@ -114,17 +114,47 @@ describe("displayVersion", () => {
 			fromCache: false,
 		});
 
-		const initialLogCount = consoleSpy?.mock.calls.length ?? 0;
 		await displayVersion();
 
-		const output = consoleSpy?.mock.calls
-			.slice(initialLogCount)
-			.flat()
-			.filter((value): value is string => typeof value === "string")
-			.join("\n");
+		expect(displayNotificationSpy).toHaveBeenCalledWith(
+			{
+				currentVersion: "2.16.0-beta.8",
+				latestVersion: "2.16.0-beta.9",
+				updateAvailable: true,
+				releaseUrl: "https://github.com/claudekit/claudekit-engineer/releases/tag/v2.16.0-beta.9",
+			},
+			{ isGlobal: true, kitName: "engineer" },
+		);
+	});
 
-		expect(output).toContain("Kit Update Available");
-		expect(output).toContain("Kit: engineer");
-		expect(output).toContain("Run: ck init -g");
+	it("infers legacy marketing installs from the metadata name", () => {
+		expect(inferLegacyKitType({ name: "ClaudeKit Marketing" })).toBe("marketing");
+		expect(inferLegacyKitType({ name: "ClaudeKit" })).toBe("engineer");
+	});
+
+	it("falls back to the legacy root version when kits are absent", () => {
+		expect(getInstalledKitVersions({ version: "1.3.2", name: "ClaudeKit Marketing" })).toEqual([
+			{ kit: "marketing", version: "1.3.2" },
+		]);
+	});
+
+	it("filters blank kit versions and ignores empty kit maps", () => {
+		expect(
+			getInstalledKitVersions({
+				kits: {
+					engineer: {
+						version: "  ",
+						installedAt: "2026-04-10T12:00:00.000Z",
+						files: [],
+					},
+					marketing: {
+						version: "1.3.2",
+						installedAt: "2026-04-10T12:00:00.000Z",
+						files: [],
+					},
+				},
+			}),
+		).toEqual([{ kit: "marketing", version: "1.3.2" }]);
+		expect(getInstalledKitVersions({ kits: {} })).toEqual([]);
 	});
 });

--- a/src/__tests__/domains/sync/config-version-checker.test.ts
+++ b/src/__tests__/domains/sync/config-version-checker.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for ConfigVersionChecker - version checking with caching and GitHub API
  */
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -231,6 +231,72 @@ describe("ConfigVersionChecker", () => {
 
 			expect(engineerResult.latestVersion).toBe("2.0.0");
 			expect(marketingResult.latestVersion).toBe("3.0.0");
+		});
+
+		it("uses separate cache files per update channel", async () => {
+			const stableCache = {
+				lastCheck: Date.now(),
+				latestVersion: "2.16.0",
+			};
+			const betaCache = {
+				lastCheck: Date.now(),
+				latestVersion: "2.17.0-beta.2",
+			};
+
+			await writeFile(
+				join(testDir, "engineer-stable-config-update-cache.json"),
+				JSON.stringify(stableCache),
+			);
+			await writeFile(
+				join(testDir, "engineer-beta-config-update-cache.json"),
+				JSON.stringify(betaCache),
+			);
+
+			const stableResult = await ConfigVersionChecker.checkForUpdates("engineer", "2.16.0", false);
+			const betaResult = await ConfigVersionChecker.checkForUpdates(
+				"engineer",
+				"2.17.0-beta.1",
+				false,
+			);
+
+			expect(stableResult.latestVersion).toBe("2.16.0");
+			expect(betaResult.latestVersion).toBe("2.17.0-beta.2");
+		});
+	});
+
+	describe("beta channel detection", () => {
+		it("checks latest beta releases when current version is a prerelease", async () => {
+			const originalFetch = globalThis.fetch;
+			globalThis.fetch = Object.assign(
+				mock(
+					async () =>
+						new Response(
+							JSON.stringify([
+								{ tag_name: "v2.15.0", prerelease: false, draft: false },
+								{ tag_name: "v2.16.0-beta.9", prerelease: true, draft: false },
+								{ tag_name: "v2.16.0-beta.10", prerelease: true, draft: false },
+							]),
+							{
+								status: 200,
+								headers: { etag: '"beta-etag"' },
+							},
+						),
+				),
+				{ preconnect: () => {} },
+			) as typeof fetch;
+
+			try {
+				const result = await ConfigVersionChecker.checkForUpdates(
+					"engineer",
+					"2.16.0-beta.9",
+					false,
+				);
+
+				expect(result.latestVersion).toBe("2.16.0-beta.10");
+				expect(result.hasUpdates).toBe(true);
+			} finally {
+				globalThis.fetch = originalFetch;
+			}
 		});
 	});
 });

--- a/src/__tests__/domains/web-server/routes/system-routes.test.ts
+++ b/src/__tests__/domains/web-server/routes/system-routes.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ConfigVersionChecker } from "@/domains/sync/config-version-checker.js";
+import { registerSystemRoutes } from "@/domains/web-server/routes/system-routes.js";
+import express, { type Express } from "express";
+
+interface TestServer {
+	server: ReturnType<Express["listen"]>;
+	baseUrl: string;
+	testHome: string;
+}
+
+async function setupServer(): Promise<TestServer> {
+	const testHome = await mkdtemp(join(tmpdir(), "ck-system-routes-"));
+	process.env.CK_TEST_HOME = testHome;
+
+	const app = express();
+	app.use(express.json());
+	registerSystemRoutes(app);
+
+	const server = app.listen(0);
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("Failed to start test server");
+	}
+
+	return {
+		server,
+		baseUrl: `http://127.0.0.1:${address.port}`,
+		testHome,
+	};
+}
+
+async function teardownServer(ctx: TestServer): Promise<void> {
+	await new Promise<void>((resolveClose) => ctx.server.close(() => resolveClose()));
+	process.env.CK_TEST_HOME = undefined;
+	await rm(ctx.testHome, { recursive: true, force: true });
+}
+
+describe("system routes", () => {
+	let ctx: TestServer;
+	let checkForUpdatesSpy: ReturnType<
+		typeof spyOn<typeof ConfigVersionChecker, "checkForUpdates">
+	> | null;
+
+	beforeEach(async () => {
+		ctx = await setupServer();
+		checkForUpdatesSpy = spyOn(ConfigVersionChecker, "checkForUpdates").mockResolvedValue({
+			hasUpdates: false,
+			currentVersion: "0.0.0",
+			latestVersion: "0.0.0",
+			fromCache: true,
+		});
+	});
+
+	afterEach(async () => {
+		checkForUpdatesSpy?.mockRestore();
+		await teardownServer(ctx);
+	});
+
+	it("falls back to 0.0.0 when a multi-kit metadata entry exists without a version", async () => {
+		const globalClaudeDir = join(ctx.testHome, ".claude");
+		await mkdir(globalClaudeDir, { recursive: true });
+		await writeFile(
+			join(globalClaudeDir, "metadata.json"),
+			JSON.stringify({
+				kits: {
+					engineer: {
+						installedAt: "2026-04-10T12:00:00.000Z",
+						files: [],
+					},
+				},
+			}),
+		);
+
+		const response = await fetch(
+			`${ctx.baseUrl}/api/system/check-updates?target=kit&kit=engineer&channel=beta`,
+		);
+
+		expect(response.status).toBe(200);
+		expect(checkForUpdatesSpy).toHaveBeenCalledWith("engineer", "0.0.0", true, "beta");
+
+		const body = (await response.json()) as {
+			current: string;
+			latest: string | null;
+			updateAvailable: boolean;
+		};
+		expect(body.current).toBe("0.0.0");
+		expect(body.latest).toBe("0.0.0");
+		expect(body.updateAvailable).toBe(false);
+	});
+});

--- a/src/__tests__/domains/web-server/routes/system-routes.test.ts
+++ b/src/__tests__/domains/web-server/routes/system-routes.test.ts
@@ -91,4 +91,26 @@ describe("system routes", () => {
 		expect(body.latest).toBe("0.0.0");
 		expect(body.updateAvailable).toBe(false);
 	});
+
+	it("auto-detects beta channel from installed kit version when channel query is omitted", async () => {
+		const globalClaudeDir = join(ctx.testHome, ".claude");
+		await mkdir(globalClaudeDir, { recursive: true });
+		await writeFile(
+			join(globalClaudeDir, "metadata.json"),
+			JSON.stringify({
+				kits: {
+					engineer: {
+						version: "2.16.0-beta.9",
+						installedAt: "2026-04-10T12:00:00.000Z",
+						files: [],
+					},
+				},
+			}),
+		);
+
+		const response = await fetch(`${ctx.baseUrl}/api/system/check-updates?target=kit&kit=engineer`);
+
+		expect(response.status).toBe(200);
+		expect(checkForUpdatesSpy).toHaveBeenCalledWith("engineer", "2.16.0-beta.9", true, "beta");
+	});
 });

--- a/src/cli/version-display.ts
+++ b/src/cli/version-display.ts
@@ -8,10 +8,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import packageInfo from "../../package.json" assert { type: "json" };
 import { ConfigVersionChecker } from "../domains/sync/config-version-checker.js";
-import {
-	CliVersionChecker,
-	displayKitNotification,
-} from "../domains/versioning/version-checker.js";
+import { CliVersionChecker, VersionChecker } from "../domains/versioning/version-checker.js";
 import { logger } from "../shared/logger.js";
 import { PathResolver } from "../shared/path-resolver.js";
 import type { KitType, Metadata } from "../types/index.js";
@@ -52,7 +49,11 @@ function getInstalledKitTypes(metadata: Metadata): KitType[] {
 	return Object.keys(metadata.kits) as KitType[];
 }
 
-function inferLegacyKitType(metadata: Metadata): KitType {
+/**
+ * Best-effort legacy inference for installs that predate the multi-kit metadata shape.
+ * If the root name field doesn't mention marketing, fall back to engineer.
+ */
+export function inferLegacyKitType(metadata: Metadata): KitType {
 	if (/\bmarketing\b/i.test(metadata.name ?? "")) {
 		return "marketing";
 	}
@@ -60,7 +61,9 @@ function inferLegacyKitType(metadata: Metadata): KitType {
 	return "engineer";
 }
 
-function getInstalledKitVersions(metadata: Metadata): Array<{ kit: KitType; version: string }> {
+export function getInstalledKitVersions(
+	metadata: Metadata,
+): Array<{ kit: KitType; version: string }> {
 	const kitTypes = getInstalledKitTypes(metadata);
 	if (kitTypes.length > 0) {
 		return kitTypes
@@ -82,14 +85,20 @@ async function maybeDisplayKitUpdateNotifications(
 	installedKits: Array<{ kit: KitType; version: string }>,
 	isGlobal: boolean,
 ): Promise<void> {
-	for (const { kit, version } of installedKits) {
-		const updateCheck = await ConfigVersionChecker.checkForUpdates(kit, version, isGlobal);
+	const updateChecks = await Promise.all(
+		installedKits.map(async ({ kit, version }) => ({
+			kit,
+			updateCheck: await ConfigVersionChecker.checkForUpdates(kit, version, isGlobal),
+		})),
+	);
+
+	for (const { kit, updateCheck } of updateChecks) {
 		if (!updateCheck.hasUpdates) {
 			continue;
 		}
 
-		const releaseUrl = `https://github.com/${AVAILABLE_KITS[kit].owner}/${AVAILABLE_KITS[kit].repo}/releases/tag/v${updateCheck.latestVersion}`;
-		displayKitNotification(
+		const releaseUrl = `https://github.com/${AVAILABLE_KITS[kit].owner}/${AVAILABLE_KITS[kit].repo}/releases/tag/v${updateCheck.latestVersion.replace(/^v/i, "")}`;
+		VersionChecker.displayNotification(
 			{
 				currentVersion: updateCheck.currentVersion,
 				latestVersion: updateCheck.latestVersion,

--- a/src/cli/version-display.ts
+++ b/src/cli/version-display.ts
@@ -7,11 +7,16 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import packageInfo from "../../package.json" assert { type: "json" };
-import { CliVersionChecker, VersionChecker } from "../domains/versioning/version-checker.js";
+import { ConfigVersionChecker } from "../domains/sync/config-version-checker.js";
+import {
+	CliVersionChecker,
+	displayKitNotification,
+} from "../domains/versioning/version-checker.js";
 import { logger } from "../shared/logger.js";
 import { PathResolver } from "../shared/path-resolver.js";
 import type { KitType, Metadata } from "../types/index.js";
 import { MetadataSchema } from "../types/index.js";
+import { AVAILABLE_KITS } from "../types/index.js";
 
 const packageVersion = packageInfo.version;
 
@@ -47,17 +52,53 @@ function getInstalledKitTypes(metadata: Metadata): KitType[] {
 	return Object.keys(metadata.kits) as KitType[];
 }
 
-/**
- * Get version for first installed kit (for update check)
- * Handles type safety for accessing metadata.kits with KitType keys
- */
-function getFirstKitVersion(metadata: Metadata): string | null {
-	const kitTypes = getInstalledKitTypes(metadata);
-	if (kitTypes.length === 0) {
-		return metadata.version ?? null;
+function inferLegacyKitType(metadata: Metadata): KitType {
+	if (/\bmarketing\b/i.test(metadata.name ?? "")) {
+		return "marketing";
 	}
-	const firstKit = kitTypes[0];
-	return metadata.kits?.[firstKit]?.version ?? null;
+
+	return "engineer";
+}
+
+function getInstalledKitVersions(metadata: Metadata): Array<{ kit: KitType; version: string }> {
+	const kitTypes = getInstalledKitTypes(metadata);
+	if (kitTypes.length > 0) {
+		return kitTypes
+			.map((kit) => ({
+				kit,
+				version: metadata.kits?.[kit]?.version ?? "",
+			}))
+			.filter(({ version }) => version.trim() !== "");
+	}
+
+	if (metadata.version?.trim()) {
+		return [{ kit: inferLegacyKitType(metadata), version: metadata.version }];
+	}
+
+	return [];
+}
+
+async function maybeDisplayKitUpdateNotifications(
+	installedKits: Array<{ kit: KitType; version: string }>,
+	isGlobal: boolean,
+): Promise<void> {
+	for (const { kit, version } of installedKits) {
+		const updateCheck = await ConfigVersionChecker.checkForUpdates(kit, version, isGlobal);
+		if (!updateCheck.hasUpdates) {
+			continue;
+		}
+
+		const releaseUrl = `https://github.com/${AVAILABLE_KITS[kit].owner}/${AVAILABLE_KITS[kit].repo}/releases/tag/v${updateCheck.latestVersion}`;
+		displayKitNotification(
+			{
+				currentVersion: updateCheck.currentVersion,
+				latestVersion: updateCheck.latestVersion,
+				updateAvailable: true,
+				releaseUrl,
+			},
+			{ isGlobal, kitName: kit },
+		);
+	}
 }
 
 /**
@@ -68,8 +109,8 @@ export async function displayVersion(): Promise<void> {
 	console.log(`CLI Version: ${packageVersion}`);
 
 	let foundAnyKit = false;
-	let localKitVersion: string | null = null;
-	let isGlobalOnlyKit = false; // Track if only global kit exists (no local)
+	let localInstalledKits: Array<{ kit: KitType; version: string }> = [];
+	let globalInstalledKits: Array<{ kit: KitType; version: string }> = [];
 
 	// Determine paths
 	const globalKitDir = PathResolver.getGlobalKitDir();
@@ -91,7 +132,7 @@ export async function displayVersion(): Promise<void> {
 			const kitsDisplay = formatInstalledKits(metadata);
 			if (kitsDisplay) {
 				console.log(`Local Kit Version: ${kitsDisplay}`);
-				localKitVersion = getFirstKitVersion(metadata);
+				localInstalledKits = getInstalledKitVersions(metadata);
 				foundAnyKit = true;
 			}
 		} catch (error) {
@@ -109,11 +150,7 @@ export async function displayVersion(): Promise<void> {
 			const kitsDisplay = formatInstalledKits(metadata);
 			if (kitsDisplay) {
 				console.log(`Global Kit Version: ${kitsDisplay}`);
-				// Use global version if no local version found
-				if (!localKitVersion) {
-					localKitVersion = getFirstKitVersion(metadata);
-					isGlobalOnlyKit = true; // Only global kit found, no local
-				}
+				globalInstalledKits = getInstalledKitVersions(metadata);
 				foundAnyKit = true;
 			}
 		} catch (error) {
@@ -140,12 +177,10 @@ export async function displayVersion(): Promise<void> {
 	}
 
 	// Check for kit updates (non-blocking)
-	if (localKitVersion) {
+	if (localInstalledKits.length > 0 || globalInstalledKits.length > 0) {
 		try {
-			const updateCheck = await VersionChecker.check(localKitVersion);
-			if (updateCheck?.updateAvailable) {
-				VersionChecker.displayNotification(updateCheck, { isGlobal: isGlobalOnlyKit });
-			}
+			await maybeDisplayKitUpdateNotifications(localInstalledKits, false);
+			await maybeDisplayKitUpdateNotifications(globalInstalledKits, true);
 		} catch (error) {
 			// Silent failure - don't block version display
 			logger.debug(`Kit version check failed: ${error}`);

--- a/src/domains/sync/config-version-checker.ts
+++ b/src/domains/sync/config-version-checker.ts
@@ -197,7 +197,9 @@ export class ConfigVersionChecker {
 				}
 
 				return parsed as ConfigUpdateCache;
-			} catch {}
+			} catch (error) {
+				logger.debug(`Failed to read cache at ${cachePath}: ${error}`);
+			}
 		}
 
 		return null;

--- a/src/domains/sync/config-version-checker.ts
+++ b/src/domains/sync/config-version-checker.ts
@@ -3,12 +3,17 @@
  */
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { isNewerVersion } from "@/domains/versioning/checking/version-utils.js";
+import {
+	isNewerVersion,
+	isPrereleaseVersion,
+	normalizeVersion,
+} from "@/domains/versioning/checking/version-utils.js";
 import { getCliUserAgent } from "@/shared/claudekit-constants.js";
 import { logger } from "@/shared/logger.js";
 import { PathResolver } from "@/shared/path-resolver.js";
 import type { KitType } from "@/types";
-import type { ConfigUpdateCache, UpdateCheckResult } from "./types.js";
+import { compareVersions } from "compare-versions";
+import type { ConfigUpdateCache, UpdateChannel, UpdateCheckResult } from "./types.js";
 
 /** Cache time-to-live in hours */
 const CACHE_TTL_HOURS = 24;
@@ -60,6 +65,7 @@ const CACHE_TTL_MS = parseCacheTtl();
 /** GitHub API timeout in milliseconds */
 const GITHUB_API_TIMEOUT_MS = 10000; // Increased from 5000
 const CACHE_FILENAME = "config-update-cache.json";
+const RELEASES_PER_PAGE = 100;
 
 /**
  * GitHub repo info for each kit type
@@ -75,12 +81,87 @@ const KIT_REPOS: Record<string, { owner: string; repo: string }> = {
  * ConfigVersionChecker handles checking for kit updates with caching
  */
 export class ConfigVersionChecker {
+	private static getLegacyCacheFilePath(kitType: KitType, global: boolean): string {
+		const cacheDir = PathResolver.getCacheDir(global);
+		return join(cacheDir, `${kitType}-${CACHE_FILENAME}`);
+	}
+
 	/**
 	 * Get cache file path for a kit type
 	 */
-	private static getCacheFilePath(kitType: KitType, global: boolean): string {
+	private static getCacheFilePath(
+		kitType: KitType,
+		global: boolean,
+		channel: UpdateChannel,
+	): string {
 		const cacheDir = PathResolver.getCacheDir(global);
-		return join(cacheDir, `${kitType}-${CACHE_FILENAME}`);
+		return join(cacheDir, `${kitType}-${channel}-${CACHE_FILENAME}`);
+	}
+
+	private static resolveChannel(currentVersion: string, override?: UpdateChannel): UpdateChannel {
+		if (override) {
+			return override;
+		}
+
+		return isPrereleaseVersion(currentVersion) ? "beta" : "stable";
+	}
+
+	private static isValidSemverCore(version: string): boolean {
+		const [coreVersion] = normalizeVersion(version).split(/[-+]/, 1);
+		const coreParts = coreVersion?.split(".") ?? [];
+		return coreParts.length === 3 && coreParts.every((part) => /^\d+$/.test(part));
+	}
+
+	private static pickHighestVersion(
+		releases: Array<{ tag_name?: string; prerelease?: boolean; draft?: boolean }>,
+	): string | null {
+		let highestVersion: string | null = null;
+
+		for (const release of releases) {
+			const tagName = release.tag_name;
+			if (!tagName || tagName.length > 256) {
+				continue;
+			}
+
+			const normalizedVersion = normalizeVersion(tagName);
+			if (!ConfigVersionChecker.isValidSemverCore(normalizedVersion)) {
+				logger.debug(`Invalid version format from GitHub: ${tagName}`);
+				continue;
+			}
+
+			if (!highestVersion || compareVersions(normalizedVersion, highestVersion) > 0) {
+				highestVersion = normalizedVersion;
+			}
+		}
+
+		return highestVersion;
+	}
+
+	private static selectLatestVersion(
+		releases: Array<{ tag_name?: string; prerelease?: boolean; draft?: boolean }>,
+		channel: UpdateChannel,
+	): string | null {
+		const visibleReleases = releases.filter((release) => !release.draft);
+		const matchingChannelReleases = visibleReleases.filter((release) =>
+			channel === "beta" ? release.prerelease : !release.prerelease,
+		);
+
+		const latestMatchingVersion = ConfigVersionChecker.pickHighestVersion(matchingChannelReleases);
+		if (latestMatchingVersion) {
+			return latestMatchingVersion;
+		}
+
+		if (channel === "beta") {
+			const latestStableVersion = ConfigVersionChecker.pickHighestVersion(
+				visibleReleases.filter((release) => !release.prerelease),
+			);
+			if (latestStableVersion) {
+				logger.debug("No beta release found, falling back to latest stable release");
+				return latestStableVersion;
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -89,30 +170,37 @@ export class ConfigVersionChecker {
 	private static async loadCache(
 		kitType: KitType,
 		global: boolean,
+		channel: UpdateChannel,
 	): Promise<ConfigUpdateCache | null> {
-		try {
-			const cachePath = ConfigVersionChecker.getCacheFilePath(kitType, global);
-			const data = await readFile(cachePath, "utf8");
-			const parsed = JSON.parse(data);
-
-			// Validate cache structure
-			if (
-				typeof parsed !== "object" ||
-				parsed === null ||
-				typeof parsed.lastCheck !== "number" ||
-				typeof parsed.latestVersion !== "string" ||
-				!parsed.latestVersion ||
-				parsed.lastCheck < 0 ||
-				parsed.lastCheck > Date.now() + 7 * 24 * 60 * 60 * 1000 // Reject future timestamps > 7 days
-			) {
-				logger.debug("Invalid cache structure, ignoring");
-				return null;
-			}
-
-			return parsed as ConfigUpdateCache;
-		} catch {
-			return null;
+		const cachePaths = [ConfigVersionChecker.getCacheFilePath(kitType, global, channel)];
+		if (channel === "stable") {
+			cachePaths.push(ConfigVersionChecker.getLegacyCacheFilePath(kitType, global));
 		}
+
+		for (const cachePath of cachePaths) {
+			try {
+				const data = await readFile(cachePath, "utf8");
+				const parsed = JSON.parse(data);
+
+				// Validate cache structure
+				if (
+					typeof parsed !== "object" ||
+					parsed === null ||
+					typeof parsed.lastCheck !== "number" ||
+					typeof parsed.latestVersion !== "string" ||
+					!parsed.latestVersion ||
+					parsed.lastCheck < 0 ||
+					parsed.lastCheck > Date.now() + 7 * 24 * 60 * 60 * 1000 // Reject future timestamps > 7 days
+				) {
+					logger.debug("Invalid cache structure, ignoring");
+					continue;
+				}
+
+				return parsed as ConfigUpdateCache;
+			} catch {}
+		}
+
+		return null;
 	}
 
 	/**
@@ -121,10 +209,11 @@ export class ConfigVersionChecker {
 	private static async saveCache(
 		kitType: KitType,
 		global: boolean,
+		channel: UpdateChannel,
 		cache: ConfigUpdateCache,
 	): Promise<void> {
 		try {
-			const cachePath = ConfigVersionChecker.getCacheFilePath(kitType, global);
+			const cachePath = ConfigVersionChecker.getCacheFilePath(kitType, global, channel);
 			const cacheDir = PathResolver.getCacheDir(global);
 			await mkdir(cacheDir, { recursive: true });
 			await writeFile(cachePath, JSON.stringify(cache, null, 2));
@@ -140,12 +229,13 @@ export class ConfigVersionChecker {
 	 */
 	private static async fetchLatestVersion(
 		kitType: KitType,
+		channel: UpdateChannel,
 		etag?: string,
 	): Promise<{ version: string; etag?: string } | "not-modified" | null> {
 		const repoInfo = KIT_REPOS[kitType];
 		if (!repoInfo) return null;
 
-		const url = `https://api.github.com/repos/${repoInfo.owner}/${repoInfo.repo}/releases/latest`;
+		const url = `https://api.github.com/repos/${repoInfo.owner}/${repoInfo.repo}/releases?per_page=${RELEASES_PER_PAGE}`;
 		const maxRetries = 3;
 		const baseBackoff = 1000;
 
@@ -194,22 +284,14 @@ export class ConfigVersionChecker {
 					throw new Error(`GitHub API returned ${response.status}`);
 				}
 
-				const data = (await response.json()) as { tag_name?: string };
-				const version = data.tag_name?.replace(/^v/, "") || null;
-
-				// Validate semver format with length limit (prevents regex DoS)
-				// Max semver length: 256 chars (generous limit for prerelease/build metadata)
-				if (!version || version.length > 256) {
-					logger.debug(`Invalid version format from GitHub: ${data.tag_name}`);
-					return null;
-				}
-
-				// Simple semver validation - avoid complex regex that could backtrack
-				// Pattern: MAJOR.MINOR.PATCH with optional prerelease/build
-				const semverParts = version.split(/[-+]/);
-				const coreParts = semverParts[0].split(".");
-				if (coreParts.length !== 3 || !coreParts.every((p) => /^\d+$/.test(p))) {
-					logger.debug(`Invalid version format from GitHub: ${data.tag_name}`);
+				const data = (await response.json()) as Array<{
+					tag_name?: string;
+					prerelease?: boolean;
+					draft?: boolean;
+				}>;
+				const version = ConfigVersionChecker.selectLatestVersion(data, channel);
+				if (!version) {
+					logger.debug(`No ${channel} release found for ${kitType}`);
 					return null;
 				}
 
@@ -246,11 +328,13 @@ export class ConfigVersionChecker {
 		kitType: KitType,
 		currentVersion: string,
 		global = false,
+		channel?: UpdateChannel,
 	): Promise<UpdateCheckResult> {
-		const normalizedCurrent = currentVersion.replace(/^v/, "");
+		const normalizedCurrent = normalizeVersion(currentVersion);
+		const resolvedChannel = ConfigVersionChecker.resolveChannel(normalizedCurrent, channel);
 
 		// Load cache
-		const cache = await ConfigVersionChecker.loadCache(kitType, global);
+		const cache = await ConfigVersionChecker.loadCache(kitType, global, resolvedChannel);
 		const now = Date.now();
 
 		// Check if cache is valid (< 24h)
@@ -265,11 +349,15 @@ export class ConfigVersionChecker {
 		}
 
 		// Fetch from GitHub with ETag
-		const result = await ConfigVersionChecker.fetchLatestVersion(kitType, cache?.etag);
+		const result = await ConfigVersionChecker.fetchLatestVersion(
+			kitType,
+			resolvedChannel,
+			cache?.etag,
+		);
 
 		if (result === "not-modified" && cache) {
 			// Update cache timestamp, keep existing data
-			await ConfigVersionChecker.saveCache(kitType, global, {
+			await ConfigVersionChecker.saveCache(kitType, global, resolvedChannel, {
 				...cache,
 				lastCheck: now,
 			});
@@ -285,7 +373,7 @@ export class ConfigVersionChecker {
 
 		if (result && result !== "not-modified") {
 			// Save new cache
-			await ConfigVersionChecker.saveCache(kitType, global, {
+			await ConfigVersionChecker.saveCache(kitType, global, resolvedChannel, {
 				lastCheck: now,
 				latestVersion: result.version,
 				etag: result.etag,
@@ -324,14 +412,21 @@ export class ConfigVersionChecker {
 	 * Clear cached update check for a kit
 	 */
 	static async clearCache(kitType: KitType, global = false): Promise<void> {
-		const cachePath = ConfigVersionChecker.getCacheFilePath(kitType, global);
-		try {
-			await unlink(cachePath);
-			logger.debug(`Cleared sync cache for ${kitType}`);
-		} catch (error) {
-			// Ignore if file doesn't exist
-			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-				throw error;
+		const cachePaths = [
+			ConfigVersionChecker.getLegacyCacheFilePath(kitType, global),
+			ConfigVersionChecker.getCacheFilePath(kitType, global, "stable"),
+			ConfigVersionChecker.getCacheFilePath(kitType, global, "beta"),
+		];
+
+		for (const cachePath of cachePaths) {
+			try {
+				await unlink(cachePath);
+				logger.debug(`Cleared sync cache for ${kitType}: ${cachePath}`);
+			} catch (error) {
+				// Ignore if file doesn't exist
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+					throw error;
+				}
 			}
 		}
 	}

--- a/src/domains/sync/types.ts
+++ b/src/domains/sync/types.ts
@@ -14,6 +14,8 @@ export interface UpdateCheckResult {
 	fromCache: boolean;
 }
 
+export type UpdateChannel = "stable" | "beta";
+
 /**
  * Cached update check data
  */

--- a/src/domains/versioning/checking/notification-display.ts
+++ b/src/domains/versioning/checking/notification-display.ts
@@ -10,6 +10,8 @@ import { type VersionCheckResult, normalizeVersion } from "./version-utils.js";
 export interface DisplayNotificationOptions {
 	/** Whether this is a global kit installation (affects command shown) */
 	isGlobal?: boolean;
+	/** Optional installed kit label for multi-kit installs */
+	kitName?: string;
 }
 
 /**
@@ -61,7 +63,7 @@ export function displayKitNotification(
 	if (!result.updateAvailable) return;
 
 	const { currentVersion, latestVersion } = result;
-	const { isGlobal = false } = options;
+	const { isGlobal = false, kitName } = options;
 
 	// Normalize versions for display (strip 'v' prefix for consistency)
 	const displayCurrent = normalizeVersion(currentVersion);
@@ -74,6 +76,8 @@ export function displayKitNotification(
 	// Build content with visual hierarchy
 	const headerText = pc.bold(pc.yellow("⬆ Kit Update Available"));
 	const headerLen = "⬆ Kit Update Available".length;
+	const kitText = kitName ? `Kit: ${pc.cyan(pc.bold(kitName))}` : null;
+	const kitLen = kitName ? `Kit: ${kitName}`.length : 0;
 
 	const versionText = `${pc.dim(displayCurrent)} ${pc.white("→")} ${pc.green(pc.bold(displayLatest))}`;
 	const versionLen = displayCurrent.length + 3 + displayLatest.length;
@@ -87,6 +91,9 @@ export function displayKitNotification(
 	console.log(topBorder);
 	console.log(emptyLine);
 	console.log(padLine(headerText, headerLen));
+	if (kitText) {
+		console.log(padLine(kitText, kitLen));
+	}
 	console.log(padLine(versionText, versionLen));
 	console.log(emptyLine);
 	console.log(padLine(commandText, commandLen));

--- a/src/domains/web-server/routes/system-routes.ts
+++ b/src/domains/web-server/routes/system-routes.ts
@@ -9,7 +9,10 @@ import { GitHubClient } from "@/domains/github/github-client.js";
 import { NpmRegistryClient } from "@/domains/github/npm-registry.js";
 import { PackageManagerDetector } from "@/domains/installation/package-manager-detector.js";
 import { ConfigVersionChecker } from "@/domains/sync/config-version-checker.js";
-import { normalizeVersion } from "@/domains/versioning/checking/version-utils.js";
+import {
+	isPrereleaseVersion,
+	normalizeVersion,
+} from "@/domains/versioning/checking/version-utils.js";
 import {
 	CLAUDEKIT_CLI_NPM_PACKAGE_NAME,
 	CLAUDEKIT_CLI_NPM_PACKAGE_URL,
@@ -104,14 +107,18 @@ function hasCliUpdate(currentVersion: string, latestVersion: string | null): boo
 export function registerSystemRoutes(app: Express): void {
 	// GET /api/system/check-updates?target=cli|kit&kit=engineer&channel=stable|beta
 	app.get("/api/system/check-updates", async (req: Request, res: Response) => {
-		const { target, kit, channel = "stable" } = req.query;
-		const normalizedChannel = typeof channel === "string" ? channel.toLowerCase() : "stable";
+		const { target, kit, channel } = req.query;
+		const normalizedChannel = typeof channel === "string" ? channel.toLowerCase() : null;
 
 		if (!target || (target !== "cli" && target !== "kit")) {
 			res.status(400).json({ error: "Missing or invalid target param (cli|kit)" });
 			return;
 		}
-		if (normalizedChannel !== "stable" && normalizedChannel !== "beta") {
+		if (
+			normalizedChannel !== null &&
+			normalizedChannel !== "stable" &&
+			normalizedChannel !== "beta"
+		) {
 			res.status(400).json({ error: "Invalid channel param (stable|beta)" });
 			return;
 		}
@@ -120,10 +127,11 @@ export function registerSystemRoutes(app: Express): void {
 			if (target === "cli") {
 				const packageJson = await getPackageJson();
 				const currentVersion = packageJson?.version ?? "0.0.0";
+				const cliChannel = normalizedChannel ?? "stable";
 
 				// Use beta/dev version for beta channel
 				let latestVersion: string | null = null;
-				if (normalizedChannel === "beta") {
+				if (cliChannel === "beta") {
 					latestVersion = await NpmRegistryClient.getDevVersion(CLAUDEKIT_CLI_NPM_PACKAGE_NAME);
 				} else {
 					latestVersion = await NpmRegistryClient.getLatestVersion(CLAUDEKIT_CLI_NPM_PACKAGE_NAME);
@@ -143,11 +151,13 @@ export function registerSystemRoutes(app: Express): void {
 				const kitName = typeof kit === "string" && isValidKitType(kit) ? kit : "engineer";
 				const metadata = await getKitMetadata(kitName);
 				const currentVersion = metadata?.version ?? "0.0.0";
+				const kitChannel =
+					normalizedChannel ?? (isPrereleaseVersion(currentVersion) ? "beta" : "stable");
 				const result = await ConfigVersionChecker.checkForUpdates(
 					kitName,
 					currentVersion,
 					true,
-					normalizedChannel,
+					kitChannel,
 				);
 				const kitConfig = AVAILABLE_KITS[kitName];
 

--- a/src/domains/web-server/routes/system-routes.ts
+++ b/src/domains/web-server/routes/system-routes.ts
@@ -410,11 +410,14 @@ async function getKitMetadata(kitName: string): Promise<{ version: string } | nu
 		const content = await readFile(metadataPath, "utf-8");
 		const metadata = JSON.parse(content);
 		// Multi-kit format
-		if (metadata.kits?.[kitName]) {
+		if (
+			typeof metadata.kits?.[kitName]?.version === "string" &&
+			metadata.kits[kitName].version.trim()
+		) {
 			return { version: metadata.kits[kitName].version };
 		}
 		// Legacy format
-		if (metadata.version) {
+		if (typeof metadata.version === "string" && metadata.version.trim()) {
 			return { version: metadata.version };
 		}
 		return null;

--- a/src/domains/web-server/routes/system-routes.ts
+++ b/src/domains/web-server/routes/system-routes.ts
@@ -8,8 +8,8 @@ import { buildInitCommand, isBetaVersion } from "@/commands/update-cli.js";
 import { GitHubClient } from "@/domains/github/github-client.js";
 import { NpmRegistryClient } from "@/domains/github/npm-registry.js";
 import { PackageManagerDetector } from "@/domains/installation/package-manager-detector.js";
+import { ConfigVersionChecker } from "@/domains/sync/config-version-checker.js";
 import { normalizeVersion } from "@/domains/versioning/checking/version-utils.js";
-import { VersionChecker } from "@/domains/versioning/version-checker.js";
 import {
 	CLAUDEKIT_CLI_NPM_PACKAGE_NAME,
 	CLAUDEKIT_CLI_NPM_PACKAGE_URL,
@@ -17,7 +17,7 @@ import {
 import { logger } from "@/shared/logger.js";
 import { PathResolver } from "@/shared/path-resolver.js";
 import type { KitType } from "@/types/index.js";
-import { AVAILABLE_KITS } from "@/types/kit.js";
+import { AVAILABLE_KITS, isValidKitType } from "@/types/kit.js";
 import { compareVersions } from "compare-versions";
 import type { Express, Request, Response } from "express";
 import packageInfo from "../../../../package.json" assert { type: "json" };
@@ -140,16 +140,22 @@ export function registerSystemRoutes(app: Express): void {
 				res.json(response);
 			} else {
 				// Kit update check
-				const kitName = (kit as string) ?? "engineer";
+				const kitName = typeof kit === "string" && isValidKitType(kit) ? kit : "engineer";
 				const metadata = await getKitMetadata(kitName);
 				const currentVersion = metadata?.version ?? "0.0.0";
-				const result = await VersionChecker.check(currentVersion);
+				const result = await ConfigVersionChecker.checkForUpdates(
+					kitName,
+					currentVersion,
+					true,
+					normalizedChannel,
+				);
+				const kitConfig = AVAILABLE_KITS[kitName];
 
 				const response: UpdateCheckResponse = {
 					current: currentVersion,
-					latest: result?.latestVersion ?? null,
-					updateAvailable: result?.updateAvailable ?? false,
-					releaseUrl: `https://github.com/anthropics/claudekit-${kitName}/releases`,
+					latest: result.latestVersion,
+					updateAvailable: result.hasUpdates,
+					releaseUrl: `https://github.com/${kitConfig.owner}/${kitConfig.repo}/releases`,
 				};
 				res.json(response);
 			}


### PR DESCRIPTION
## Summary
- fix `ck -V` so it checks installed kits individually instead of collapsing to a single first-kit version
- make kit update checks channel-aware so beta installs compare against beta releases and stable installs compare against stable releases
- align the system update API route with the same per-kit detection logic and make the banner identify which kit is outdated

## Validation
- bun test src/__tests__/domains/sync/config-version-checker.test.ts src/__tests__/cli/version-display.test.ts
- bun run typecheck
- bun run validate

## Notes
- reproduces the mixed local/global case where local marketing and global engineer beta are both current and should not trigger a false update banner

Docs impact: none
Action: no update needed — this changes internal detection logic only.
