### PR TITLE
feat: add phase 1 rust backend core for desktop control center

### DIFF
--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -48,7 +48,13 @@ The codebase underwent a major modularization refactor, reducing 24 large files 
 ### Desktop App (Tauri v2)
 - **Tauri v2**: Native desktop wrapper (Rust backend, system webview)
 - **Plugins**: tauri-plugin-updater (auto-update), tauri-plugin-store (persistence), tauri-plugin-dialog (native dialogs)
-- **Rust crates**: dirs (platform paths), serde/serde_json (serialization)
+- **Rust crates**: dirs (platform paths), serde/serde_json (serialization), walkdir (filesystem scans), serde_yaml (frontmatter parsing)
+
+### Desktop App Implementation
+- `src-tauri/` now contains Phase 1 native read-side coverage for sessions, agents, commands, skills, MCP discovery, dashboard aggregates, and system diagnostics.
+- `src-tauri/src/core/` now includes shared helpers for frontmatter parsing and Claude project/session path resolution.
+- `src/ui/src/lib/tauri-commands.ts` now exposes the expanded typed invoke surface for native mode.
+- Browser mode still uses the Express `/api` backend for live UI data flow; the desktop routing switchover remains a later phase.
 
 ### Development Tools
 - **Biome**: Fast linting and formatting

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -14,6 +14,12 @@ ClaudeKit CLI (`ck`) is a command-line tool for bootstrapping and updating Claud
 
 **Current Status**: Active Development / Maintenance Phase
 
+## Desktop Control Center Foundation
+
+- Tauri v2 native shell now has Phase 1 backend coverage for sessions, entity browsers, MCP discovery, dashboard aggregates, and system diagnostics.
+- Typed invoke wrappers in `src/ui/src/lib/tauri-commands.ts` cover the expanded native command surface.
+- Browser mode still uses the Express `/api` backend today; the dual-mode routing switchover is still pending follow-up phases.
+
 ---
 
 ## Release Timeline

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -77,6 +77,9 @@ Commands maintain context object threaded through phases. Enables shared state, 
 2. project-creation: Create from template
 3. post-setup: Optional packages, skills
 
+### desktop/ - Tauri Control Center (native mode)
+Native shell for the shared dashboard. The Phase 1 invoke bridge now covers config/statusline, project registry, sessions, entity browsers, MCP discovery, dashboard aggregates, and system diagnostics. Pure helpers live in `src-tauri/src/core/`. Browser mode still uses the Express `/api` backend for the actual dashboard routing.
+
 ### skills/ - Skills Management
 Multi-select installation, registry tracking, uninstall per agent.
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -325,14 +325,18 @@ dependencies = [
 name = "claudekit-control-center"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "dirs",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-store",
  "tauri-plugin-updater",
+ "uuid",
+ "walkdir",
 ]
 
 [[package]]
@@ -2966,6 +2970,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,6 +3244,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.1",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4344,6 +4367,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,10 @@ tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-updater = "2"
 tauri-plugin-store = "2"
 tauri-plugin-dialog = "2"
+base64 = "0.22"
 dirs = "6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
+uuid = { version = "1", features = ["v4"] }
+walkdir = "2"

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -1,0 +1,292 @@
+use crate::core::{frontmatter::parse_frontmatter, paths};
+use serde::Serialize;
+use serde_json::{Map, Value};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentListItem {
+    pub slug: String,
+    pub name: String,
+    pub description: String,
+    pub model: Option<String>,
+    pub color: Option<String>,
+    pub skill_count: usize,
+    pub dir_label: String,
+    pub relative_path: String,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentDetail {
+    #[serde(flatten)]
+    pub summary: AgentListItem,
+    pub frontmatter: Map<String, Value>,
+    pub body: String,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentsBrowseResponse {
+    pub agents: Vec<AgentListItem>,
+    pub total: usize,
+}
+
+pub async fn browse_agents() -> Result<AgentsBrowseResponse, String> {
+    tauri::async_runtime::spawn_blocking(browse_agents_blocking)
+        .await
+        .map_err(|err| format!("Failed to browse agents: {err}"))?
+}
+
+#[tauri::command]
+pub async fn scan_agents() -> Result<Vec<AgentListItem>, String> {
+    browse_agents().await.map(|response| response.agents)
+}
+
+#[tauri::command]
+pub async fn get_agent_detail(slug: String) -> Result<AgentDetail, String> {
+    tauri::async_runtime::spawn_blocking(move || get_agent_detail_blocking(&slug))
+        .await
+        .map_err(|err| format!("Failed to read agent detail: {err}"))?
+}
+
+fn browse_agents_blocking() -> Result<AgentsBrowseResponse, String> {
+    let home_dir =
+        paths::home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
+    let cwd = std::env::current_dir().map_err(|err| format!("Failed to read cwd: {err}"))?;
+    let mut agents = Vec::new();
+
+    for (dir_path, dir_label) in resolve_agent_dirs(&cwd, &home_dir) {
+        agents.extend(scan_agent_dir(&dir_path, &dir_label, &home_dir)?);
+    }
+
+    agents.sort_by(|left, right| left.name.cmp(&right.name).then(left.slug.cmp(&right.slug)));
+
+    Ok(AgentsBrowseResponse {
+        total: agents.len(),
+        agents,
+    })
+}
+
+fn get_agent_detail_blocking(slug: &str) -> Result<AgentDetail, String> {
+    if !is_valid_slug(slug) {
+        return Err("Invalid agent slug".to_string());
+    }
+
+    let home_dir =
+        paths::home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
+    let cwd = std::env::current_dir().map_err(|err| format!("Failed to read cwd: {err}"))?;
+
+    for (dir_path, dir_label) in resolve_agent_dirs(&cwd, &home_dir) {
+        let file_path = dir_path.join(format!("{slug}.md"));
+        if !file_path.is_file() {
+            continue;
+        }
+
+        let content = fs::read_to_string(&file_path)
+            .map_err(|err| format!("Failed to read {}: {err}", file_path.display()))?;
+        let parsed = parse_frontmatter(&content)?;
+        return Ok(AgentDetail {
+            summary: build_agent_summary(
+                slug.to_string(),
+                dir_label,
+                &file_path,
+                &home_dir,
+                &parsed.frontmatter,
+                parsed.body.clone(),
+            ),
+            frontmatter: parsed.frontmatter,
+            body: parsed.body,
+        });
+    }
+
+    Err("Agent not found".to_string())
+}
+
+fn resolve_agent_dirs(cwd: &Path, home_dir: &Path) -> Vec<(PathBuf, String)> {
+    let mut seen = HashSet::new();
+    let mut dirs = Vec::new();
+
+    let candidates = [
+        (
+            cwd.join(".claude").join("agents"),
+            ".claude/agents".to_string(),
+        ),
+        (
+            home_dir.join(".claude").join("agents"),
+            "~/.claude/agents".to_string(),
+        ),
+    ];
+
+    for (path, label) in candidates {
+        let key = path.to_string_lossy().to_string();
+        if seen.insert(key) {
+            dirs.push((path, label));
+        }
+    }
+
+    dirs
+}
+
+fn scan_agent_dir(
+    dir_path: &Path,
+    dir_label: &str,
+    home_dir: &Path,
+) -> Result<Vec<AgentListItem>, String> {
+    let mut items = Vec::new();
+    let entries = match fs::read_dir(dir_path) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(items),
+    };
+
+    for entry in entries.flatten() {
+        let file_path = entry.path();
+        if !file_path.is_file()
+            || file_path.extension().and_then(|value| value.to_str()) != Some("md")
+        {
+            continue;
+        }
+
+        let Ok(content) = fs::read_to_string(&file_path) else {
+            continue;
+        };
+        let Ok(parsed) = parse_frontmatter(&content) else {
+            continue;
+        };
+        let Some(slug) = file_path.file_stem().and_then(|value| value.to_str()) else {
+            continue;
+        };
+
+        items.push(build_agent_summary(
+            slug.to_string(),
+            dir_label.to_string(),
+            &file_path,
+            home_dir,
+            &parsed.frontmatter,
+            parsed.body,
+        ));
+    }
+
+    items.sort_by(|left, right| left.name.cmp(&right.name).then(left.slug.cmp(&right.slug)));
+    Ok(items)
+}
+
+fn build_agent_summary(
+    slug: String,
+    dir_label: String,
+    file_path: &Path,
+    home_dir: &Path,
+    frontmatter: &Map<String, Value>,
+    body: String,
+) -> AgentListItem {
+    AgentListItem {
+        name: frontmatter
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or(&slug)
+            .to_string(),
+        description: frontmatter
+            .get("description")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| first_descriptive_line(&body).unwrap_or_default()),
+        model: frontmatter
+            .get("model")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        color: frontmatter
+            .get("color")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        skill_count: count_skills(frontmatter.get("tools")),
+        dir_label,
+        relative_path: relative_to_home(file_path, home_dir),
+        slug,
+    }
+}
+
+fn count_skills(value: Option<&Value>) -> usize {
+    value
+        .and_then(Value::as_str)
+        .map(|tools| {
+            tools
+                .split(',')
+                .map(str::trim)
+                .filter(|tool| !tool.is_empty())
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+fn first_descriptive_line(body: &str) -> Option<String> {
+    body.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(str::to_string)
+}
+
+fn relative_to_home(file_path: &Path, home_dir: &Path) -> String {
+    file_path
+        .strip_prefix(home_dir)
+        .map(|path| path.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_else(|_| file_path.to_string_lossy().replace('\\', "/"))
+}
+
+fn is_valid_slug(slug: &str) -> bool {
+    !slug.is_empty()
+        && slug
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{count_skills, scan_agent_dir};
+    use serde_json::json;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be valid")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("ck-agents-{name}-{unique}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+
+    #[test]
+    fn counts_comma_separated_tools() {
+        assert_eq!(count_skills(Some(&json!("alpha, beta, gamma"))), 3);
+        assert_eq!(count_skills(Some(&json!("alpha,, beta"))), 2);
+        assert_eq!(count_skills(Some(&json!(["alpha"]))), 0);
+    }
+
+    #[test]
+    fn scans_agents_and_skips_invalid_files() {
+        let home_dir = temp_dir("home");
+        let agent_dir = home_dir.join(".claude").join("agents");
+        fs::create_dir_all(&agent_dir).expect("agent dir should exist");
+
+        fs::write(
+            agent_dir.join("reviewer.md"),
+            "---\nname: Reviewer\ndescription: Reviews code\nmodel: opus\ntools: one, two\n---\n# Body\n",
+        )
+        .expect("agent should be written");
+        fs::write(agent_dir.join("broken.md"), "---\nname: bad\n")
+            .expect("invalid agent should exist");
+
+        let items =
+            scan_agent_dir(&agent_dir, "~/.claude/agents", &home_dir).expect("scan should succeed");
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].slug, "reviewer");
+        assert_eq!(items[0].skill_count, 2);
+        assert_eq!(items[0].relative_path, ".claude/agents/reviewer.md");
+    }
+}

--- a/src-tauri/src/commands/commands-browser.rs
+++ b/src-tauri/src/commands/commands-browser.rs
@@ -1,0 +1,255 @@
+use crate::core::{frontmatter::parse_frontmatter, paths};
+use serde::Serialize;
+use std::cmp::Ordering;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CommandNode {
+    pub name: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub children: Option<Vec<CommandNode>>,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CommandDetail {
+    pub name: String,
+    pub path: String,
+    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[tauri::command]
+pub async fn list_commands() -> Result<Vec<CommandNode>, String> {
+    tauri::async_runtime::spawn_blocking(list_commands_blocking)
+        .await
+        .map_err(|err| format!("Failed to list commands: {err}"))?
+}
+
+#[tauri::command]
+pub async fn scan_commands() -> Result<Vec<CommandNode>, String> {
+    list_commands().await
+}
+
+#[tauri::command]
+pub async fn get_command_detail(slug: String) -> Result<CommandDetail, String> {
+    tauri::async_runtime::spawn_blocking(move || get_command_detail_blocking(&slug))
+        .await
+        .map_err(|err| format!("Failed to read command detail: {err}"))?
+}
+
+fn list_commands_blocking() -> Result<Vec<CommandNode>, String> {
+    let commands_dir = paths::global_commands_dir()
+        .ok_or_else(|| "Cannot determine commands directory".to_string())?;
+    if !commands_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    build_command_tree(&commands_dir, &commands_dir)
+}
+
+pub(crate) fn scan_commands_blocking() -> Result<Vec<CommandNode>, String> {
+    list_commands_blocking()
+}
+
+fn get_command_detail_blocking(slug: &str) -> Result<CommandDetail, String> {
+    let commands_dir = paths::global_commands_dir()
+        .ok_or_else(|| "Cannot determine commands directory".to_string())?;
+    let relative = slug_to_relative_path(slug)?;
+    let mut file_path = commands_dir.join(&relative);
+    if file_path.extension().and_then(|value| value.to_str()) != Some("md") {
+        file_path.set_extension("md");
+    }
+    if !file_path.is_file() {
+        return Err("Command not found".to_string());
+    }
+
+    let content = fs::read_to_string(&file_path)
+        .map_err(|err| format!("Failed to read {}: {err}", file_path.display()))?;
+    let parsed = parse_frontmatter(&content)?;
+    let path = relative
+        .with_extension("")
+        .to_string_lossy()
+        .replace('\\', "/");
+    let name = file_path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_string();
+
+    Ok(CommandDetail {
+        name,
+        path,
+        content,
+        description: parsed
+            .frontmatter
+            .get("description")
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+    })
+}
+
+fn build_command_tree(dir: &Path, base_dir: &Path) -> Result<Vec<CommandNode>, String> {
+    let mut entries = fs::read_dir(dir)
+        .map_err(|err| format!("Failed to read {}: {err}", dir.display()))?
+        .flatten()
+        .collect::<Vec<_>>();
+
+    entries.sort_by(
+        |left, right| match (left.path().is_dir(), right.path().is_dir()) {
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            _ => left.file_name().cmp(&right.file_name()),
+        },
+    );
+
+    let mut nodes = Vec::new();
+    for entry in entries {
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        let full_path = entry.path();
+        let rel_path = full_path
+            .strip_prefix(base_dir)
+            .map(|path| path.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_else(|_| file_name.to_string());
+
+        if full_path.is_dir() {
+            let children = build_command_tree(&full_path, base_dir)?;
+            if !children.is_empty() {
+                nodes.push(CommandNode {
+                    name: file_name.to_string(),
+                    path: rel_path,
+                    description: None,
+                    children: Some(children),
+                });
+            }
+            continue;
+        }
+
+        if full_path.extension().and_then(|value| value.to_str()) != Some("md") {
+            continue;
+        }
+
+        let description = fs::read_to_string(&full_path)
+            .ok()
+            .and_then(|content| parse_frontmatter(&content).ok())
+            .and_then(|parsed| {
+                parsed
+                    .frontmatter
+                    .get("description")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string)
+            });
+
+        nodes.push(CommandNode {
+            name: full_path
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .unwrap_or_default()
+                .to_string(),
+            path: rel_path,
+            description,
+            children: None,
+        });
+    }
+
+    Ok(nodes)
+}
+
+pub(crate) fn count_command_nodes(nodes: &[CommandNode]) -> usize {
+    nodes
+        .iter()
+        .map(|node| match &node.children {
+            Some(children) => count_command_nodes(children),
+            None => 1,
+        })
+        .sum()
+}
+
+fn slug_to_relative_path(slug: &str) -> Result<PathBuf, String> {
+    if slug.is_empty() {
+        return Err("Missing command path".to_string());
+    }
+    if slug.contains('\0') {
+        return Err("Invalid path".to_string());
+    }
+
+    let decoded = slug.replace("--", "/");
+    let path = Path::new(&decoded);
+    let mut safe = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::Normal(value) => safe.push(value),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err("Invalid path".to_string())
+            }
+        }
+    }
+
+    if safe.as_os_str().is_empty() {
+        return Err("Invalid path".to_string());
+    }
+
+    Ok(safe)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_command_tree, slug_to_relative_path};
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be valid")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("ck-commands-{name}-{unique}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+
+    #[test]
+    fn rejects_traversal_in_command_slug() {
+        assert!(slug_to_relative_path("../evil").is_err());
+        assert!(slug_to_relative_path("group--..--evil").is_err());
+        assert_eq!(
+            slug_to_relative_path("ck--plan")
+                .expect("path should be valid")
+                .to_string_lossy(),
+            "ck/plan"
+        );
+    }
+
+    #[test]
+    fn builds_directory_first_command_tree() {
+        let root = temp_dir("tree");
+        fs::create_dir_all(root.join("ck")).expect("subdir should exist");
+        fs::write(root.join("zeta.md"), "---\ndescription: zeta\n---\n")
+            .expect("file should exist");
+        fs::write(
+            root.join("ck").join("plan.md"),
+            "---\ndescription: plan\n---\n",
+        )
+        .expect("file should exist");
+
+        let tree = build_command_tree(&root, &root).expect("tree should build");
+
+        assert_eq!(tree.len(), 2);
+        assert_eq!(tree[0].name, "ck");
+        assert_eq!(tree[1].name, "zeta");
+        assert_eq!(
+            tree[0].children.as_ref().expect("children")[0].path,
+            "ck/plan.md"
+        );
+    }
+}

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -21,9 +21,9 @@ fn validate_project_path(project_path: &str) -> Result<String, String> {
     if !p.is_absolute() {
         return Err(format!("Project path must be absolute: {project_path}"));
     }
-    let canonical = p
-        .canonicalize()
-        .map_err(|e| format!("Project path does not exist or is inaccessible: {project_path} ({e})"))?;
+    let canonical = p.canonicalize().map_err(|e| {
+        format!("Project path does not exist or is inaccessible: {project_path} ({e})")
+    })?;
     if !canonical.is_dir() {
         return Err(format!("Project path is not a directory: {project_path}"));
     }
@@ -130,8 +130,7 @@ pub fn write_statusline(project_path: String, config: Value) -> Result<(), Strin
         "statuslineLayout",
     ];
 
-    if let (Value::Object(ref mut existing), Value::Object(ref incoming)) =
-        (&mut settings, &config)
+    if let (Value::Object(ref mut existing), Value::Object(ref incoming)) = (&mut settings, &config)
     {
         for key in &allowed_keys {
             if let Some(v) = incoming.get(*key) {
@@ -153,8 +152,8 @@ pub fn write_statusline(project_path: String, config: Value) -> Result<(), Strin
 /// Returns an error if the home directory cannot be determined.
 #[tauri::command]
 pub fn get_global_config_path() -> Result<String, String> {
-    let dir = paths::global_claude_dir()
-        .ok_or_else(|| "Cannot determine home directory".to_string())?;
+    let dir =
+        paths::global_claude_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
     let path = paths::settings_path(&dir);
     Ok(path.to_string_lossy().into_owned())
 }

--- a/src-tauri/src/commands/dashboard.rs
+++ b/src-tauri/src/commands/dashboard.rs
@@ -1,0 +1,385 @@
+use crate::core::{frontmatter::parse_frontmatter, paths};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+use walkdir::WalkDir;
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentEntry {
+    pub name: String,
+    pub model: String,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelDistribution {
+    pub opus: usize,
+    pub sonnet: usize,
+    pub haiku: usize,
+    pub unset: usize,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardStats {
+    pub agents: usize,
+    pub commands: usize,
+    pub skills: usize,
+    pub mcp_servers: usize,
+    pub model_distribution: ModelDistribution,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardSuggestion {
+    pub r#type: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectsRegistry {
+    projects: Vec<RegisteredProject>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegisteredProject {
+    path: String,
+}
+
+#[tauri::command]
+pub async fn get_dashboard_stats() -> Result<DashboardStats, String> {
+    tauri::async_runtime::spawn_blocking(get_dashboard_stats_blocking)
+        .await
+        .map_err(|err| format!("Failed to load dashboard stats: {err}"))?
+}
+
+#[tauri::command]
+pub async fn list_dashboard_agents(limit: Option<u32>) -> Result<Vec<AgentEntry>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let mut agents = read_agents()?;
+        agents.truncate(limit.unwrap_or(6) as usize);
+        Ok(agents)
+    })
+    .await
+    .map_err(|err| format!("Failed to load dashboard agents: {err}"))?
+}
+
+#[tauri::command]
+pub async fn get_dashboard_agents() -> Result<Vec<AgentEntry>, String> {
+    list_dashboard_agents(Some(6)).await
+}
+
+#[tauri::command]
+pub async fn list_dashboard_suggestions() -> Result<Vec<DashboardSuggestion>, String> {
+    tauri::async_runtime::spawn_blocking(list_dashboard_suggestions_blocking)
+        .await
+        .map_err(|err| format!("Failed to load dashboard suggestions: {err}"))?
+}
+
+#[tauri::command]
+pub async fn get_suggestions() -> Result<Vec<DashboardSuggestion>, String> {
+    list_dashboard_suggestions().await
+}
+
+fn get_dashboard_stats_blocking() -> Result<DashboardStats, String> {
+    let agents = read_agents()?;
+    let mut model_distribution = ModelDistribution::default();
+    for agent in &agents {
+        match classify_model(&agent.model) {
+            "opus" => model_distribution.opus += 1,
+            "sonnet" => model_distribution.sonnet += 1,
+            "haiku" => model_distribution.haiku += 1,
+            _ => model_distribution.unset += 1,
+        }
+    }
+
+    Ok(DashboardStats {
+        agents: agents.len(),
+        commands: count_markdown_files(paths::global_commands_dir().as_deref()),
+        skills: count_installed_skills(paths::global_skills_dir().as_deref()),
+        mcp_servers: count_mcp_servers()?,
+        model_distribution,
+    })
+}
+
+fn list_dashboard_suggestions_blocking() -> Result<Vec<DashboardSuggestion>, String> {
+    let agents = read_agents()?;
+    let mut suggestions = Vec::new();
+
+    let unset_count = agents
+        .iter()
+        .filter(|agent| classify_model(&agent.model) == "unset")
+        .count();
+    if unset_count > 0 {
+        suggestions.push(DashboardSuggestion {
+            r#type: "warning".to_string(),
+            message: format!(
+                "{unset_count} agent{} have no model set",
+                if unset_count > 1 { "s" } else { "" }
+            ),
+            target: Some("agents".to_string()),
+        });
+    }
+
+    if count_installed_skills(paths::global_skills_dir().as_deref()) == 0 {
+        suggestions.push(DashboardSuggestion {
+            r#type: "info".to_string(),
+            message: "No skills installed — browse the Skills Marketplace".to_string(),
+            target: Some("skills".to_string()),
+        });
+    }
+
+    let settings_exists = paths::global_claude_dir()
+        .map(|dir| dir.join("settings.json").is_file())
+        .unwrap_or(false);
+    if !settings_exists {
+        suggestions.push(DashboardSuggestion {
+            r#type: "warning".to_string(),
+            message: "No ~/.claude/settings.json found — run ck init to create one".to_string(),
+            target: None,
+        });
+    }
+
+    if agents.is_empty() {
+        suggestions.push(DashboardSuggestion {
+            r#type: "info".to_string(),
+            message: "No agents configured in ~/.claude/agents/".to_string(),
+            target: Some("agents".to_string()),
+        });
+    }
+
+    if suggestions.is_empty() {
+        suggestions.push(DashboardSuggestion {
+            r#type: "success".to_string(),
+            message: "Everything looks good!".to_string(),
+            target: None,
+        });
+    }
+
+    Ok(suggestions)
+}
+
+fn read_agents() -> Result<Vec<AgentEntry>, String> {
+    let Some(agents_dir) = paths::global_agents_dir() else {
+        return Ok(Vec::new());
+    };
+    let entries = match fs::read_dir(&agents_dir) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(Vec::new()),
+    };
+
+    let mut agents = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("md") {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(parsed) = parse_frontmatter(&content) else {
+            continue;
+        };
+        let file_stem = path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .unwrap_or_default();
+        agents.push(AgentEntry {
+            name: parsed
+                .frontmatter
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or(file_stem)
+                .to_string(),
+            model: parsed
+                .frontmatter
+                .get("model")
+                .and_then(Value::as_str)
+                .unwrap_or("unset")
+                .to_string(),
+            description: parsed
+                .frontmatter
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            color: parsed
+                .frontmatter
+                .get("color")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        });
+    }
+
+    agents.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(agents)
+}
+
+fn count_markdown_files(dir: Option<&Path>) -> usize {
+    let Some(dir) = dir else {
+        return 0;
+    };
+    if !dir.is_dir() {
+        return 0;
+    }
+
+    WalkDir::new(dir)
+        .max_depth(10)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().is_file())
+        .filter(|entry| entry.path().extension().and_then(|value| value.to_str()) == Some("md"))
+        .count()
+}
+
+fn count_installed_skills(dir: Option<&Path>) -> usize {
+    let Some(dir) = dir else {
+        return 0;
+    };
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return 0,
+    };
+    entries
+        .flatten()
+        .filter(|entry| entry.path().join("SKILL.md").is_file())
+        .count()
+}
+
+fn count_mcp_servers() -> Result<usize, String> {
+    let home_dir =
+        paths::home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
+    let claude_dir = home_dir.join(".claude");
+    let mut seen = HashSet::new();
+
+    collect_mcp_names(
+        read_json(claude_dir.join("settings.json"))?.as_ref(),
+        &mut seen,
+        true,
+    );
+    collect_mcp_names(
+        read_json(home_dir.join(".claude.json"))?.as_ref(),
+        &mut seen,
+        true,
+    );
+    collect_mcp_names(
+        read_json(claude_dir.join(".mcp.json"))?.as_ref(),
+        &mut seen,
+        false,
+    );
+
+    for project in registered_projects(&home_dir)? {
+        let path = Path::new(&project.path);
+        if project.path.contains("..") || !path.exists() || !path.starts_with(&home_dir) {
+            continue;
+        }
+        collect_mcp_names(
+            read_json(path.join(".mcp.json"))?.as_ref(),
+            &mut seen,
+            false,
+        );
+    }
+
+    Ok(seen.len())
+}
+
+fn collect_mcp_names(value: Option<&Value>, seen: &mut HashSet<String>, nested: bool) {
+    let Some(value) = value else {
+        return;
+    };
+    let servers = if nested {
+        value.get("mcpServers").and_then(Value::as_object)
+    } else {
+        value
+            .get("mcpServers")
+            .and_then(Value::as_object)
+            .or_else(|| value.as_object())
+    };
+
+    if let Some(servers) = servers {
+        for key in servers.keys() {
+            seen.insert(key.clone());
+        }
+    }
+}
+
+fn read_json(path: impl AsRef<Path>) -> Result<Option<Value>, String> {
+    let path = path.as_ref();
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(path)
+        .map_err(|err| format!("Failed to read {}: {err}", path.display()))?;
+    let parsed = serde_json::from_str(&content)
+        .map_err(|err| format!("Failed to parse {}: {err}", path.display()))?;
+    Ok(Some(parsed))
+}
+
+fn registered_projects(home_dir: &Path) -> Result<Vec<RegisteredProject>, String> {
+    let Some(value) = read_json(home_dir.join(".claudekit").join("projects.json"))? else {
+        return Ok(Vec::new());
+    };
+    let parsed = serde_json::from_value::<ProjectsRegistry>(value)
+        .map_err(|err| format!("Failed to parse projects registry: {err}"))?;
+    Ok(parsed.projects)
+}
+
+fn classify_model(model: &str) -> &'static str {
+    let lower = model.to_lowercase();
+    if lower.is_empty() || lower == "unset" {
+        "unset"
+    } else if lower.contains("opus") {
+        "opus"
+    } else if lower.contains("haiku") {
+        "haiku"
+    } else if lower.contains("sonnet") {
+        "sonnet"
+    } else {
+        "unset"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_model, count_installed_skills};
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be valid")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("ck-dashboard-{name}-{unique}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+
+    #[test]
+    fn classifies_known_model_tiers() {
+        assert_eq!(classify_model("claude-3-opus"), "opus");
+        assert_eq!(classify_model("Claude 3.5 Sonnet"), "sonnet");
+        assert_eq!(classify_model("haiku"), "haiku");
+        assert_eq!(classify_model(""), "unset");
+    }
+
+    #[test]
+    fn counts_skill_directories_with_skill_md_only() {
+        let root = temp_dir("skills");
+        fs::create_dir_all(root.join("one")).expect("dir should exist");
+        fs::create_dir_all(root.join("two")).expect("dir should exist");
+        fs::write(root.join("one").join("SKILL.md"), "# skill").expect("skill should exist");
+        fs::write(root.join("two").join("README.md"), "# nope").expect("file should exist");
+
+        assert_eq!(count_installed_skills(Some(&root)), 1);
+    }
+}

--- a/src-tauri/src/commands/dashboard.rs
+++ b/src-tauri/src/commands/dashboard.rs
@@ -61,7 +61,6 @@ pub async fn get_dashboard_stats() -> Result<DashboardStats, String> {
         .map_err(|err| format!("Failed to load dashboard stats: {err}"))?
 }
 
-#[tauri::command]
 pub async fn list_dashboard_agents(limit: Option<u32>) -> Result<Vec<AgentEntry>, String> {
     tauri::async_runtime::spawn_blocking(move || {
         let mut agents = read_agents()?;
@@ -77,7 +76,6 @@ pub async fn get_dashboard_agents() -> Result<Vec<AgentEntry>, String> {
     list_dashboard_agents(Some(6)).await
 }
 
-#[tauri::command]
 pub async fn list_dashboard_suggestions() -> Result<Vec<DashboardSuggestion>, String> {
     tauri::async_runtime::spawn_blocking(list_dashboard_suggestions_blocking)
         .await

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -1,0 +1,366 @@
+use crate::core::paths;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpServerEntry {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env_keys: Option<Vec<String>>,
+    pub source: String,
+    pub source_label: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectsRegistry {
+    projects: Vec<RegisteredProject>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegisteredProject {
+    path: String,
+    alias: Option<String>,
+}
+
+#[tauri::command]
+pub async fn list_mcp_servers() -> Result<Vec<McpServerEntry>, String> {
+    tauri::async_runtime::spawn_blocking(list_mcp_servers_blocking)
+        .await
+        .map_err(|err| format!("Failed to list MCP servers: {err}"))?
+}
+
+#[tauri::command]
+pub async fn discover_mcp_servers(
+    project_path: Option<String>,
+) -> Result<Vec<McpServerEntry>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        discover_mcp_servers_blocking(project_path.as_deref())
+    })
+    .await
+    .map_err(|err| format!("Failed to discover MCP servers: {err}"))?
+}
+
+fn list_mcp_servers_blocking() -> Result<Vec<McpServerEntry>, String> {
+    let home_dir =
+        paths::home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
+    let claude_dir = home_dir.join(".claude");
+    let mut lists = Vec::new();
+
+    if let Some(settings) = read_json(claude_dir.join("settings.json"))? {
+        if let Some(servers) = settings.get("mcpServers").and_then(Value::as_object) {
+            lists.push(parse_mcp_servers(
+                servers,
+                "settings.json".to_string(),
+                "settings.json".to_string(),
+            ));
+        }
+    }
+
+    if let Some(claude_json) = read_json(home_dir.join(".claude.json"))? {
+        if let Some(servers) = claude_json.get("mcpServers").and_then(Value::as_object) {
+            lists.push(parse_mcp_servers(
+                servers,
+                "claude.json".to_string(),
+                "~/.claude.json".to_string(),
+            ));
+        }
+    }
+
+    lists.push(read_mcp_json(
+        claude_dir.join(".mcp.json"),
+        ".mcp.json".to_string(),
+        ".mcp.json".to_string(),
+    )?);
+
+    for project in registered_projects(&home_dir)? {
+        if !is_safe_project_path(&project.path, &home_dir) {
+            continue;
+        }
+        let source_label = format!(
+            "Project: {}",
+            project.alias.unwrap_or_else(|| {
+                Path::new(&project.path)
+                    .file_name()
+                    .and_then(|value| value.to_str())
+                    .unwrap_or(&project.path)
+                    .to_string()
+            })
+        );
+        lists.push(read_mcp_json(
+            Path::new(&project.path).join(".mcp.json"),
+            format!("project:{}", project.path),
+            source_label,
+        )?);
+    }
+
+    Ok(merge_servers(lists))
+}
+
+pub(crate) fn discover_mcp_servers_blocking(
+    project_path: Option<&str>,
+) -> Result<Vec<McpServerEntry>, String> {
+    if let Some(project_path) = project_path {
+        let project_root = Path::new(project_path);
+        if project_root.is_absolute() && project_root.exists() {
+            let home_dir =
+                paths::home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
+            let claude_dir = home_dir.join(".claude");
+            let mut lists = Vec::new();
+
+            if let Some(settings) = read_json(claude_dir.join("settings.json"))? {
+                if let Some(servers) = settings.get("mcpServers").and_then(Value::as_object) {
+                    lists.push(parse_mcp_servers(
+                        servers,
+                        "settings.json".to_string(),
+                        "settings.json".to_string(),
+                    ));
+                }
+            }
+
+            if let Some(claude_json) = read_json(home_dir.join(".claude.json"))? {
+                if let Some(servers) = claude_json.get("mcpServers").and_then(Value::as_object) {
+                    lists.push(parse_mcp_servers(
+                        servers,
+                        "claude.json".to_string(),
+                        "~/.claude.json".to_string(),
+                    ));
+                }
+            }
+
+            lists.push(read_mcp_json(
+                claude_dir.join(".mcp.json"),
+                ".mcp.json".to_string(),
+                ".mcp.json".to_string(),
+            )?);
+            lists.push(read_mcp_json(
+                project_root.join(".mcp.json"),
+                format!("project:{project_path}"),
+                format!(
+                    "Project: {}",
+                    project_root
+                        .file_name()
+                        .and_then(|value| value.to_str())
+                        .unwrap_or(project_path)
+                ),
+            )?);
+            lists.push(read_mcp_json(
+                project_root.join(".claude.json"),
+                format!("project-claude:{project_path}"),
+                format!(
+                    "Project Claude: {}",
+                    project_root
+                        .file_name()
+                        .and_then(|value| value.to_str())
+                        .unwrap_or(project_path)
+                ),
+            )?);
+            return Ok(merge_servers(lists));
+        }
+    }
+
+    list_mcp_servers_blocking()
+}
+
+fn parse_mcp_servers(
+    raw: &Map<String, Value>,
+    source: String,
+    source_label: String,
+) -> Vec<McpServerEntry> {
+    let mut entries = Vec::new();
+    for (name, value) in raw {
+        let Some(config) = value.as_object() else {
+            continue;
+        };
+        let Some(command) = config.get("command").and_then(Value::as_str) else {
+            continue;
+        };
+        if command.is_empty() {
+            continue;
+        }
+
+        let args = config
+            .get("args")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        let env_keys = config.get("env").and_then(Value::as_object).map(|env| {
+            let mut keys = env.keys().cloned().collect::<Vec<_>>();
+            keys.sort();
+            keys
+        });
+
+        entries.push(McpServerEntry {
+            name: name.clone(),
+            command: command.to_string(),
+            args,
+            env_keys: env_keys.filter(|keys| !keys.is_empty()),
+            source: source.clone(),
+            source_label: source_label.clone(),
+        });
+    }
+
+    entries
+}
+
+fn read_mcp_json(
+    file_path: PathBuf,
+    source: String,
+    source_label: String,
+) -> Result<Vec<McpServerEntry>, String> {
+    let Some(value) = read_json(file_path)? else {
+        return Ok(Vec::new());
+    };
+
+    let servers = value
+        .get("mcpServers")
+        .and_then(Value::as_object)
+        .or_else(|| value.as_object())
+        .cloned()
+        .unwrap_or_default();
+
+    Ok(parse_mcp_servers(&servers, source, source_label))
+}
+
+fn read_json(file_path: PathBuf) -> Result<Option<Value>, String> {
+    if !file_path.is_file() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(&file_path)
+        .map_err(|err| format!("Failed to read {}: {err}", file_path.display()))?;
+    let parsed = serde_json::from_str::<Value>(&content)
+        .map_err(|err| format!("Failed to parse {}: {err}", file_path.display()))?;
+    Ok(Some(parsed))
+}
+
+fn registered_projects(home_dir: &Path) -> Result<Vec<RegisteredProject>, String> {
+    let registry_path = home_dir.join(".claudekit").join("projects.json");
+    let Some(registry) = read_json(registry_path)? else {
+        return Ok(Vec::new());
+    };
+    let parsed = serde_json::from_value::<ProjectsRegistry>(registry)
+        .map_err(|err| format!("Failed to parse projects registry: {err}"))?;
+    Ok(parsed.projects)
+}
+
+fn is_safe_project_path(project_path: &str, home_dir: &Path) -> bool {
+    if project_path.contains("..") {
+        return false;
+    }
+
+    let Ok(canonical) = Path::new(project_path).canonicalize() else {
+        return false;
+    };
+    canonical.starts_with(home_dir)
+}
+
+fn merge_servers(lists: Vec<Vec<McpServerEntry>>) -> Vec<McpServerEntry> {
+    let mut merged = Vec::new();
+    let mut seen = HashSet::new();
+
+    for list in lists {
+        for server in list {
+            if seen.insert(server.name.clone()) {
+                merged.push(server);
+            }
+        }
+    }
+
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{merge_servers, parse_mcp_servers, read_mcp_json, McpServerEntry};
+    use serde_json::json;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be valid")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("ck-mcp-{name}-{unique}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+
+    #[test]
+    fn parses_command_args_and_redacted_env_keys() {
+        let parsed = parse_mcp_servers(
+            json!({
+                "demo": {
+                    "command": "node",
+                    "args": ["server.js"],
+                    "env": { "API_KEY": "secret", "TOKEN": "secret" }
+                }
+            })
+            .as_object()
+            .expect("object"),
+            "settings.json".to_string(),
+            "settings.json".to_string(),
+        );
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].args, vec!["server.js".to_string()]);
+        assert_eq!(
+            parsed[0].env_keys.as_ref().expect("env keys"),
+            &vec!["API_KEY".to_string(), "TOKEN".to_string()]
+        );
+    }
+
+    #[test]
+    fn standalone_mcp_json_supports_flat_and_nested_shapes() {
+        let dir = temp_dir("json");
+        let path = dir.join(".mcp.json");
+        fs::write(&path, "{\"mcpServers\":{\"demo\":{\"command\":\"node\"}}}")
+            .expect("file should exist");
+        let nested =
+            read_mcp_json(path.clone(), "a".to_string(), "A".to_string()).expect("nested parse");
+        fs::write(&path, "{\"flat\":{\"command\":\"bun\"}}").expect("file should exist");
+        let flat = read_mcp_json(path, "b".to_string(), "B".to_string()).expect("flat parse");
+
+        assert_eq!(nested[0].name, "demo");
+        assert_eq!(flat[0].command, "bun");
+    }
+
+    #[test]
+    fn merge_keeps_first_server_for_duplicate_names() {
+        let merged = merge_servers(vec![
+            vec![McpServerEntry {
+                name: "demo".to_string(),
+                command: "node".to_string(),
+                args: Vec::new(),
+                env_keys: None,
+                source: "settings.json".to_string(),
+                source_label: "settings.json".to_string(),
+            }],
+            vec![McpServerEntry {
+                name: "demo".to_string(),
+                command: "bun".to_string(),
+                args: Vec::new(),
+                env_keys: None,
+                source: ".mcp.json".to_string(),
+                source_label: ".mcp.json".to_string(),
+            }],
+        ]);
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].command, "node");
+    }
+}

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -78,8 +78,8 @@ fn list_mcp_servers_blocking() -> Result<Vec<McpServerEntry>, String> {
         ".mcp.json".to_string(),
     )?);
 
-    for project in registered_projects(&home_dir)? {
-        if !is_safe_project_path(&project.path, &home_dir) {
+    for project in registered_projects()? {
+        if !is_safe_project_path(&project.path) {
             continue;
         }
         let source_label = format!(
@@ -246,8 +246,9 @@ fn read_json(file_path: PathBuf) -> Result<Option<Value>, String> {
     Ok(Some(parsed))
 }
 
-fn registered_projects(home_dir: &Path) -> Result<Vec<RegisteredProject>, String> {
-    let registry_path = home_dir.join(".claudekit").join("projects.json");
+fn registered_projects() -> Result<Vec<RegisteredProject>, String> {
+    let registry_path = paths::projects_registry_path()
+        .ok_or_else(|| "Cannot determine projects registry path".to_string())?;
     let Some(registry) = read_json(registry_path)? else {
         return Ok(Vec::new());
     };
@@ -256,7 +257,7 @@ fn registered_projects(home_dir: &Path) -> Result<Vec<RegisteredProject>, String
     Ok(parsed.projects)
 }
 
-fn is_safe_project_path(project_path: &str, home_dir: &Path) -> bool {
+fn is_safe_project_path(project_path: &str) -> bool {
     if project_path.contains("..") {
         return false;
     }
@@ -264,7 +265,11 @@ fn is_safe_project_path(project_path: &str, home_dir: &Path) -> bool {
     let Ok(canonical) = Path::new(project_path).canonicalize() else {
         return false;
     };
-    canonical.starts_with(home_dir)
+    canonical.is_dir()
+        && !canonical.starts_with("/etc")
+        && !canonical.starts_with("/proc")
+        && !canonical.starts_with("/sys")
+        && !canonical.starts_with("/dev")
 }
 
 fn merge_servers(lists: Vec<Vec<McpServerEntry>>) -> Vec<McpServerEntry> {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,4 +3,13 @@
 // Each sub-module maps to a domain area. Register commands from these modules
 // in lib.rs via tauri::generate_handler!.
 
+pub mod agents;
+#[path = "commands-browser.rs"]
+pub mod commands_browser;
 pub mod config;
+pub mod dashboard;
+pub mod mcp;
+pub mod sessions;
+#[path = "skills-browser.rs"]
+pub mod skills_browser;
+pub mod system;

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -10,7 +10,7 @@ const MAX_PROJECT_SESSION_LIMIT: usize = 100;
 const DEFAULT_PROJECT_SESSION_LIMIT: usize = 10;
 const DEFAULT_DETAIL_LIMIT: usize = 50;
 const MAX_DETAIL_LIMIT: usize = 500;
-const MAX_TOOL_TEXT_BYTES: usize = 8192;
+const MAX_TOOL_TEXT_CHARS: usize = 8192;
 const MAX_SESSION_FILE_BYTES: u64 = 50 * 1024 * 1024;
 const SYSTEM_TAGS: [&str; 5] = [
     "system-reminder",
@@ -114,8 +114,11 @@ pub async fn scan_sessions() -> Result<Vec<ProjectSessionSummary>, String> {
 }
 
 #[tauri::command]
-pub async fn list_project_sessions(project_id: String) -> Result<Vec<SessionMeta>, String> {
-    tauri::async_runtime::spawn_blocking(move || list_project_sessions_blocking(&project_id))
+pub async fn list_project_sessions(
+    project_id: String,
+    limit: Option<u32>,
+) -> Result<Vec<SessionMeta>, String> {
+    tauri::async_runtime::spawn_blocking(move || list_project_sessions_blocking(&project_id, limit))
         .await
         .map_err(|err| format!("Failed to list project sessions: {err}"))?
 }
@@ -198,7 +201,10 @@ fn scan_sessions_blocking() -> Result<Vec<ProjectSessionSummary>, String> {
     Ok(projects)
 }
 
-fn list_project_sessions_blocking(project_id: &str) -> Result<Vec<SessionMeta>, String> {
+fn list_project_sessions_blocking(
+    project_id: &str,
+    limit: Option<u32>,
+) -> Result<Vec<SessionMeta>, String> {
     if project_id.contains("..") {
         return Err("Invalid project ID".to_string());
     }
@@ -222,11 +228,13 @@ fn list_project_sessions_blocking(project_id: &str) -> Result<Vec<SessionMeta>, 
         .collect::<Vec<_>>();
     entries.sort_by(|left, right| right.1.cmp(&left.1));
 
+    let clamped_limit = limit
+        .map(|value| value.max(1) as usize)
+        .unwrap_or(DEFAULT_PROJECT_SESSION_LIMIT)
+        .min(MAX_PROJECT_SESSION_LIMIT);
+
     let mut sessions = Vec::new();
-    for (path, _) in entries
-        .into_iter()
-        .take(DEFAULT_PROJECT_SESSION_LIMIT.min(MAX_PROJECT_SESSION_LIMIT))
-    {
+    for (path, _) in entries.into_iter().take(clamped_limit) {
         if let Some(parsed) = parse_session_meta(&path) {
             sessions.push(parsed);
         }
@@ -286,8 +294,14 @@ fn get_session_activity_blocking(period: Option<&str>) -> Result<ActivityMetrics
         }
 
         let encoded = entry.file_name().to_string_lossy().to_string();
-        let decoded_path =
-            project_ids::decode_claude_project_path(&encoded).unwrap_or_else(|_| encoded.clone());
+        let resolved_path = project_ids::project_path_from_session_dir(&path, &encoded)
+            .unwrap_or_else(|_| PathBuf::from(encoded.clone()));
+        let decoded_path = resolved_path.to_string_lossy().to_string();
+        let name = resolved_path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or(&decoded_path)
+            .to_string();
         let session_files = session_files_in_dir(&path);
         if session_files.is_empty() {
             continue;
@@ -321,7 +335,7 @@ fn get_session_activity_blocking(period: Option<&str>) -> Result<ActivityMetrics
 
         total_sessions += period_count;
         projects.push(ProjectActivity {
-            name: encoded,
+            name,
             path: decoded_path,
             session_count: period_count,
             last_active,
@@ -366,14 +380,26 @@ fn session_files_in_dir(dir: &Path) -> Vec<PathBuf> {
 }
 
 fn parse_session_meta(path: &Path) -> Option<SessionMeta> {
-    let content = fs::read_to_string(path).ok()?;
+    let metadata = fs::metadata(path).ok()?;
+    if metadata.len() > MAX_SESSION_FILE_BYTES {
+        return None;
+    }
+
+    let file = File::open(path).ok()?;
+    let reader = BufReader::new(file);
     let mut summary = String::new();
     let mut session_id = String::new();
     let mut first_timestamp: Option<std::time::SystemTime> = None;
     let mut last_timestamp: Option<std::time::SystemTime> = None;
 
-    for line in content.lines().filter(|line| !line.trim().is_empty()) {
-        let Ok(event) = serde_json::from_str::<Value>(line) else {
+    for line in reader.lines() {
+        let Ok(line) = line else {
+            continue;
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(event) = serde_json::from_str::<Value>(&line) else {
             continue;
         };
 
@@ -437,7 +463,7 @@ fn parse_session_detail(path: &Path, limit: usize, offset: usize) -> Result<Sess
                 content_blocks: vec![ContentBlock {
                     r#type: "text".to_string(),
                     text: Some(format!(
-                        "Session file too large ({:.1} MB, limit 10 MB). Showing summary only.",
+                        "Session file too large ({:.1} MB, limit 50 MB). Showing summary only.",
                         metadata.len() as f64 / 1024.0 / 1024.0
                     )),
                     tool_name: None,
@@ -804,12 +830,12 @@ fn extract_tool_result_content(block: &Value) -> Option<String> {
 }
 
 fn cap_string(text: String) -> String {
-    if text.chars().count() <= MAX_TOOL_TEXT_BYTES {
+    if text.chars().count() <= MAX_TOOL_TEXT_CHARS {
         return text;
     }
     format!(
         "{}...",
-        text.chars().take(MAX_TOOL_TEXT_BYTES).collect::<String>()
+        text.chars().take(MAX_TOOL_TEXT_CHARS).collect::<String>()
     )
 }
 
@@ -843,14 +869,17 @@ fn to_iso_string(timestamp: std::time::SystemTime) -> String {
 }
 
 fn local_date_string(timestamp: std::time::SystemTime) -> String {
+    // Phase 1 limitation: these helpers format UTC-derived calendar values.
     chrono_like::Timestamp::from_system_time(timestamp).local_date_string()
 }
 
 fn local_time_string(timestamp: std::time::SystemTime) -> String {
+    // Phase 1 limitation: these helpers format UTC-derived clock values.
     chrono_like::Timestamp::from_system_time(timestamp).local_time_string()
 }
 
 fn local_month_day_string(timestamp: std::time::SystemTime) -> String {
+    // Phase 1 limitation: these helpers format UTC-derived month/day values.
     chrono_like::Timestamp::from_system_time(timestamp).local_month_day_string()
 }
 

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -1,0 +1,1053 @@
+use crate::core::{paths, project_ids};
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+const MAX_PROJECT_SESSION_LIMIT: usize = 100;
+const DEFAULT_PROJECT_SESSION_LIMIT: usize = 10;
+const DEFAULT_DETAIL_LIMIT: usize = 50;
+const MAX_DETAIL_LIMIT: usize = 500;
+const MAX_TOOL_TEXT_BYTES: usize = 8192;
+const MAX_SESSION_FILE_BYTES: u64 = 50 * 1024 * 1024;
+const SYSTEM_TAGS: [&str; 5] = [
+    "system-reminder",
+    "task-notification",
+    "local-command-stdout",
+    "local-command-caveat",
+    "antml:thinking",
+];
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectSessionSummary {
+    pub id: String,
+    pub name: String,
+    pub path: String,
+    pub session_count: usize,
+    pub last_active: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionMeta {
+    pub id: String,
+    pub timestamp: String,
+    pub duration: String,
+    pub summary: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectActivity {
+    pub name: String,
+    pub path: String,
+    pub session_count: usize,
+    pub last_active: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DailyCount {
+    pub date: String,
+    pub count: usize,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityMetrics {
+    pub total_sessions: usize,
+    pub projects: Vec<ProjectActivity>,
+    pub daily_counts: Vec<DailyCount>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentBlock {
+    pub r#type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_input: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_use_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionMessage {
+    pub role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    pub content_blocks: Vec<ContentBlock>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionSummary {
+    pub message_count: usize,
+    pub tool_call_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionDetail {
+    pub messages: Vec<SessionMessage>,
+    pub summary: SessionSummary,
+}
+
+#[tauri::command]
+pub async fn scan_sessions() -> Result<Vec<ProjectSessionSummary>, String> {
+    tauri::async_runtime::spawn_blocking(scan_sessions_blocking)
+        .await
+        .map_err(|err| format!("Failed to scan sessions: {err}"))?
+}
+
+#[tauri::command]
+pub async fn list_project_sessions(project_id: String) -> Result<Vec<SessionMeta>, String> {
+    tauri::async_runtime::spawn_blocking(move || list_project_sessions_blocking(&project_id))
+        .await
+        .map_err(|err| format!("Failed to list project sessions: {err}"))?
+}
+
+#[tauri::command]
+pub async fn get_session_detail(
+    project_id: String,
+    session_id: String,
+    limit: Option<u32>,
+    offset: Option<u32>,
+) -> Result<SessionDetail, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        get_session_detail_blocking(&project_id, &session_id, limit, offset)
+    })
+    .await
+    .map_err(|err| format!("Failed to read session detail: {err}"))?
+}
+
+#[tauri::command]
+pub async fn get_session_activity(period: Option<String>) -> Result<ActivityMetrics, String> {
+    tauri::async_runtime::spawn_blocking(move || get_session_activity_blocking(period.as_deref()))
+        .await
+        .map_err(|err| format!("Failed to scan activity metrics: {err}"))?
+}
+
+fn scan_sessions_blocking() -> Result<Vec<ProjectSessionSummary>, String> {
+    let Some(projects_dir) = paths::global_projects_dir() else {
+        return Ok(Vec::new());
+    };
+    if !projects_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut projects = Vec::new();
+    for entry in fs::read_dir(&projects_dir)
+        .map_err(|err| format!("Failed to read {}: {err}", projects_dir.display()))?
+        .flatten()
+    {
+        let entry_path = entry.path();
+        if !entry_path.is_dir() {
+            continue;
+        }
+
+        let jsonl_files = session_files_in_dir(&entry_path);
+        if jsonl_files.is_empty() {
+            continue;
+        }
+
+        let mut last_active = std::time::SystemTime::UNIX_EPOCH;
+        for file_path in jsonl_files.iter().rev().take(5) {
+            if let Ok(metadata) = fs::metadata(file_path) {
+                if let Ok(modified) = metadata.modified() {
+                    if modified > last_active {
+                        last_active = modified;
+                    }
+                }
+            }
+        }
+
+        let encoded = entry.file_name().to_string_lossy().to_string();
+        let resolved_path = project_ids::project_path_from_session_dir(&entry_path, &encoded)
+            .unwrap_or_else(|_| PathBuf::from(encoded.clone()));
+        let decoded_path = resolved_path.to_string_lossy().to_string();
+        let name = Path::new(&decoded_path)
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or(&decoded_path)
+            .to_string();
+
+        projects.push(ProjectSessionSummary {
+            id: project_ids::discovered_project_id(&decoded_path),
+            name,
+            path: decoded_path,
+            session_count: jsonl_files.len(),
+            last_active: to_iso_string(last_active),
+        });
+    }
+
+    projects.sort_by(|left, right| right.last_active.cmp(&left.last_active));
+    Ok(projects)
+}
+
+fn list_project_sessions_blocking(project_id: &str) -> Result<Vec<SessionMeta>, String> {
+    if project_id.contains("..") {
+        return Err("Invalid project ID".to_string());
+    }
+
+    let project_dir =
+        resolve_session_dir(project_id)?.ok_or_else(|| "Project not found".to_string())?;
+    let allowed_base = paths::global_projects_dir()
+        .ok_or_else(|| "Cannot determine projects directory".to_string())?;
+    if !project_dir.starts_with(&allowed_base) {
+        return Err("Access denied".to_string());
+    }
+
+    let mut entries = session_files_in_dir(&project_dir)
+        .into_iter()
+        .map(|path| {
+            let mtime = fs::metadata(&path)
+                .and_then(|metadata| metadata.modified())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+            (path, mtime)
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| right.1.cmp(&left.1));
+
+    let mut sessions = Vec::new();
+    for (path, _) in entries
+        .into_iter()
+        .take(DEFAULT_PROJECT_SESSION_LIMIT.min(MAX_PROJECT_SESSION_LIMIT))
+    {
+        if let Some(parsed) = parse_session_meta(&path) {
+            sessions.push(parsed);
+        }
+    }
+    Ok(sessions)
+}
+
+fn get_session_detail_blocking(
+    project_id: &str,
+    session_id: &str,
+    limit: Option<u32>,
+    offset: Option<u32>,
+) -> Result<SessionDetail, String> {
+    if project_id.contains("..")
+        || session_id.contains("..")
+        || session_id.contains('/')
+        || session_id.contains('\\')
+    {
+        return Err("Invalid session path".to_string());
+    }
+
+    let project_dir =
+        resolve_session_dir(project_id)?.ok_or_else(|| "Project not found".to_string())?;
+    let session_path = project_dir.join(format!("{session_id}.jsonl"));
+    if !session_path.exists() {
+        return Err("Session not found".to_string());
+    }
+
+    parse_session_detail(
+        &session_path,
+        limit.unwrap_or(DEFAULT_DETAIL_LIMIT as u32) as usize,
+        offset.unwrap_or(0) as usize,
+    )
+}
+
+fn get_session_activity_blocking(period: Option<&str>) -> Result<ActivityMetrics, String> {
+    let Some(projects_dir) = paths::global_projects_dir() else {
+        return Ok(empty_activity_metrics(period_days(period)));
+    };
+    if !projects_dir.exists() {
+        return Ok(empty_activity_metrics(period_days(period)));
+    }
+
+    let days = period_days(period);
+    let mut daily_counts = build_daily_buckets(days);
+    let cutoff = chrono_like_cutoff(days);
+    let mut projects = Vec::new();
+    let mut total_sessions = 0usize;
+
+    for entry in fs::read_dir(&projects_dir)
+        .map_err(|err| format!("Failed to read {}: {err}", projects_dir.display()))?
+        .flatten()
+    {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let encoded = entry.file_name().to_string_lossy().to_string();
+        let decoded_path =
+            project_ids::decode_claude_project_path(&encoded).unwrap_or_else(|_| encoded.clone());
+        let session_files = session_files_in_dir(&path);
+        if session_files.is_empty() {
+            continue;
+        }
+
+        let mut last_active: Option<String> = None;
+        let mut latest_mtime = std::time::SystemTime::UNIX_EPOCH;
+        let mut period_count = 0usize;
+
+        for session_file in session_files {
+            if let Ok(metadata) = fs::metadata(&session_file) {
+                if let Ok(modified) = metadata.modified() {
+                    if modified >= cutoff {
+                        period_count += 1;
+                        let date_key = local_date_string(modified);
+                        if let Some(count) = daily_counts.get_mut(&date_key) {
+                            *count += 1;
+                        }
+                    }
+                    if modified > latest_mtime {
+                        latest_mtime = modified;
+                        last_active = Some(to_iso_string(modified));
+                    }
+                }
+            }
+        }
+
+        if period_count == 0 {
+            continue;
+        }
+
+        total_sessions += period_count;
+        projects.push(ProjectActivity {
+            name: encoded,
+            path: decoded_path,
+            session_count: period_count,
+            last_active,
+        });
+    }
+
+    projects.sort_by(|left, right| right.session_count.cmp(&left.session_count));
+    let mut daily_counts_vec = daily_counts
+        .into_iter()
+        .map(|(date, count)| DailyCount { date, count })
+        .collect::<Vec<_>>();
+    daily_counts_vec.sort_by(|left, right| left.date.cmp(&right.date));
+
+    Ok(ActivityMetrics {
+        total_sessions,
+        projects,
+        daily_counts: daily_counts_vec,
+    })
+}
+
+fn resolve_session_dir(project_id: &str) -> Result<Option<PathBuf>, String> {
+    if project_id.starts_with("discovered-") {
+        return project_ids::resolve_discovered_session_dir(project_id);
+    }
+    let project_path = project_ids::resolve_project_path(project_id)?;
+    project_path
+        .as_deref()
+        .map(project_ids::session_dir_for_project)
+        .transpose()
+}
+
+fn session_files_in_dir(dir: &Path) -> Vec<PathBuf> {
+    fs::read_dir(dir)
+        .map(|entries| {
+            entries
+                .flatten()
+                .map(|entry| entry.path())
+                .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("jsonl"))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_session_meta(path: &Path) -> Option<SessionMeta> {
+    let content = fs::read_to_string(path).ok()?;
+    let mut summary = String::new();
+    let mut session_id = String::new();
+    let mut first_timestamp: Option<std::time::SystemTime> = None;
+    let mut last_timestamp: Option<std::time::SystemTime> = None;
+
+    for line in content.lines().filter(|line| !line.trim().is_empty()) {
+        let Ok(event) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+
+        if summary.is_empty() {
+            if let Some(text) = event.get("summary").and_then(|value| value.as_str()) {
+                summary = text.to_string();
+            }
+        }
+        if session_id.is_empty() {
+            if let Some(value) = event.get("sessionId").and_then(|value| value.as_str()) {
+                session_id = value.to_string();
+            }
+        }
+
+        if let Some(timestamp) = event.get("timestamp").and_then(|value| value.as_str()) {
+            if let Ok(parsed) = timestamp.parse::<chrono_like::Timestamp>() {
+                let system_time = parsed.to_system_time();
+                if first_timestamp.is_none() {
+                    first_timestamp = Some(system_time);
+                }
+                last_timestamp = Some(system_time);
+            }
+        }
+
+        if summary.is_empty() && event.get("type").and_then(|value| value.as_str()) == Some("user")
+        {
+            if let Some(message) = event.get("message") {
+                let text = extract_message_text(message.get("content"));
+                if !text.is_empty() {
+                    summary = truncate_summary(&text);
+                }
+            }
+        }
+    }
+
+    let first_timestamp = first_timestamp?;
+    if session_id.is_empty() {
+        session_id = path.file_stem()?.to_string_lossy().to_string();
+    }
+
+    Some(SessionMeta {
+        id: session_id,
+        timestamp: format_timestamp(first_timestamp),
+        duration: format_duration(first_timestamp, last_timestamp.unwrap_or(first_timestamp)),
+        summary: if summary.is_empty() {
+            "No summary available".to_string()
+        } else {
+            summary
+        },
+    })
+}
+
+fn parse_session_detail(path: &Path, limit: usize, offset: usize) -> Result<SessionDetail, String> {
+    let metadata =
+        fs::metadata(path).map_err(|err| format!("Failed to stat {}: {err}", path.display()))?;
+    if metadata.len() > MAX_SESSION_FILE_BYTES {
+        return Ok(SessionDetail {
+            messages: vec![SessionMessage {
+                role: "system".to_string(),
+                timestamp: None,
+                content_blocks: vec![ContentBlock {
+                    r#type: "text".to_string(),
+                    text: Some(format!(
+                        "Session file too large ({:.1} MB, limit 10 MB). Showing summary only.",
+                        metadata.len() as f64 / 1024.0 / 1024.0
+                    )),
+                    tool_name: None,
+                    tool_input: None,
+                    tool_use_id: None,
+                    result: None,
+                    is_error: None,
+                }],
+            }],
+            summary: SessionSummary {
+                message_count: 0,
+                tool_call_count: 0,
+                duration: None,
+            },
+        });
+    }
+
+    let mut tool_results = HashMap::new();
+    for_each_jsonl_line(path, |line| {
+        let Ok(event) = serde_json::from_str::<Value>(&line) else {
+            return;
+        };
+        let Some(content) = event
+            .get("message")
+            .and_then(|message| message.get("content"))
+            .and_then(|content| content.as_array())
+        else {
+            return;
+        };
+
+        for block in content {
+            if block.get("type").and_then(|value| value.as_str()) != Some("tool_result") {
+                continue;
+            }
+            let Some(tool_use_id) = block.get("tool_use_id").and_then(|value| value.as_str())
+            else {
+                continue;
+            };
+            let result = extract_tool_result_content(block);
+            if result.is_none() {
+                continue;
+            }
+            tool_results.insert(
+                tool_use_id.to_string(),
+                (
+                    result.unwrap_or_default(),
+                    block
+                        .get("is_error")
+                        .and_then(|value| value.as_bool())
+                        .unwrap_or(false),
+                ),
+            );
+        }
+    })?;
+
+    let mut messages = Vec::new();
+    let mut first_timestamp: Option<std::time::SystemTime> = None;
+    let mut last_timestamp: Option<std::time::SystemTime> = None;
+    let mut tool_call_count = 0usize;
+
+    for_each_jsonl_line(path, |line| {
+        let Ok(event) = serde_json::from_str::<Value>(&line) else {
+            return;
+        };
+        let event_type = event.get("type").and_then(|value| value.as_str());
+        if event_type != Some("user") && event_type != Some("assistant") {
+            return;
+        }
+
+        if let Some(timestamp) = event.get("timestamp").and_then(|value| value.as_str()) {
+            if let Ok(parsed) = timestamp.parse::<chrono_like::Timestamp>() {
+                let system_time = parsed.to_system_time();
+                if first_timestamp.is_none() {
+                    first_timestamp = Some(system_time);
+                }
+                last_timestamp = Some(system_time);
+            }
+        }
+
+        let Some(message) = event.get("message") else {
+            return;
+        };
+        let Some(role) = message.get("role").and_then(|value| value.as_str()) else {
+            return;
+        };
+
+        let mut content_blocks = Vec::new();
+        match message.get("content") {
+            Some(Value::String(text)) => {
+                let (system_blocks, remaining) = extract_system_tags(text);
+                content_blocks.extend(system_blocks);
+                if !remaining.is_empty() {
+                    content_blocks.push(text_block(remaining));
+                }
+            }
+            Some(Value::Array(blocks)) => {
+                for block in blocks {
+                    match block.get("type").and_then(|value| value.as_str()) {
+                        Some("text") => {
+                            let text = block
+                                .get("text")
+                                .and_then(|value| value.as_str())
+                                .unwrap_or("");
+                            let (system_blocks, remaining) = extract_system_tags(text);
+                            content_blocks.extend(system_blocks);
+                            if !remaining.is_empty() {
+                                content_blocks.push(text_block(remaining));
+                            }
+                        }
+                        Some("thinking") => {
+                            let text = block
+                                .get("thinking")
+                                .or_else(|| block.get("text"))
+                                .and_then(|value| value.as_str())
+                                .unwrap_or("");
+                            if !text.is_empty() {
+                                content_blocks.push(ContentBlock {
+                                    r#type: "thinking".to_string(),
+                                    text: Some(text.to_string()),
+                                    tool_name: None,
+                                    tool_input: None,
+                                    tool_use_id: None,
+                                    result: None,
+                                    is_error: None,
+                                });
+                            }
+                        }
+                        Some("tool_use") => {
+                            let tool_name = block
+                                .get("name")
+                                .and_then(|value| value.as_str())
+                                .unwrap_or("");
+                            if tool_name.is_empty() {
+                                continue;
+                            }
+                            let tool_use_id = block
+                                .get("id")
+                                .and_then(|value| value.as_str())
+                                .map(|value| value.to_string());
+                            let mut tool_block = ContentBlock {
+                                r#type: "tool_use".to_string(),
+                                text: None,
+                                tool_name: Some(tool_name.to_string()),
+                                tool_input: stringify_input(block.get("input")),
+                                tool_use_id: tool_use_id.clone(),
+                                result: None,
+                                is_error: None,
+                            };
+                            if let Some(tool_use_id) = &tool_use_id {
+                                if let Some((result, is_error)) = tool_results.get(tool_use_id) {
+                                    tool_block.result = Some(result.clone());
+                                    tool_block.is_error = Some(*is_error);
+                                }
+                            }
+                            content_blocks.push(tool_block);
+                            tool_call_count += 1;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        if !content_blocks.is_empty() {
+            messages.push(SessionMessage {
+                role: role.to_string(),
+                timestamp: event
+                    .get("timestamp")
+                    .and_then(|value| value.as_str())
+                    .map(|value| value.to_string()),
+                content_blocks,
+            });
+        }
+    })?;
+
+    let total_messages = messages.len();
+    let clamped_limit = limit.max(1).min(MAX_DETAIL_LIMIT);
+    let paged_messages = messages
+        .into_iter()
+        .skip(offset)
+        .take(clamped_limit)
+        .collect::<Vec<_>>();
+
+    Ok(SessionDetail {
+        messages: paged_messages,
+        summary: SessionSummary {
+            message_count: total_messages,
+            tool_call_count,
+            duration: match (first_timestamp, last_timestamp) {
+                (Some(start), Some(end)) if end > start => Some(format_duration(start, end)),
+                _ => None,
+            },
+        },
+    })
+}
+
+fn period_days(period: Option<&str>) -> usize {
+    match period.unwrap_or("7d") {
+        "24h" => 1,
+        "30d" => 30,
+        _ => 7,
+    }
+}
+
+fn empty_activity_metrics(days: usize) -> ActivityMetrics {
+    let mut daily_counts = build_daily_buckets(days)
+        .into_iter()
+        .map(|(date, count)| DailyCount { date, count })
+        .collect::<Vec<_>>();
+    daily_counts.sort_by(|left, right| left.date.cmp(&right.date));
+    ActivityMetrics {
+        total_sessions: 0,
+        projects: Vec::new(),
+        daily_counts,
+    }
+}
+
+fn build_daily_buckets(days: usize) -> HashMap<String, usize> {
+    let mut buckets = HashMap::new();
+    let now = std::time::SystemTime::now();
+    for day_offset in 0..days {
+        let timestamp = now
+            .checked_sub(std::time::Duration::from_secs(
+                (day_offset as u64) * 24 * 60 * 60,
+            ))
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        buckets.insert(local_date_string(timestamp), 0);
+    }
+    buckets
+}
+
+fn chrono_like_cutoff(days: usize) -> std::time::SystemTime {
+    std::time::SystemTime::now()
+        .checked_sub(std::time::Duration::from_secs((days as u64) * 24 * 60 * 60))
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+}
+
+fn for_each_jsonl_line<F>(path: &Path, mut callback: F) -> Result<(), String>
+where
+    F: FnMut(String),
+{
+    let file =
+        File::open(path).map_err(|err| format!("Failed to open {}: {err}", path.display()))?;
+    let reader = BufReader::new(file);
+    for line in reader.lines() {
+        let line = line.map_err(|err| format!("Failed to read {}: {err}", path.display()))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        callback(line);
+    }
+    Ok(())
+}
+
+fn extract_message_text(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::String(text)) => text.to_string(),
+        Some(Value::Array(blocks)) => blocks
+            .iter()
+            .find_map(|block| block.get("text").and_then(|value| value.as_str()))
+            .unwrap_or("")
+            .to_string(),
+        _ => String::new(),
+    }
+}
+
+fn truncate_summary(text: &str) -> String {
+    let cleaned = text.replace(['\n', '\r'], " ");
+    let without_tags = strip_angle_tags(&cleaned);
+    if without_tags.chars().count() <= 100 {
+        return without_tags;
+    }
+    format!("{}...", without_tags.chars().take(100).collect::<String>())
+}
+
+fn strip_angle_tags(text: &str) -> String {
+    let mut output = String::with_capacity(text.len());
+    let mut inside_tag = false;
+    for character in text.chars() {
+        match character {
+            '<' => inside_tag = true,
+            '>' => inside_tag = false,
+            _ if !inside_tag => output.push(character),
+            _ => {}
+        }
+    }
+    output.trim().to_string()
+}
+
+fn extract_system_tags(text: &str) -> (Vec<ContentBlock>, String) {
+    let mut remaining = text.to_string();
+    let mut blocks = Vec::new();
+
+    loop {
+        let mut next_match: Option<(usize, &str)> = None;
+        for tag in SYSTEM_TAGS {
+            let open = format!("<{tag}>");
+            if let Some(index) = remaining.find(&open) {
+                match next_match {
+                    Some((best_index, _)) if best_index <= index => {}
+                    _ => next_match = Some((index, tag)),
+                }
+            }
+        }
+
+        let Some((start, tag)) = next_match else {
+            break;
+        };
+        let open = format!("<{tag}>");
+        let close = format!("</{tag}>");
+        let content_start = start + open.len();
+        let Some(relative_close) = remaining[content_start..].find(&close) else {
+            break;
+        };
+        let content_end = content_start + relative_close;
+        let content = remaining[content_start..content_end].trim().to_string();
+        blocks.push(ContentBlock {
+            r#type: "system".to_string(),
+            text: Some(format!("[{tag}]\n{content}")),
+            tool_name: None,
+            tool_input: None,
+            tool_use_id: None,
+            result: None,
+            is_error: None,
+        });
+        remaining.replace_range(start..content_end + close.len(), "");
+    }
+
+    (blocks, remaining.trim().to_string())
+}
+
+fn text_block(text: String) -> ContentBlock {
+    ContentBlock {
+        r#type: "text".to_string(),
+        text: Some(text),
+        tool_name: None,
+        tool_input: None,
+        tool_use_id: None,
+        result: None,
+        is_error: None,
+    }
+}
+
+fn stringify_input(input: Option<&Value>) -> Option<String> {
+    let input = input?;
+    let raw = if let Some(text) = input.as_str() {
+        text.to_string()
+    } else {
+        serde_json::to_string_pretty(input).ok()?
+    };
+    Some(cap_string(raw))
+}
+
+fn extract_tool_result_content(block: &Value) -> Option<String> {
+    match block.get("content") {
+        Some(Value::String(text)) => Some(cap_string(text.to_string())),
+        Some(Value::Array(parts)) => parts
+            .iter()
+            .find_map(|part| part.get("text").and_then(|value| value.as_str()))
+            .map(|text| cap_string(text.to_string())),
+        _ => None,
+    }
+}
+
+fn cap_string(text: String) -> String {
+    if text.chars().count() <= MAX_TOOL_TEXT_BYTES {
+        return text;
+    }
+    format!(
+        "{}...",
+        text.chars().take(MAX_TOOL_TEXT_BYTES).collect::<String>()
+    )
+}
+
+fn format_timestamp(timestamp: std::time::SystemTime) -> String {
+    let now = std::time::SystemTime::now();
+    let now_date = local_date_string(now);
+    let timestamp_date = local_date_string(timestamp);
+    let time = local_time_string(timestamp);
+    if now_date == timestamp_date {
+        return format!("Today {time}");
+    }
+    format!("{} {time}", local_month_day_string(timestamp))
+}
+
+fn format_duration(start: std::time::SystemTime, end: std::time::SystemTime) -> String {
+    let Ok(duration) = end.duration_since(start) else {
+        return "0min".to_string();
+    };
+    let minutes = duration.as_secs() / 60;
+    let hours = minutes / 60;
+    let remaining = minutes % 60;
+    if hours == 0 {
+        format!("{remaining}min")
+    } else {
+        format!("{hours}h {remaining}min")
+    }
+}
+
+fn to_iso_string(timestamp: std::time::SystemTime) -> String {
+    chrono_like::Timestamp::from_system_time(timestamp).to_iso_string()
+}
+
+fn local_date_string(timestamp: std::time::SystemTime) -> String {
+    chrono_like::Timestamp::from_system_time(timestamp).local_date_string()
+}
+
+fn local_time_string(timestamp: std::time::SystemTime) -> String {
+    chrono_like::Timestamp::from_system_time(timestamp).local_time_string()
+}
+
+fn local_month_day_string(timestamp: std::time::SystemTime) -> String {
+    chrono_like::Timestamp::from_system_time(timestamp).local_month_day_string()
+}
+
+mod chrono_like {
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    pub struct Timestamp {
+        seconds: i64,
+    }
+
+    impl Timestamp {
+        pub fn to_system_time(&self) -> SystemTime {
+            if self.seconds <= 0 {
+                return UNIX_EPOCH;
+            }
+            UNIX_EPOCH + Duration::from_secs(self.seconds as u64)
+        }
+
+        pub fn from_system_time(timestamp: SystemTime) -> Self {
+            let seconds = timestamp
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| duration.as_secs() as i64)
+                .unwrap_or_default();
+            Self { seconds }
+        }
+
+        pub fn to_iso_string(&self) -> String {
+            // Enough for parity in Phase 1: UTC second precision.
+            let timestamp = self.to_system_time();
+            let datetime = timestamp
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| duration.as_secs())
+                .unwrap_or_default();
+            let tm = civil_from_unix(datetime as i64);
+            format!(
+                "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+                tm.year, tm.month, tm.day, tm.hour, tm.minute, tm.second
+            )
+        }
+
+        pub fn local_date_string(&self) -> String {
+            let tm = civil_from_unix(self.seconds);
+            format!("{:04}-{:02}-{:02}", tm.year, tm.month, tm.day)
+        }
+
+        pub fn local_time_string(&self) -> String {
+            let tm = civil_from_unix(self.seconds);
+            format!("{:02}:{:02}", tm.hour, tm.minute)
+        }
+
+        pub fn local_month_day_string(&self) -> String {
+            const MONTHS: [&str; 12] = [
+                "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+            ];
+            let tm = civil_from_unix(self.seconds);
+            format!("{} {}", MONTHS[(tm.month - 1) as usize], tm.day)
+        }
+    }
+
+    impl std::str::FromStr for Timestamp {
+        type Err = String;
+
+        fn from_str(value: &str) -> Result<Self, Self::Err> {
+            // Accept RFC3339-ish strings by trimming fractional seconds and Z/offset.
+            let core = value
+                .split(['Z', '+'])
+                .next()
+                .unwrap_or(value)
+                .split('.')
+                .next()
+                .unwrap_or(value);
+            let parts = core
+                .split(['-', 'T', ':'])
+                .map(|segment| {
+                    segment
+                        .parse::<i64>()
+                        .map_err(|_| "invalid timestamp".to_string())
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            if parts.len() < 6 {
+                return Err("invalid timestamp".to_string());
+            }
+            let seconds =
+                unix_from_civil(parts[0], parts[1], parts[2], parts[3], parts[4], parts[5]);
+            Ok(Self { seconds })
+        }
+    }
+
+    struct CivilTime {
+        year: i64,
+        month: i64,
+        day: i64,
+        hour: i64,
+        minute: i64,
+        second: i64,
+    }
+
+    fn unix_from_civil(
+        year: i64,
+        month: i64,
+        day: i64,
+        hour: i64,
+        minute: i64,
+        second: i64,
+    ) -> i64 {
+        let days = days_from_civil(year, month, day);
+        days * 86_400 + hour * 3_600 + minute * 60 + second
+    }
+
+    fn civil_from_unix(seconds: i64) -> CivilTime {
+        let days = seconds.div_euclid(86_400);
+        let secs_of_day = seconds.rem_euclid(86_400);
+        let (year, month, day) = civil_from_days(days);
+        CivilTime {
+            year,
+            month,
+            day,
+            hour: secs_of_day / 3_600,
+            minute: (secs_of_day % 3_600) / 60,
+            second: secs_of_day % 60,
+        }
+    }
+
+    fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+        let year = year - (month <= 2) as i64;
+        let era = if year >= 0 { year } else { year - 399 } / 400;
+        let yoe = year - era * 400;
+        let doy = (153 * (month + if month > 2 { -3 } else { 9 }) + 2) / 5 + day - 1;
+        let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+        era * 146_097 + doe - 719_468
+    }
+
+    fn civil_from_days(days: i64) -> (i64, i64, i64) {
+        let z = days + 719_468;
+        let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+        let doe = z - era * 146_097;
+        let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+        let y = yoe + era * 400;
+        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+        let mp = (5 * doy + 2) / 153;
+        let day = doy - (153 * mp + 2) / 5 + 1;
+        let month = mp + if mp < 10 { 3 } else { -9 };
+        let year = y + (month <= 2) as i64;
+        (year, month, day)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_system_tags, parse_session_detail, text_block};
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn write_fixture(name: &str, content: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join("claudekit-control-center-tests");
+        fs::create_dir_all(&dir).expect("temp dir should be created");
+        let path = dir.join(name);
+        fs::write(&path, content).expect("fixture should be written");
+        path
+    }
+
+    #[test]
+    fn extracts_system_tags_from_text() {
+        let (blocks, remaining) =
+            extract_system_tags("hello <system-reminder>pay attention</system-reminder> world");
+        assert_eq!(remaining, "hello  world".trim().to_string());
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(
+            blocks[0].text.as_deref(),
+            Some("[system-reminder]\npay attention")
+        );
+    }
+
+    #[test]
+    fn parses_session_detail_with_tool_results() {
+        let path = write_fixture(
+            "session-detail.jsonl",
+            "{\"type\":\"assistant\",\"timestamp\":\"2026-04-15T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Read\",\"id\":\"tool_1\",\"input\":{\"path\":\"/tmp/demo\"}}]}}\n\
+             {\"type\":\"assistant\",\"timestamp\":\"2026-04-15T10:01:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"tool_1\",\"content\":\"done\",\"is_error\":false}]}}\n",
+        );
+        let detail = parse_session_detail(&path, 50, 0).expect("detail should parse");
+        assert_eq!(detail.summary.tool_call_count, 1);
+        assert_eq!(detail.messages.len(), 1);
+        assert_eq!(
+            detail.messages[0].content_blocks[0].tool_name.as_deref(),
+            Some("Read")
+        );
+        assert_eq!(
+            detail.messages[0].content_blocks[0].result.as_deref(),
+            Some("done")
+        );
+    }
+
+    #[test]
+    fn text_block_helper_sets_text_type() {
+        let block = text_block("demo".to_string());
+        assert_eq!(block.r#type, "text");
+        assert_eq!(block.text.as_deref(), Some("demo"));
+    }
+}

--- a/src-tauri/src/commands/skills-browser.rs
+++ b/src-tauri/src/commands/skills-browser.rs
@@ -1,0 +1,369 @@
+use crate::core::{frontmatter::parse_frontmatter, paths};
+use serde::Serialize;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SkillSource {
+    Local,
+    Github,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillBrowserItem {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub triggers: Option<Vec<String>>,
+    pub source: SkillSource,
+    pub installed: bool,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillBrowserDetail {
+    #[serde(flatten)]
+    pub summary: SkillBrowserItem,
+    pub content: String,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillSearchResult {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    pub score: f64,
+    pub path: String,
+}
+
+#[tauri::command]
+pub async fn browse_skills() -> Result<Vec<SkillBrowserItem>, String> {
+    tauri::async_runtime::spawn_blocking(list_skills_blocking)
+        .await
+        .map_err(|err| format!("Failed to browse skills: {err}"))?
+}
+
+#[tauri::command]
+pub async fn scan_skills() -> Result<Vec<SkillBrowserItem>, String> {
+    browse_skills().await
+}
+
+#[tauri::command]
+pub async fn get_skill_detail(name: String) -> Result<SkillBrowserDetail, String> {
+    tauri::async_runtime::spawn_blocking(move || get_skill_detail_blocking(&name))
+        .await
+        .map_err(|err| format!("Failed to read skill detail: {err}"))?
+}
+
+#[tauri::command]
+pub async fn search_skills(
+    query: String,
+    limit: Option<u32>,
+) -> Result<Vec<SkillSearchResult>, String> {
+    tauri::async_runtime::spawn_blocking(move || search_skills_blocking(&query, limit))
+        .await
+        .map_err(|err| format!("Failed to search skills: {err}"))?
+}
+
+fn list_skills_blocking() -> Result<Vec<SkillBrowserItem>, String> {
+    let skills_dir = skills_dir()?;
+    let entries = match fs::read_dir(&skills_dir) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(Vec::new()),
+    };
+
+    let mut items = Vec::new();
+    for entry in entries.flatten() {
+        let skill_dir = entry.path();
+        let skill_md = skill_dir.join("SKILL.md");
+        if !skill_md.is_file() {
+            continue;
+        }
+        let Some(name) = skill_dir.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        items.push(read_skill_summary(name, &skill_dir, &skill_md)?);
+    }
+
+    items.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(items)
+}
+
+pub(crate) fn load_skills() -> Result<Vec<SkillBrowserItem>, String> {
+    list_skills_blocking()
+}
+
+fn get_skill_detail_blocking(name: &str) -> Result<SkillBrowserDetail, String> {
+    if !is_valid_skill_name(name) {
+        return Err("Invalid skill name".to_string());
+    }
+
+    let skills_dir = skills_dir()?;
+    let skill_dir = skills_dir.join(name);
+    let skill_md = skill_dir.join("SKILL.md");
+    if !skill_md.is_file() {
+        return Err(format!("Skill \"{name}\" not found"));
+    }
+
+    let content = fs::read_to_string(&skill_md)
+        .map_err(|err| format!("Failed to read {}: {err}", skill_md.display()))?;
+    Ok(SkillBrowserDetail {
+        summary: build_skill_item(name, &skill_dir, &content),
+        content,
+    })
+}
+
+fn search_skills_blocking(
+    query: &str,
+    limit: Option<u32>,
+) -> Result<Vec<SkillSearchResult>, String> {
+    let trimmed = query.trim();
+    if trimmed.is_empty() {
+        return Err("Missing query parameter: q".to_string());
+    }
+
+    let capped_limit = limit.unwrap_or(10).clamp(1, 100) as usize;
+    let terms = trimmed
+        .to_lowercase()
+        .split_whitespace()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+    let skills_dir = skills_dir()?;
+    let mut results = Vec::new();
+    for item in list_skills_blocking()? {
+        let skill_path = skills_dir.join(&item.name).join("SKILL.md");
+        let content = fs::read_to_string(&skill_path).unwrap_or_default();
+        let parsed = parse_frontmatter(&content)?;
+        let tokens = format!(
+            "{} {} {}",
+            item.name,
+            item.description.clone().unwrap_or_default(),
+            item.triggers.clone().unwrap_or_default().join(" ")
+        )
+        .to_lowercase();
+
+        let mut score = 0.0;
+        for term in &terms {
+            if item.name.to_lowercase().contains(term) {
+                score += 3.0;
+            } else if tokens.contains(term) {
+                score += 1.0;
+            }
+        }
+
+        if score > 0.0 {
+            results.push(SkillSearchResult {
+                name: item.name.clone(),
+                display_name: parsed
+                    .frontmatter
+                    .get("displayName")
+                    .or_else(|| parsed.frontmatter.get("display_name"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                description: item.description.clone(),
+                category: parsed
+                    .frontmatter
+                    .get("category")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                score,
+                path: format!("{}/SKILL.md", item.name),
+            });
+        }
+    }
+
+    results.sort_by(|left, right| {
+        right
+            .score
+            .partial_cmp(&left.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(left.name.cmp(&right.name))
+    });
+    results.truncate(capped_limit);
+    Ok(results)
+}
+
+fn skills_dir() -> Result<PathBuf, String> {
+    paths::global_skills_dir().ok_or_else(|| "Cannot determine skills directory".to_string())
+}
+
+fn read_skill_summary(
+    name: &str,
+    skill_dir: &Path,
+    skill_md: &Path,
+) -> Result<SkillBrowserItem, String> {
+    let content = fs::read_to_string(skill_md)
+        .map_err(|err| format!("Failed to read {}: {err}", skill_md.display()))?;
+    Ok(build_skill_item(name, skill_dir, &content))
+}
+
+fn build_skill_item(name: &str, skill_dir: &Path, content: &str) -> SkillBrowserItem {
+    let parsed = parse_frontmatter(content).ok();
+    let description = parsed
+        .as_ref()
+        .and_then(|value| value.frontmatter.get("description"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            parsed
+                .as_ref()
+                .and_then(|value| first_descriptive_line(&value.body))
+        });
+
+    SkillBrowserItem {
+        name: name.to_string(),
+        description,
+        triggers: parsed
+            .as_ref()
+            .and_then(|value| extract_string_list(value.frontmatter.get("triggers"))),
+        source: detect_source(skill_dir),
+        installed: true,
+    }
+}
+
+fn detect_source(skill_dir: &Path) -> SkillSource {
+    let imports = skill_dir.join(".imports.json");
+    if let Ok(content) = fs::read_to_string(imports) {
+        if content.contains("github") {
+            return SkillSource::Github;
+        }
+    }
+
+    let git_config = skill_dir.join(".git").join("config");
+    if let Ok(content) = fs::read_to_string(git_config) {
+        if content.contains("github.com") {
+            return SkillSource::Github;
+        }
+    }
+
+    SkillSource::Local
+}
+
+fn extract_string_list(value: Option<&Value>) -> Option<Vec<String>> {
+    let list = match value? {
+        Value::Array(items) => items
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect::<Vec<_>>(),
+        Value::String(raw) => raw
+            .split(',')
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>(),
+        _ => Vec::new(),
+    };
+
+    if list.is_empty() {
+        None
+    } else {
+        Some(list)
+    }
+}
+
+fn first_descriptive_line(body: &str) -> Option<String> {
+    body.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(str::to_string)
+}
+
+fn is_valid_skill_name(name: &str) -> bool {
+    !name.is_empty()
+        && !name.contains("..")
+        && !name.contains('/')
+        && !name.contains('\\')
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_skill_item, extract_string_list, search_skills_blocking, SkillSource};
+    use serde_json::json;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be valid")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("ck-skills-{name}-{unique}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+
+    #[test]
+    fn extracts_trigger_lists_from_arrays_and_strings() {
+        assert_eq!(
+            extract_string_list(Some(&json!(["one", "two"]))),
+            Some(vec!["one".to_string(), "two".to_string()])
+        );
+        assert_eq!(
+            extract_string_list(Some(&json!("one, two"))),
+            Some(vec!["one".to_string(), "two".to_string()])
+        );
+    }
+
+    #[test]
+    fn builds_skill_item_with_description_fallback_and_github_source() {
+        let skill_dir = temp_dir("item");
+        fs::write(skill_dir.join(".imports.json"), "{\"source\":\"github\"}")
+            .expect("imports should exist");
+        let item = build_skill_item(
+            "demo",
+            &skill_dir,
+            "---\ntriggers:\n  - search\n---\nFirst descriptive line\n# Heading\n",
+        );
+
+        assert_eq!(item.description.as_deref(), Some("First descriptive line"));
+        assert_eq!(item.triggers.expect("triggers")[0], "search");
+        assert_eq!(item.source, SkillSource::Github);
+    }
+
+    #[test]
+    fn searches_skills_by_name_and_trigger_text() {
+        let home_dir = temp_dir("home");
+        let skills_dir = home_dir.join(".claude").join("skills");
+        let alpha_dir = skills_dir.join("alpha");
+        let beta_dir = skills_dir.join("beta");
+        fs::create_dir_all(&alpha_dir).expect("alpha dir should exist");
+        fs::create_dir_all(&beta_dir).expect("beta dir should exist");
+        fs::write(
+            alpha_dir.join("SKILL.md"),
+            "---\ndescription: search docs\ntriggers:\n  - docs\n---\n",
+        )
+        .expect("alpha skill should exist");
+        fs::write(
+            beta_dir.join("SKILL.md"),
+            "---\ndescription: terminal helper\n---\n",
+        )
+        .expect("beta skill should exist");
+
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", &home_dir);
+        let results = search_skills_blocking("docs", Some(5)).expect("search should succeed");
+        if let Some(home) = original_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "alpha");
+    }
+}

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -111,7 +111,7 @@ pub fn get_system_info() -> Result<SystemInfo, String> {
         },
         os: format!("{} {}", std::env::consts::OS, std::env::consts::ARCH),
         cli_version: env!("CARGO_PKG_VERSION").to_string(),
-        package_manager: detect_package_manager(),
+        package_manager: detect_package_manager(None),
         install_location: run_command(which_command("ck"), "not found"),
         git_version: run_command(version_command("git"), "unknown"),
         gh_version: run_command(version_command("gh"), "unknown")
@@ -384,8 +384,10 @@ fn which_command(binary: &str) -> (&str, Vec<&str>) {
     }
 }
 
-fn detect_package_manager() -> String {
-    let agent = std::env::var("npm_config_user_agent").unwrap_or_default();
+fn detect_package_manager(agent_override: Option<&str>) -> String {
+    let agent = agent_override
+        .map(str::to_string)
+        .unwrap_or_else(|| std::env::var("npm_config_user_agent").unwrap_or_default());
     if agent.contains("bun/") {
         "bun".to_string()
     } else if agent.contains("pnpm/") {
@@ -494,8 +496,6 @@ mod tests {
 
     #[test]
     fn detects_package_manager_from_env() {
-        std::env::set_var("npm_config_user_agent", "bun/1.3.11");
-        assert_eq!(detect_package_manager(), "bun");
-        std::env::remove_var("npm_config_user_agent");
+        assert_eq!(detect_package_manager(Some("bun/1.3.11")), "bun");
     }
 }

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -1,0 +1,501 @@
+use crate::core::{paths, project_ids};
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+use std::process::Command;
+use std::sync::OnceLock;
+use std::time::{Instant, SystemTime};
+
+static APP_START: OnceLock<Instant> = OnceLock::new();
+const DEFAULT_HOOK_LIMIT: usize = 50;
+const MAX_HOOK_LIMIT: usize = 200;
+const MAX_INSPECTED_LINES: usize = 2_000;
+const MAX_READ_BYTES: usize = 512 * 1024;
+const MAX_HOOK_PROJECT_ID_LENGTH: usize = 512;
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemInfo {
+    pub config_path: String,
+    pub node_version: String,
+    pub bun_version: Option<String>,
+    pub os: String,
+    pub cli_version: String,
+    pub package_manager: String,
+    pub install_location: String,
+    pub git_version: String,
+    pub gh_version: String,
+    pub shell: String,
+    pub home_dir: String,
+    pub cpu_cores: usize,
+    pub total_memory_gb: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthStatus {
+    pub status: String,
+    pub timestamp: String,
+    pub uptime: u64,
+    pub settings_exists: bool,
+    pub claude_json_exists: bool,
+    pub projects_registry_exists: bool,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HookDiagnosticEntry {
+    pub ts: String,
+    pub hook: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dur: Option<f64>,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HookDiagnosticsSummary {
+    pub total: usize,
+    pub parse_errors: usize,
+    pub last_event_at: Option<String>,
+    pub inspected_lines: usize,
+    pub truncated: bool,
+    pub status_counts: HashMap<String, usize>,
+    pub hook_counts: HashMap<String, usize>,
+    pub tool_counts: HashMap<String, usize>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HookDiagnosticsResponse {
+    pub scope: String,
+    pub project_id: Option<String>,
+    pub path: String,
+    pub exists: bool,
+    pub entries: Vec<HookDiagnosticEntry>,
+    pub summary: HookDiagnosticsSummary,
+}
+
+pub fn mark_app_started() {
+    let _ = APP_START.get_or_init(Instant::now);
+}
+
+#[tauri::command]
+pub fn get_system_info() -> Result<SystemInfo, String> {
+    let home_dir =
+        paths::home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
+    let config_path = paths::global_claude_dir()
+        .ok_or_else(|| "Cannot determine global Claude directory".to_string())?;
+
+    Ok(SystemInfo {
+        config_path: config_path.to_string_lossy().to_string(),
+        node_version: run_command(version_command("node"), "unknown"),
+        bun_version: match run_command(version_command("bun"), "").trim() {
+            "" => None,
+            value => Some(value.to_string()),
+        },
+        os: format!("{} {}", std::env::consts::OS, std::env::consts::ARCH),
+        cli_version: env!("CARGO_PKG_VERSION").to_string(),
+        package_manager: detect_package_manager(),
+        install_location: run_command(which_command("ck"), "not found"),
+        git_version: run_command(version_command("git"), "unknown"),
+        gh_version: run_command(version_command("gh"), "unknown")
+            .lines()
+            .next()
+            .unwrap_or("unknown")
+            .to_string(),
+        shell: std::env::var("SHELL")
+            .or_else(|_| std::env::var("ComSpec"))
+            .unwrap_or_else(|_| "unknown".to_string()),
+        home_dir: home_dir.to_string_lossy().to_string(),
+        cpu_cores: std::thread::available_parallelism()
+            .map(|count| count.get())
+            .unwrap_or(1),
+        total_memory_gb: format!("{:.1}", system_memory_gb()),
+    })
+}
+
+#[tauri::command]
+pub fn get_health() -> Result<HealthStatus, String> {
+    let now = SystemTime::now();
+    let started = APP_START.get_or_init(Instant::now);
+    let global_dir = paths::global_claude_dir()
+        .ok_or_else(|| "Cannot determine global Claude directory".to_string())?;
+    let settings_exists = global_dir.join("settings.json").exists();
+    let claude_json_exists = paths::global_claude_json_path()
+        .map(|path| path.exists())
+        .unwrap_or(false);
+    let projects_registry_exists = paths::home_dir()
+        .map(|path| path.join(".claudekit").join("projects.json").exists())
+        .unwrap_or(false);
+
+    Ok(HealthStatus {
+        status: "ok".to_string(),
+        timestamp: iso_now(now),
+        uptime: started.elapsed().as_secs(),
+        settings_exists,
+        claude_json_exists,
+        projects_registry_exists,
+    })
+}
+
+#[tauri::command]
+pub async fn get_hook_diagnostics(
+    scope: Option<String>,
+    project_id: Option<String>,
+    limit: Option<u32>,
+) -> Result<HookDiagnosticsResponse, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        get_hook_diagnostics_blocking(scope.as_deref(), project_id.as_deref(), limit)
+    })
+    .await
+    .map_err(|err| format!("Failed to read hook diagnostics: {err}"))?
+}
+
+fn get_hook_diagnostics_blocking(
+    raw_scope: Option<&str>,
+    raw_project_id: Option<&str>,
+    limit: Option<u32>,
+) -> Result<HookDiagnosticsResponse, String> {
+    let scope = match raw_scope.unwrap_or("global") {
+        "global" => "global",
+        "project" => "project",
+        _ => return Err("scope must be either 'global' or 'project'".to_string()),
+    };
+
+    if let Some(project_id) = raw_project_id {
+        if project_id.len() > MAX_HOOK_PROJECT_ID_LENGTH {
+            return Err(format!(
+                "projectId must be {MAX_HOOK_PROJECT_ID_LENGTH} characters or fewer"
+            ));
+        }
+    }
+    if scope == "project" && raw_project_id.is_none() {
+        return Err("projectId is required when scope=project".to_string());
+    }
+
+    let base_path = if scope == "global" {
+        paths::global_claude_dir()
+            .ok_or_else(|| "Cannot determine global Claude directory".to_string())?
+    } else {
+        let project_id = raw_project_id.expect("checked above");
+        project_ids::resolve_project_path(project_id)?
+            .ok_or_else(|| "Project not found".to_string())?
+    };
+
+    let log_path = if scope == "global" {
+        base_path.join("hooks").join(".logs").join("hook-log.jsonl")
+    } else {
+        base_path
+            .join(".claude")
+            .join("hooks")
+            .join(".logs")
+            .join("hook-log.jsonl")
+    };
+
+    let mut summary = HookDiagnosticsSummary {
+        total: 0,
+        parse_errors: 0,
+        last_event_at: None,
+        inspected_lines: 0,
+        truncated: false,
+        status_counts: HashMap::new(),
+        hook_counts: HashMap::new(),
+        tool_counts: HashMap::new(),
+    };
+
+    if !log_path.exists() {
+        return Ok(HookDiagnosticsResponse {
+            scope: scope.to_string(),
+            project_id: raw_project_id.map(|value| value.to_string()),
+            path: log_path.to_string_lossy().to_string(),
+            exists: false,
+            entries: Vec::new(),
+            summary,
+        });
+    }
+
+    let (lines, truncated) = read_log_tail(&log_path)?;
+    summary.inspected_lines = lines.len();
+    summary.truncated = truncated;
+
+    let mut parsed = Vec::new();
+    for line in lines {
+        match serde_json::from_str::<Value>(&line) {
+            Ok(value) => {
+                if let Some(entry) = parse_hook_entry(&value) {
+                    parsed.push(entry);
+                } else {
+                    summary.parse_errors += 1;
+                }
+            }
+            Err(_) => summary.parse_errors += 1,
+        }
+    }
+
+    parsed.sort_by(|left, right| right.ts.cmp(&left.ts));
+    if let Some(entry) = parsed.first() {
+        summary.last_event_at = Some(entry.ts.clone());
+    }
+    for entry in &parsed {
+        summary.total += 1;
+        increment(&mut summary.status_counts, &entry.status);
+        increment(&mut summary.hook_counts, &entry.hook);
+        if let Some(tool) = &entry.tool {
+            increment(&mut summary.tool_counts, tool);
+        }
+    }
+
+    let entries = parsed
+        .into_iter()
+        .take(clamp_hook_limit(limit))
+        .collect::<Vec<_>>();
+
+    Ok(HookDiagnosticsResponse {
+        scope: scope.to_string(),
+        project_id: raw_project_id.map(|value| value.to_string()),
+        path: log_path.to_string_lossy().to_string(),
+        exists: true,
+        entries,
+        summary,
+    })
+}
+
+fn parse_hook_entry(value: &Value) -> Option<HookDiagnosticEntry> {
+    Some(HookDiagnosticEntry {
+        ts: value.get("ts")?.as_str()?.to_string(),
+        hook: value.get("hook")?.as_str()?.to_string(),
+        event: value
+            .get("event")
+            .and_then(|item| item.as_str())
+            .map(|item| item.to_string()),
+        tool: value
+            .get("tool")
+            .and_then(|item| item.as_str())
+            .map(|item| item.to_string()),
+        target: value
+            .get("target")
+            .and_then(|item| item.as_str())
+            .map(|item| item.to_string()),
+        note: value
+            .get("note")
+            .and_then(|item| item.as_str())
+            .map(|item| item.to_string()),
+        dur: value.get("dur").and_then(|item| item.as_f64()),
+        status: value.get("status")?.as_str()?.to_string(),
+        exit: value.get("exit").and_then(|item| item.as_i64()),
+        error: value
+            .get("error")
+            .and_then(|item| item.as_str())
+            .map(|item| item.to_string()),
+    })
+}
+
+fn clamp_hook_limit(limit: Option<u32>) -> usize {
+    match limit {
+        Some(value) if value > 0 => usize::try_from(value)
+            .unwrap_or(DEFAULT_HOOK_LIMIT)
+            .min(MAX_HOOK_LIMIT),
+        _ => DEFAULT_HOOK_LIMIT,
+    }
+}
+
+fn read_log_tail(path: &Path) -> Result<(Vec<String>, bool), String> {
+    let mut file =
+        File::open(path).map_err(|err| format!("Failed to open {}: {err}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .map_err(|err| format!("Failed to stat {}: {err}", path.display()))?;
+    if metadata.len() == 0 {
+        return Ok((Vec::new(), false));
+    }
+
+    let bytes_to_read = usize::try_from(metadata.len())
+        .unwrap_or(MAX_READ_BYTES)
+        .min(MAX_READ_BYTES);
+    let start = metadata.len().saturating_sub(bytes_to_read as u64);
+    let mut buffer = vec![0u8; bytes_to_read];
+    file.seek(SeekFrom::Start(start))
+        .map_err(|err| format!("Failed to seek {}: {err}", path.display()))?;
+    file.read_exact(&mut buffer)
+        .map_err(|err| format!("Failed to read {}: {err}", path.display()))?;
+
+    let mut raw = String::from_utf8_lossy(&buffer).to_string();
+    let mut truncated = start > 0;
+    if truncated {
+        if let Some(newline_index) = raw.find('\n') {
+            raw = raw[(newline_index + 1)..].to_string();
+        } else {
+            raw.clear();
+        }
+    }
+
+    let mut lines = raw
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+    if lines.len() > MAX_INSPECTED_LINES {
+        lines = lines.split_off(lines.len() - MAX_INSPECTED_LINES);
+        truncated = true;
+    }
+    Ok((lines, truncated))
+}
+
+fn increment(map: &mut HashMap<String, usize>, key: &str) {
+    *map.entry(key.to_string()).or_insert(0) += 1;
+}
+
+fn run_command((command, args): (&str, Vec<&str>), fallback: &str) -> String {
+    Command::new(command)
+        .args(args)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|output| !output.is_empty())
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+fn version_command(command: &str) -> (&str, Vec<&str>) {
+    (command, vec!["--version"])
+}
+
+fn which_command(binary: &str) -> (&str, Vec<&str>) {
+    if cfg!(target_os = "windows") {
+        ("where", vec![binary])
+    } else {
+        ("which", vec![binary])
+    }
+}
+
+fn detect_package_manager() -> String {
+    let agent = std::env::var("npm_config_user_agent").unwrap_or_default();
+    if agent.contains("bun/") {
+        "bun".to_string()
+    } else if agent.contains("pnpm/") {
+        "pnpm".to_string()
+    } else if agent.contains("yarn/") {
+        "yarn".to_string()
+    } else if agent.contains("npm/") {
+        "npm".to_string()
+    } else {
+        "npm".to_string()
+    }
+}
+
+fn system_memory_gb() -> f64 {
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(meminfo) = std::fs::read_to_string("/proc/meminfo") {
+            if let Some(line) = meminfo.lines().find(|line| line.starts_with("MemTotal:")) {
+                if let Some(kb) = line
+                    .split_whitespace()
+                    .nth(1)
+                    .and_then(|value| value.parse::<f64>().ok())
+                {
+                    return kb / 1024.0 / 1024.0;
+                }
+            }
+        }
+    }
+    0.0
+}
+
+fn iso_now(now: SystemTime) -> String {
+    let seconds = now
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default();
+    let (year, month, day, hour, minute, second) = civil_from_unix(seconds as i64);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+fn civil_from_unix(seconds: i64) -> (i64, i64, i64, i64, i64, i64) {
+    let days = seconds.div_euclid(86_400);
+    let secs_of_day = seconds.rem_euclid(86_400);
+    let (year, month, day) = civil_from_days(days);
+    (
+        year,
+        month,
+        day,
+        secs_of_day / 3_600,
+        (secs_of_day % 3_600) / 60,
+        secs_of_day % 60,
+    )
+}
+
+fn civil_from_days(days: i64) -> (i64, i64, i64) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = mp + if mp < 10 { 3 } else { -9 };
+    let year = y + (month <= 2) as i64;
+    (year, month, day)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{clamp_hook_limit, detect_package_manager, parse_hook_entry, read_log_tail};
+    use serde_json::json;
+    use std::fs;
+
+    #[test]
+    fn parses_hook_entry_shape() {
+        let entry = parse_hook_entry(&json!({
+            "ts": "2026-04-15T10:00:00Z",
+            "hook": "pre-commit",
+            "status": "ok",
+            "tool": "bash"
+        }))
+        .expect("hook entry should parse");
+        assert_eq!(entry.hook, "pre-commit");
+        assert_eq!(entry.status, "ok");
+        assert_eq!(entry.tool.as_deref(), Some("bash"));
+    }
+
+    #[test]
+    fn clamps_hook_limit() {
+        assert_eq!(clamp_hook_limit(None), 50);
+        assert_eq!(clamp_hook_limit(Some(500)), 200);
+        assert_eq!(clamp_hook_limit(Some(5)), 5);
+    }
+
+    #[test]
+    fn reads_log_tail_without_empty_lines() {
+        let dir = std::env::temp_dir().join("claudekit-control-center-tests");
+        fs::create_dir_all(&dir).expect("temp dir should be created");
+        let path = dir.join("hook-log.jsonl");
+        fs::write(&path, "\nline1\nline2\n").expect("fixture should be written");
+        let (lines, truncated) = read_log_tail(&path).expect("tail should read");
+        assert!(!truncated);
+        assert_eq!(lines, vec!["line1".to_string(), "line2".to_string()]);
+    }
+
+    #[test]
+    fn detects_package_manager_from_env() {
+        std::env::set_var("npm_config_user_agent", "bun/1.3.11");
+        assert_eq!(detect_package_manager(), "bun");
+        std::env::remove_var("npm_config_user_agent");
+    }
+}

--- a/src-tauri/src/core/config_parser.rs
+++ b/src-tauri/src/core/config_parser.rs
@@ -23,8 +23,7 @@ pub fn read_json_file(path: &Path) -> Result<Value, String> {
         return Ok(Value::Object(serde_json::Map::new()));
     }
 
-    serde_json::from_str(&content)
-        .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))
+    serde_json::from_str(&content).map_err(|e| format!("Failed to parse {}: {}", path.display(), e))
 }
 
 /// Write a JSON value to disk as pretty-printed JSON.
@@ -39,6 +38,5 @@ pub fn write_json_file(path: &Path, value: &Value) -> Result<(), String> {
     let content = serde_json::to_string_pretty(value)
         .map_err(|e| format!("Failed to serialize JSON: {}", e))?;
 
-    fs::write(path, content)
-        .map_err(|e| format!("Failed to write {}: {}", path.display(), e))
+    fs::write(path, content).map_err(|e| format!("Failed to write {}: {}", path.display(), e))
 }

--- a/src-tauri/src/core/frontmatter.rs
+++ b/src-tauri/src/core/frontmatter.rs
@@ -7,14 +7,15 @@ pub struct ParsedFrontmatter {
 }
 
 pub fn parse_frontmatter(content: &str) -> Result<ParsedFrontmatter, String> {
-    if !content.starts_with("---\n") {
+    let normalized = content.replace("\r\n", "\n");
+    if !normalized.starts_with("---\n") {
         return Ok(ParsedFrontmatter {
             frontmatter: Map::new(),
             body: content.to_string(),
         });
     }
 
-    let remainder = &content[4..];
+    let remainder = &normalized[4..];
     let Some(split_index) = remainder.find("\n---\n") else {
         return Err("Invalid frontmatter: missing closing delimiter".to_string());
     };

--- a/src-tauri/src/core/frontmatter.rs
+++ b/src-tauri/src/core/frontmatter.rs
@@ -1,0 +1,73 @@
+use serde_json::{Map, Value};
+
+#[derive(Debug)]
+pub struct ParsedFrontmatter {
+    pub frontmatter: Map<String, Value>,
+    pub body: String,
+}
+
+pub fn parse_frontmatter(content: &str) -> Result<ParsedFrontmatter, String> {
+    if !content.starts_with("---\n") {
+        return Ok(ParsedFrontmatter {
+            frontmatter: Map::new(),
+            body: content.to_string(),
+        });
+    }
+
+    let remainder = &content[4..];
+    let Some(split_index) = remainder.find("\n---\n") else {
+        return Err("Invalid frontmatter: missing closing delimiter".to_string());
+    };
+
+    let yaml = &remainder[..split_index];
+    let body = &remainder[split_index + 5..];
+    let yaml_value: serde_yaml::Value =
+        serde_yaml::from_str(yaml).map_err(|err| format!("Invalid frontmatter: {err}"))?;
+    let json_value = serde_json::to_value(yaml_value)
+        .map_err(|err| format!("Frontmatter conversion failed: {err}"))?;
+
+    let frontmatter = match json_value {
+        Value::Object(map) => map,
+        _ => Map::new(),
+    };
+
+    Ok(ParsedFrontmatter {
+        frontmatter,
+        body: body.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_frontmatter;
+
+    #[test]
+    fn parses_yaml_frontmatter_and_body() {
+        let parsed = parse_frontmatter(
+            "---\nname: test\ndescription: demo\nkeywords:\n  - one\n  - two\n---\n# Body\n",
+        )
+        .expect("frontmatter should parse");
+
+        assert_eq!(
+            parsed
+                .frontmatter
+                .get("name")
+                .and_then(|value| value.as_str()),
+            Some("test")
+        );
+        assert_eq!(parsed.body.trim(), "# Body");
+    }
+
+    #[test]
+    fn returns_empty_frontmatter_when_missing() {
+        let parsed = parse_frontmatter("# No frontmatter").expect("parse should succeed");
+        assert!(parsed.frontmatter.is_empty());
+        assert_eq!(parsed.body, "# No frontmatter");
+    }
+
+    #[test]
+    fn rejects_unclosed_frontmatter_block() {
+        let err = parse_frontmatter("---\nname: broken\n").expect_err("parse should fail");
+        assert!(err.contains("missing closing delimiter"));
+    }
+}

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -4,5 +4,7 @@
 // These are pure Rust — no Tauri-specific APIs here.
 
 pub mod config_parser;
+pub mod frontmatter;
 pub mod paths;
+pub mod project_ids;
 pub mod schema;

--- a/src-tauri/src/core/paths.rs
+++ b/src-tauri/src/core/paths.rs
@@ -10,9 +10,41 @@ pub fn global_claude_dir() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".claude"))
 }
 
+pub fn home_dir() -> Option<PathBuf> {
+    dirs::home_dir()
+}
+
 /// Get project-specific Claude config directory (<project>/.claude/)
 pub fn project_claude_dir(project_path: &str) -> PathBuf {
     PathBuf::from(project_path).join(".claude")
+}
+
+pub fn global_projects_dir() -> Option<PathBuf> {
+    global_claude_dir().map(|dir| dir.join("projects"))
+}
+
+pub fn global_agents_dir() -> Option<PathBuf> {
+    global_claude_dir().map(|dir| dir.join("agents"))
+}
+
+pub fn global_commands_dir() -> Option<PathBuf> {
+    global_claude_dir().map(|dir| dir.join("commands"))
+}
+
+pub fn global_skills_dir() -> Option<PathBuf> {
+    global_claude_dir().map(|dir| dir.join("skills"))
+}
+
+pub fn global_claude_json_path() -> Option<PathBuf> {
+    home_dir().map(|dir| dir.join(".claude.json"))
+}
+
+pub fn global_mcp_json_path() -> Option<PathBuf> {
+    global_claude_dir().map(|dir| dir.join(".mcp.json"))
+}
+
+pub fn projects_registry_path() -> Option<PathBuf> {
+    home_dir().map(|dir| dir.join(".claudekit").join("projects.json"))
 }
 
 /// Get settings.json path within a given base directory

--- a/src-tauri/src/core/project_ids.rs
+++ b/src-tauri/src/core/project_ids.rs
@@ -29,6 +29,12 @@ pub fn encode_claude_project_path(project_path: &str) -> String {
     project_path.replace('\\', "/").replace('/', "-")
 }
 
+/// Decode Claude's session-directory naming convention.
+///
+/// NOTE: This decode is lossy because raw hyphens in path segments are
+/// indistinguishable from path separators after flattening. Prefer
+/// `extract_project_path_from_session_dir()` or discovered base64 ids when an
+/// exact project path is required.
 pub fn decode_claude_project_path(encoded: &str) -> Result<String, String> {
     let decoded = encoded.replacen('-', "/", 1).replace('-', "/");
     if decoded.contains("..") {
@@ -208,8 +214,8 @@ fn normalize_existing_path(path: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::{
-        decode_discovered_project_id, discovered_project_id, encode_claude_project_path,
-        extract_project_path_from_session_dir,
+        decode_claude_project_path, decode_discovered_project_id, discovered_project_id,
+        encode_claude_project_path, extract_project_path_from_session_dir,
     };
     use std::fs;
     use std::path::PathBuf;
@@ -239,6 +245,14 @@ mod tests {
             encode_claude_project_path("/Users/kai/demo-project"),
             "-Users-kai-demo-project"
         );
+    }
+
+    #[test]
+    fn decode_is_lossy_for_hyphenated_directory_names() {
+        let decoded =
+            decode_claude_project_path("-Users-kai-demo-project").expect("decode should succeed");
+        assert_eq!(decoded, "/Users/kai/demo/project");
+        assert_ne!(decoded, "/Users/kai/demo-project");
     }
 
     #[test]

--- a/src-tauri/src/core/project_ids.rs
+++ b/src-tauri/src/core/project_ids.rs
@@ -1,0 +1,262 @@
+use crate::core::paths;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use serde::Deserialize;
+use serde_json::Value;
+use std::env;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredProject {
+    pub path: PathBuf,
+    pub session_dir: PathBuf,
+}
+
+#[derive(Deserialize)]
+struct ProjectsRegistry {
+    projects: Vec<RegisteredProject>,
+}
+
+#[derive(Deserialize)]
+struct RegisteredProject {
+    id: String,
+    path: String,
+}
+
+pub fn encode_claude_project_path(project_path: &str) -> String {
+    project_path.replace('\\', "/").replace('/', "-")
+}
+
+pub fn decode_claude_project_path(encoded: &str) -> Result<String, String> {
+    let decoded = encoded.replacen('-', "/", 1).replace('-', "/");
+    if decoded.contains("..") {
+        return Err("Invalid encoded project path".to_string());
+    }
+    Ok(decoded)
+}
+
+pub fn discovered_project_id(project_path: &str) -> String {
+    format!(
+        "discovered-{}",
+        URL_SAFE_NO_PAD.encode(project_path.as_bytes())
+    )
+}
+
+pub fn decode_discovered_project_id(project_id: &str) -> Result<String, String> {
+    let encoded = project_id
+        .strip_prefix("discovered-")
+        .ok_or_else(|| "Invalid discovered project id".to_string())?;
+    let bytes = URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|err| format!("Failed to decode project id: {err}"))?;
+    String::from_utf8(bytes).map_err(|err| format!("Invalid UTF-8 in project id: {err}"))
+}
+
+pub fn resolve_project_path(project_id: &str) -> Result<Option<PathBuf>, String> {
+    match project_id {
+        "current" => {
+            let cwd = env::current_dir().map_err(|err| format!("Failed to read cwd: {err}"))?;
+            return Ok(Some(cwd));
+        }
+        "global" => {
+            return Ok(paths::global_claude_dir());
+        }
+        _ => {}
+    }
+
+    if project_id.starts_with("discovered-") {
+        let expected = PathBuf::from(decode_discovered_project_id(project_id)?);
+        let expected_canonical = normalize_existing_path(&expected);
+        let discovered = scan_discovered_projects()?;
+        return Ok(discovered
+            .into_iter()
+            .find(|project| normalize_existing_path(&project.path) == expected_canonical)
+            .map(|project| project.path));
+    }
+
+    lookup_registered_project(project_id)
+}
+
+pub fn resolve_discovered_session_dir(project_id: &str) -> Result<Option<PathBuf>, String> {
+    let expected = PathBuf::from(decode_discovered_project_id(project_id)?);
+    let expected_canonical = normalize_existing_path(&expected);
+    let discovered = scan_discovered_projects()?;
+    Ok(discovered
+        .into_iter()
+        .find(|project| normalize_existing_path(&project.path) == expected_canonical)
+        .map(|project| project.session_dir))
+}
+
+pub fn session_dir_for_project(project_path: &Path) -> Result<PathBuf, String> {
+    let projects_dir = paths::global_projects_dir()
+        .ok_or_else(|| "Cannot determine projects directory".to_string())?;
+    Ok(projects_dir.join(encode_claude_project_path(&project_path.to_string_lossy())))
+}
+
+pub fn project_path_from_session_dir(
+    session_dir: &Path,
+    encoded_dir_name: &str,
+) -> Result<PathBuf, String> {
+    if let Some(path) = extract_project_path_from_session_dir(session_dir)? {
+        return Ok(path);
+    }
+
+    decode_claude_project_path(encoded_dir_name).map(PathBuf::from)
+}
+
+pub fn scan_discovered_projects() -> Result<Vec<DiscoveredProject>, String> {
+    let Some(projects_dir) = paths::global_projects_dir() else {
+        return Ok(Vec::new());
+    };
+    if !projects_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut discovered = Vec::new();
+    let mut seen_paths = std::collections::HashSet::new();
+
+    for entry in fs::read_dir(&projects_dir)
+        .map_err(|err| format!("Failed to read {}: {err}", projects_dir.display()))?
+        .flatten()
+    {
+        let session_dir = entry.path();
+        if !session_dir.is_dir() {
+            continue;
+        }
+
+        let encoded_dir_name = entry.file_name().to_string_lossy().to_string();
+        let Some(path) = extract_project_path_from_session_dir(&session_dir)?.or_else(|| {
+            decode_claude_project_path(&encoded_dir_name)
+                .ok()
+                .map(PathBuf::from)
+        }) else {
+            continue;
+        };
+
+        let normalized = normalize_existing_path(&path).to_string_lossy().to_string();
+        if seen_paths.insert(normalized) {
+            discovered.push(DiscoveredProject { path, session_dir });
+        }
+    }
+
+    Ok(discovered)
+}
+
+fn projects_registry_path() -> Result<PathBuf, String> {
+    paths::projects_registry_path()
+        .ok_or_else(|| "Cannot determine projects registry path".to_string())
+}
+
+fn lookup_registered_project(project_id: &str) -> Result<Option<PathBuf>, String> {
+    let registry_path = projects_registry_path()?;
+    if !registry_path.exists() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(&registry_path)
+        .map_err(|err| format!("Failed to read {}: {err}", registry_path.display()))?;
+    let parsed: ProjectsRegistry = serde_json::from_str(&content)
+        .map_err(|err| format!("Failed to parse projects registry: {err}"))?;
+
+    Ok(parsed
+        .projects
+        .into_iter()
+        .find(|project| project.id == project_id)
+        .map(|project| PathBuf::from(project.path)))
+}
+
+fn extract_project_path_from_session_dir(session_dir: &Path) -> Result<Option<PathBuf>, String> {
+    let entries = match fs::read_dir(session_dir) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(None),
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("jsonl") {
+            continue;
+        }
+
+        let file = fs::File::open(&path)
+            .map_err(|err| format!("Failed to read {}: {err}", path.display()))?;
+        let reader = BufReader::new(file);
+        for line in reader.lines().take(10) {
+            let line = line.map_err(|err| format!("Failed to read {}: {err}", path.display()))?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            let Ok(value) = serde_json::from_str::<Value>(&line) else {
+                continue;
+            };
+            if let Some(cwd) = value.get("cwd").and_then(|value| value.as_str()) {
+                if !cwd.trim().is_empty() {
+                    return Ok(Some(PathBuf::from(cwd)));
+                }
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+fn normalize_existing_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        decode_discovered_project_id, discovered_project_id, encode_claude_project_path,
+        extract_project_path_from_session_dir,
+    };
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be valid")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("ck-project-ids-{name}-{unique}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+
+    #[test]
+    fn discovered_project_ids_round_trip() {
+        let original = "/Users/kai/demo-project";
+        let project_id = discovered_project_id(original);
+        let decoded = decode_discovered_project_id(&project_id).expect("decode should succeed");
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn preserves_hyphens_in_encoded_session_dir_names() {
+        assert_eq!(
+            encode_claude_project_path("/Users/kai/demo-project"),
+            "-Users-kai-demo-project"
+        );
+    }
+
+    #[test]
+    fn extracts_project_path_from_session_cwd() {
+        let root = temp_dir("session-dir");
+        let session_dir = root.join("-Users-kai-demo-project");
+        fs::create_dir_all(&session_dir).expect("session dir should exist");
+        fs::write(
+            session_dir.join("session.jsonl"),
+            "{\"cwd\":\"/Users/kai/demo-project\"}\n",
+        )
+        .expect("fixture should be written");
+
+        let path =
+            extract_project_path_from_session_dir(&session_dir).expect("extract should succeed");
+        assert_eq!(
+            path.expect("cwd should be found"),
+            PathBuf::from("/Users/kai/demo-project")
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod tray;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    commands::system::mark_app_started();
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::default().build())
@@ -22,6 +23,11 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            // Agent/browser commands (Phase 1B)
+            commands::agents::scan_agents,
+            commands::agents::get_agent_detail,
+            commands::commands_browser::scan_commands,
+            commands::commands_browser::get_command_detail,
             // Config commands (Phase 1B)
             commands::config::read_config,
             commands::config::write_config,
@@ -35,6 +41,23 @@ pub fn run() {
             projects::add_project,
             projects::remove_project,
             projects::scan_for_projects,
+            // Session commands (Phase 1A)
+            commands::sessions::scan_sessions,
+            commands::sessions::list_project_sessions,
+            commands::sessions::get_session_detail,
+            commands::sessions::get_session_activity,
+            // System commands (Phase 1E)
+            commands::system::get_system_info,
+            commands::system::get_health,
+            commands::system::get_hook_diagnostics,
+            // Skills, MCP, and dashboard commands (Phase 1B/1C/1D)
+            commands::skills_browser::scan_skills,
+            commands::skills_browser::get_skill_detail,
+            commands::skills_browser::search_skills,
+            commands::mcp::discover_mcp_servers,
+            commands::dashboard::get_dashboard_stats,
+            commands::dashboard::get_dashboard_agents,
+            commands::dashboard::get_suggestions,
         ])
         .run(tauri::generate_context!())
         .expect("error while running ClaudeKit Control Center");

--- a/src-tauri/src/projects.rs
+++ b/src-tauri/src/projects.rs
@@ -1,116 +1,92 @@
 // ClaudeKit Control Center — Project management commands
 //
-// Provides Tauri commands for multi-project management:
-//   - list_projects   — Return all registered projects from persistent store
-//   - add_project     — Register a directory as a project
-//   - remove_project  — Unregister a project by path
-//   - scan_for_projects — Recursively discover .claude/ directories
+// Uses the same ~/.claudekit/projects.json registry as the CLI/web backend so
+// desktop project actions and desktop read commands share one source of truth.
 
+use crate::core::paths;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
-use tauri_plugin_store::StoreExt;
+use uuid::Uuid;
 
-/// Metadata about a ClaudeKit project directory
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ProjectInfo {
-    /// Directory name (last path component)
     pub name: String,
-    /// Absolute path to the project root
     pub path: String,
-    /// Whether .claude/ directory exists
     pub has_claude_config: bool,
-    /// Whether .claude/.ck.json exists (indicates CK-managed project)
     pub has_ck_config: bool,
 }
 
-/// Store key under which the list of project paths is persisted
-const STORE_KEY: &str = "paths";
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RegisteredProject {
+    id: String,
+    path: String,
+    alias: String,
+    added_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_opened: Option<String>,
+}
 
-/// List all registered projects from the persistent store.
-///
-/// Returns an empty list if no projects have been added yet.
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct ProjectsRegistry {
+    version: u32,
+    projects: Vec<RegisteredProject>,
+}
+
+const REGISTRY_VERSION: u32 = 1;
+
 #[tauri::command]
-pub fn list_projects(app: tauri::AppHandle) -> Result<Vec<ProjectInfo>, String> {
-    let store = app
-        .store("projects.json")
-        .map_err(|e| format!("Failed to open store: {e}"))?;
-
-    let paths: Vec<String> = store
-        .get(STORE_KEY)
-        .and_then(|v| serde_json::from_value(v).ok())
-        .unwrap_or_default();
-
-    Ok(paths
+pub fn list_projects(_app: tauri::AppHandle) -> Result<Vec<ProjectInfo>, String> {
+    let registry = load_registry()?;
+    Ok(registry
+        .projects
         .iter()
-        .filter(|p| Path::new(p.as_str()).is_dir())
-        .map(|p| build_project_info(p.as_str()))
+        .filter(|project| Path::new(&project.path).is_dir())
+        .map(|project| build_project_info(&project.path))
         .collect())
 }
 
-/// Add a project directory to the persistent store.
-///
-/// Validates that the path exists on disk. Silently skips duplicates.
-/// Returns the ProjectInfo for the newly-added (or already-present) project.
 #[tauri::command]
-pub fn add_project(app: tauri::AppHandle, path: String) -> Result<ProjectInfo, String> {
-    if !Path::new(&path).is_dir() {
-        return Err(format!("Path is not a directory or does not exist: {path}"));
+pub fn add_project(_app: tauri::AppHandle, path: String) -> Result<ProjectInfo, String> {
+    let canonical_path = canonical_project_path(&path)?;
+    let mut registry = load_registry()?;
+
+    if !registry
+        .projects
+        .iter()
+        .any(|project| project.path == canonical_path)
+    {
+        let project_name = Path::new(&canonical_path)
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or(&canonical_path)
+            .to_string();
+
+        registry.projects.push(RegisteredProject {
+            id: Uuid::new_v4().to_string(),
+            path: canonical_path.clone(),
+            alias: project_name,
+            added_at: current_timestamp_iso(),
+            last_opened: None,
+        });
+        save_registry(&registry)?;
     }
 
-    let store = app
-        .store("projects.json")
-        .map_err(|e| format!("Failed to open store: {e}"))?;
-
-    let mut paths: Vec<String> = store
-        .get(STORE_KEY)
-        .and_then(|v| serde_json::from_value(v).ok())
-        .unwrap_or_default();
-
-    if !paths.contains(&path) {
-        paths.push(path.clone());
-        store.set(
-            STORE_KEY,
-            serde_json::to_value(&paths).map_err(|e| format!("Serialization error: {e}"))?,
-        );
-        store.save().map_err(|e| format!("Failed to save store: {e}"))?;
-    }
-
-    Ok(build_project_info(&path))
+    Ok(build_project_info(&canonical_path))
 }
 
-/// Remove a project directory from the persistent store.
-///
-/// No-ops if the path is not registered.
 #[tauri::command]
-pub fn remove_project(app: tauri::AppHandle, path: String) -> Result<(), String> {
-    let store = app
-        .store("projects.json")
-        .map_err(|e| format!("Failed to open store: {e}"))?;
-
-    let mut paths: Vec<String> = store
-        .get(STORE_KEY)
-        .and_then(|v| serde_json::from_value(v).ok())
-        .unwrap_or_default();
-
-    paths.retain(|p| p != &path);
-
-    store.set(
-        STORE_KEY,
-        serde_json::to_value(&paths).map_err(|e| format!("Serialization error: {e}"))?,
-    );
-    store.save().map_err(|e| format!("Failed to save store: {e}"))?;
-
-    Ok(())
+pub fn remove_project(_app: tauri::AppHandle, path: String) -> Result<(), String> {
+    let normalized_path = normalize_input_path(&path);
+    let mut registry = load_registry()?;
+    registry.projects.retain(|project| {
+        let project_path = normalize_input_path(&project.path);
+        project_path != normalized_path && project.path != path
+    });
+    save_registry(&registry)
 }
 
-/// Recursively scan a root directory for ClaudeKit projects (those containing .claude/).
-///
-/// `max_depth` caps recursion depth (default 3) to avoid unbounded traversal.
-/// Hidden directories, node_modules, target, and dist are skipped.
-///
-/// Validation (is_absolute, is_dir) runs synchronously before handing off to
-/// `spawn_blocking` so that cheap path checks never block the async runtime.
 #[tauri::command]
 pub async fn scan_for_projects(
     root_path: String,
@@ -121,38 +97,106 @@ pub async fn scan_for_projects(
         return Err(format!("Scan root must be an absolute path: {root_path}"));
     }
     if !p.is_dir() {
-        return Err(format!("Scan root is not a directory or does not exist: {root_path}"));
+        return Err(format!(
+            "Scan root is not a directory or does not exist: {root_path}"
+        ));
     }
     let depth = max_depth.unwrap_or(3);
 
     tauri::async_runtime::spawn_blocking(move || {
         let mut found: Vec<ProjectInfo> = Vec::new();
-        scan_recursive(std::path::Path::new(&root_path), depth, &mut found);
+        scan_recursive(Path::new(&root_path), depth, &mut found);
         found
     })
     .await
     .map_err(|e| format!("Scan failed: {e}"))
 }
 
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
+fn registry_path() -> Result<std::path::PathBuf, String> {
+    paths::projects_registry_path()
+        .ok_or_else(|| "Cannot determine projects registry path".to_string())
+}
 
-/// Walk `dir` recursively up to `depth` levels, collecting directories that
-/// contain a `.claude/` subdirectory.
+fn load_registry() -> Result<ProjectsRegistry, String> {
+    let path = registry_path()?;
+    if !path.exists() {
+        return Ok(ProjectsRegistry {
+            version: REGISTRY_VERSION,
+            projects: Vec::new(),
+        });
+    }
+
+    let content = fs::read_to_string(&path)
+        .map_err(|err| format!("Failed to read {}: {err}", path.display()))?;
+    serde_json::from_str::<ProjectsRegistry>(&content)
+        .map_err(|err| format!("Failed to parse {}: {err}", path.display()))
+}
+
+fn save_registry(registry: &ProjectsRegistry) -> Result<(), String> {
+    let path = registry_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|err| format!("Failed to create {}: {err}", parent.display()))?;
+    }
+
+    let content = serde_json::to_string_pretty(registry)
+        .map_err(|err| format!("Failed to serialize projects registry: {err}"))?;
+    fs::write(&path, content).map_err(|err| format!("Failed to write {}: {err}", path.display()))
+}
+
+fn canonical_project_path(path: &str) -> Result<String, String> {
+    let project_path = Path::new(path);
+    if !project_path.is_dir() {
+        return Err(format!("Path is not a directory or does not exist: {path}"));
+    }
+    project_path
+        .canonicalize()
+        .map(|path| path.to_string_lossy().into_owned())
+        .map_err(|err| format!("Path is not a directory or does not exist: {path} ({err})"))
+}
+
+fn normalize_input_path(path: &str) -> String {
+    Path::new(path)
+        .canonicalize()
+        .unwrap_or_else(|_| Path::new(path).to_path_buf())
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn current_timestamp_iso() -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default();
+    let days = (now / 86_400) as i64;
+    let secs_of_day = (now % 86_400) as i64;
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = mp + if mp < 10 { 3 } else { -9 };
+    let year = y + (month <= 2) as i64;
+    let hour = secs_of_day / 3_600;
+    let minute = (secs_of_day % 3_600) / 60;
+    let second = secs_of_day % 60;
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
 fn scan_recursive(dir: &Path, depth: u32, results: &mut Vec<ProjectInfo>) {
     if depth == 0 {
         return;
     }
 
-    // Record this directory if it is itself a CK project
     if dir.join(".claude").is_dir() {
         results.push(build_project_info(&dir.to_string_lossy()));
     }
 
     let entries = match fs::read_dir(dir) {
         Ok(e) => e,
-        // Silently skip unreadable directories (permissions, broken symlinks)
         Err(_) => return,
     };
 
@@ -163,8 +207,6 @@ fn scan_recursive(dir: &Path, depth: u32, results: &mut Vec<ProjectInfo>) {
         }
 
         let name = path.file_name().unwrap_or_default().to_string_lossy();
-
-        // Skip hidden dirs and well-known build/dependency dirs to stay fast
         if name.starts_with('.') || name == "node_modules" || name == "target" || name == "dist" {
             continue;
         }
@@ -173,12 +215,8 @@ fn scan_recursive(dir: &Path, depth: u32, results: &mut Vec<ProjectInfo>) {
     }
 }
 
-/// Build a `ProjectInfo` from a raw path string.
-///
-/// Does not require the path to exist — callers must pre-validate when needed.
 fn build_project_info(path: &str) -> ProjectInfo {
     let p = Path::new(path);
-
     let name = p
         .file_name()
         .unwrap_or_default()

--- a/src-tauri/src/projects.rs
+++ b/src-tauri/src/projects.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct ProjectInfo {
     pub name: String,
     pub path: String,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -17,8 +17,13 @@ use tauri::{
 /// Must be called from the `setup` closure in `tauri::Builder`.
 pub fn create_tray<R: Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
     let show = MenuItem::with_id(app, "show", "Open Control Center", true, None::<&str>)?;
-    let check_updates =
-        MenuItem::with_id(app, "check_updates", "Check for Updates", true, None::<&str>)?;
+    let check_updates = MenuItem::with_id(
+        app,
+        "check_updates",
+        "Check for Updates",
+        true,
+        None::<&str>,
+    )?;
     let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
 
     let menu = Menu::with_items(app, &[&show, &check_updates, &quit])?;

--- a/src/ui/src/lib/tauri-commands.ts
+++ b/src/ui/src/lib/tauri-commands.ts
@@ -1,5 +1,5 @@
 /**
- * Typed wrappers for all 11 Tauri v2 commands registered in src-tauri/src/lib.rs.
+ * Typed wrappers for all 29 Tauri v2 commands registered in src-tauri/src/lib.rs.
  *
  * Command names and parameter names match the Rust side exactly (snake_case),
  * since Tauri's invoke() serialises JS camelCase keys to snake_case automatically
@@ -97,3 +97,301 @@ export const scanForProjects = (rootPath: string, maxDepth?: number): Promise<Pr
 		root_path: rootPath,
 		...(maxDepth !== undefined && { max_depth: maxDepth }),
 	});
+
+// ---------------------------------------------------------------------------
+// Session commands — src-tauri/src/commands/sessions.rs
+// ---------------------------------------------------------------------------
+
+export interface ProjectSessionSummary {
+	id: string;
+	name: string;
+	path: string;
+	sessionCount: number;
+	lastActive: string;
+}
+
+export interface SessionMeta {
+	id: string;
+	timestamp: string;
+	duration: string;
+	summary: string;
+}
+
+export interface ProjectActivity {
+	name: string;
+	path: string;
+	sessionCount: number;
+	lastActive: string | null;
+}
+
+export interface DailyCount {
+	date: string;
+	count: number;
+}
+
+export interface ActivityMetrics {
+	totalSessions: number;
+	projects: ProjectActivity[];
+	dailyCounts: DailyCount[];
+}
+
+export interface SessionContentBlock {
+	type: "text" | "thinking" | "tool_use" | "tool_result" | "system";
+	text?: string;
+	toolName?: string;
+	toolInput?: string;
+	toolUseId?: string;
+	result?: string;
+	isError?: boolean;
+}
+
+export interface SessionMessage {
+	role: string;
+	timestamp?: string;
+	contentBlocks: SessionContentBlock[];
+}
+
+export interface SessionSummary {
+	messageCount: number;
+	toolCallCount: number;
+	duration?: string;
+}
+
+export interface SessionDetail {
+	messages: SessionMessage[];
+	summary: SessionSummary;
+}
+
+export const scanSessions = (): Promise<ProjectSessionSummary[]> =>
+	invoke<ProjectSessionSummary[]>("scan_sessions");
+
+export const listProjectSessions = (projectId: string): Promise<SessionMeta[]> =>
+	invoke<SessionMeta[]>("list_project_sessions", { project_id: projectId });
+
+export const getSessionDetail = (
+	projectId: string,
+	sessionId: string,
+	limit?: number,
+	offset?: number,
+): Promise<SessionDetail> =>
+	invoke<SessionDetail>("get_session_detail", {
+		project_id: projectId,
+		session_id: sessionId,
+		...(limit !== undefined && { limit }),
+		...(offset !== undefined && { offset }),
+	});
+
+export const getSessionActivity = (period?: string): Promise<ActivityMetrics> =>
+	invoke<ActivityMetrics>("get_session_activity", {
+		...(period !== undefined && { period }),
+	});
+
+// ---------------------------------------------------------------------------
+// System commands — src-tauri/src/commands/system.rs
+// ---------------------------------------------------------------------------
+
+export interface DesktopSystemInfo {
+	configPath: string;
+	nodeVersion: string;
+	bunVersion: string | null;
+	os: string;
+	cliVersion: string;
+	packageManager: string;
+	installLocation: string;
+	gitVersion: string;
+	ghVersion: string;
+	shell: string;
+	homeDir: string;
+	cpuCores: number;
+	totalMemoryGb: string;
+}
+
+export interface DesktopHealthStatus {
+	status: string;
+	timestamp: string;
+	uptime: number;
+	settingsExists: boolean;
+	claudeJsonExists: boolean;
+	projectsRegistryExists: boolean;
+}
+
+export interface HookDiagnosticEntry {
+	ts: string;
+	hook: string;
+	event?: string;
+	tool?: string;
+	target?: string;
+	note?: string;
+	dur?: number;
+	status: string;
+	exit?: number;
+	error?: string;
+}
+
+export interface HookDiagnosticsSummary {
+	total: number;
+	parseErrors: number;
+	lastEventAt: string | null;
+	inspectedLines: number;
+	truncated: boolean;
+	statusCounts: Record<string, number>;
+	hookCounts: Record<string, number>;
+	toolCounts: Record<string, number>;
+}
+
+export interface HookDiagnosticsResponse {
+	scope: "global" | "project";
+	projectId: string | null;
+	path: string;
+	exists: boolean;
+	entries: HookDiagnosticEntry[];
+	summary: HookDiagnosticsSummary;
+}
+
+export const getSystemInfo = (): Promise<DesktopSystemInfo> =>
+	invoke<DesktopSystemInfo>("get_system_info");
+
+export const getHealth = (): Promise<DesktopHealthStatus> =>
+	invoke<DesktopHealthStatus>("get_health");
+
+export const getHookDiagnostics = (
+	scope?: "global" | "project",
+	projectId?: string,
+	limit?: number,
+): Promise<HookDiagnosticsResponse> =>
+	invoke<HookDiagnosticsResponse>("get_hook_diagnostics", {
+		...(scope !== undefined && { scope }),
+		...(projectId !== undefined && { project_id: projectId }),
+		...(limit !== undefined && { limit }),
+	});
+
+// ---------------------------------------------------------------------------
+// Entity browser commands — src-tauri/src/commands/*.rs
+// ---------------------------------------------------------------------------
+
+export interface AgentInfo {
+	slug: string;
+	name: string;
+	description: string;
+	model?: string | null;
+	color?: string | null;
+	skillCount: number;
+	dirLabel: string;
+	relativePath: string;
+}
+
+export interface AgentDetail extends AgentInfo {
+	frontmatter: Record<string, unknown>;
+	body: string;
+}
+
+export interface CommandNode {
+	name: string;
+	path: string;
+	description?: string;
+	children?: CommandNode[];
+}
+
+export interface CommandDetail {
+	name: string;
+	path: string;
+	content: string;
+	description?: string;
+}
+
+export interface SkillInfo {
+	name: string;
+	description?: string;
+	triggers?: string[];
+	source: "local" | "github";
+	installed: boolean;
+}
+
+export interface SkillDetail {
+	name: string;
+	content: string;
+	description?: string;
+	triggers?: string[];
+	source: "local" | "github";
+	installed: boolean;
+}
+
+export interface SkillSearchResult {
+	name: string;
+	displayName?: string;
+	description?: string;
+	category?: string;
+	score: number;
+	path: string;
+}
+
+export interface McpServerInfo {
+	name: string;
+	command: string;
+	args: string[];
+	envKeys?: string[];
+	source: string;
+	sourceLabel: string;
+}
+
+export interface ModelDistribution {
+	opus: number;
+	sonnet: number;
+	haiku: number;
+	unset: number;
+}
+
+export interface DashboardStats {
+	agents: number;
+	commands: number;
+	skills: number;
+	mcpServers: number;
+	modelDistribution: ModelDistribution;
+}
+
+export interface DashboardAgentEntry {
+	name: string;
+	model: string;
+	description: string;
+	color?: string;
+}
+
+export interface Suggestion {
+	type: "warning" | "info" | "success" | string;
+	message: string;
+	target?: string;
+}
+
+export const scanAgents = (): Promise<AgentInfo[]> => invoke<AgentInfo[]>("scan_agents");
+
+export const getAgentDetail = (slug: string): Promise<AgentDetail> =>
+	invoke<AgentDetail>("get_agent_detail", { slug });
+
+export const scanCommands = (): Promise<CommandNode[]> => invoke<CommandNode[]>("scan_commands");
+
+export const getCommandDetail = (slug: string): Promise<CommandDetail> =>
+	invoke<CommandDetail>("get_command_detail", { slug });
+
+export const scanSkills = (): Promise<SkillInfo[]> => invoke<SkillInfo[]>("scan_skills");
+
+export const getSkillDetail = (name: string): Promise<SkillDetail> =>
+	invoke<SkillDetail>("get_skill_detail", { name });
+
+export const searchSkills = (query: string, limit?: number): Promise<SkillSearchResult[]> =>
+	invoke<SkillSearchResult[]>("search_skills", {
+		query,
+		...(limit !== undefined && { limit }),
+	});
+
+export const discoverMcpServers = (projectPath?: string): Promise<McpServerInfo[]> =>
+	invoke<McpServerInfo[]>("discover_mcp_servers", {
+		...(projectPath !== undefined && { project_path: projectPath }),
+	});
+
+export const getDashboardStats = (): Promise<DashboardStats> =>
+	invoke<DashboardStats>("get_dashboard_stats");
+
+export const getDashboardAgents = (): Promise<DashboardAgentEntry[]> =>
+	invoke<DashboardAgentEntry[]>("get_dashboard_agents");
+
+export const getSuggestions = (): Promise<Suggestion[]> => invoke<Suggestion[]>("get_suggestions");

--- a/src/ui/src/lib/tauri-commands.ts
+++ b/src/ui/src/lib/tauri-commands.ts
@@ -63,9 +63,9 @@ export interface ProjectInfo {
 	/** Absolute path to the project root */
 	path: string;
 	/** Whether .claude/ directory exists */
-	has_claude_config: boolean;
+	hasClaudeConfig: boolean;
 	/** Whether .claude/.ck.json exists (indicates CK-managed project) */
-	has_ck_config: boolean;
+	hasCkConfig: boolean;
 }
 
 /**
@@ -165,8 +165,11 @@ export interface SessionDetail {
 export const scanSessions = (): Promise<ProjectSessionSummary[]> =>
 	invoke<ProjectSessionSummary[]>("scan_sessions");
 
-export const listProjectSessions = (projectId: string): Promise<SessionMeta[]> =>
-	invoke<SessionMeta[]>("list_project_sessions", { project_id: projectId });
+export const listProjectSessions = (projectId: string, limit?: number): Promise<SessionMeta[]> =>
+	invoke<SessionMeta[]>("list_project_sessions", {
+		project_id: projectId,
+		...(limit !== undefined && { limit }),
+	});
 
 export const getSessionDetail = (
 	projectId: string,


### PR DESCRIPTION
## Summary

Implements issue #676 Phase 1 for the desktop-first Control Center backend.

This adds the native Tauri/Rust read-side foundation for:
- sessions and session detail/activity
- agents, commands, and skills browser/search
- MCP server discovery
- dashboard stats, dashboard agents, and suggestions
- system info, health, and hook diagnostics
- typed desktop invoke bindings in `src/ui/src/lib/tauri-commands.ts`

This PR does not switch the UI off Express yet. It keeps the current web-mode routing intact and lands the backend foundation Phase 2 will consume.

## Key Changes

- adds new Rust command modules under `src-tauri/src/commands/`
- adds shared Rust helpers for frontmatter parsing and project/session id resolution
- unifies the desktop project registry with `~/.claudekit/projects.json`
- validates discovered project ids against actual Claude-discovered projects instead of trusting arbitrary base64 payloads
- makes session path resolution use real `cwd` values from session JSONL where available
- hardens string truncation to avoid UTF-8 slicing panics
- updates desktop architecture docs to reflect the expanded Phase 1 bridge

## Validation

- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`
- [x] `bun run validate`
- [x] pre-commit hook passed
- [x] pre-push hook passed

## Docs Impact

Docs impact: minor
Action: updated `docs/codebase-summary.md`, `docs/system-architecture.md`, and `docs/project-roadmap.md`

## Issue Links

Part of #676
Closes #677
Closes #678
Closes #679
Closes #680
Closes #681
