### PR TITLE
fix(init): skip runtime artifacts in legacy migration

### DIFF
--- a/src/domains/migration/legacy-migration.ts
+++ b/src/domains/migration/legacy-migration.ts
@@ -3,8 +3,9 @@ import { join, relative } from "node:path";
 import { ManifestWriter } from "@/services/file-operations/manifest-writer.js";
 import { OwnershipChecker } from "@/services/file-operations/ownership-checker.js";
 import { mapWithLimit } from "@/shared/concurrent-file-ops.js";
+import { getOptimalConcurrency } from "@/shared/environment.js";
 import { logger } from "@/shared/logger.js";
-import { SKIP_DIRS_ALL } from "@/shared/skip-directories.js";
+import { SKIP_DIRS_ALL, hasSkippedDirectorySegment } from "@/shared/skip-directories.js";
 import type { Metadata, TrackedFile } from "@/types";
 import { writeFile } from "fs-extra";
 import { type ReleaseManifest, ReleaseManifestLoader } from "./release-manifest.js";
@@ -107,11 +108,23 @@ export class LegacyMigration {
 		manifest: ReleaseManifest,
 	): Promise<MigrationPreview> {
 		const files = await LegacyMigration.scanFiles(claudeDir);
+		const relevantFiles = files.filter((file) => {
+			const relativePath = relative(claudeDir, file).replace(/\\/g, "/");
+			return !hasSkippedDirectorySegment(relativePath);
+		});
+		const skippedRuntimeArtifacts = files.length - relevantFiles.length;
+
+		if (skippedRuntimeArtifacts > 0) {
+			logger.debug(
+				`Legacy migration ignored ${skippedRuntimeArtifacts} runtime artifact file(s) after scan`,
+			);
+		}
+
 		const preview: MigrationPreview = {
 			ckPristine: [],
 			ckModified: [],
 			userCreated: [],
-			totalFiles: files.length,
+			totalFiles: relevantFiles.length,
 		};
 
 		// Separate files by whether they're in manifest (need checksum) or not
@@ -121,7 +134,7 @@ export class LegacyMigration {
 			manifestChecksum: string;
 		}> = [];
 
-		for (const file of files) {
+		for (const file of relevantFiles) {
 			const relativePath = relative(claudeDir, file).replace(/\\/g, "/");
 			const manifestEntry = ReleaseManifestLoader.findFile(manifest, relativePath);
 
@@ -145,6 +158,7 @@ export class LegacyMigration {
 					const actualChecksum = await OwnershipChecker.calculateChecksum(file);
 					return { relativePath, actualChecksum, manifestChecksum };
 				},
+				getOptimalConcurrency(),
 			);
 
 			// Classify based on checksum comparison
@@ -236,6 +250,7 @@ export class LegacyMigration {
 					const checksum = await OwnershipChecker.calculateChecksum(fullPath);
 					return { relativePath, checksum, ownership };
 				},
+				getOptimalConcurrency(),
 			);
 
 			for (const { relativePath, checksum, ownership } of checksumResults) {

--- a/src/domains/migration/legacy-migration.ts
+++ b/src/domains/migration/legacy-migration.ts
@@ -109,7 +109,7 @@ export class LegacyMigration {
 	): Promise<MigrationPreview> {
 		const files = await LegacyMigration.scanFiles(claudeDir);
 		const relevantFiles = files.filter((file) => {
-			const relativePath = relative(claudeDir, file).replace(/\\/g, "/");
+			const relativePath = relative(claudeDir, file);
 			return !hasSkippedDirectorySegment(relativePath);
 		});
 		const skippedRuntimeArtifacts = files.length - relevantFiles.length;

--- a/src/shared/skip-directories.ts
+++ b/src/shared/skip-directories.ts
@@ -47,6 +47,23 @@ export const SKIP_DIRS_ALL: readonly string[] = [
 	...CLAUDE_CODE_INTERNAL_DIRS,
 ];
 
+const SKIP_DIRS_ALL_SET = new Set(SKIP_DIRS_ALL);
+
+/**
+ * Check whether a relative path contains any skipped directory segment.
+ * This is a defensive fallback for callers that operate on file paths
+ * after scanning, so runtime artifact trees never re-enter later stages.
+ */
+export function hasSkippedDirectorySegment(
+	relativePath: string,
+	skipDirs: readonly string[] = SKIP_DIRS_ALL,
+): boolean {
+	const segments = relativePath.replace(/\\/g, "/").split("/").filter(Boolean);
+	const skipSet = skipDirs === SKIP_DIRS_ALL ? SKIP_DIRS_ALL_SET : new Set(skipDirs);
+
+	return segments.some((segment) => skipSet.has(segment));
+}
+
 /**
  * Only Claude Code internal directories to skip
  * Use this for ClaudeKit-specific scanning (e.g., counting components)

--- a/tests/lib/migration/legacy-migration.test.ts
+++ b/tests/lib/migration/legacy-migration.test.ts
@@ -113,6 +113,36 @@ describe("LegacyMigration", () => {
 			expect(files.some((f) => f.includes("debug"))).toBe(false);
 			expect(files.some((f) => f.includes("projects"))).toBe(false);
 		});
+
+		test("skips nested runtime dependency directories inside skills", async () => {
+			await mkdir(join(tempDir, "skills", "mcp-management", "scripts", "node_modules", "ajv"), {
+				recursive: true,
+			});
+			await mkdir(join(tempDir, "skills", ".venv", "Lib", "site-packages", "pytz"), {
+				recursive: true,
+			});
+			await writeFile(join(tempDir, "skills", "custom-skill.md"), "# custom");
+			await writeFile(
+				join(tempDir, "skills", "mcp-management", "scripts", "install.ts"),
+				"console.log('install')",
+			);
+			await writeFile(
+				join(tempDir, "skills", "mcp-management", "scripts", "node_modules", "ajv", "index.js"),
+				"module.exports = {}",
+			);
+			await writeFile(
+				join(tempDir, "skills", ".venv", "Lib", "site-packages", "pytz", "__init__.py"),
+				"# pytz",
+			);
+
+			const files = await LegacyMigration.scanFiles(tempDir);
+
+			expect(files).toHaveLength(2);
+			expect(files.some((f) => f.endsWith("skills/custom-skill.md"))).toBe(true);
+			expect(files.some((f) => f.endsWith("skills/mcp-management/scripts/install.ts"))).toBe(true);
+			expect(files.some((f) => f.includes("node_modules"))).toBe(false);
+			expect(files.some((f) => f.includes(".venv"))).toBe(false);
+		});
 	});
 
 	describe("classifyFiles", () => {
@@ -170,6 +200,42 @@ describe("LegacyMigration", () => {
 
 			expect(preview.userCreated).toContain("custom.txt");
 		});
+
+		test("ignores nested runtime dependency trees when classifying files", async () => {
+			await mkdir(join(tempDir, "skills", "mcp-management", "scripts", "node_modules", "ajv"), {
+				recursive: true,
+			});
+			await mkdir(join(tempDir, "skills", ".venv", "Lib", "site-packages", "pytz"), {
+				recursive: true,
+			});
+			await writeFile(join(tempDir, "skills", "custom-skill.md"), "# custom");
+			await writeFile(
+				join(tempDir, "skills", "mcp-management", "scripts", "install.ts"),
+				"console.log('install')",
+			);
+			await writeFile(
+				join(tempDir, "skills", "mcp-management", "scripts", "node_modules", "ajv", "index.js"),
+				"module.exports = {}",
+			);
+			await writeFile(
+				join(tempDir, "skills", ".venv", "Lib", "site-packages", "pytz", "__init__.py"),
+				"# pytz",
+			);
+
+			const manifest = {
+				version: "1.0.0",
+				generatedAt: new Date().toISOString(),
+				files: [],
+			};
+
+			const preview = await LegacyMigration.classifyFiles(tempDir, manifest);
+
+			expect(preview.totalFiles).toBe(2);
+			expect(preview.userCreated).toContain("skills/custom-skill.md");
+			expect(preview.userCreated).toContain("skills/mcp-management/scripts/install.ts");
+			expect(preview.userCreated.some((f) => f.includes("node_modules"))).toBe(false);
+			expect(preview.userCreated.some((f) => f.includes(".venv"))).toBe(false);
+		});
 	});
 
 	describe("migrate", () => {
@@ -217,6 +283,47 @@ describe("LegacyMigration", () => {
 
 			expect(ckTracked?.ownership).toBe("ck");
 			expect(userTracked?.ownership).toBe("user");
+		});
+
+		test("does not track nested runtime dependency trees during migration", async () => {
+			const ckFile = join(tempDir, "commands", "plan.md");
+			const userFile = join(tempDir, "skills", "custom-skill.md");
+
+			await mkdir(join(tempDir, "commands"), { recursive: true });
+			await mkdir(join(tempDir, "skills", "mcp-management", "scripts", "node_modules", "ajv"), {
+				recursive: true,
+			});
+			await mkdir(join(tempDir, "skills", ".venv", "Lib", "site-packages", "pytz"), {
+				recursive: true,
+			});
+
+			await writeFile(ckFile, "# plan");
+			await writeFile(userFile, "# custom");
+			await writeFile(
+				join(tempDir, "skills", "mcp-management", "scripts", "node_modules", "ajv", "index.js"),
+				"module.exports = {}",
+			);
+			await writeFile(
+				join(tempDir, "skills", ".venv", "Lib", "site-packages", "pytz", "__init__.py"),
+				"# pytz",
+			);
+
+			const ckChecksum = await OwnershipChecker.calculateChecksum(ckFile);
+			const manifest = {
+				version: "1.0.0",
+				generatedAt: new Date().toISOString(),
+				files: [{ path: "commands/plan.md", checksum: ckChecksum, size: 6 }],
+			};
+
+			await LegacyMigration.migrate(tempDir, manifest, "test-kit", "1.0.0", false);
+
+			const metadata = await ManifestWriter.readManifest(tempDir);
+			const trackedPaths = metadata?.files?.map((file) => file.path) || [];
+
+			expect(trackedPaths).toContain("commands/plan.md");
+			expect(trackedPaths).toContain("skills/custom-skill.md");
+			expect(trackedPaths.some((path) => path.includes("node_modules"))).toBe(false);
+			expect(trackedPaths.some((path) => path.includes(".venv"))).toBe(false);
 		});
 	});
 });

--- a/tests/lib/migration/legacy-migration.test.ts
+++ b/tests/lib/migration/legacy-migration.test.ts
@@ -136,10 +136,13 @@ describe("LegacyMigration", () => {
 			);
 
 			const files = await LegacyMigration.scanFiles(tempDir);
+			const normalizedFiles = files.map((file) => file.replace(/\\/g, "/"));
 
 			expect(files).toHaveLength(2);
-			expect(files.some((f) => f.endsWith("skills/custom-skill.md"))).toBe(true);
-			expect(files.some((f) => f.endsWith("skills/mcp-management/scripts/install.ts"))).toBe(true);
+			expect(normalizedFiles.some((f) => f.endsWith("skills/custom-skill.md"))).toBe(true);
+			expect(
+				normalizedFiles.some((f) => f.endsWith("skills/mcp-management/scripts/install.ts")),
+			).toBe(true);
 			expect(files.some((f) => f.includes("node_modules"))).toBe(false);
 			expect(files.some((f) => f.includes(".venv"))).toBe(false);
 		});


### PR DESCRIPTION
## Summary

- skip nested runtime dependency trees such as `skills/.venv` and `skills/**/node_modules` during legacy ownership migration
- use platform-tuned checksum concurrency in the migration path instead of the generic default
- add regression tests covering scan, classify, and migrate behavior for nested runtime artifacts

## Root Cause

`ck init` was entering the legacy ownership-migration path for installs without current metadata and then hashing far too many files under `.claude/skills`. On Windows this included large runtime-generated trees like `.venv` and nested `node_modules`, which could exhaust file handles and fail with `EMFILE`.

## Validation

- [x] `bun test tests/lib/migration/legacy-migration.test.ts`
- [x] `bun test tests/utils/file-scanner.test.ts`
- [x] `bun test tests/lib/merge.test.ts`
- [x] `bun run validate`
