### PR TITLE
fix: statusline theme colors stripped by Zod schema

### DIFF
--- a/src-tauri/src/core/schema.rs
+++ b/src-tauri/src/core/schema.rs
@@ -94,4 +94,10 @@ pub struct StatuslineTheme {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub separator: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quota_low: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quota_high: Option<String>,
 }

--- a/src/__tests__/types/statusline-layout-schema.test.ts
+++ b/src/__tests__/types/statusline-layout-schema.test.ts
@@ -77,6 +77,49 @@ describe("StatuslineLayoutSchema", () => {
 			});
 			expect(result.success).toBe(true);
 		});
+
+		// TDD Red: quotaLow/quotaHigh missing from StatuslineThemeSchema — fields get stripped silently
+		it("accepts quotaLow and quotaHigh in theme", () => {
+			const result = StatuslineLayoutSchema.safeParse({
+				theme: { quotaLow: "green", quotaHigh: "yellow" },
+			});
+			expect(result.success).toBe(true);
+			// These assertions fail because Zod strips unknown fields
+			if (result.success) {
+				expect(result.data.theme?.quotaLow).toBe("green");
+				expect(result.data.theme?.quotaHigh).toBe("yellow");
+			}
+		});
+
+		// TDD Red: fields stripped when routed through CkConfigSchema
+		it("preserves quotaLow/quotaHigh through CkConfigSchema parse", () => {
+			const result = CkConfigSchema.safeParse({
+				statuslineLayout: {
+					theme: { quotaLow: "cyan", quotaHigh: "red" },
+				},
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.statuslineLayout?.theme?.quotaLow).toBe("cyan");
+				expect(result.data.statuslineLayout?.theme?.quotaHigh).toBe("red");
+			}
+		});
+
+		// TDD Red: non-alphabetic quotaLow should be rejected (currently ignored — schema doesn't know the field)
+		it("rejects non-alphabetic quotaLow", () => {
+			const result = StatuslineLayoutSchema.safeParse({
+				theme: { quotaLow: "#ff0000" },
+			});
+			expect(result.success).toBe(false);
+		});
+
+		// Regression guard: must still pass after schema fix
+		it("accepts theme without quotaLow/quotaHigh (backward compat)", () => {
+			const result = StatuslineLayoutSchema.safeParse({
+				theme: { contextLow: "green" },
+			});
+			expect(result.success).toBe(true);
+		});
 	});
 });
 

--- a/src/types/ck-config.ts
+++ b/src/types/ck-config.ts
@@ -147,6 +147,16 @@ export const StatuslineThemeSchema = z.object({
 		.max(30)
 		.regex(/^[a-zA-Z]+$/)
 		.default("dim"),
+	quotaLow: z
+		.string()
+		.max(30)
+		.regex(/^[a-zA-Z]+$/)
+		.optional(),
+	quotaHigh: z
+		.string()
+		.max(30)
+		.regex(/^[a-zA-Z]+$/)
+		.optional(),
 });
 export type StatuslineTheme = z.infer<typeof StatuslineThemeSchema>;
 


### PR DESCRIPTION
## Summary

- Added `quotaLow` and `quotaHigh` optional fields to `StatuslineThemeSchema` (Zod) and `StatuslineTheme` (Rust/Tauri)
- These fields were silently stripped on config save, causing Builder-configured quota colors to not apply at runtime

Closes #674

## Root Cause

`StatuslineThemeSchema` in `ck-config.ts` did not include `quotaLow`/`quotaHigh`. The UI `StatuslineTheme` interface had them, and the Builder sent them on save, but `CkConfigSchema.parse()` stripped unknown fields. Runtime `getQuotaColorName()` fell back to `theme.muted` (dim) — nearly invisible on dark terminals.

## Changes

| File | Change |
|------|--------|
| `src/types/ck-config.ts` | Added `quotaLow`, `quotaHigh` optional fields to `StatuslineThemeSchema` |
| `src-tauri/src/core/schema.rs` | Added `quota_low`, `quota_high` to Rust `StatuslineTheme` struct |
| `src/__tests__/types/statusline-layout-schema.test.ts` | Added 4 TDD tests for schema validation |

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` passes
- [x] `bun test` — 4109 pass, 0 fail
- [x] UI tests — 83 pass
- [x] `cargo check` — clean
- [x] quotaLow/quotaHigh survive CkConfigSchema roundtrip
- [x] Non-alphabetic values rejected
- [x] Backward compat — configs without quota fields still parse