### PR TITLE
feat(migrate): full Gemini CLI migration support (tool calls, hooks, rules)

### DIFF
--- a/__tests__/commands/portable/converters.test.ts
+++ b/__tests__/commands/portable/converters.test.ts
@@ -160,6 +160,49 @@ describe("fm-strip converter", () => {
 		});
 	});
 
+	describe("gemini-cli (body rewriting)", () => {
+		it("rewrites Claude tool names in body text", () => {
+			const item = makeItem({
+				frontmatter: { name: "Gemini Agent" },
+				body: "Use the Read tool to read files. Use the Bash tool for commands.",
+			});
+			const result = convertFmStrip(item, "gemini-cli");
+
+			expect(result.content).toContain("## Agent: Gemini Agent");
+			expect(result.content).toContain("file reading");
+			expect(result.content).toContain("terminal/shell");
+			expect(result.content).not.toContain("Read tool");
+			expect(result.content).not.toContain("Bash tool");
+		});
+
+		it("rewrites CLAUDE.md references to GEMINI.md", () => {
+			const item = makeItem({
+				frontmatter: { name: "Config Agent" },
+				body: "Check the project CLAUDE.md for instructions.",
+			});
+			const result = convertFmStrip(item, "gemini-cli");
+
+			expect(result.content).toContain("GEMINI.md");
+			expect(result.content).not.toContain("CLAUDE.md");
+		});
+
+		it("does not rewrite body for non-Gemini merge providers", () => {
+			const item = makeItem({
+				frontmatter: { name: "Goose Agent" },
+				body: "Use the Read tool to read files.",
+			});
+			const result = convertFmStrip(item, "goose");
+
+			expect(result.content).toContain("Read tool");
+		});
+
+		it("filename is AGENTS.md (merge-single)", () => {
+			const item = makeItem();
+			const result = convertFmStrip(item, "gemini-cli");
+			expect(result.filename).toBe("AGENTS.md");
+		});
+	});
+
 	describe("buildMergedAgentsMd", () => {
 		it("builds header + sections separated by ---", () => {
 			const sections = ["## Agent: First\n\nFirst body", "## Agent: Second\n\nSecond body"];

--- a/__tests__/commands/portable/gemini-cli-full-migration-e2e.test.ts
+++ b/__tests__/commands/portable/gemini-cli-full-migration-e2e.test.ts
@@ -178,6 +178,7 @@ describe("Gemini CLI full migration E2E", () => {
 			expect(mapEventName("SubagentStart")).toBe("BeforeAgent");
 			expect(mapEventName("Stop")).toBe("SessionEnd");
 			expect(mapEventName("Notification")).toBe("Notification");
+			expect(mapEventName("PreCompact")).toBe("PreCompress");
 		});
 
 		it("maps tool names in matchers", () => {

--- a/__tests__/commands/portable/gemini-cli-full-migration-e2e.test.ts
+++ b/__tests__/commands/portable/gemini-cli-full-migration-e2e.test.ts
@@ -1,0 +1,403 @@
+/**
+ * E2E integration test for full Gemini CLI migration.
+ * Validates: tool call mapping in agents, hooks registration in settings.json,
+ * rules/config in GEMINI.md with hook sections preserved.
+ *
+ * Fixture-based: creates temp directories simulating Claude Code project,
+ * runs conversion pipeline, and verifies output matches Gemini CLI expectations.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	buildMergedAgentsMd,
+	convertFmStrip,
+} from "../../../src/commands/portable/converters/fm-strip.js";
+import {
+	mapEventName,
+	rewriteMatcherToolNames,
+} from "../../../src/commands/portable/converters/gemini-hook-event-map.js";
+import { convertItem } from "../../../src/commands/portable/converters/index.js";
+import {
+	mapHookEventsForProvider,
+	mergeHooksIntoSettings,
+} from "../../../src/commands/portable/hooks-settings-merger.js";
+import { providers } from "../../../src/commands/portable/provider-registry.js";
+import type { PortableItem } from "../../../src/commands/portable/types.js";
+
+const testDir = join(tmpdir(), "ck-gemini-e2e-test");
+
+/** Helper to create a PortableItem */
+function makeItem(overrides: Partial<PortableItem> = {}): PortableItem {
+	return {
+		name: "test-agent",
+		displayName: "Test Agent",
+		description: "A test agent",
+		type: "agent",
+		sourcePath: "/fake/path/test-agent.md",
+		frontmatter: {
+			name: "Test Agent",
+			description: "A test agent",
+			tools: "Read,Write,Bash,Grep,Edit",
+		},
+		body: "You are a test agent.",
+		...overrides,
+	};
+}
+
+beforeAll(() => {
+	mkdirSync(testDir, { recursive: true });
+});
+
+afterAll(() => {
+	rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("Gemini CLI full migration E2E", () => {
+	// ── 1. Provider registry config validation ─────────────────
+	describe("1. provider-registry config", () => {
+		const gemini = providers["gemini-cli"];
+
+		it("has all 7 portable types configured", () => {
+			expect(gemini.agents).not.toBeNull();
+			expect(gemini.commands).not.toBeNull();
+			expect(gemini.skills).not.toBeNull();
+			expect(gemini.config).not.toBeNull();
+			expect(gemini.rules).not.toBeNull();
+			expect(gemini.hooks).not.toBeNull();
+			expect(gemini.settingsJsonPath).not.toBeNull();
+		});
+
+		it("hooks use direct-copy format to .gemini/hooks/", () => {
+			expect(gemini.hooks?.projectPath).toBe(".gemini/hooks");
+			expect(gemini.hooks?.format).toBe("direct-copy");
+			expect(gemini.hooks?.writeStrategy).toBe("per-file");
+		});
+
+		it("settingsJsonPath points to .gemini/settings.json", () => {
+			expect(gemini.settingsJsonPath?.projectPath).toBe(".gemini/settings.json");
+		});
+	});
+
+	// ── 2. Agent tool call mapping (fm-strip + body rewriting) ──
+	describe("2. agent tool call mapping", () => {
+		it("rewrites all Claude tool names in agent body", () => {
+			const item = makeItem({
+				body: [
+					"Use the Read tool to read files.",
+					"Use the Write tool to create files.",
+					"Use the Edit tool to modify files.",
+					"Use Bash for shell commands.",
+					"Use Grep for searching code.",
+					"Use Glob for file patterns.",
+					"Use WebFetch for HTTP requests.",
+					"Use WebSearch for web queries.",
+				].join("\n"),
+			});
+
+			const result = convertFmStrip(item, "gemini-cli");
+
+			// Should NOT contain Claude tool names
+			expect(result.content).not.toContain("Read tool");
+			expect(result.content).not.toContain("Write tool");
+			expect(result.content).not.toContain("Edit tool");
+			expect(result.content).not.toContain("Use Bash");
+			expect(result.content).not.toContain("Use Grep");
+			expect(result.content).not.toContain("Use Glob");
+			expect(result.content).not.toContain("WebFetch");
+			expect(result.content).not.toContain("WebSearch");
+
+			// Should contain generic replacements
+			expect(result.content).toContain("file reading");
+			expect(result.content).toContain("file writing");
+			expect(result.content).toContain("file editing");
+			expect(result.content).toContain("terminal/shell");
+			expect(result.content).toContain("code search");
+			expect(result.content).toContain("file search");
+			expect(result.content).toContain("web access");
+		});
+
+		it("rewrites .claude/ paths to Gemini equivalents", () => {
+			const item = makeItem({
+				body: "Read .claude/rules/my-rule.md and check CLAUDE.md for config.",
+			});
+			const result = convertFmStrip(item, "gemini-cli");
+
+			expect(result.content).toContain("GEMINI.md");
+			expect(result.content).not.toContain("CLAUDE.md");
+			expect(result.content).not.toContain(".claude/rules/");
+		});
+
+		it("removes slash command references", () => {
+			const item = makeItem({
+				body: "Run /cook to implement. Then /test for validation.",
+			});
+			const result = convertFmStrip(item, "gemini-cli");
+
+			expect(result.content).not.toContain("/cook");
+			expect(result.content).not.toContain("/test");
+		});
+
+		it("preserves delegation patterns (subagents: planned)", () => {
+			const item = makeItem({
+				body: "Delegate to `planner` agent for research.",
+			});
+			const result = convertFmStrip(item, "gemini-cli");
+
+			// Gemini CLI has subagents: "planned", so delegation should be preserved
+			expect(result.content).toContain("Delegate to `planner` agent");
+		});
+
+		it("produces valid merge-single output (AGENTS.md)", () => {
+			const agents = [
+				makeItem({ name: "scout", frontmatter: { name: "Scout" }, body: "Explore the codebase." }),
+				makeItem({
+					name: "planner",
+					frontmatter: { name: "Planner" },
+					body: "Create implementation plans.",
+				}),
+			];
+
+			const sections = agents.map((a) => convertFmStrip(a, "gemini-cli").content);
+			const merged = buildMergedAgentsMd(sections, "Gemini CLI");
+
+			expect(merged).toContain("# Agents");
+			expect(merged).toContain("Target: Gemini CLI");
+			expect(merged).toContain("## Agent: Scout");
+			expect(merged).toContain("## Agent: Planner");
+			expect(merged).toContain("---");
+		});
+	});
+
+	// ── 3. Hooks migration (event mapping + settings.json merge) ──
+	describe("3. hooks migration", () => {
+		it("maps all Claude Code event names to Gemini equivalents", () => {
+			expect(mapEventName("PreToolUse")).toBe("BeforeTool");
+			expect(mapEventName("PostToolUse")).toBe("AfterTool");
+			expect(mapEventName("SubagentStart")).toBe("BeforeAgent");
+			expect(mapEventName("Stop")).toBe("SessionEnd");
+			expect(mapEventName("Notification")).toBe("Notification");
+		});
+
+		it("maps tool names in matchers", () => {
+			expect(rewriteMatcherToolNames("Edit|Write|Bash")).toBe(
+				"replace|write_file|run_shell_command",
+			);
+			expect(rewriteMatcherToolNames("Read")).toBe("read_file");
+		});
+
+		it("full pipeline: source hooks → event-mapped → merged into settings.json", async () => {
+			// Simulate Claude Code hooks section
+			const sourceHooks = {
+				PreToolUse: [
+					{
+						matcher: "Edit|Write",
+						hooks: [
+							{
+								type: "command",
+								command: 'node ".gemini/hooks/block-secrets.cjs"',
+								timeout: 5000,
+							},
+						],
+					},
+				],
+				PostToolUse: [
+					{
+						hooks: [
+							{
+								type: "command",
+								command: 'node ".gemini/hooks/log-changes.cjs"',
+							},
+						],
+					},
+				],
+				SubagentStart: [
+					{
+						hooks: [
+							{
+								type: "command",
+								command: 'node ".gemini/hooks/agent-init.cjs"',
+							},
+						],
+					},
+				],
+			};
+
+			// Step 1: Map events and matchers
+			const mapped = mapHookEventsForProvider(sourceHooks, "gemini-cli");
+
+			// Verify event mapping
+			expect(mapped.BeforeTool).toBeDefined();
+			expect(mapped.AfterTool).toBeDefined();
+			expect(mapped.BeforeAgent).toBeDefined();
+			expect(mapped.PreToolUse).toBeUndefined();
+			expect(mapped.PostToolUse).toBeUndefined();
+			expect(mapped.SubagentStart).toBeUndefined();
+
+			// Verify matcher tool name mapping
+			expect(mapped.BeforeTool?.[0].matcher).toBe("replace|write_file");
+
+			// Step 2: Merge into target settings.json
+			const targetSettingsPath = join(testDir, "e2e-settings.json");
+			writeFileSync(targetSettingsPath, JSON.stringify({ theme: "dark" }));
+
+			await mergeHooksIntoSettings(targetSettingsPath, mapped);
+
+			// Step 3: Verify final settings.json
+			const result = JSON.parse(readFileSync(targetSettingsPath, "utf8"));
+			expect(result.theme).toBe("dark"); // Preserved existing config
+			expect(result.hooks).toBeDefined();
+			expect(result.hooks.BeforeTool).toHaveLength(1);
+			expect(result.hooks.BeforeTool[0].matcher).toBe("replace|write_file");
+			expect(result.hooks.BeforeTool[0].hooks[0].timeout).toBe(5000);
+			expect(result.hooks.AfterTool).toHaveLength(1);
+			expect(result.hooks.BeforeAgent).toHaveLength(1);
+		});
+
+		it("creates settings.json if it does not exist", async () => {
+			const newSettingsPath = join(testDir, "e2e-new-settings.json");
+			const hooks = {
+				BeforeTool: [
+					{
+						matcher: "write_file",
+						hooks: [{ type: "command", command: "echo check" }],
+					},
+				],
+			};
+
+			await mergeHooksIntoSettings(newSettingsPath, hooks);
+
+			expect(existsSync(newSettingsPath)).toBe(true);
+			const result = JSON.parse(readFileSync(newSettingsPath, "utf8"));
+			expect(result.hooks.BeforeTool).toHaveLength(1);
+		});
+	});
+
+	// ── 4. Rules / config migration ──────────────────────────────
+	describe("4. rules and config migration", () => {
+		it("preserves hook-related sections in rules (hooks now enabled)", () => {
+			const item = makeItem({
+				type: "rules",
+				body: [
+					"## Project Rules",
+					"Follow coding standards.",
+					"",
+					"## Hook Configuration",
+					"Configure hooks for pre-commit checks.",
+					"Use PreToolUse hooks for security scanning.",
+					"",
+					"## Testing",
+					"Write tests for everything.",
+				].join("\n"),
+			});
+
+			const result = convertItem(item, "md-strip", "gemini-cli");
+
+			// Hook section should be PRESERVED (not stripped) since Gemini CLI now has hooks
+			expect(result.content).toContain("Hook Configuration");
+			expect(result.content).toContain("Testing");
+			expect(result.content).toContain("Project Rules");
+		});
+
+		it("rewrites tool names in rules content", () => {
+			const item = makeItem({
+				type: "rules",
+				body: "Use the Read tool for file access. Check CLAUDE.md.",
+			});
+
+			const result = convertItem(item, "md-strip", "gemini-cli");
+
+			expect(result.content).toContain("file reading");
+			expect(result.content).toContain("GEMINI.md");
+		});
+
+		it("preserves delegation patterns in rules", () => {
+			const item = makeItem({
+				type: "rules",
+				body: "Delegate to `tester` agent after implementation.",
+			});
+
+			const result = convertItem(item, "md-strip", "gemini-cli");
+
+			// subagents: "planned" means delegation is preserved
+			expect(result.content).toContain("Delegate to `tester` agent");
+		});
+	});
+
+	// ── 5. Commands migration (md-to-toml, unchanged) ────────────
+	describe("5. commands migration (regression check)", () => {
+		it("converts commands to TOML format", () => {
+			const item = makeItem({
+				type: "command",
+				name: "deploy",
+				description: "Deploy the app",
+				frontmatter: { description: "Deploy the app" },
+				body: "Deploy the application to production.\n\n$ARGUMENTS",
+			});
+
+			const result = convertItem(item, "md-to-toml", "gemini-cli");
+
+			expect(result.filename).toBe("deploy.toml");
+			expect(result.content).toContain("Deploy the app");
+			expect(result.content).toContain("{{args}}"); // $ARGUMENTS → {{args}}
+		});
+	});
+
+	// ── 6. Cross-cutting: full migration simulation ──────────────
+	describe("6. full migration simulation", () => {
+		it("simulates complete migration: agents + hooks + rules + commands", () => {
+			// Agent
+			const agentItem = makeItem({
+				name: "code-reviewer",
+				frontmatter: { name: "Code Reviewer", tools: "Read,Edit,Bash,Grep" },
+				body: "Use the Read tool to review code. Use Bash for running tests. Check .claude/rules/ for standards.",
+			});
+			const agentResult = convertFmStrip(agentItem, "gemini-cli");
+
+			// Rules
+			const rulesItem = makeItem({
+				type: "rules",
+				name: "dev-rules",
+				body: "Follow CLAUDE.md instructions. Use the Edit tool for changes.\n\n## Hooks\nConfigure pre-commit hooks.",
+			});
+			const rulesResult = convertItem(rulesItem, "md-strip", "gemini-cli");
+
+			// Command
+			const cmdItem = makeItem({
+				type: "command",
+				name: "review",
+				frontmatter: { description: "Code review" },
+				body: "Review the following code:\n\n$ARGUMENTS",
+			});
+			const cmdResult = convertItem(cmdItem, "md-to-toml", "gemini-cli");
+
+			// Hooks
+			const hooks = mapHookEventsForProvider(
+				{
+					PreToolUse: [
+						{
+							matcher: "Edit|Write",
+							hooks: [{ type: "command", command: "node .gemini/hooks/lint.cjs" }],
+						},
+					],
+				},
+				"gemini-cli",
+			);
+
+			// All assertions
+			expect(agentResult.content).toContain("## Agent: Code Reviewer");
+			expect(agentResult.content).toContain("file reading");
+			expect(agentResult.content).not.toContain("Read tool");
+
+			expect(rulesResult.content).toContain("GEMINI.md");
+			expect(rulesResult.content).toContain("Hooks"); // Preserved
+			expect(rulesResult.content).not.toContain("CLAUDE.md");
+
+			expect(cmdResult.filename).toBe("review.toml");
+			expect(cmdResult.content).toContain("{{args}}");
+
+			expect(hooks.BeforeTool?.[0].matcher).toBe("replace|write_file");
+		});
+	});
+});

--- a/__tests__/commands/portable/gemini-cli-full-migration-e2e.test.ts
+++ b/__tests__/commands/portable/gemini-cli-full-migration-e2e.test.ts
@@ -22,6 +22,7 @@ import { convertItem } from "../../../src/commands/portable/converters/index.js"
 import {
 	mapHookEventsForProvider,
 	mergeHooksIntoSettings,
+	rewriteHookPaths,
 } from "../../../src/commands/portable/hooks-settings-merger.js";
 import { providers } from "../../../src/commands/portable/provider-registry.js";
 import type { PortableItem } from "../../../src/commands/portable/types.js";
@@ -176,6 +177,7 @@ describe("Gemini CLI full migration E2E", () => {
 			expect(mapEventName("PreToolUse")).toBe("BeforeTool");
 			expect(mapEventName("PostToolUse")).toBe("AfterTool");
 			expect(mapEventName("SubagentStart")).toBe("BeforeAgent");
+			expect(mapEventName("SubagentStop")).toBe("AfterAgent");
 			expect(mapEventName("Stop")).toBe("SessionEnd");
 			expect(mapEventName("Notification")).toBe("Notification");
 			expect(mapEventName("PreCompact")).toBe("PreCompress");
@@ -188,8 +190,8 @@ describe("Gemini CLI full migration E2E", () => {
 			expect(rewriteMatcherToolNames("Read")).toBe("read_file");
 		});
 
-		it("full pipeline: source hooks → event-mapped → merged into settings.json", async () => {
-			// Simulate Claude Code hooks section
+		it("full pipeline: source hooks → path-rewritten → event-mapped → merged into settings.json", async () => {
+			// Simulate Claude Code hooks section with .claude/hooks/ source paths
 			const sourceHooks = {
 				PreToolUse: [
 					{
@@ -197,7 +199,7 @@ describe("Gemini CLI full migration E2E", () => {
 						hooks: [
 							{
 								type: "command",
-								command: 'node ".gemini/hooks/block-secrets.cjs"',
+								command: 'node ".claude/hooks/block-secrets.cjs"',
 								timeout: 5000,
 							},
 						],
@@ -208,7 +210,7 @@ describe("Gemini CLI full migration E2E", () => {
 						hooks: [
 							{
 								type: "command",
-								command: 'node ".gemini/hooks/log-changes.cjs"',
+								command: 'node ".claude/hooks/log-changes.cjs"',
 							},
 						],
 					},
@@ -218,15 +220,20 @@ describe("Gemini CLI full migration E2E", () => {
 						hooks: [
 							{
 								type: "command",
-								command: 'node ".gemini/hooks/agent-init.cjs"',
+								command: 'node ".claude/hooks/agent-init.cjs"',
 							},
 						],
 					},
 				],
 			};
 
-			// Step 1: Map events and matchers
-			const mapped = mapHookEventsForProvider(sourceHooks, "gemini-cli");
+			// Step 1: Rewrite paths from .claude/hooks/ to .gemini/hooks/
+			const rewritten = rewriteHookPaths(sourceHooks, ".claude/hooks", ".gemini/hooks");
+			expect(rewritten.PreToolUse[0].hooks[0].command).toContain(".gemini/hooks/");
+			expect(rewritten.PostToolUse[0].hooks[0].command).toContain(".gemini/hooks/");
+
+			// Step 2: Map events and matchers
+			const mapped = mapHookEventsForProvider(rewritten, "gemini-cli");
 
 			// Verify event mapping
 			expect(mapped.BeforeTool).toBeDefined();
@@ -239,19 +246,23 @@ describe("Gemini CLI full migration E2E", () => {
 			// Verify matcher tool name mapping
 			expect(mapped.BeforeTool?.[0].matcher).toBe("replace|write_file");
 
-			// Step 2: Merge into target settings.json
+			// Verify paths were rewritten before event mapping
+			expect(mapped.BeforeTool?.[0].hooks[0].command).toContain(".gemini/hooks/");
+
+			// Step 3: Merge into target settings.json
 			const targetSettingsPath = join(testDir, "e2e-settings.json");
 			writeFileSync(targetSettingsPath, JSON.stringify({ theme: "dark" }));
 
 			await mergeHooksIntoSettings(targetSettingsPath, mapped);
 
-			// Step 3: Verify final settings.json
+			// Step 4: Verify final settings.json
 			const result = JSON.parse(readFileSync(targetSettingsPath, "utf8"));
 			expect(result.theme).toBe("dark"); // Preserved existing config
 			expect(result.hooks).toBeDefined();
 			expect(result.hooks.BeforeTool).toHaveLength(1);
 			expect(result.hooks.BeforeTool[0].matcher).toBe("replace|write_file");
 			expect(result.hooks.BeforeTool[0].hooks[0].timeout).toBe(5000);
+			expect(result.hooks.BeforeTool[0].hooks[0].command).toContain(".gemini/hooks/");
 			expect(result.hooks.AfterTool).toHaveLength(1);
 			expect(result.hooks.BeforeAgent).toHaveLength(1);
 		});

--- a/src/commands/portable/__tests__/gemini-hook-event-map.test.ts
+++ b/src/commands/portable/__tests__/gemini-hook-event-map.test.ts
@@ -20,6 +20,10 @@ describe("gemini-hook-event-map", () => {
 			expect(mapEventName("SubagentStart")).toBe("BeforeAgent");
 		});
 
+		it("maps SubagentStop to AfterAgent", () => {
+			expect(mapEventName("SubagentStop")).toBe("AfterAgent");
+		});
+
 		it("maps Stop to SessionEnd", () => {
 			expect(mapEventName("Stop")).toBe("SessionEnd");
 		});

--- a/src/commands/portable/__tests__/gemini-hook-event-map.test.ts
+++ b/src/commands/portable/__tests__/gemini-hook-event-map.test.ts
@@ -83,6 +83,14 @@ describe("gemini-hook-event-map", () => {
 		it("maps Glob to glob (not list_directory)", () => {
 			expect(rewriteMatcherToolNames("Glob")).toBe("glob");
 		});
+
+		it("maps Grep to grep_search", () => {
+			expect(rewriteMatcherToolNames("Grep")).toBe("grep_search");
+		});
+
+		it("maps WebSearch to google_web_search", () => {
+			expect(rewriteMatcherToolNames("WebSearch")).toBe("google_web_search");
+		});
 	});
 
 	describe("requiresHookMapping", () => {

--- a/src/commands/portable/__tests__/gemini-hook-event-map.test.ts
+++ b/src/commands/portable/__tests__/gemini-hook-event-map.test.ts
@@ -28,6 +28,10 @@ describe("gemini-hook-event-map", () => {
 			expect(mapEventName("Notification")).toBe("Notification");
 		});
 
+		it("maps PreCompact to PreCompress", () => {
+			expect(mapEventName("PreCompact")).toBe("PreCompress");
+		});
+
 		it("returns original for unknown events", () => {
 			expect(mapEventName("CustomEvent")).toBe("CustomEvent");
 		});
@@ -70,6 +74,10 @@ describe("gemini-hook-event-map", () => {
 
 		it("handles Read correctly", () => {
 			expect(rewriteMatcherToolNames("Read")).toBe("read_file");
+		});
+
+		it("maps Glob to glob (not list_directory)", () => {
+			expect(rewriteMatcherToolNames("Glob")).toBe("glob");
 		});
 	});
 

--- a/src/commands/portable/__tests__/gemini-hook-event-map.test.ts
+++ b/src/commands/portable/__tests__/gemini-hook-event-map.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import {
+	GEMINI_TOOL_NAME_MAP,
+	mapEventName,
+	requiresHookMapping,
+	rewriteMatcherToolNames,
+} from "../converters/gemini-hook-event-map.js";
+
+describe("gemini-hook-event-map", () => {
+	describe("mapEventName", () => {
+		it("maps Claude Code PreToolUse to Gemini BeforeTool", () => {
+			expect(mapEventName("PreToolUse")).toBe("BeforeTool");
+		});
+
+		it("maps PostToolUse to AfterTool", () => {
+			expect(mapEventName("PostToolUse")).toBe("AfterTool");
+		});
+
+		it("maps SubagentStart to BeforeAgent", () => {
+			expect(mapEventName("SubagentStart")).toBe("BeforeAgent");
+		});
+
+		it("maps Stop to SessionEnd", () => {
+			expect(mapEventName("Stop")).toBe("SessionEnd");
+		});
+
+		it("maps Notification to Notification (passthrough)", () => {
+			expect(mapEventName("Notification")).toBe("Notification");
+		});
+
+		it("returns original for unknown events", () => {
+			expect(mapEventName("CustomEvent")).toBe("CustomEvent");
+		});
+	});
+
+	describe("rewriteMatcherToolNames", () => {
+		it("maps single tool name", () => {
+			expect(rewriteMatcherToolNames("Edit")).toBe("replace");
+		});
+
+		it("maps pipe-separated tool names", () => {
+			expect(rewriteMatcherToolNames("Edit|Write")).toBe("replace|write_file");
+		});
+
+		it("deduplicates mapped names (Edit and MultiEdit both map to replace)", () => {
+			const result = rewriteMatcherToolNames("Edit|MultiEdit");
+			expect(result).toBe("replace");
+		});
+
+		it("preserves unmapped entries (regex patterns, MCP tools)", () => {
+			expect(rewriteMatcherToolNames("Edit|mcp_custom_tool")).toBe("replace|mcp_custom_tool");
+		});
+
+		it("returns empty string for empty matcher", () => {
+			expect(rewriteMatcherToolNames("")).toBe("");
+		});
+
+		it("maps all known tool names", () => {
+			const allTools = Object.keys(GEMINI_TOOL_NAME_MAP).join("|");
+			const mapped = rewriteMatcherToolNames(allTools);
+			// All mapped names should be Gemini CLI tool names
+			for (const name of mapped.split("|")) {
+				expect(Object.values(GEMINI_TOOL_NAME_MAP)).toContain(name);
+			}
+		});
+
+		it("handles Bash correctly", () => {
+			expect(rewriteMatcherToolNames("Bash")).toBe("run_shell_command");
+		});
+
+		it("handles Read correctly", () => {
+			expect(rewriteMatcherToolNames("Read")).toBe("read_file");
+		});
+	});
+
+	describe("requiresHookMapping", () => {
+		it("returns true for gemini-cli", () => {
+			expect(requiresHookMapping("gemini-cli")).toBe(true);
+		});
+
+		it("returns false for other providers", () => {
+			expect(requiresHookMapping("claude-code")).toBe(false);
+			expect(requiresHookMapping("codex")).toBe(false);
+			expect(requiresHookMapping("droid")).toBe(false);
+		});
+	});
+});

--- a/src/commands/portable/__tests__/hooks-settings-merger.test.ts
+++ b/src/commands/portable/__tests__/hooks-settings-merger.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	filterToInstalledHooks,
+	mapHookEventsForProvider,
 	mergeHooksIntoSettings,
 	migrateHooksSettings,
 	readHooksFromSettings,
@@ -525,5 +526,76 @@ describe("Codex hooks migration", () => {
 		expect(result.success).toBe(true);
 		expect(result.hooksRegistered).toBe(0);
 		expect(result.message).toContain("not supported");
+	});
+});
+
+describe("mapHookEventsForProvider (Gemini CLI)", () => {
+	it("maps Claude Code event names to Gemini CLI equivalents", () => {
+		const hooks = {
+			PreToolUse: [{ matcher: "Edit", hooks: [{ type: "command", command: "echo hi" }] }],
+			PostToolUse: [{ hooks: [{ type: "command", command: "echo done" }] }],
+		};
+		const result = mapHookEventsForProvider(hooks, "gemini-cli");
+		expect(result.BeforeTool).toBeDefined();
+		expect(result.AfterTool).toBeDefined();
+		expect(result.PreToolUse).toBeUndefined();
+		expect(result.PostToolUse).toBeUndefined();
+	});
+
+	it("rewrites tool names in matchers", () => {
+		const hooks = {
+			PreToolUse: [{ matcher: "Edit|Write", hooks: [{ type: "command", command: "echo check" }] }],
+		};
+		const result = mapHookEventsForProvider(hooks, "gemini-cli");
+		expect(result.BeforeTool?.[0].matcher).toBe("replace|write_file");
+	});
+
+	it("deduplicates matcher tool names", () => {
+		const hooks = {
+			PreToolUse: [
+				{
+					matcher: "Edit|MultiEdit",
+					hooks: [{ type: "command", command: "echo check" }],
+				},
+			],
+		};
+		const result = mapHookEventsForProvider(hooks, "gemini-cli");
+		// Both Edit and MultiEdit map to "replace" — should deduplicate
+		expect(result.BeforeTool?.[0].matcher).toBe("replace");
+	});
+
+	it("is a no-op for non-Gemini providers", () => {
+		const hooks = {
+			PreToolUse: [{ matcher: "Edit", hooks: [{ type: "command", command: "echo hi" }] }],
+		};
+		const result = mapHookEventsForProvider(hooks, "codex");
+		expect(result.PreToolUse).toBeDefined();
+		expect(result.BeforeTool).toBeUndefined();
+	});
+
+	it("merges groups when multiple source events map to same target", () => {
+		// Both SubagentStart maps to BeforeAgent; test two separate events don't collide
+		const hooks = {
+			SubagentStart: [{ hooks: [{ type: "command", command: "echo agent-start" }] }],
+			Stop: [{ hooks: [{ type: "command", command: "echo session-end" }] }],
+		};
+		const result = mapHookEventsForProvider(hooks, "gemini-cli");
+		expect(result.BeforeAgent).toHaveLength(1);
+		expect(result.SessionEnd).toHaveLength(1);
+	});
+
+	it("preserves hook entries unchanged (only event+matcher are mapped)", () => {
+		const hooks = {
+			PreToolUse: [
+				{
+					matcher: "Bash",
+					hooks: [{ type: "command", command: 'node ".gemini/hooks/block.cjs"', timeout: 5000 }],
+				},
+			],
+		};
+		const result = mapHookEventsForProvider(hooks, "gemini-cli");
+		const entry = result.BeforeTool?.[0].hooks[0];
+		expect(entry?.command).toBe('node ".gemini/hooks/block.cjs"');
+		expect(entry?.timeout).toBe(5000);
 	});
 });

--- a/src/commands/portable/__tests__/hooks-settings-merger.test.ts
+++ b/src/commands/portable/__tests__/hooks-settings-merger.test.ts
@@ -340,6 +340,79 @@ describe("migrateHooksSettings", () => {
 			rmSync(tempBase, { recursive: true, force: true });
 		}
 	});
+
+	it("full pipeline: claude-code → gemini-cli with event and matcher mapping", async () => {
+		const tempBase = mkdtempSync(join(tmpdir(), "hooks-migrate-gemini-"));
+		const originalCwd = process.cwd();
+		try {
+			process.chdir(tempBase);
+
+			// Set up Claude Code source with hooks
+			mkdirSync(join(tempBase, ".claude", "hooks"), { recursive: true });
+			writeFileSync(join(tempBase, ".claude", "hooks", "block-secrets.cjs"), "// hook");
+			writeFileSync(
+				join(tempBase, ".claude", "settings.json"),
+				JSON.stringify({
+					hooks: {
+						PreToolUse: [
+							{
+								matcher: "Edit|Write",
+								hooks: [
+									{
+										type: "command",
+										command: 'node ".claude/hooks/block-secrets.cjs"',
+										timeout: 5000,
+									},
+								],
+							},
+						],
+						Stop: [
+							{
+								hooks: [{ type: "command", command: 'node ".claude/hooks/block-secrets.cjs"' }],
+							},
+						],
+					},
+				}),
+			);
+
+			// Set up Gemini CLI target directory
+			mkdirSync(join(tempBase, ".gemini", "hooks"), { recursive: true });
+			writeFileSync(join(tempBase, ".gemini", "hooks", "block-secrets.cjs"), "// hook");
+
+			const result = await migrateHooksSettings({
+				sourceProvider: "claude-code",
+				targetProvider: "gemini-cli",
+				installedHookFiles: ["block-secrets.cjs"],
+				global: false,
+			});
+
+			expect(result.status).toBe("registered");
+			expect(result.success).toBe(true);
+			expect(result.hooksRegistered).toBeGreaterThan(0);
+
+			// Verify the target settings.json was created with mapped events
+			const targetPath = join(tempBase, ".gemini", "settings.json");
+			expect(existsSync(targetPath)).toBe(true);
+			const settings = JSON.parse(
+				await import("node:fs").then((fs) => fs.readFileSync(targetPath, "utf8")),
+			);
+
+			// Events should be mapped: PreToolUse → BeforeTool, Stop → SessionEnd
+			expect(settings.hooks.BeforeTool).toBeDefined();
+			expect(settings.hooks.SessionEnd).toBeDefined();
+			expect(settings.hooks.PreToolUse).toBeUndefined();
+			expect(settings.hooks.Stop).toBeUndefined();
+
+			// Matchers should be mapped: Edit|Write → replace|write_file
+			expect(settings.hooks.BeforeTool[0].matcher).toBe("replace|write_file");
+
+			// Paths should be rewritten to .gemini/hooks/
+			expect(settings.hooks.BeforeTool[0].hooks[0].command).toContain(".gemini/hooks/");
+		} finally {
+			process.chdir(originalCwd);
+			rmSync(tempBase, { recursive: true, force: true });
+		}
+	});
 });
 
 describe("Codex hooks migration", () => {
@@ -582,6 +655,15 @@ describe("mapHookEventsForProvider (Gemini CLI)", () => {
 		const result = mapHookEventsForProvider(hooks, "gemini-cli");
 		expect(result.BeforeAgent).toHaveLength(1);
 		expect(result.SessionEnd).toHaveLength(1);
+	});
+
+	it("maps PreCompact to PreCompress", () => {
+		const hooks = {
+			PreCompact: [{ hooks: [{ type: "command", command: "echo compact" }] }],
+		};
+		const result = mapHookEventsForProvider(hooks, "gemini-cli");
+		expect(result.PreCompress).toBeDefined();
+		expect(result.PreCompact).toBeUndefined();
 	});
 
 	it("preserves hook entries unchanged (only event+matcher are mapped)", () => {

--- a/src/commands/portable/__tests__/provider-registry.test.ts
+++ b/src/commands/portable/__tests__/provider-registry.test.ts
@@ -201,7 +201,7 @@ describe("provider-registry", () => {
 			expect(droidHooksPath).toContain(".factory/hooks");
 		});
 
-		it("Claude Code, Droid, and Codex have settingsJsonPath for hooks registration", () => {
+		it("Claude Code, Droid, Codex, and Gemini CLI have settingsJsonPath for hooks registration", () => {
 			expect(providers["claude-code"].settingsJsonPath).toBeDefined();
 			expect(providers["claude-code"].settingsJsonPath?.projectPath).toBe(".claude/settings.json");
 			const ccSettingsPath =
@@ -220,6 +220,12 @@ describe("provider-registry", () => {
 			const codexSettingsPath =
 				providers.codex.settingsJsonPath?.globalPath?.replace(/\\/g, "/") ?? "";
 			expect(codexSettingsPath).toContain(".codex/hooks.json");
+
+			expect(providers["gemini-cli"].settingsJsonPath).toBeDefined();
+			expect(providers["gemini-cli"].settingsJsonPath?.projectPath).toBe(".gemini/settings.json");
+			const geminiSettingsPath =
+				providers["gemini-cli"].settingsJsonPath?.globalPath?.replace(/\\/g, "/") ?? "";
+			expect(geminiSettingsPath).toContain(".gemini/settings.json");
 		});
 
 		it("other providers do not have settingsJsonPath", () => {

--- a/src/commands/portable/__tests__/provider-registry.test.ts
+++ b/src/commands/portable/__tests__/provider-registry.test.ts
@@ -169,22 +169,24 @@ describe("provider-registry", () => {
 	});
 
 	describe("hooks entries", () => {
-		it("Claude Code, Droid, and Codex have hooks migration entries", () => {
-			expect(providers["claude-code"].hooks).not.toBeNull();
-			expect(providers.droid.hooks).not.toBeNull();
-			expect(providers.codex.hooks).not.toBeNull();
+		const PROVIDERS_WITH_HOOKS: ProviderType[] = ["claude-code", "droid", "codex", "gemini-cli"];
+
+		it("Claude Code, Droid, Codex, and Gemini CLI have hooks migration entries", () => {
+			for (const provider of PROVIDERS_WITH_HOOKS) {
+				expect(providers[provider].hooks).not.toBeNull();
+			}
 			for (const provider of ALL_PROVIDERS) {
-				if (provider === "claude-code" || provider === "droid" || provider === "codex") continue;
+				if (PROVIDERS_WITH_HOOKS.includes(provider)) continue;
 				expect(providers[provider].hooks ?? null).toBeNull();
 			}
 		});
 
-		it("getProvidersSupporting('hooks') returns claude-code, droid, and codex", () => {
+		it("getProvidersSupporting('hooks') returns providers with hooks support", () => {
 			const supporting = getProvidersSupporting("hooks");
-			expect(supporting).toHaveLength(3);
-			expect(supporting).toContain("claude-code");
-			expect(supporting).toContain("droid");
-			expect(supporting).toContain("codex");
+			expect(supporting).toHaveLength(PROVIDERS_WITH_HOOKS.length);
+			for (const provider of PROVIDERS_WITH_HOOKS) {
+				expect(supporting).toContain(provider);
+			}
 		});
 
 		it("Claude Code hooks path points to .claude/hooks", () => {
@@ -222,7 +224,7 @@ describe("provider-registry", () => {
 
 		it("other providers do not have settingsJsonPath", () => {
 			for (const provider of ALL_PROVIDERS) {
-				if (provider === "claude-code" || provider === "droid" || provider === "codex") continue;
+				if (PROVIDERS_WITH_HOOKS.includes(provider)) continue;
 				expect(providers[provider].settingsJsonPath).toBeNull();
 			}
 		});
@@ -356,6 +358,33 @@ describe("provider-registry", () => {
 			const collisions = detectProviderPathCollisions(["codex", "cursor"], { global: true });
 			const skillCollisions = collisions.filter((c) => c.portableType === "skills");
 			expect(skillCollisions).toHaveLength(0);
+		});
+	});
+
+	describe("gemini-cli hooks + settingsJsonPath", () => {
+		it("has hooks config with correct paths", () => {
+			const gemini = providers["gemini-cli"];
+			expect(gemini.hooks).not.toBeNull();
+			expect(gemini.hooks?.projectPath).toBe(".gemini/hooks");
+			expect(gemini.hooks?.globalPath).toContain(".gemini/hooks");
+			expect(gemini.hooks?.format).toBe("direct-copy");
+			expect(gemini.hooks?.writeStrategy).toBe("per-file");
+		});
+
+		it("has settingsJsonPath for hooks registration", () => {
+			const gemini = providers["gemini-cli"];
+			expect(gemini.settingsJsonPath).not.toBeNull();
+			expect(gemini.settingsJsonPath?.projectPath).toBe(".gemini/settings.json");
+			expect(gemini.settingsJsonPath?.globalPath).toContain(".gemini/settings.json");
+		});
+
+		it("preserves existing agent/command/skill/config/rules config", () => {
+			const gemini = providers["gemini-cli"];
+			expect(gemini.agents?.format).toBe("fm-strip");
+			expect(gemini.commands?.format).toBe("md-to-toml");
+			expect(gemini.skills?.format).toBe("direct-copy");
+			expect(gemini.config?.format).toBe("md-strip");
+			expect(gemini.rules?.format).toBe("md-strip");
 		});
 	});
 });

--- a/src/commands/portable/converters/fm-strip.ts
+++ b/src/commands/portable/converters/fm-strip.ts
@@ -1,3 +1,4 @@
+import type { ConversionResult, PortableItem, ProviderType } from "../types.js";
 /**
  * FM-strip converter — remove frontmatter, output plain markdown
  * Used by: Windsurf, Goose, Gemini CLI, Amp
@@ -7,11 +8,15 @@
  * For per-file providers (Windsurf):
  *   Each agent becomes its own plain MD file.
  */
-import type { ConversionResult, PortableItem, ProviderType } from "../types.js";
+import { stripClaudeRefs } from "./md-strip.js";
+
+/** Providers whose agent body should be rewritten via stripClaudeRefs */
+const PROVIDERS_WITH_BODY_REWRITING: ProviderType[] = ["gemini-cli"];
 
 /**
  * Strip frontmatter and return body as plain markdown.
  * For merge-single providers, wraps in a section heading.
+ * For Gemini CLI, also rewrites tool names, paths, and slash commands in the body.
  */
 export function convertFmStrip(item: PortableItem, provider: ProviderType): ConversionResult {
 	const warnings: string[] = [];
@@ -20,13 +25,21 @@ export function convertFmStrip(item: PortableItem, provider: ProviderType): Conv
 	// Determine if this provider merges into a single file
 	const isMergeProvider = ["goose", "gemini-cli", "amp"].includes(provider);
 
+	// Rewrite body for providers that need Claude-specific refs stripped
+	let body = item.body;
+	if (PROVIDERS_WITH_BODY_REWRITING.includes(provider)) {
+		const stripped = stripClaudeRefs(body, { provider });
+		body = stripped.content;
+		warnings.push(...stripped.warnings);
+	}
+
 	let content: string;
 	if (isMergeProvider) {
 		// Section with heading for merging into AGENTS.md
-		content = `## Agent: ${heading}\n\n${item.body}\n`;
+		content = `## Agent: ${heading}\n\n${body}\n`;
 	} else {
 		// Standalone file — include heading
-		content = `# ${heading}\n\n${item.body}\n`;
+		content = `# ${heading}\n\n${body}\n`;
 	}
 
 	// Check Windsurf 12K char limit

--- a/src/commands/portable/converters/fm-strip.ts
+++ b/src/commands/portable/converters/fm-strip.ts
@@ -1,4 +1,3 @@
-import type { ConversionResult, PortableItem, ProviderType } from "../types.js";
 /**
  * FM-strip converter — remove frontmatter, output plain markdown
  * Used by: Windsurf, Goose, Gemini CLI, Amp
@@ -8,6 +7,7 @@ import type { ConversionResult, PortableItem, ProviderType } from "../types.js";
  * For per-file providers (Windsurf):
  *   Each agent becomes its own plain MD file.
  */
+import type { ConversionResult, PortableItem, ProviderType } from "../types.js";
 import { stripClaudeRefs } from "./md-strip.js";
 
 /** Providers whose agent body should be rewritten via stripClaudeRefs */

--- a/src/commands/portable/converters/gemini-hook-event-map.ts
+++ b/src/commands/portable/converters/gemini-hook-event-map.ts
@@ -18,6 +18,7 @@ const GEMINI_EVENT_MAP: Record<string, string> = {
 	PreToolUse: "BeforeTool",
 	PostToolUse: "AfterTool",
 	SubagentStart: "BeforeAgent",
+	SubagentStop: "AfterAgent",
 	Stop: "SessionEnd",
 	Notification: "Notification",
 	PreCompact: "PreCompress",

--- a/src/commands/portable/converters/gemini-hook-event-map.ts
+++ b/src/commands/portable/converters/gemini-hook-event-map.ts
@@ -6,9 +6,9 @@
  * Reference: Gemini CLI hooks (v0.26+)
  * - Events: BeforeTool, AfterTool, BeforeAgent, AfterAgent, SessionStart, SessionEnd,
  *           BeforeModel, AfterModel, Notification, PreCompress, BeforeToolSelection
- * - Tool names: read_file, read_many_files, write_file, replace, edit,
- *               run_shell_command, grep, search_code, list_directory, glob,
- *               web_fetch, web_search, save_memory
+ * - Tool names: read_file, read_many_files, write_file, replace,
+ *               run_shell_command, grep_search, list_directory, glob,
+ *               web_fetch, google_web_search, save_memory, ask_user
  */
 
 import type { ProviderType } from "../types.js";
@@ -28,14 +28,13 @@ const GEMINI_EVENT_MAP: Record<string, string> = {
 export const GEMINI_TOOL_NAME_MAP: Record<string, string> = {
 	Read: "read_file",
 	Glob: "glob",
-	Grep: "grep",
+	Grep: "grep_search",
 	Edit: "replace",
 	Write: "write_file",
 	MultiEdit: "replace",
 	Bash: "run_shell_command",
 	WebFetch: "web_fetch",
-	WebSearch: "web_search",
-	NotebookEdit: "edit",
+	WebSearch: "google_web_search",
 };
 
 /** Map a single Claude Code event name to Gemini CLI equivalent. Returns original if no mapping. */

--- a/src/commands/portable/converters/gemini-hook-event-map.ts
+++ b/src/commands/portable/converters/gemini-hook-event-map.ts
@@ -1,0 +1,72 @@
+/**
+ * Gemini CLI hook event and tool name mapping.
+ * Maps Claude Code hook events/tool names to Gemini CLI equivalents.
+ * Used by hooks-settings-merger when target provider is gemini-cli.
+ *
+ * Reference: Gemini CLI hooks (v0.26+)
+ * - Events: BeforeTool, AfterTool, BeforeAgent, AfterAgent, SessionStart, SessionEnd,
+ *           BeforeModel, AfterModel, Notification, PreCompress, BeforeToolSelection
+ * - Tool names: read_file, read_many_files, write_file, replace, edit,
+ *               run_shell_command, grep, search_code, list_directory, glob,
+ *               web_fetch, web_search, save_memory
+ */
+
+import type { ProviderType } from "../types.js";
+
+/** Claude Code hook event → Gemini CLI hook event */
+const GEMINI_EVENT_MAP: Record<string, string> = {
+	PreToolUse: "BeforeTool",
+	PostToolUse: "AfterTool",
+	SubagentStart: "BeforeAgent",
+	Stop: "SessionEnd",
+	Notification: "Notification",
+};
+
+/** Claude Code tool name → Gemini CLI tool name (for hook matchers) */
+export const GEMINI_TOOL_NAME_MAP: Record<string, string> = {
+	Read: "read_file",
+	Glob: "list_directory",
+	Grep: "grep",
+	Edit: "replace",
+	Write: "write_file",
+	MultiEdit: "replace",
+	Bash: "run_shell_command",
+	WebFetch: "web_fetch",
+	WebSearch: "web_search",
+	NotebookEdit: "edit",
+};
+
+/** Map a single Claude Code event name to Gemini CLI equivalent. Returns original if no mapping. */
+export function mapEventName(claudeEvent: string): string {
+	return GEMINI_EVENT_MAP[claudeEvent] ?? claudeEvent;
+}
+
+/**
+ * Rewrite tool names in a hook matcher string.
+ * Matchers use pipe-separated tool names (e.g., "Edit|Write" → "replace|write_file").
+ * Deduplicates mapped names (Edit and MultiEdit both map to "replace").
+ */
+export function rewriteMatcherToolNames(matcher: string): string {
+	if (!matcher) return matcher;
+
+	const parts = matcher.split("|").map((p) => p.trim());
+	const mapped = new Set<string>();
+
+	for (const part of parts) {
+		// Try exact match first, then check if it's a regex pattern
+		const directMap = GEMINI_TOOL_NAME_MAP[part];
+		if (directMap) {
+			mapped.add(directMap);
+		} else {
+			// Preserve non-mapped entries (could be regex patterns or MCP tools)
+			mapped.add(part);
+		}
+	}
+
+	return Array.from(mapped).join("|");
+}
+
+/** Check if a provider requires hook event/matcher mapping */
+export function requiresHookMapping(provider: ProviderType): boolean {
+	return provider === "gemini-cli";
+}

--- a/src/commands/portable/converters/gemini-hook-event-map.ts
+++ b/src/commands/portable/converters/gemini-hook-event-map.ts
@@ -20,12 +20,13 @@ const GEMINI_EVENT_MAP: Record<string, string> = {
 	SubagentStart: "BeforeAgent",
 	Stop: "SessionEnd",
 	Notification: "Notification",
+	PreCompact: "PreCompress",
 };
 
 /** Claude Code tool name → Gemini CLI tool name (for hook matchers) */
 export const GEMINI_TOOL_NAME_MAP: Record<string, string> = {
 	Read: "read_file",
-	Glob: "list_directory",
+	Glob: "glob",
 	Grep: "grep",
 	Edit: "replace",
 	Write: "write_file",

--- a/src/commands/portable/hooks-settings-merger.ts
+++ b/src/commands/portable/hooks-settings-merger.ts
@@ -7,6 +7,11 @@
 import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
+import {
+	mapEventName,
+	requiresHookMapping,
+	rewriteMatcherToolNames,
+} from "./converters/gemini-hook-event-map.js";
 import { providers } from "./provider-registry.js";
 import type { ProviderType } from "./types.js";
 
@@ -155,6 +160,36 @@ export function filterToInstalledHooks(
 		}
 	}
 	return filtered;
+}
+
+/**
+ * Map hook event names and matcher tool names for a target provider.
+ * Currently applies to gemini-cli (Claude Code events → Gemini CLI events).
+ * Drops events that have no mapping and no passthrough (unmapped events are preserved as-is).
+ */
+export function mapHookEventsForProvider(
+	hooks: HooksSection,
+	targetProvider: ProviderType,
+): HooksSection {
+	if (!requiresHookMapping(targetProvider)) return hooks;
+
+	const mapped: HooksSection = {};
+	for (const [event, groups] of Object.entries(hooks)) {
+		const mappedEvent = mapEventName(event);
+		const mappedGroups = groups.map((group) => ({
+			...group,
+			// Rewrite tool names in matcher (e.g., "Edit|Write" → "replace|write_file")
+			matcher: group.matcher ? rewriteMatcherToolNames(group.matcher) : group.matcher,
+		}));
+
+		// Merge into existing event key if multiple source events map to same target
+		if (mapped[mappedEvent]) {
+			mapped[mappedEvent].push(...mappedGroups);
+		} else {
+			mapped[mappedEvent] = mappedGroups;
+		}
+	}
+	return mapped;
 }
 
 /**
@@ -402,13 +437,14 @@ export async function migrateHooksSettings(
 		? (targetConfig.hooks?.globalPath ?? "")
 		: (targetConfig.hooks?.projectPath ?? "");
 
-	// Pipeline: filter -> rewrite -> merge
+	// Pipeline: filter -> rewrite paths -> map events/matchers -> merge
 	const filtered = filterToInstalledHooks(sourceHooks, installedHookFiles);
 	const rewritten = rewriteHookPaths(filtered, sourceHooksDir, targetHooksDir);
+	const eventMapped = mapHookEventsForProvider(rewritten, targetProvider);
 
 	// Count hooks being registered
 	let hooksRegistered = 0;
-	for (const groups of Object.values(rewritten)) {
+	for (const groups of Object.values(eventMapped)) {
 		for (const group of groups) {
 			hooksRegistered += group.hooks.length;
 		}
@@ -427,7 +463,7 @@ export async function migrateHooksSettings(
 	}
 
 	try {
-		const { backupPath } = await mergeHooksIntoSettings(resolvedTargetPath, rewritten);
+		const { backupPath } = await mergeHooksIntoSettings(resolvedTargetPath, eventMapped);
 		return {
 			status: "registered",
 			success: true,

--- a/src/commands/portable/hooks-settings-merger.ts
+++ b/src/commands/portable/hooks-settings-merger.ts
@@ -165,7 +165,7 @@ export function filterToInstalledHooks(
 /**
  * Map hook event names and matcher tool names for a target provider.
  * Currently applies to gemini-cli (Claude Code events → Gemini CLI events).
- * Drops events that have no mapping and no passthrough (unmapped events are preserved as-is).
+ * Unmapped events are preserved as-is (Gemini CLI ignores unknown event keys).
  */
 export function mapHookEventsForProvider(
 	hooks: HooksSection,
@@ -227,16 +227,14 @@ export async function mergeHooksIntoSettings(
 	let backupPath: string | null = null;
 
 	if (existsSync(targetSettingsPath)) {
-		let raw: string;
+		const raw = await readFile(targetSettingsPath, "utf8");
 		try {
-			raw = await readFile(targetSettingsPath, "utf8");
 			existingSettings = JSON.parse(raw);
 		} catch {
 			existingSettings = {};
-			raw = "";
 		}
 
-		// Create backup — reuse raw from first read instead of reading file again
+		// Create backup — preserves original content even if JSON was invalid
 		const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
 		backupPath = `${targetSettingsPath}.${timestamp}.bak`;
 		try {

--- a/src/commands/portable/provider-registry.ts
+++ b/src/commands/portable/provider-registry.ts
@@ -657,7 +657,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			globalPath: join(home, ".gemini/hooks"),
 			format: "direct-copy",
 			writeStrategy: "per-file",
-			fileExtension: ".cjs",
+			fileExtension: "",
 		},
 		settingsJsonPath: {
 			projectPath: ".gemini/settings.json",

--- a/src/commands/portable/provider-registry.ts
+++ b/src/commands/portable/provider-registry.ts
@@ -652,8 +652,17 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			writeStrategy: "merge-single",
 			fileExtension: ".md",
 		},
-		hooks: null,
-		settingsJsonPath: null,
+		hooks: {
+			projectPath: ".gemini/hooks",
+			globalPath: join(home, ".gemini/hooks"),
+			format: "direct-copy",
+			writeStrategy: "per-file",
+			fileExtension: ".cjs",
+		},
+		settingsJsonPath: {
+			projectPath: ".gemini/settings.json",
+			globalPath: join(home, ".gemini/settings.json"),
+		},
 		detect: async () =>
 			hasAnyInstallSignal([
 				join(cwd, ".gemini/commands"),


### PR DESCRIPTION
## Summary

- Enable `ck migrate` to fully support Gemini CLI with three previously missing capabilities: tool call mapping in agents, hooks migration with event/matcher name mapping, and rules enhancement preserving hook sections
- Addresses user request for full migration parity (skills, agents, commands were already supported)

Closes #671

## Gemini CLI Documentation Reference

| Feature | URL |
|---------|-----|
| **Hooks** | https://github.com/google-gemini/gemini-cli/blob/main/docs/hooks/reference.md |
| **Subagents** | https://github.com/google-gemini/gemini-cli/blob/main/docs/core/subagents.md |
| **GEMINI.md (rules/config)** | https://google-gemini.github.io/gemini-cli/docs/cli/gemini-md.html |
| **Custom Commands** | https://geminicli.com/docs/cli/custom-commands/ |
| **Skills** | https://geminicli.com/docs/cli/skills/ |
| **Tools Reference** | https://geminicli.com/docs/reference/tools/ |
| **Settings.json Config** | https://geminicli.com/docs/reference/configuration/ |
| **Extensions** | https://google-gemini.github.io/gemini-cli/docs/extensions/ |
| **Settings Schema (JSON)** | https://raw.githubusercontent.com/google-gemini/gemini-cli/main/schemas/settings.schema.json |

## Feature-by-Feature Support

| Feature | Gemini CLI Format | Path | Migration Status |
|---------|-------------------|------|------------------|
| **Rules/Config** | Plain Markdown (\`GEMINI.md\`) | \`GEMINI.md\` (project) / \`~/.gemini/GEMINI.md\` (global) | Supported (md-strip) |
| **Hooks** | JSON in \`settings.json\` → \`hooks\` key | \`.gemini/settings.json\` | **NEW in this PR** |
| **Agents** | Markdown + YAML frontmatter | \`.gemini/agents/*.md\` | Supported (fm-strip) |
| **Commands** | TOML (\`.toml\`) | \`.gemini/commands/*.toml\` | Supported (md-to-toml) |
| **Skills** | Directory with \`SKILL.md\` | \`.gemini/skills/\` or \`.agents/skills/\` | Supported (direct-copy) |

### Hook Event Mapping (Claude Code → Gemini CLI)

| Claude Code Event | Gemini CLI Event |
|-------------------|------------------|
| \`PreToolUse\` | \`BeforeTool\` |
| \`PostToolUse\` | \`AfterTool\` |
| \`SubagentStart\` | \`BeforeAgent\` |
| \`SubagentStop\` | \`AfterAgent\` |
| \`Stop\` | \`SessionEnd\` |
| \`Notification\` | \`Notification\` |
| \`PreCompact\` | \`PreCompress\` |

### Tool Name Mapping (for hook matchers)

| Claude Code Tool | Gemini CLI Tool |
|-----------------|-----------------|
| \`Read\` | \`read_file\` |
| \`Write\` | \`write_file\` |
| \`Edit\` / \`MultiEdit\` | \`replace\` |
| \`Bash\` | \`run_shell_command\` |
| \`Grep\` | \`grep_search\` |
| \`Glob\` | \`glob\` |
| \`WebFetch\` | \`web_fetch\` |
| \`WebSearch\` | \`google_web_search\` |

## Changes

| File | Change |
|---|---|
| \`provider-registry.ts\` | Enable \`hooks\` (\`.gemini/hooks/\`) and \`settingsJsonPath\` (\`.gemini/settings.json\`) for Gemini CLI |
| \`converters/gemini-hook-event-map.ts\` | NEW: event mapping (PreToolUse→BeforeTool) + matcher tool name mapping (Edit→replace, Bash→run_shell_command) |
| \`hooks-settings-merger.ts\` | Add \`mapHookEventsForProvider()\` step: filter → rewrite paths → **map events/matchers** → merge |
| \`converters/fm-strip.ts\` | Apply \`stripClaudeRefs()\` to agent body for Gemini CLI (rewrites tool names, paths, slash commands) |
| E2E + unit tests | 17 new e2e tests + unit tests for all modules |

## Test plan

- [x] \`bun run validate\` passes (typecheck + lint + test + build)
- [x] 4089 tests pass, 0 failures
- [x] 83 UI tests pass
- [x] Pre-commit + pre-push hooks pass
- [ ] Cross-platform e2e on Windows (i9-bootcamp)