### PR TITLE
fix(security): disable gray-matter JS engine in all matter() calls

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -128,13 +128,20 @@ jobs:
             --notes "Desktop release v${VERSION} for macOS, Windows, and Linux." \
             "${ASSETS[@]}"
 
+      - name: Check updater signing key
+        run: |
+          if [ -z "${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" ]; then
+            echo "::warning::TAURI_SIGNING_PRIVATE_KEY not configured — skipping updater manifest"
+            echo "SKIP_UPDATER=true" >> "$GITHUB_ENV"
+          fi
+
       - name: Generate latest.json for auto-updater
+        if: env.SKIP_UPDATER != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ github.ref_name }}"
           VERSION="${TAG#desktop-v}"
-          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${TAG}"
 
           # Build platform url map from uploaded assets
           DARWIN_URL=$(gh release view "$TAG" --json assets --jq \
@@ -144,8 +151,7 @@ jobs:
           WIN_URL=$(gh release view "$TAG" --json assets --jq \
             '.assets[] | select(.name | endswith(".msi")) | .browserDownloadUrl' | head -1)
 
-          # TODO: extract .sig files from tauri build output and embed here
-          # Requires TAURI_SIGNING_PRIVATE_KEY secret to sign bundles
+          # TODO: populate signatures from .sig files once TAURI_SIGNING_PRIVATE_KEY is set
           cat > latest.json <<EOF
           {
             "version": "${VERSION}",
@@ -160,4 +166,10 @@ jobs:
           }
           EOF
 
+          # Upload to desktop-specific stable tag for updater endpoint
           gh release upload "$TAG" latest.json --clobber
+          # Also maintain a floating 'desktop-latest' release for the updater endpoint
+          gh release create "desktop-latest" --title "Desktop Latest (auto-updater)" \
+            --notes "Auto-maintained by CI. Points to latest desktop release." \
+            --latest=false 2>/dev/null || true
+          gh release upload "desktop-latest" latest.json --clobber

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
 	"plugins": {
 		"updater": {
 			"endpoints": [
-				"https://github.com/mrgoonie/claudekit-cli/releases/latest/download/latest.json"
+				"https://github.com/mrgoonie/claudekit-cli/releases/download/desktop-latest/latest.json"
 			],
 			"pubkey": ""
 		}

--- a/src/commands/portable/frontmatter-parser.ts
+++ b/src/commands/portable/frontmatter-parser.ts
@@ -78,7 +78,9 @@ function parseFrontmatterFallback(content: string): FrontmatterParseResult | nul
  */
 export function parseFrontmatter(content: string): FrontmatterParseResult {
 	try {
-		const { data, content: body } = matter(content);
+		const { data, content: body } = matter(content, {
+			engines: { javascript: { parse: () => ({}) } },
+		});
 		const frontmatter: ParsedFrontmatter = {};
 		const warnings: string[] = [];
 

--- a/src/domains/plan-parser/plan-table-parser.ts
+++ b/src/domains/plan-parser/plan-table-parser.ts
@@ -468,7 +468,7 @@ export function parsePhasesFromBody(
  * Strips frontmatter once, then delegates to format parsers.
  */
 export function parsePlanPhases(content: string, dir: string, options?: ParseOptions): PlanPhase[] {
-	const { content: body } = matter(content);
+	const { content: body } = matter(content, { engines: { javascript: { parse: () => ({}) } } });
 	return parsePhasesFromBody(body, dir, options);
 }
 
@@ -482,7 +482,9 @@ export function parsePlanFile(
 ): { frontmatter: Record<string, unknown>; phases: PlanPhase[] } {
 	const content = readFileSync(planFilePath, "utf8");
 	const dir = dirname(planFilePath);
-	const { data: frontmatter, content: body } = matter(content);
+	const { data: frontmatter, content: body } = matter(content, {
+		engines: { javascript: { parse: () => ({}) } },
+	});
 	const phases = parsePhasesFromBody(body, dir, options);
 	return { frontmatter: frontmatter as Record<string, unknown>, phases };
 }

--- a/src/domains/plan-parser/plan-validator.ts
+++ b/src/domains/plan-parser/plan-validator.ts
@@ -21,7 +21,9 @@ export function validatePlanFile(filePath: string, strict = false): ValidationRe
 	const lines = content.split("\n");
 
 	// Check 1: YAML frontmatter present — reuse stripped body to avoid double-parse
-	const { data: frontmatter, content: body } = matter(content);
+	const { data: frontmatter, content: body } = matter(content, {
+		engines: { javascript: { parse: () => ({}) } },
+	});
 	if (!frontmatter || Object.keys(frontmatter).length === 0) {
 		issues.push({
 			line: 1,

--- a/src/domains/plan-parser/plan-writer.ts
+++ b/src/domains/plan-parser/plan-writer.ts
@@ -251,7 +251,9 @@ export function updatePhaseStatus(
 		return;
 	}
 
-	const { data: frontmatter, content: body } = matter(raw);
+	const { data: frontmatter, content: body } = matter(raw, {
+		engines: { javascript: { parse: () => ({}) } },
+	});
 
 	// Map status to display string (title case for table)
 	const statusDisplay: Record<string, string> = {
@@ -330,7 +332,9 @@ function updatePhaseFileFrontmatter(
 	newStatus: "pending" | "in-progress" | "completed",
 ): void {
 	const raw = readFileSync(phaseFile, "utf8");
-	const { data: frontmatter, content: body } = matter(raw);
+	const { data: frontmatter, content: body } = matter(raw, {
+		engines: { javascript: { parse: () => ({}) } },
+	});
 	const updated = { ...frontmatter, status: newStatus };
 	writeFileSync(phaseFile, matter.stringify(body, updated), "utf8");
 }
@@ -355,7 +359,9 @@ export function addPhase(
 		throw new Error("Non-canonical plan.md — cannot add phase");
 	}
 
-	const { data: frontmatter, content: body } = matter(raw);
+	const { data: frontmatter, content: body } = matter(raw, {
+		engines: { javascript: { parse: () => ({}) } },
+	});
 	const planDir = dirname(planFile);
 
 	// Collect existing phase IDs from table

--- a/src/domains/web-server/routes/action-routes.ts
+++ b/src/domains/web-server/routes/action-routes.ts
@@ -784,11 +784,19 @@ async function isActionPathAllowed(dirPath: string, projectId?: string): Promise
 
 	// Discovered projects encode their path in the ID (base64url after "discovered-" prefix).
 	// Decode and verify the requested path matches the encoded path.
+	// Security: also verify the decoded path is within cwd or homedir bounds
+	// to prevent forged discovered-* IDs from opening arbitrary directories.
 	if (projectId?.startsWith("discovered-")) {
 		try {
 			const encodedPath = projectId.slice("discovered-".length);
-			const discoveredPath = Buffer.from(encodedPath, "base64url").toString("utf-8");
-			if (resolve(discoveredPath) === dirPath) return true;
+			const discoveredPath = resolve(Buffer.from(encodedPath, "base64url").toString("utf-8"));
+			if (
+				discoveredPath === dirPath &&
+				(isPathInsideBase(discoveredPath, process.cwd()) ||
+					isPathInsideBase(discoveredPath, homedir()))
+			) {
+				return true;
+			}
 		} catch {
 			// Invalid base64 — fall through to other checks
 		}


### PR DESCRIPTION
## Summary

**Security fixes (3 commits):**

1. **gray-matter RCE** — Disable JS engine (`eval()`) in 7 remaining `matter()` callsites. `gray-matter` evaluates `---js` frontmatter blocks by default.
   - `plan-writer.ts` (3 calls), `plan-table-parser.ts` (2), `plan-validator.ts` (1), `frontmatter-parser.ts` (1)

2. **discovered-* ID bypass** — Forged `discovered-<base64>` project IDs could bypass action path allowlist, allowing `/api/actions/open` to open arbitrary directories. Now validates decoded path is within `cwd` or `homedir` bounds.

3. **Desktop updater** — Changed updater endpoint from `releases/latest` (shadowed by CLI releases) to `desktop-latest` tag. Skip `latest.json` generation if signing key not configured.

Closes #649

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run build` passes
- [x] 3928 tests pass (1 pre-existing flaky timeout)
- [x] Codex adversarial review — all 3 findings addressed
- [ ] Verify `ck plan create` parses plan frontmatter correctly
- [ ] Verify dashboard skill browser loads skill metadata
- [ ] Verify `/api/actions/open` rejects forged discovered-* IDs