### PR TITLE
fix(migrate): improve provider detection with binary checks and grouped UI

### DIFF
--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -300,6 +300,18 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		const detectedProviders = await detectInstalledProviders();
 		let selectedProviders: ProviderType[];
 
+		// Build the full set of providers that support at least one portable type
+		const allSupportedProviders = Array.from(
+			new Set<ProviderType>([
+				...getProvidersSupporting("agents"),
+				...getProvidersSupporting("commands"),
+				...getProvidersSupporting("skills"),
+				...getProvidersSupporting("config"),
+				...getProvidersSupporting("rules"),
+				...getProvidersSupporting("hooks"),
+			]),
+		);
+
 		if (options.agent && options.agent.length > 0) {
 			// Validate provider names
 			const validProviders = Object.keys(providers);
@@ -312,65 +324,50 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			}
 			selectedProviders = options.agent as ProviderType[];
 		} else if (options.all) {
-			// All providers that support at least one type
-			const allProviders = new Set<ProviderType>([
-				...getProvidersSupporting("agents"),
-				...getProvidersSupporting("commands"),
-				...getProvidersSupporting("skills"),
-				...getProvidersSupporting("config"),
-				...getProvidersSupporting("rules"),
-				...getProvidersSupporting("hooks"),
-			]);
-			selectedProviders = Array.from(allProviders);
+			selectedProviders = allSupportedProviders;
 			p.log.info(`Migrating to all ${selectedProviders.length} providers`);
-		} else if (detectedProviders.length === 0) {
-			if (options.yes) {
-				const allProviders = new Set<ProviderType>([
-					...getProvidersSupporting("agents"),
-					...getProvidersSupporting("commands"),
-					...getProvidersSupporting("skills"),
-					...getProvidersSupporting("config"),
-					...getProvidersSupporting("rules"),
-					...getProvidersSupporting("hooks"),
-				]);
-				selectedProviders = Array.from(allProviders);
+		} else if (options.yes) {
+			// Non-interactive: auto-select detected providers, fall back to all
+			if (detectedProviders.length > 0) {
+				selectedProviders = detectedProviders;
+				p.log.info(
+					`Migrating to: ${detectedProviders.map((a) => pc.cyan(providers[a].displayName)).join(", ")}`,
+				);
+			} else {
+				selectedProviders = allSupportedProviders;
 				p.log.info("No providers detected, migrating to all");
+			}
+		} else {
+			// Interactive: grouped multiselect with detected + not-detected sections
+			const detectedSet = new Set(detectedProviders);
+			const notDetected = allSupportedProviders.filter((pv) => !detectedSet.has(pv));
+			const toOption = (key: ProviderType) => ({
+				value: key,
+				label: providers[key].displayName,
+			});
+
+			if (detectedProviders.length > 0) {
+				p.log.info(`Detected ${pc.cyan(String(detectedProviders.length))} installed provider(s)`);
 			} else {
 				p.log.warn("No providers detected on your system.");
-				const allProviders = new Set<ProviderType>([
-					...getProvidersSupporting("agents"),
-					...getProvidersSupporting("commands"),
-					...getProvidersSupporting("skills"),
-					...getProvidersSupporting("config"),
-					...getProvidersSupporting("rules"),
-					...getProvidersSupporting("hooks"),
-				]);
-				const selected = await p.multiselect({
-					message: "Select providers to migrate to",
-					options: Array.from(allProviders).map((key) => ({
-						value: key,
-						label: providers[key].displayName,
-					})),
-					required: true,
-				});
-				if (p.isCancel(selected)) {
-					p.cancel("Migrate cancelled");
-					return;
-				}
-				selectedProviders = selected as ProviderType[];
 			}
-		} else if (detectedProviders.length === 1 || options.yes) {
-			selectedProviders = detectedProviders;
-			p.log.info(
-				`Migrating to: ${detectedProviders.map((a) => pc.cyan(providers[a].displayName)).join(", ")}`,
-			);
-		} else {
-			const selected = await p.multiselect({
+
+			const groupOptions: Record<string, Array<{ value: ProviderType; label: string }>> = {};
+
+			if (detectedProviders.length > 0) {
+				groupOptions[`Detected ${pc.dim("(installed)")}`] = detectedProviders
+					.filter((d) => allSupportedProviders.includes(d))
+					.map(toOption);
+			}
+			if (notDetected.length > 0) {
+				groupOptions[`Not detected ${pc.dim("(select manually if installed)")}`] =
+					notDetected.map(toOption);
+			}
+
+			const selected = await p.groupMultiselect({
 				message: "Select providers to migrate to",
-				options: detectedProviders.map((a) => ({
-					value: a,
-					label: providers[a].displayName,
-				})),
+				options: groupOptions,
+				initialValues: detectedProviders.filter((d) => allSupportedProviders.includes(d)),
 				required: true,
 			});
 			if (p.isCancel(selected)) {

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -355,19 +355,22 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			const groupOptions: Record<string, Array<{ value: ProviderType; label: string }>> = {};
 
 			if (detectedProviders.length > 0) {
-				groupOptions[`Detected ${pc.dim("(installed)")}`] = detectedProviders
-					.filter((d) => allSupportedProviders.includes(d))
-					.map(toOption);
+				groupOptions[`Detected ${pc.dim("(installed)")}`] = detectedProviders.map(toOption);
 			}
 			if (notDetected.length > 0) {
 				groupOptions[`Not detected ${pc.dim("(select manually if installed)")}`] =
 					notDetected.map(toOption);
 			}
 
+			if (Object.keys(groupOptions).length === 0) {
+				p.cancel("No providers available");
+				return;
+			}
+
 			const selected = await p.groupMultiselect({
 				message: "Select providers to migrate to",
 				options: groupOptions,
-				initialValues: detectedProviders.filter((d) => allSupportedProviders.includes(d)),
+				initialValues: detectedProviders,
 				required: true,
 			});
 			if (p.isCancel(selected)) {

--- a/src/commands/portable/__tests__/provider-registry.test.ts
+++ b/src/commands/portable/__tests__/provider-registry.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import {
+	binaryCache,
 	detectProviderPathCollisions,
 	getProvidersSupporting,
+	hasBinaryInPath,
 	providers,
 } from "../provider-registry.js";
 import type { ProviderType } from "../types.js";
@@ -392,5 +394,59 @@ describe("provider-registry", () => {
 			expect(gemini.config?.format).toBe("md-strip");
 			expect(gemini.rules?.format).toBe("md-strip");
 		});
+	});
+
+	describe("hasBinaryInPath", () => {
+		afterEach(() => {
+			binaryCache.clear();
+		});
+
+		it("returns true for a binary known to exist (node)", () => {
+			// `node` is always available in the test environment
+			expect(hasBinaryInPath("node")).toBe(true);
+		});
+
+		it("returns false for a non-existent binary", () => {
+			expect(hasBinaryInPath("ck-nonexistent-binary-xyz-12345")).toBe(false);
+		});
+
+		it("caches results across repeated calls", () => {
+			// First call populates cache
+			const result1 = hasBinaryInPath("node");
+			expect(binaryCache.has("node")).toBe(true);
+
+			// Second call uses cache — same result, no extra shell spawn
+			const result2 = hasBinaryInPath("node");
+			expect(result1).toBe(result2);
+		});
+
+		it("caches false results too", () => {
+			hasBinaryInPath("ck-nonexistent-binary-xyz-12345");
+			expect(binaryCache.get("ck-nonexistent-binary-xyz-12345")).toBe(false);
+		});
+	});
+
+	describe("detect functions include binary checks", () => {
+		// Verify that providers with CLI binaries include hasBinaryInPath in their detect
+		// by checking that detect() returns a boolean (basic smoke test)
+		const providersWithBinaryDetection: ProviderType[] = [
+			"claude-code",
+			"codex",
+			"opencode",
+			"cursor",
+			"droid",
+			"goose",
+			"gemini-cli",
+			"amp",
+			"windsurf",
+			"antigravity",
+		];
+
+		for (const providerName of providersWithBinaryDetection) {
+			it(`${providerName} detect() returns a boolean`, async () => {
+				const result = await providers[providerName].detect();
+				expect(typeof result).toBe("boolean");
+			});
+		}
 	});
 });

--- a/src/commands/portable/provider-registry.ts
+++ b/src/commands/portable/provider-registry.ts
@@ -2,7 +2,7 @@
  * Provider registry — defines all supported providers with their
  * path configurations for agents, commands, and skills.
  */
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
@@ -37,19 +37,18 @@ function hasAnyInstallSignal(paths: Array<string | null | undefined>): boolean {
 }
 
 /** Cache for binary lookups (avoids repeated shell spawns within a single run) */
-const binaryCache = new Map<string, boolean>();
+export const binaryCache = new Map<string, boolean>();
 
 /**
  * Check if a binary exists in PATH. Uses `which` (Unix) or `where` (Windows).
  * Results are cached per binary name for the duration of the process.
  */
-function hasBinaryInPath(name: string): boolean {
+export function hasBinaryInPath(name: string): boolean {
 	const cached = binaryCache.get(name);
 	if (cached !== undefined) return cached;
 
 	try {
-		const cmd = isWin ? `where ${name}` : `which ${name}`;
-		execSync(cmd, { stdio: "pipe", timeout: 3000 });
+		execFileSync(isWin ? "where" : "which", [name], { stdio: "pipe", timeout: 3000 });
 		binaryCache.set(name, true);
 		return true;
 	} catch {
@@ -793,6 +792,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 		settingsJsonPath: null, // ~/.gemini/settings.json format incompatible with Claude Code
 		detect: async () =>
 			hasBinaryInPath("agy") ||
+			hasBinaryInPath("antigravity") ||
 			hasAnyInstallSignal([
 				join(cwd, ".agent/rules"),
 				join(cwd, ".agent/skills"),

--- a/src/commands/portable/provider-registry.ts
+++ b/src/commands/portable/provider-registry.ts
@@ -2,6 +2,7 @@
  * Provider registry — defines all supported providers with their
  * path configurations for agents, commands, and skills.
  */
+import { execSync } from "node:child_process";
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
@@ -9,7 +10,8 @@ import type { ProviderConfig, ProviderType } from "./types.js";
 
 const home = homedir();
 const cwd = process.cwd();
-const OPENCODE_BINARY_NAME = platform() === "win32" ? "opencode.exe" : "opencode";
+const isWin = platform() === "win32";
+const OPENCODE_BINARY_NAME = isWin ? "opencode.exe" : "opencode";
 
 function hasInstallSignal(path: string | null | undefined): boolean {
 	if (!path || !existsSync(path)) {
@@ -34,17 +36,42 @@ function hasAnyInstallSignal(paths: Array<string | null | undefined>): boolean {
 	return paths.some((path) => hasInstallSignal(path));
 }
 
+/** Cache for binary lookups (avoids repeated shell spawns within a single run) */
+const binaryCache = new Map<string, boolean>();
+
+/**
+ * Check if a binary exists in PATH. Uses `which` (Unix) or `where` (Windows).
+ * Results are cached per binary name for the duration of the process.
+ */
+function hasBinaryInPath(name: string): boolean {
+	const cached = binaryCache.get(name);
+	if (cached !== undefined) return cached;
+
+	try {
+		const cmd = isWin ? `where ${name}` : `which ${name}`;
+		execSync(cmd, { stdio: "pipe", timeout: 3000 });
+		binaryCache.set(name, true);
+		return true;
+	} catch {
+		binaryCache.set(name, false);
+		return false;
+	}
+}
+
 function hasOpenCodeInstallSignal(): boolean {
-	return hasAnyInstallSignal([
-		join(cwd, "opencode.json"),
-		join(cwd, "opencode.jsonc"),
-		join(cwd, ".opencode/agents"),
-		join(cwd, ".opencode/commands"),
-		join(home, ".config/opencode/AGENTS.md"),
-		join(home, ".config/opencode/agents"),
-		join(home, ".config/opencode/commands"),
-		join(home, ".opencode/bin", OPENCODE_BINARY_NAME),
-	]);
+	return (
+		hasBinaryInPath("opencode") ||
+		hasAnyInstallSignal([
+			join(cwd, "opencode.json"),
+			join(cwd, "opencode.jsonc"),
+			join(cwd, ".opencode/agents"),
+			join(cwd, ".opencode/commands"),
+			join(home, ".config/opencode/AGENTS.md"),
+			join(home, ".config/opencode/agents"),
+			join(home, ".config/opencode/commands"),
+			join(home, ".opencode/bin", OPENCODE_BINARY_NAME),
+		])
+	);
 }
 
 /**
@@ -102,6 +129,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			globalPath: join(home, ".claude/settings.json"),
 		},
 		detect: async () =>
+			hasBinaryInPath("claude") ||
 			hasAnyInstallSignal([
 				join(cwd, ".claude/agents"),
 				join(cwd, ".claude/commands"),
@@ -258,6 +286,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			globalPath: join(home, ".codex/hooks.json"),
 		},
 		detect: async () =>
+			hasBinaryInPath("codex") ||
 			hasAnyInstallSignal([
 				join(cwd, ".codex/config.toml"),
 				join(cwd, ".codex/agents"),
@@ -322,6 +351,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			globalPath: join(home, ".factory/settings.json"),
 		},
 		detect: async () =>
+			hasBinaryInPath("droid") ||
 			hasAnyInstallSignal([
 				join(cwd, ".factory/droids"),
 				join(cwd, ".factory/commands"),
@@ -376,6 +406,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 		// Note: .agents/skills/ intentionally omitted — it's shared across 5+ providers
 		// and can't identify cursor specifically. Cursor users always have .cursor/rules.
 		detect: async () =>
+			hasBinaryInPath("cursor") ||
 			hasAnyInstallSignal([
 				join(cwd, ".cursor/rules"),
 				join(home, ".cursor/rules"),
@@ -563,6 +594,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 		hooks: null,
 		settingsJsonPath: null,
 		detect: async () =>
+			hasBinaryInPath("windsurf") ||
 			hasAnyInstallSignal([
 				join(cwd, ".windsurf/rules"),
 				join(cwd, ".windsurf/workflows"),
@@ -606,6 +638,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 		hooks: null,
 		settingsJsonPath: null,
 		detect: async () =>
+			hasBinaryInPath("goose") ||
 			hasAnyInstallSignal([
 				join(cwd, ".goosehints"),
 				join(cwd, ".goose/skills"),
@@ -664,6 +697,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			globalPath: join(home, ".gemini/settings.json"),
 		},
 		detect: async () =>
+			hasBinaryInPath("gemini") ||
 			hasAnyInstallSignal([
 				join(cwd, ".gemini/commands"),
 				join(cwd, "GEMINI.md"),
@@ -707,6 +741,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 		hooks: null,
 		settingsJsonPath: null,
 		detect: async () =>
+			hasBinaryInPath("amp") ||
 			hasAnyInstallSignal([
 				join(cwd, ".amp/rules"),
 				join(cwd, "AGENT.md"), // Amp's primary config (not shared with other providers)
@@ -757,12 +792,14 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 		hooks: null, // ~/.gemini/settings.json has no user-configurable hooks section
 		settingsJsonPath: null, // ~/.gemini/settings.json format incompatible with Claude Code
 		detect: async () =>
+			hasBinaryInPath("agy") ||
 			hasAnyInstallSignal([
 				join(cwd, ".agent/rules"),
 				join(cwd, ".agent/skills"),
 				join(cwd, ".agent/workflows"),
 				join(cwd, "GEMINI.md"),
-				join(home, ".gemini/antigravity/skills"), // Global skills dir (requires actual usage, not just install)
+				join(home, ".gemini/antigravity"), // Global antigravity config dir
+				join(home, ".gemini/antigravity/skills"),
 			]),
 	},
 	cline: {


### PR DESCRIPTION
## Summary

- Add `hasBinaryInPath()` detection for 11 CLI providers (claude, codex, opencode, cursor, droid, goose, gemini, amp, windsurf, agy/antigravity) — previously only config dirs were checked, so providers with installed binaries but no config yet were invisible
- Replace flat `multiselect` with `groupMultiselect` showing "Detected (installed)" pre-selected and "Not detected (select manually if installed)" — users can now override missed detections without being forced to install to unknown stacks
- Add `~/.gemini/antigravity/` dir check for Antigravity detection

Reported by user: `ck migrate` only showed 2 providers (Claude Code + OpenCode) despite having Codex TUI and others installed.

## Test plan

- [x] Typecheck passes
- [x] Lint passes
- [x] 4141 tests pass, 0 fail
- [x] Build passes
- [x] UI build + UI tests pass
- [ ] Manual: run `ck migrate` on system with Codex TUI installed — should now appear in "Detected" group
- [ ] Manual: verify undetected providers appear in "Not detected" group and can be manually selected