### PR TITLE
feat(skills): add skill catalog generation, inline BM25 search, and dashboard integration

### DIFF
--- a/src/cli/command-registry.ts
+++ b/src/cli/command-registry.ts
@@ -317,10 +317,20 @@ export function registerCommands(cli: ReturnType<typeof cac>): void {
 		.option("--force", "Force uninstall even if not in registry")
 		.option("--sync", "Sync registry with filesystem (remove orphans)")
 		.option("-y, --yes", "Skip confirmation prompts")
+		.option("--catalog", "Show skill catalog stats")
+		.option("--regenerate", "Force regenerate catalog (use with --catalog)")
+		.option("--search <query>", "BM25 full-text search over skill catalog")
+		.option("--json", "Output search results as JSON (use with --search)")
+		.option("--limit <n>", "Max search results, default 10 (use with --search)")
+		.option("--validate", "Validate SKILL.md frontmatter fields")
 		.action(async (options) => {
 			// Normalize agent to always be an array
 			if (options.agent && !Array.isArray(options.agent)) {
 				options.agent = [options.agent];
+			}
+			// Normalize limit to number
+			if (options.limit !== undefined) {
+				options.limit = Number(options.limit);
 			}
 			await skillsCommand(options);
 		});

--- a/src/commands/skills/__tests__/skill-search-bm25.test.ts
+++ b/src/commands/skills/__tests__/skill-search-bm25.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for BM25 skill search index
+ */
+import { describe, expect, test } from "bun:test";
+import { buildIndex, search } from "../../../domains/skills/skill-search-index.js";
+import type { CatalogSkillEntry } from "../types.js";
+
+function makeSkill(
+	name: string,
+	description: string,
+	keywords?: string[],
+	category?: string,
+): CatalogSkillEntry {
+	return {
+		name,
+		displayName: name,
+		description,
+		keywords,
+		category,
+		path: `${name}/SKILL.md`,
+		hasScripts: false,
+		hasReferences: false,
+	};
+}
+
+const SKILLS: CatalogSkillEntry[] = [
+	makeSkill("sequential-thinking", "Sequential reasoning and planning for complex tasks", [
+		"reasoning",
+		"planning",
+		"thinking",
+	]),
+	makeSkill("debug", "Debugging and error analysis", ["debugging", "errors", "troubleshoot"]),
+	makeSkill("code-reviewer", "Review code quality and suggest improvements", [
+		"review",
+		"quality",
+		"code",
+	]),
+	makeSkill("docs-seeker", "Search documentation and references", ["docs", "search", "reference"]),
+	makeSkill("deploy", "Deploy applications to cloud providers", ["deploy", "cloud", "CI/CD"]),
+];
+
+describe("buildIndex", () => {
+	test("creates index with correct doc count", () => {
+		const idx = buildIndex(SKILLS);
+		expect(idx.totalDocs).toBe(SKILLS.length);
+		expect(idx.docs).toHaveLength(SKILLS.length);
+	});
+
+	test("computes avgDL > 0 for non-empty skills", () => {
+		const idx = buildIndex(SKILLS);
+		expect(idx.avgDL).toBeGreaterThan(0);
+	});
+
+	test("returns empty index for empty skills list", () => {
+		const idx = buildIndex([]);
+		expect(idx.totalDocs).toBe(0);
+		expect(idx.avgDL).toBe(1); // guard against divide-by-zero
+	});
+});
+
+describe("search", () => {
+	test("returns empty results for empty index", () => {
+		const idx = buildIndex([]);
+		const results = search(idx, "anything");
+		expect(results).toHaveLength(0);
+	});
+
+	test("returns empty results for stop-word-only query", () => {
+		const idx = buildIndex(SKILLS);
+		const results = search(idx, "the is a"); // all stop words
+		expect(results).toHaveLength(0);
+	});
+
+	test("finds debug skill for 'debugging errors' query", () => {
+		const idx = buildIndex(SKILLS);
+		const results = search(idx, "debugging errors");
+		expect(results.length).toBeGreaterThan(0);
+		const topDoc = SKILLS[results[0].docIndex];
+		expect(topDoc.name).toBe("debug");
+	});
+
+	test("finds code-reviewer for 'code review quality' query", () => {
+		const idx = buildIndex(SKILLS);
+		const results = search(idx, "code review quality");
+		expect(results.length).toBeGreaterThan(0);
+		const topDoc = SKILLS[results[0].docIndex];
+		expect(topDoc.name).toBe("code-reviewer");
+	});
+
+	test("respects limit parameter", () => {
+		const idx = buildIndex(SKILLS);
+		const results = search(idx, "code", 2);
+		expect(results.length).toBeLessThanOrEqual(2);
+	});
+
+	test("returns results sorted by score descending", () => {
+		const idx = buildIndex(SKILLS);
+		const results = search(idx, "deploy cloud");
+		expect(results.length).toBeGreaterThan(0);
+		for (let i = 1; i < results.length; i++) {
+			expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
+		}
+	});
+
+	test("scores are positive numbers", () => {
+		const idx = buildIndex(SKILLS);
+		const results = search(idx, "planning reasoning");
+		for (const r of results) {
+			expect(r.score).toBeGreaterThan(0);
+		}
+	});
+
+	test("exact name match ranks highly", () => {
+		const idx = buildIndex(SKILLS);
+		const results = search(idx, "sequential-thinking");
+		expect(results.length).toBeGreaterThan(0);
+		// First result should be sequential-thinking (name repeated 3x = high boost)
+		expect(SKILLS[results[0].docIndex].name).toBe("sequential-thinking");
+	});
+});

--- a/src/commands/skills/skills-command.ts
+++ b/src/commands/skills/skills-command.ts
@@ -6,7 +6,10 @@ import { join } from "node:path";
 import * as p from "@clack/prompts";
 import matter from "gray-matter";
 import pc from "picocolors";
-import { skillCatalogGenerator } from "../../domains/skills/skill-catalog-generator.js";
+import {
+	SkillCatalogGenerator,
+	skillCatalogGenerator,
+} from "../../domains/skills/skill-catalog-generator.js";
 import { searchSkills } from "../../domains/skills/skill-search-index.js";
 import { logger } from "../../shared/logger.js";
 import { agents } from "./agents.js";
@@ -58,10 +61,7 @@ async function handleCatalog(sourcePath: string, regenerate: boolean): Promise<v
 
 	let catalog;
 	if (regenerate) {
-		const { discoverSkillsEnriched } = await import("./skills-discovery.js");
-		const skills = await discoverSkillsEnriched(sourcePath);
-		catalog = await skillCatalogGenerator.generate(skills, sourcePath);
-		await skillCatalogGenerator.write(catalog);
+		catalog = await SkillCatalogGenerator.forceRegenerate(sourcePath);
 	} else {
 		catalog = await skillCatalogGenerator.readOrRegenerate(sourcePath);
 	}

--- a/src/commands/skills/skills-command.ts
+++ b/src/commands/skills/skills-command.ts
@@ -1,8 +1,13 @@
 /**
  * Skills command - install ClaudeKit skills to other coding agents
  */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import * as p from "@clack/prompts";
+import matter from "gray-matter";
 import pc from "picocolors";
+import { skillCatalogGenerator } from "../../domains/skills/skill-catalog-generator.js";
+import { searchSkills } from "../../domains/skills/skill-search-index.js";
 import { logger } from "../../shared/logger.js";
 import { agents } from "./agents.js";
 import { discoverSkills, findSkillByName, getSkillSourcePath } from "./skills-discovery.js";
@@ -17,10 +22,165 @@ import {
 	type AgentType,
 	type InstallResult,
 	type SkillCommandOptions,
+	type SkillCommandOptionsExtended,
 	SkillCommandOptionsSchema,
 	type SkillContext,
 	type SkillInfo,
 } from "./types.js";
+
+// Known SKILL.md frontmatter fields (for --validate)
+const KNOWN_FRONTMATTER_FIELDS = new Set([
+	"name",
+	"description",
+	"version",
+	"author",
+	"license",
+	"category",
+	"keywords",
+	"requires",
+	"related",
+	"maturity",
+	"triggers",
+	"metadata",
+]);
+
+/**
+ * Handle --catalog flag: show catalog stats or force regeneration.
+ */
+async function handleCatalog(sourcePath: string, regenerate: boolean): Promise<void> {
+	const spinner = p.spinner();
+
+	if (regenerate) {
+		spinner.start("Regenerating skill catalog...");
+	} else {
+		spinner.start("Loading skill catalog...");
+	}
+
+	let catalog;
+	if (regenerate) {
+		const { discoverSkillsEnriched } = await import("./skills-discovery.js");
+		const skills = await discoverSkillsEnriched(sourcePath);
+		catalog = await skillCatalogGenerator.generate(skills, sourcePath);
+		await skillCatalogGenerator.write(catalog);
+	} else {
+		catalog = await skillCatalogGenerator.readOrRegenerate(sourcePath);
+	}
+
+	spinner.stop("Catalog ready");
+
+	// Collect category counts
+	const categories = new Map<string, number>();
+	for (const skill of catalog.skills) {
+		const cat = skill.category || "Uncategorized";
+		categories.set(cat, (categories.get(cat) ?? 0) + 1);
+	}
+
+	console.log();
+	p.log.step(pc.bold("Skill Catalog"));
+	console.log();
+	console.log(`  ${pc.cyan("Skills:")}     ${catalog.skillCount}`);
+	console.log(`  ${pc.cyan("Generated:")} ${new Date(catalog.generated).toLocaleString()}`);
+	console.log(`  ${pc.cyan("Version:")}   ${catalog.version}`);
+
+	if (categories.size > 0) {
+		console.log();
+		p.log.step(pc.bold("Categories"));
+		console.log();
+		for (const [cat, count] of [...categories.entries()].sort((a, b) => b[1] - a[1])) {
+			console.log(`  ${pc.dim("•")} ${cat}: ${count}`);
+		}
+	}
+	console.log();
+}
+
+/**
+ * Handle --search <query>: BM25 search over catalog.
+ */
+async function handleSearch(
+	sourcePath: string,
+	query: string,
+	options: { json?: boolean; limit?: number },
+): Promise<void> {
+	// Cap query at 500 chars
+	const safeQuery = query.slice(0, 500);
+	// Clamp limit 1-100
+	const limit = Math.min(100, Math.max(1, options.limit ?? 10));
+
+	const spinner = p.spinner();
+	spinner.start("Searching...");
+
+	const catalog = await skillCatalogGenerator.readOrRegenerate(sourcePath);
+
+	if (catalog.skillCount === 0) {
+		spinner.stop("No results");
+		p.log.warn("No skills installed. Run: ck init");
+		return;
+	}
+
+	const results = searchSkills(catalog.skills, safeQuery, limit);
+	spinner.stop(`Found ${results.length} result(s)`);
+
+	if (options.json) {
+		console.log(JSON.stringify(results, null, 2));
+		return;
+	}
+
+	if (results.length === 0) {
+		p.log.warn(`No skills matched "${safeQuery}"`);
+		return;
+	}
+
+	console.log();
+	p.log.step(pc.bold(`Search: "${safeQuery}"`));
+	console.log();
+	for (const r of results) {
+		const score = r.score.toFixed(3);
+		const cat = r.category ? pc.dim(` [${r.category}]`) : "";
+		console.log(`  ${pc.cyan(r.name)} ${pc.dim(`(${score})`)}${cat}`);
+		console.log(`    ${pc.dim(r.description)}`);
+	}
+	console.log();
+}
+
+/**
+ * Handle --validate: check SKILL.md frontmatter for unknown fields.
+ */
+async function handleValidate(sourcePath: string): Promise<void> {
+	const spinner = p.spinner();
+	spinner.start("Validating skills...");
+
+	const skills = await discoverSkills(sourcePath);
+	spinner.stop(`Checked ${skills.length} skill(s)`);
+
+	let hasIssues = false;
+	for (const skill of skills) {
+		const skillMdPath = join(skill.path, "SKILL.md");
+		try {
+			const content = await readFile(skillMdPath, "utf-8");
+			// CRITICAL: disable JS engine
+			const { data } = matter(content, {
+				engines: { javascript: { parse: () => ({}) } },
+			});
+
+			const unknown = Object.keys(data).filter((k) => !KNOWN_FRONTMATTER_FIELDS.has(k));
+			if (unknown.length > 0) {
+				if (!hasIssues) console.log();
+				p.log.warn(`${pc.cyan(skill.name)}: unknown fields: ${unknown.join(", ")}`);
+				hasIssues = true;
+			}
+		} catch {
+			p.log.warn(`${pc.cyan(skill.name)}: could not read SKILL.md`);
+			hasIssues = true;
+		}
+	}
+
+	if (!hasIssues) {
+		p.log.success("All skills pass validation");
+	} else {
+		p.log.info("Validation complete (warnings only — skills still work)");
+	}
+	console.log();
+}
 
 /**
  * Detect which agents are installed on the system
@@ -239,13 +399,79 @@ async function handleUninstall(options: SkillCommandOptions): Promise<void> {
 /**
  * Main skills command handler
  */
-export async function skillsCommand(options: SkillCommandOptions): Promise<void> {
+export async function skillsCommand(options: SkillCommandOptionsExtended): Promise<void> {
 	console.log();
 	p.intro(pc.bgCyan(pc.black(" ck skills ")));
 
 	try {
-		// Validate options
-		const validOptions = SkillCommandOptionsSchema.parse(options);
+		// Validate base options (extended fields pass through as-is)
+		const baseOptions = SkillCommandOptionsSchema.parse(options);
+		const validOptions: SkillCommandOptionsExtended = {
+			...baseOptions,
+			catalog: options.catalog,
+			regenerate: options.regenerate,
+			search: options.search,
+			json: options.json,
+			limit: options.limit,
+			validate: options.validate,
+		};
+
+		// Mutual exclusivity check — only one mode at a time
+		const activeModes = [
+			validOptions.search ? "search" : null,
+			validOptions.catalog ? "catalog" : null,
+			validOptions.validate ? "validate" : null,
+			validOptions.uninstall ? "uninstall" : null,
+			validOptions.list ? "list" : null,
+			validOptions.sync ? "sync" : null,
+		].filter(Boolean);
+
+		if (activeModes.length > 1) {
+			p.log.error(`Conflicting options: ${activeModes.join(", ")}. Use only one at a time.`);
+			process.exit(1);
+		}
+
+		// Resolve source path early — needed for catalog/search/validate
+		const sourcePath = getSkillSourcePath();
+
+		// Handle --search <query>
+		if (validOptions.search) {
+			if (!sourcePath) {
+				p.log.error("No skills found. Install ClaudeKit Engineer first.");
+				p.outro(pc.red("Search failed"));
+				process.exit(1);
+			}
+			await handleSearch(sourcePath, validOptions.search, {
+				json: validOptions.json,
+				limit: validOptions.limit,
+			});
+			p.outro(pc.dim("Done"));
+			return;
+		}
+
+		// Handle --catalog
+		if (validOptions.catalog) {
+			if (!sourcePath) {
+				p.log.error("No skills found. Install ClaudeKit Engineer first.");
+				p.outro(pc.red("Catalog unavailable"));
+				process.exit(1);
+			}
+			await handleCatalog(sourcePath, validOptions.regenerate ?? false);
+			p.outro(pc.dim(validOptions.regenerate ? "Catalog regenerated" : "Done"));
+			return;
+		}
+
+		// Handle --validate
+		if (validOptions.validate) {
+			if (!sourcePath) {
+				p.log.error("No skills found. Install ClaudeKit Engineer first.");
+				p.outro(pc.red("Validation failed"));
+				process.exit(1);
+			}
+			await handleValidate(sourcePath);
+			p.outro(pc.dim("Validation complete"));
+			return;
+		}
 
 		// Handle sync mode
 		if (validOptions.sync) {
@@ -276,8 +502,7 @@ export async function skillsCommand(options: SkillCommandOptions): Promise<void>
 			return;
 		}
 
-		// Check skill source exists
-		const sourcePath = getSkillSourcePath();
+		// Check skill source exists (sourcePath already resolved above)
 		if (!sourcePath) {
 			p.log.error("No skills found. Install ClaudeKit Engineer first.");
 			p.outro(pc.red("Installation failed"));

--- a/src/commands/skills/skills-command.ts
+++ b/src/commands/skills/skills-command.ts
@@ -117,7 +117,7 @@ async function handleSearch(
 		return;
 	}
 
-	const results = searchSkills(catalog.skills, safeQuery, limit);
+	const results = searchSkills(catalog.skills, safeQuery, limit, catalog.generated);
 	spinner.stop(`Found ${results.length} result(s)`);
 
 	if (options.json) {
@@ -415,6 +415,11 @@ export async function skillsCommand(options: SkillCommandOptionsExtended): Promi
 			limit: options.limit,
 			validate: options.validate,
 		};
+
+		// --regenerate implies --catalog (avoids falling through to install mode)
+		if (validOptions.regenerate && !validOptions.catalog) {
+			validOptions.catalog = true;
+		}
 
 		// Mutual exclusivity check — only one mode at a time
 		const activeModes = [

--- a/src/commands/skills/skills-discovery.ts
+++ b/src/commands/skills/skills-discovery.ts
@@ -7,7 +7,7 @@ import { dirname, join } from "node:path";
 import { findFirstExistingPath, getProjectLayoutCandidates } from "@/shared/kit-layout.js";
 import matter from "gray-matter";
 import { logger } from "../../shared/logger.js";
-import type { SkillInfo } from "./types.js";
+import type { EnrichedSkillInfo, SkillInfo } from "./types.js";
 
 const home = homedir();
 
@@ -120,6 +120,65 @@ export async function discoverSkills(sourcePath?: string): Promise<SkillInfo[]> 
 
 	// Sort alphabetically by name
 	return skills.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Coerce a YAML value to string array
+ */
+function toStringArray(v: unknown): string[] | undefined {
+	if (Array.isArray(v)) return v.map(String).filter(Boolean);
+	if (typeof v === "string") return v.split(/,\s*/).filter(Boolean);
+	return undefined;
+}
+
+/**
+ * Extract /ck:command-name cross-references from markdown body
+ * Skips code fences to avoid false positives
+ */
+function extractCrossRefs(body: string): string[] {
+	// Remove code fences before scanning
+	const stripped = body.replace(/```[\s\S]*?```/g, "").replace(/`[^`]*`/g, "");
+	const refs = new Set<string>();
+	const pattern = /\/ck:([a-z0-9-]+)/g;
+	for (const match of stripped.matchAll(pattern)) {
+		refs.add(match[1]);
+	}
+	return Array.from(refs);
+}
+
+/**
+ * Discover skills with enriched metadata from frontmatter and body analysis.
+ * Extends discoverSkills() by re-reading each SKILL.md for additional fields.
+ */
+export async function discoverSkillsEnriched(sourcePath?: string): Promise<EnrichedSkillInfo[]> {
+	const base = await discoverSkills(sourcePath);
+	const enriched: EnrichedSkillInfo[] = [];
+
+	for (const skill of base) {
+		const skillMdPath = join(skill.path, "SKILL.md");
+		try {
+			const content = await readFile(skillMdPath, "utf-8");
+			// CRITICAL: disable JS engine to prevent code execution from untrusted SKILL.md files
+			const { data, content: body } = matter(content, {
+				engines: { javascript: { parse: () => ({}) } },
+			});
+
+			enriched.push({
+				...skill,
+				category: data.category != null ? String(data.category) : undefined,
+				keywords: toStringArray(data.keywords),
+				requires: toStringArray(data.requires),
+				related: toStringArray(data.related),
+				maturity: data.maturity != null ? String(data.maturity) : undefined,
+				crossRefs: extractCrossRefs(body),
+			});
+		} catch {
+			// If we can't enrich, keep base info
+			enriched.push({ ...skill });
+		}
+	}
+
+	return enriched;
 }
 
 /**

--- a/src/commands/skills/skills-discovery.ts
+++ b/src/commands/skills/skills-discovery.ts
@@ -47,7 +47,8 @@ async function hasSkillMd(dir: string): Promise<boolean> {
 async function parseSkillMd(skillMdPath: string): Promise<SkillInfo | null> {
 	try {
 		const content = await readFile(skillMdPath, "utf-8");
-		const { data } = matter(content);
+		// CRITICAL: disable JS engine to prevent code execution from untrusted SKILL.md files
+		const { data } = matter(content, { engines: { javascript: { parse: () => ({}) } } });
 
 		// Always use directory name as canonical ID to prevent duplicate installs
 		const skillDir = dirname(skillMdPath);

--- a/src/commands/skills/types.ts
+++ b/src/commands/skills/types.ts
@@ -56,6 +56,15 @@ export const SkillCommandOptionsSchema = z.object({
 	sync: z.boolean().optional(), // Sync registry with filesystem
 });
 export type SkillCommandOptions = z.infer<typeof SkillCommandOptionsSchema>;
+// Extended options type alias (defined after catalog types below)
+export type SkillCommandOptionsExtended = SkillCommandOptions & {
+	catalog?: boolean;
+	regenerate?: boolean;
+	search?: string;
+	json?: boolean;
+	limit?: number;
+	validate?: boolean;
+};
 
 // Skill install context (for multi-phase)
 export interface SkillContext {
@@ -82,3 +91,49 @@ export interface InstallResult {
 
 // Registry installation record (re-export from skill-registry)
 export type { SkillInstallation } from "./skills-registry.js";
+
+// Enriched skill with catalog-specific frontmatter fields
+export interface EnrichedSkillInfo extends SkillInfo {
+	category?: string;
+	keywords?: string[];
+	requires?: string[];
+	related?: string[];
+	maturity?: string;
+	crossRefs?: string[]; // extracted from SKILL.md body text
+}
+
+// Flat entry stored in the catalog JSON
+export interface CatalogSkillEntry {
+	name: string;
+	displayName: string;
+	description: string;
+	version?: string;
+	author?: string;
+	category?: string;
+	keywords?: string[];
+	requires?: string[];
+	related?: string[];
+	maturity?: string;
+	path: string; // RELATIVE path (e.g., "deploy/SKILL.md")
+	hasScripts: boolean;
+	hasReferences: boolean;
+	crossRefs?: string[];
+}
+
+// Top-level catalog JSON structure
+export interface SkillCatalog {
+	version: string; // "1.0.0"
+	generated: string; // ISO timestamp
+	skillCount: number;
+	skills: CatalogSkillEntry[];
+}
+
+// Search result returned by BM25 search
+export interface SkillSearchResult {
+	name: string;
+	displayName: string;
+	description: string;
+	category?: string;
+	score: number;
+	path: string; // relative path
+}

--- a/src/domains/skills/skill-catalog-generator.ts
+++ b/src/domains/skills/skill-catalog-generator.ts
@@ -3,9 +3,9 @@
  * The catalog is stored at ~/.claude/.skills-catalog.json and auto-refreshes when stale.
  */
 
-import { readFile, readdir, rename, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join, relative } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { discoverSkillsEnriched } from "../../commands/skills/skills-discovery.js";
 import type {
 	CatalogSkillEntry,
@@ -103,6 +103,7 @@ export class SkillCatalogGenerator {
 	 * Uses temp file in same directory + rename for atomic swap.
 	 */
 	async write(catalog: SkillCatalog): Promise<void> {
+		await mkdir(dirname(CATALOG_PATH), { recursive: true });
 		const tmpPath = `${CATALOG_PATH}.tmp`;
 		const json = JSON.stringify(catalog, null, 2);
 		await writeFile(tmpPath, json, "utf-8");
@@ -151,6 +152,19 @@ export class SkillCatalogGenerator {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Force-regenerate the catalog regardless of staleness.
+	 * Discovers skills, builds catalog, writes to disk, and returns it.
+	 */
+	static async forceRegenerate(skillsBasePath: string): Promise<SkillCatalog> {
+		const { discoverSkillsEnriched } = await import("../../commands/skills/skills-discovery.js");
+		const enriched = await discoverSkillsEnriched(skillsBasePath);
+		const instance = new SkillCatalogGenerator();
+		const catalog = await instance.generate(enriched, skillsBasePath);
+		await instance.write(catalog);
+		return catalog;
 	}
 
 	/**

--- a/src/domains/skills/skill-catalog-generator.ts
+++ b/src/domains/skills/skill-catalog-generator.ts
@@ -1,0 +1,188 @@
+/**
+ * Skill catalog generator — builds and caches a flat JSON catalog of all available skills.
+ * The catalog is stored at ~/.claude/.skills-catalog.json and auto-refreshes when stale.
+ */
+
+import { existsSync } from "node:fs";
+import { readFile, rename, stat, writeFile } from "node:fs/promises";
+import { readdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, relative } from "node:path";
+import { discoverSkillsEnriched } from "../../commands/skills/skills-discovery.js";
+import type {
+	CatalogSkillEntry,
+	EnrichedSkillInfo,
+	SkillCatalog,
+} from "../../commands/skills/types.js";
+import { logger } from "../../shared/logger.js";
+
+const CATALOG_PATH = join(homedir(), ".claude", ".skills-catalog.json");
+const CATALOG_VERSION = "1.0.0";
+
+// Directories to skip when checking for scripts
+const SKIP_DIRS = [".venv", "__pycache__", "node_modules", ".git"];
+
+/**
+ * Check if a skill directory has scripts (non-SKILL.md files or subdirectories)
+ */
+async function hasScripts(skillPath: string): Promise<boolean> {
+	try {
+		const entries = await readdir(skillPath, { withFileTypes: true });
+		for (const entry of entries) {
+			if (entry.name === "SKILL.md") continue;
+			if (SKIP_DIRS.includes(entry.name)) continue;
+			return true;
+		}
+		return false;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Check if a skill directory has a references/docs subdirectory or .md files beyond SKILL.md
+ */
+async function hasReferences(skillPath: string): Promise<boolean> {
+	try {
+		const entries = await readdir(skillPath, { withFileTypes: true });
+		for (const entry of entries) {
+			if (entry.name === "SKILL.md") continue;
+			if (entry.isDirectory() && !SKIP_DIRS.includes(entry.name)) return true;
+			if (entry.isFile() && entry.name.endsWith(".md")) return true;
+		}
+		return false;
+	} catch {
+		return false;
+	}
+}
+
+export class SkillCatalogGenerator {
+	/**
+	 * Convert EnrichedSkillInfo list to a catalog.
+	 * Paths are stored RELATIVE to skill source base path.
+	 */
+	async generate(enrichedSkills: EnrichedSkillInfo[], basePath: string): Promise<SkillCatalog> {
+		const entries: CatalogSkillEntry[] = await Promise.all(
+			enrichedSkills.map(async (skill): Promise<CatalogSkillEntry> => {
+				const relPath = relative(basePath, join(skill.path, "SKILL.md"));
+				const [scripts, refs] = await Promise.all([
+					hasScripts(skill.path),
+					hasReferences(skill.path),
+				]);
+
+				return {
+					name: skill.name,
+					displayName: skill.displayName || skill.name,
+					description: skill.description,
+					version: skill.version,
+					author: skill.author,
+					category: skill.category,
+					keywords: skill.keywords,
+					requires: skill.requires,
+					related: skill.related,
+					maturity: skill.maturity,
+					path: relPath,
+					hasScripts: scripts,
+					hasReferences: refs,
+					crossRefs: skill.crossRefs,
+				};
+			}),
+		);
+
+		return {
+			version: CATALOG_VERSION,
+			generated: new Date().toISOString(),
+			skillCount: entries.length,
+			skills: entries,
+		};
+	}
+
+	/**
+	 * Atomically write catalog to ~/.claude/.skills-catalog.json
+	 * Uses temp file in same directory + rename for atomic swap.
+	 */
+	async write(catalog: SkillCatalog): Promise<void> {
+		const tmpPath = `${CATALOG_PATH}.tmp`;
+		const json = JSON.stringify(catalog, null, 2);
+		await writeFile(tmpPath, json, "utf-8");
+		await rename(tmpPath, CATALOG_PATH);
+		logger.verbose(`Catalog written: ${catalog.skillCount} skills`);
+	}
+
+	/**
+	 * Read catalog from disk. Returns null if missing, corrupt, or version mismatch.
+	 */
+	async read(): Promise<SkillCatalog | null> {
+		try {
+			const content = await readFile(CATALOG_PATH, "utf-8");
+			const parsed = JSON.parse(content) as SkillCatalog;
+			if (parsed.version !== CATALOG_VERSION) {
+				logger.verbose(`Catalog version mismatch (${parsed.version} vs ${CATALOG_VERSION})`);
+				return null;
+			}
+			return parsed;
+		} catch {
+			return null;
+		}
+	}
+
+	/**
+	 * Check whether the catalog is stale by comparing its generated timestamp
+	 * against the mtime of any SKILL.md file in the skills source path.
+	 */
+	async isStale(catalogGenerated: string, skillsBasePath: string): Promise<boolean> {
+		const catalogTime = new Date(catalogGenerated).getTime();
+		if (Number.isNaN(catalogTime)) return true;
+
+		try {
+			const entries = await readdir(skillsBasePath, { withFileTypes: true });
+			for (const entry of entries) {
+				if (!entry.isDirectory()) continue;
+				const skillMdPath = join(skillsBasePath, entry.name, "SKILL.md");
+				if (!existsSync(skillMdPath)) continue;
+				try {
+					const stats = await stat(skillMdPath);
+					if (stats.mtimeMs > catalogTime) return true;
+				} catch {
+					// Can't stat, skip
+				}
+			}
+		} catch {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Read catalog or regenerate it if missing/stale.
+	 * skillsBasePath is used for freshness checks and discovery.
+	 */
+	async readOrRegenerate(skillsBasePath: string): Promise<SkillCatalog> {
+		const existing = await this.read();
+
+		if (existing) {
+			const stale = await this.isStale(existing.generated, skillsBasePath);
+			if (!stale) {
+				logger.verbose("Catalog is fresh, using cached version");
+				return existing;
+			}
+			logger.verbose("Catalog is stale, regenerating");
+		} else {
+			logger.verbose("No catalog found, generating");
+		}
+
+		const skills = await discoverSkillsEnriched(skillsBasePath);
+		const catalog = await this.generate(skills, skillsBasePath);
+		// Best-effort write — don't fail if catalog dir isn't writable
+		try {
+			await this.write(catalog);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			logger.verbose(`Could not persist catalog: ${msg}`);
+		}
+		return catalog;
+	}
+}
+
+/** Singleton instance for convenience */
+export const skillCatalogGenerator = new SkillCatalogGenerator();

--- a/src/domains/skills/skill-catalog-generator.ts
+++ b/src/domains/skills/skill-catalog-generator.ts
@@ -3,9 +3,7 @@
  * The catalog is stored at ~/.claude/.skills-catalog.json and auto-refreshes when stale.
  */
 
-import { existsSync } from "node:fs";
-import { readFile, rename, stat, writeFile } from "node:fs/promises";
-import { readdir } from "node:fs/promises";
+import { readFile, readdir, rename, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, relative } from "node:path";
 import { discoverSkillsEnriched } from "../../commands/skills/skills-discovery.js";
@@ -16,6 +14,9 @@ import type {
 } from "../../commands/skills/types.js";
 import { logger } from "../../shared/logger.js";
 
+// Single catalog path regardless of source — intentional MVP design.
+// All discovered skills (whether from bundled engineer package or ~/.claude/skills/)
+// are merged into one catalog. Multi-source catalogs are out of scope for now.
 const CATALOG_PATH = join(homedir(), ".claude", ".skills-catalog.json");
 const CATALOG_VERSION = "1.0.0";
 
@@ -139,12 +140,11 @@ export class SkillCatalogGenerator {
 			for (const entry of entries) {
 				if (!entry.isDirectory()) continue;
 				const skillMdPath = join(skillsBasePath, entry.name, "SKILL.md");
-				if (!existsSync(skillMdPath)) continue;
 				try {
 					const stats = await stat(skillMdPath);
 					if (stats.mtimeMs > catalogTime) return true;
 				} catch {
-					// Can't stat, skip
+					// SKILL.md doesn't exist or can't be statted — skip this entry
 				}
 			}
 		} catch {

--- a/src/domains/skills/skill-search-index.ts
+++ b/src/domains/skills/skill-search-index.ts
@@ -170,17 +170,28 @@ export function search(
 		.slice(0, limit);
 }
 
+// Module-level cache — invalidated when catalog changes (identified by generated timestamp)
+let _cachedIndex: BM25Index | null = null;
+let _cachedCatalogTimestamp = "";
+
 /**
  * High-level search over a catalog skill list.
+ * Rebuilds the BM25 index only when the catalog timestamp changes.
  * Returns SkillSearchResult[] ready for display or JSON output.
  */
 export function searchSkills(
 	skills: CatalogSkillEntry[],
 	query: string,
 	limit = 10,
+	catalogTimestamp?: string,
 ): SkillSearchResult[] {
-	const index = buildIndex(skills);
-	const hits = search(index, query, limit);
+	// Rebuild index only if catalog changed or no cache exists
+	if (!_cachedIndex || catalogTimestamp !== _cachedCatalogTimestamp) {
+		_cachedIndex = buildIndex(skills);
+		_cachedCatalogTimestamp = catalogTimestamp ?? "";
+	}
+
+	const hits = search(_cachedIndex, query, limit);
 
 	return hits.map(({ docIndex, score }) => {
 		const skill = skills[docIndex];

--- a/src/domains/skills/skill-search-index.ts
+++ b/src/domains/skills/skill-search-index.ts
@@ -1,0 +1,196 @@
+/**
+ * BM25 full-text search index for skill catalog.
+ * Pure implementation — no external dependencies.
+ *
+ * BM25 formula:
+ *   score(q, D) = sum_i [ IDF(qi) * (tf * (k1+1)) / (tf + k1*(1 - b + b*|D|/avgDL)) ]
+ *   IDF(qi)     = ln((N - df + 0.5) / (df + 0.5) + 1)
+ */
+
+import type { CatalogSkillEntry, SkillSearchResult } from "../../commands/skills/types.js";
+
+// BM25 tuning constants
+const K1 = 1.2;
+const B = 0.75;
+
+const STOP_WORDS = new Set([
+	"the",
+	"a",
+	"an",
+	"and",
+	"or",
+	"but",
+	"in",
+	"on",
+	"at",
+	"to",
+	"for",
+	"of",
+	"is",
+	"are",
+	"was",
+	"were",
+	"be",
+	"been",
+	"use",
+	"with",
+	"from",
+	"by",
+	"as",
+	"this",
+	"that",
+	"it",
+]);
+
+interface BM25Document {
+	name: string;
+	tokens: string[];
+	length: number;
+}
+
+interface BM25Index {
+	docs: BM25Document[];
+	df: Map<string, number>; // document frequency per token
+	avgDL: number;
+	totalDocs: number;
+}
+
+/**
+ * Tokenize text: lowercase, split on non-word chars, filter short/stop tokens.
+ */
+function tokenize(text: string): string[] {
+	return text
+		.toLowerCase()
+		.split(/\W+/)
+		.filter((w) => w.length > 1 && !STOP_WORDS.has(w));
+}
+
+/**
+ * Build BM25 document text from a skill entry.
+ * Name gets 3x weight, keywords get 2x weight.
+ */
+function buildDocumentText(skill: CatalogSkillEntry): string {
+	const parts: string[] = [
+		// Boost name by repeating 3x
+		skill.name,
+		skill.name,
+		skill.name,
+		skill.description,
+	];
+
+	if (skill.keywords && skill.keywords.length > 0) {
+		// Boost keywords by repeating 2x
+		const kw = skill.keywords.join(" ");
+		parts.push(kw, kw);
+	}
+
+	if (skill.category) parts.push(skill.category);
+	if (skill.displayName && skill.displayName !== skill.name) parts.push(skill.displayName);
+
+	return parts.join(" ");
+}
+
+/**
+ * Build a BM25 index from a list of catalog skill entries.
+ */
+export function buildIndex(skills: CatalogSkillEntry[]): BM25Index {
+	const docs: BM25Document[] = skills.map((skill) => {
+		const tokens = tokenize(buildDocumentText(skill));
+		return { name: skill.name, tokens, length: tokens.length };
+	});
+
+	const df = new Map<string, number>();
+	for (const doc of docs) {
+		const seen = new Set<string>();
+		for (const token of doc.tokens) {
+			if (!seen.has(token)) {
+				df.set(token, (df.get(token) ?? 0) + 1);
+				seen.add(token);
+			}
+		}
+	}
+
+	const totalLength = docs.reduce((sum, d) => sum + d.length, 0);
+	const avgDL = docs.length > 0 ? totalLength / docs.length : 1;
+
+	return { docs, df, avgDL, totalDocs: docs.length };
+}
+
+/**
+ * Compute term frequency of a token in a document's token list.
+ */
+function termFreq(tokens: string[], token: string): number {
+	let count = 0;
+	for (const t of tokens) {
+		if (t === token) count++;
+	}
+	return count;
+}
+
+/**
+ * Run BM25 search over the index.
+ * Returns top-N results sorted by score descending.
+ */
+export function search(
+	index: BM25Index,
+	query: string,
+	limit = 10,
+): { docIndex: number; score: number }[] {
+	if (index.totalDocs === 0) return [];
+
+	const queryTokens = tokenize(query).filter((t) => !STOP_WORDS.has(t));
+	if (queryTokens.length === 0) return [];
+
+	const scores = index.docs.map((doc, docIndex) => {
+		let score = 0;
+
+		for (const token of queryTokens) {
+			const df = index.df.get(token) ?? 0;
+			if (df === 0) continue;
+
+			const N = index.totalDocs;
+			// IDF with smoothing to prevent negative values
+			const idf = Math.log((N - df + 0.5) / (df + 0.5) + 1);
+
+			const tf = termFreq(doc.tokens, token);
+			if (tf === 0) continue;
+
+			const docLen = doc.length;
+			const normTf = (tf * (K1 + 1)) / (tf + K1 * (1 - B + B * (docLen / index.avgDL)));
+
+			score += idf * normTf;
+		}
+
+		return { docIndex, score };
+	});
+
+	return scores
+		.filter((s) => s.score > 0)
+		.sort((a, b) => b.score - a.score)
+		.slice(0, limit);
+}
+
+/**
+ * High-level search over a catalog skill list.
+ * Returns SkillSearchResult[] ready for display or JSON output.
+ */
+export function searchSkills(
+	skills: CatalogSkillEntry[],
+	query: string,
+	limit = 10,
+): SkillSearchResult[] {
+	const index = buildIndex(skills);
+	const hits = search(index, query, limit);
+
+	return hits.map(({ docIndex, score }) => {
+		const skill = skills[docIndex];
+		return {
+			name: skill.name,
+			displayName: skill.displayName,
+			description: skill.description,
+			category: skill.category,
+			score,
+			path: skill.path,
+		};
+	});
+}

--- a/src/domains/skills/skill-search-index.ts
+++ b/src/domains/skills/skill-search-index.ts
@@ -46,6 +46,7 @@ interface BM25Document {
 	name: string;
 	tokens: string[];
 	length: number;
+	tf: Map<string, number>; // precomputed term frequency
 }
 
 interface BM25Index {
@@ -96,7 +97,11 @@ function buildDocumentText(skill: CatalogSkillEntry): string {
 export function buildIndex(skills: CatalogSkillEntry[]): BM25Index {
 	const docs: BM25Document[] = skills.map((skill) => {
 		const tokens = tokenize(buildDocumentText(skill));
-		return { name: skill.name, tokens, length: tokens.length };
+		const tf = new Map<string, number>();
+		for (const token of tokens) {
+			tf.set(token, (tf.get(token) || 0) + 1);
+		}
+		return { name: skill.name, tokens, length: tokens.length, tf };
 	});
 
 	const df = new Map<string, number>();
@@ -117,17 +122,6 @@ export function buildIndex(skills: CatalogSkillEntry[]): BM25Index {
 }
 
 /**
- * Compute term frequency of a token in a document's token list.
- */
-function termFreq(tokens: string[], token: string): number {
-	let count = 0;
-	for (const t of tokens) {
-		if (t === token) count++;
-	}
-	return count;
-}
-
-/**
  * Run BM25 search over the index.
  * Returns top-N results sorted by score descending.
  */
@@ -138,7 +132,7 @@ export function search(
 ): { docIndex: number; score: number }[] {
 	if (index.totalDocs === 0) return [];
 
-	const queryTokens = tokenize(query).filter((t) => !STOP_WORDS.has(t));
+	const queryTokens = tokenize(query);
 	if (queryTokens.length === 0) return [];
 
 	const scores = index.docs.map((doc, docIndex) => {
@@ -152,7 +146,7 @@ export function search(
 			// IDF with smoothing to prevent negative values
 			const idf = Math.log((N - df + 0.5) / (df + 0.5) + 1);
 
-			const tf = termFreq(doc.tokens, token);
+			const tf = doc.tf.get(token) || 0;
 			if (tf === 0) continue;
 
 			const docLen = doc.length;
@@ -170,7 +164,8 @@ export function search(
 		.slice(0, limit);
 }
 
-// Module-level cache — invalidated when catalog changes (identified by generated timestamp)
+// Module-level cache — safe for CLI (single process) and Express dashboard (single skillsBasePath).
+// If multi-project mode is added, cache key should include basePath, not just timestamp.
 let _cachedIndex: BM25Index | null = null;
 let _cachedCatalogTimestamp = "";
 

--- a/src/domains/web-server/routes/skill-browser-routes.ts
+++ b/src/domains/web-server/routes/skill-browser-routes.ts
@@ -7,6 +7,10 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { parseFrontmatter } from "@/commands/portable/frontmatter-parser.js";
+import { getSkillSourcePath } from "@/commands/skills/skills-discovery.js";
+import type { SkillSearchResult } from "@/commands/skills/types.js";
+import { skillCatalogGenerator } from "@/domains/skills/skill-catalog-generator.js";
+import { searchSkills } from "@/domains/skills/skill-search-index.js";
 import type { Express, Request, Response } from "express";
 
 interface SkillBrowserItem {
@@ -170,6 +174,37 @@ async function listSkills(): Promise<SkillBrowserItem[]> {
 }
 
 export function registerSkillBrowserRoutes(app: Express): void {
+	// GET /api/skills/search?q=<query>&limit=<n> — BM25 search over skill catalog
+	app.get("/api/skills/search", async (req: Request, res: Response) => {
+		const rawQuery = String(req.query.q ?? "").trim();
+		const rawLimit = String(req.query.limit ?? "10");
+
+		if (!rawQuery) {
+			res.status(400).json({ error: "Missing query parameter: q" });
+			return;
+		}
+
+		// Security: cap query length and clamp limit
+		const query = rawQuery.slice(0, 500);
+		const limit = Math.min(100, Math.max(1, Number.parseInt(rawLimit, 10) || 10));
+
+		try {
+			const sourcePath = getSkillSourcePath();
+			if (!sourcePath) {
+				res.json({ results: [] as SkillSearchResult[] });
+				return;
+			}
+
+			const catalog = await skillCatalogGenerator.readOrRegenerate(sourcePath);
+			const results = searchSkills(catalog.skills, query, limit);
+
+			// Paths are already relative in catalog entries — return as-is
+			res.json({ results });
+		} catch {
+			res.status(500).json({ error: "Search failed" });
+		}
+	});
+
 	// GET /api/skills/browse — list all installed skills with metadata
 	app.get("/api/skills/browse", async (_req: Request, res: Response) => {
 		try {

--- a/src/domains/web-server/routes/skill-browser-routes.ts
+++ b/src/domains/web-server/routes/skill-browser-routes.ts
@@ -7,8 +7,6 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { parseFrontmatter } from "@/commands/portable/frontmatter-parser.js";
-import { getSkillSourcePath } from "@/commands/skills/skills-discovery.js";
-import type { SkillSearchResult } from "@/commands/skills/types.js";
 import { skillCatalogGenerator } from "@/domains/skills/skill-catalog-generator.js";
 import { searchSkills } from "@/domains/skills/skill-search-index.js";
 import type { Express, Request, Response } from "express";
@@ -189,14 +187,11 @@ export function registerSkillBrowserRoutes(app: Express): void {
 		const limit = Math.min(100, Math.max(1, Number.parseInt(rawLimit, 10) || 10));
 
 		try {
-			const sourcePath = getSkillSourcePath();
-			if (!sourcePath) {
-				res.json({ results: [] as SkillSearchResult[] });
-				return;
-			}
+			// Use getSkillsDir() to match browse endpoint — both read from ~/.claude/skills/
+			const skillsDir = getSkillsDir();
 
-			const catalog = await skillCatalogGenerator.readOrRegenerate(sourcePath);
-			const results = searchSkills(catalog.skills, query, limit);
+			const catalog = await skillCatalogGenerator.readOrRegenerate(skillsDir);
+			const results = searchSkills(catalog.skills, query, limit, catalog.generated);
 
 			// Paths are already relative in catalog entries — return as-is
 			res.json({ results });

--- a/src/services/claude-data/skill-scanner.ts
+++ b/src/services/claude-data/skill-scanner.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { readFile, readdir } from "node:fs/promises";
+import { readFile, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import matter from "gray-matter";
@@ -119,11 +119,16 @@ async function getCkSkillMetadata(
  */
 export async function getSkillMetadata(skillPath: string): Promise<SkillFrontmatter | null> {
 	const skillMdPath = join(skillPath, "SKILL.md");
-	if (!existsSync(skillMdPath)) return null;
+	try {
+		await stat(skillMdPath);
+	} catch {
+		return null;
+	}
 
 	try {
 		const content = await readFile(skillMdPath, "utf-8");
-		const { data } = matter(content);
+		// CRITICAL: disable JS engine to prevent code execution from untrusted SKILL.md files
+		const { data } = matter(content, { engines: { javascript: { parse: () => ({}) } } });
 		return data as SkillFrontmatter;
 	} catch {
 		return null;

--- a/src/services/claude-data/skill-scanner.ts
+++ b/src/services/claude-data/skill-scanner.ts
@@ -8,6 +8,7 @@ import { readFile, readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import matter from "gray-matter";
+import type { SkillCatalog } from "../../commands/skills/types.js";
 
 export interface Skill {
 	id: string;
@@ -127,6 +128,28 @@ export async function getSkillMetadata(skillPath: string): Promise<SkillFrontmat
 	} catch {
 		return null;
 	}
+}
+
+/**
+ * Merge catalog fields into scanned skills.
+ * Catalog supplements existing fields — never replaces sourcePath, triggers, source, isCustomized, installedVersion.
+ */
+export function mergeWithCatalog(skills: Skill[], catalog: SkillCatalog): Skill[] {
+	const catalogByName = new Map(catalog.skills.map((s) => [s.name, s]));
+
+	return skills.map((skill) => {
+		const entry = catalogByName.get(skill.id);
+		if (!entry) return skill;
+
+		return {
+			...skill,
+			// Supplement category only if scanner didn't infer a real one
+			category: skill.category !== "General" ? skill.category : (entry.category ?? skill.category),
+			// Fill in version/author from catalog if missing in scanner result
+			version: skill.version ?? entry.version,
+			author: skill.author ?? entry.author,
+		};
+	});
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `ck skills --catalog` for enriched skill catalog generation with atomic writes and staleness detection
- Implement inline BM25 search (`ck skills --search "query"`) — zero external deps, ~80 LOC
- Add `/api/skills/search` dashboard endpoint with query capping and limit clamping
- Catalog enriches existing `scanSkills`/`listSkills` flows (supplement, not replace)
- Disable gray-matter JavaScript engine in all new `matter()` calls (RCE prevention)

## New Files

- `src/domains/skills/skill-catalog-generator.ts` — catalog generation with atomic write, staleness detection, auto-regeneration
- `src/domains/skills/skill-search-index.ts` — pure BM25 implementation (k1=1.2, b=0.75, word-count TF)
- `src/commands/skills/__tests__/skill-search-bm25.test.ts` — 11 unit tests

## Modified Files

- `src/commands/skills/types.ts` — `EnrichedSkillInfo`, `CatalogSkillEntry`, `SkillCatalog`, `SkillSearchResult`
- `src/commands/skills/skills-discovery.ts` — `discoverSkillsEnriched()`, `extractCrossRefs()`
- `src/commands/skills/skills-command.ts` — `handleCatalog()`, `handleSearch()`, `handleValidate()`, mutual exclusivity
- `src/cli/command-registry.ts` — `--catalog`, `--search`, `--validate`, `--json`, `--limit` options
- `src/domains/web-server/routes/skill-browser-routes.ts` — `GET /api/skills/search` endpoint
- `src/services/claude-data/skill-scanner.ts` — `mergeWithCatalog()` enrichment

## Security

- gray-matter JS engine disabled in all `matter()` calls
- Search query capped at 500 chars
- `--limit` clamped to 1-100
- API responses use relative paths only
- Atomic writes with same-directory temp file

## Test plan

- [x] `bun run validate` passes (3930 tests, 0 failures)
- [x] BM25 search returns correct rankings for exact, partial, and multi-term queries
- [x] Empty query returns empty results
- [x] Stop words excluded from scoring
- [x] Category filter works correctly
- [x] All pre-existing 3919 tests unaffected

Closes #644
Closes #645