### PR TITLE
fix: normalize BOM-prefixed migrate frontmatter parsing

### DIFF
--- a/__tests__/commands/portable/frontmatter-parser.test.ts
+++ b/__tests__/commands/portable/frontmatter-parser.test.ts
@@ -110,6 +110,23 @@ Body.`;
 		expect(result.body).toBe("Body.");
 	});
 
+	it("handles BOM-prefixed frontmatter blocks", () => {
+		const content = `\uFEFF---
+description: Create API_SPEC.md + DB_DESIGN.md (Stage 3: Detail)
+argument-hint: [path1] [path2] ... or monorepo path
+---
+Body.`;
+
+		const result = parseFrontmatter(content);
+
+		expect(result.frontmatter.description).toBe(
+			"Create API_SPEC.md + DB_DESIGN.md (Stage 3: Detail)",
+		);
+		expect(result.frontmatter.argumentHint).toBe("[path1] [path2] ... or monorepo path");
+		expect(result.body).toBe("Body.");
+		expect(result.warnings).toEqual([]);
+	});
+
 	it("returns empty frontmatter when no frontmatter block exists", () => {
 		const content = "No frontmatter delimiters here.";
 

--- a/src/commands/__tests__/frontmatter-bom-discovery.test.ts
+++ b/src/commands/__tests__/frontmatter-bom-discovery.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { discoverAgents } from "../agents/agents-discovery.js";
+import { discoverCommands } from "../commands/commands-discovery.js";
+
+describe("frontmatter discovery with BOM-prefixed markdown", () => {
+	const testDir = join(tmpdir(), "claudekit-frontmatter-bom-discovery-test");
+
+	beforeAll(() => {
+		mkdirSync(testDir, { recursive: true });
+	});
+
+	afterAll(() => {
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	async function captureWarnings<T>(
+		fn: () => Promise<T>,
+	): Promise<{ result: T; warnings: string[] }> {
+		const originalLog = console.log;
+		const warnings: string[] = [];
+
+		console.log = (...args: unknown[]) => {
+			const message = args.map(String).join(" ");
+			if (message.includes("Failed to parse frontmatter")) {
+				warnings.push(message);
+			}
+		};
+
+		try {
+			const result = await fn();
+			return { result, warnings };
+		} finally {
+			console.log = originalLog;
+		}
+	}
+
+	it("recovers BOM-prefixed command frontmatter without warning", async () => {
+		const commandsDir = join(testDir, "commands");
+		mkdirSync(commandsDir, { recursive: true });
+		writeFileSync(
+			join(commandsDir, "plan.md"),
+			`\uFEFF---
+description: Create API_SPEC.md + DB_DESIGN.md (Stage 3: Detail)
+argument-hint: [path1] [path2] ... or monorepo path
+---
+
+# Plan
+`,
+		);
+
+		const { result: commands, warnings } = await captureWarnings(() =>
+			discoverCommands(commandsDir),
+		);
+
+		expect(warnings).toEqual([]);
+		expect(commands).toHaveLength(1);
+		expect(commands[0].description).toBe("Create API_SPEC.md + DB_DESIGN.md (Stage 3: Detail)");
+		expect(commands[0].frontmatter.argumentHint).toBe("[path1] [path2] ... or monorepo path");
+		expect(commands[0].body).toContain("# Plan");
+	});
+
+	it("recovers BOM-prefixed agent frontmatter without warning", async () => {
+		const agentsDir = join(testDir, "agents");
+		mkdirSync(agentsDir, { recursive: true });
+		writeFileSync(
+			join(agentsDir, "planner.md"),
+			`\uFEFF---
+name: Project Planner
+description: Create SRD.md + UI_SPEC.md (Stage 1: Specification)
+---
+
+# Planner
+`,
+		);
+
+		const { result: agents, warnings } = await captureWarnings(() => discoverAgents(agentsDir));
+
+		expect(warnings).toEqual([]);
+		expect(agents).toHaveLength(1);
+		expect(agents[0].displayName).toBe("Project Planner");
+		expect(agents[0].description).toBe("Create SRD.md + UI_SPEC.md (Stage 1: Specification)");
+		expect(agents[0].body).toContain("# Planner");
+	});
+});

--- a/src/commands/__tests__/frontmatter-bom-discovery.test.ts
+++ b/src/commands/__tests__/frontmatter-bom-discovery.test.ts
@@ -1,7 +1,8 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, spyOn } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { logger } from "../../shared/logger.js";
 import { discoverAgents } from "../agents/agents-discovery.js";
 import { discoverCommands } from "../commands/commands-discovery.js";
 
@@ -15,27 +16,6 @@ describe("frontmatter discovery with BOM-prefixed markdown", () => {
 	afterAll(() => {
 		rmSync(testDir, { recursive: true, force: true });
 	});
-
-	async function captureWarnings<T>(
-		fn: () => Promise<T>,
-	): Promise<{ result: T; warnings: string[] }> {
-		const originalLog = console.log;
-		const warnings: string[] = [];
-
-		console.log = (...args: unknown[]) => {
-			const message = args.map(String).join(" ");
-			if (message.includes("Failed to parse frontmatter")) {
-				warnings.push(message);
-			}
-		};
-
-		try {
-			const result = await fn();
-			return { result, warnings };
-		} finally {
-			console.log = originalLog;
-		}
-	}
 
 	it("recovers BOM-prefixed command frontmatter without warning", async () => {
 		const commandsDir = join(testDir, "commands");
@@ -51,15 +31,20 @@ argument-hint: [path1] [path2] ... or monorepo path
 `,
 		);
 
-		const { result: commands, warnings } = await captureWarnings(() =>
-			discoverCommands(commandsDir),
-		);
+		const warningSpy = spyOn(logger, "warning").mockImplementation(() => {});
+		try {
+			const commands = await discoverCommands(commandsDir);
 
-		expect(warnings).toEqual([]);
-		expect(commands).toHaveLength(1);
-		expect(commands[0].description).toBe("Create API_SPEC.md + DB_DESIGN.md (Stage 3: Detail)");
-		expect(commands[0].frontmatter.argumentHint).toBe("[path1] [path2] ... or monorepo path");
-		expect(commands[0].body).toContain("# Plan");
+			expect(warningSpy).not.toHaveBeenCalledWith(
+				expect.stringContaining("Failed to parse frontmatter"),
+			);
+			expect(commands).toHaveLength(1);
+			expect(commands[0].description).toBe("Create API_SPEC.md + DB_DESIGN.md (Stage 3: Detail)");
+			expect(commands[0].frontmatter.argumentHint).toBe("[path1] [path2] ... or monorepo path");
+			expect(commands[0].body).toContain("# Plan");
+		} finally {
+			warningSpy.mockRestore();
+		}
 	});
 
 	it("recovers BOM-prefixed agent frontmatter without warning", async () => {
@@ -76,12 +61,19 @@ description: Create SRD.md + UI_SPEC.md (Stage 1: Specification)
 `,
 		);
 
-		const { result: agents, warnings } = await captureWarnings(() => discoverAgents(agentsDir));
+		const warningSpy = spyOn(logger, "warning").mockImplementation(() => {});
+		try {
+			const agents = await discoverAgents(agentsDir);
 
-		expect(warnings).toEqual([]);
-		expect(agents).toHaveLength(1);
-		expect(agents[0].displayName).toBe("Project Planner");
-		expect(agents[0].description).toBe("Create SRD.md + UI_SPEC.md (Stage 1: Specification)");
-		expect(agents[0].body).toContain("# Planner");
+			expect(warningSpy).not.toHaveBeenCalledWith(
+				expect.stringContaining("Failed to parse frontmatter"),
+			);
+			expect(agents).toHaveLength(1);
+			expect(agents[0].displayName).toBe("Project Planner");
+			expect(agents[0].description).toBe("Create SRD.md + UI_SPEC.md (Stage 1: Specification)");
+			expect(agents[0].body).toContain("# Planner");
+		} finally {
+			warningSpy.mockRestore();
+		}
 	});
 });

--- a/src/commands/portable/frontmatter-parser.ts
+++ b/src/commands/portable/frontmatter-parser.ts
@@ -36,6 +36,10 @@ const KNOWN_KEYS: Record<string, keyof ParsedFrontmatter> = {
 	"argument-hint": "argumentHint",
 };
 
+function normalizeFrontmatterInput(content: string): string {
+	return content.replace(/^\uFEFF/, "");
+}
+
 /**
  * Regex-based fallback parser for when gray-matter/js-yaml fails on
  * unquoted YAML values containing colons, brackets, or other special chars.
@@ -77,8 +81,10 @@ function parseFrontmatterFallback(content: string): FrontmatterParseResult | nul
  * Parse frontmatter and body from markdown content string
  */
 export function parseFrontmatter(content: string): FrontmatterParseResult {
+	const normalizedContent = normalizeFrontmatterInput(content);
+
 	try {
-		const { data, content: body } = matter(content, {
+		const { data, content: body } = matter(normalizedContent, {
 			engines: { javascript: { parse: () => ({}) } },
 		});
 		const frontmatter: ParsedFrontmatter = {};
@@ -108,7 +114,7 @@ export function parseFrontmatter(content: string): FrontmatterParseResult {
 	} catch (error) {
 		// gray-matter failed (e.g. unquoted YAML values with colons/brackets).
 		// Try regex-based fallback before giving up.
-		const fallback = parseFrontmatterFallback(content);
+		const fallback = parseFrontmatterFallback(normalizedContent);
 		if (fallback && Object.keys(fallback.frontmatter).length > 0) {
 			logger.verbose(
 				`Failed to parse frontmatter: ${error instanceof Error ? error.message : "Unknown error"} (recovered via fallback)`,
@@ -119,7 +125,7 @@ export function parseFrontmatter(content: string): FrontmatterParseResult {
 		logger.warning(
 			`Failed to parse frontmatter: ${error instanceof Error ? error.message : "Unknown error"}`,
 		);
-		return { frontmatter: {}, body: content.trim(), warnings: [] };
+		return { frontmatter: {}, body: normalizedContent.trim(), warnings: [] };
 	}
 }
 


### PR DESCRIPTION
## Summary

- strip a leading UTF-8 BOM before markdown frontmatter parsing
- reuse the normalized input for both `gray-matter` and the regex fallback path
- add regression coverage for BOM-prefixed command and agent discovery

## Root Cause

`ck migrate` command and agent discovery expected the frontmatter delimiter `---` at byte 0. Files saved with a UTF-8 BOM caused `gray-matter` to fail, and the fallback parser missed the frontmatter block for the same reason, which surfaced noisy parse warnings during discovery.

## Validation

- [x] `bun run validate`
- [x] regression test for BOM-prefixed command discovery
- [x] regression test for BOM-prefixed agent discovery
