### PR TITLE
feat(desktop): implement phase 2 frontend dual-mode wiring

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -157,3 +157,11 @@ pub fn get_global_config_path() -> Result<String, String> {
     let path = paths::settings_path(&dir);
     Ok(path.to_string_lossy().into_owned())
 }
+
+/// Return the absolute path to the global .claude directory.
+#[tauri::command]
+pub fn get_global_config_dir() -> Result<String, String> {
+    let dir =
+        paths::global_claude_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
+    Ok(dir.to_string_lossy().into_owned())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod commands_browser;
 pub mod config;
 pub mod dashboard;
 pub mod mcp;
+pub mod plans;
 pub mod sessions;
 #[path = "skills-browser.rs"]
 pub mod skills_browser;

--- a/src-tauri/src/commands/plans.rs
+++ b/src-tauri/src/commands/plans.rs
@@ -74,6 +74,9 @@ pub async fn list_plans(dir: String, limit: Option<usize>, offset: Option<usize>
 #[tauri::command]
 pub async fn parse_plan(file: String) -> Result<PlanDetail, String> {
     let p = Path::new(&file);
+    if !p.is_absolute() {
+        return Err(format!("Plan file path must be absolute: {file}"));
+    }
     if !p.is_file() {
         return Err(format!("Plan file not found: {file}"));
     }
@@ -104,6 +107,9 @@ pub async fn parse_plan(file: String) -> Result<PlanDetail, String> {
 #[tauri::command]
 pub async fn get_plan_summary(file: String) -> Result<PlanSummary, String> {
     let p = Path::new(&file);
+    if !p.is_absolute() {
+        return Err(format!("Plan file path must be absolute: {file}"));
+    }
     build_plan_summary(p)
 }
 

--- a/src-tauri/src/commands/plans.rs
+++ b/src-tauri/src/commands/plans.rs
@@ -81,11 +81,15 @@ pub async fn parse_plan(file: String) -> Result<PlanDetail, String> {
     let content = fs::read_to_string(p).map_err(|e| format!("Failed to read {file}: {e}"))?;
     let parsed = parse_frontmatter(&content)?;
 
-    // Basic phase parsing (look for markdown headers with [ ] or [x])
+    // Improved phase parsing (match ## Phase N, ### Phase N, or H1 with Phase)
     let mut phases = Vec::new();
     for line in parsed.body.lines() {
-        if line.starts_with("## Phase ") || (line.starts_with("# ") && line.contains("Phase")) {
-            phases.push(Value::String(line.to_string()));
+        let trimmed = line.trim();
+        if trimmed.starts_with("## Phase")
+            || trimmed.starts_with("### Phase")
+            || (trimmed.starts_with("# ") && trimmed.contains("Phase"))
+        {
+            phases.push(Value::String(trimmed.to_string()));
         }
     }
 
@@ -104,23 +108,57 @@ pub async fn get_plan_summary(file: String) -> Result<PlanSummary, String> {
 }
 
 fn build_plan_summary(path: &Path) -> Result<PlanSummary, String> {
-    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+    let content =
+        fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
     let parsed = parse_frontmatter(&content)?;
-    
-    let plan_dir = path.parent().unwrap_or(Path::new(".")).to_string_lossy().to_string();
-    let name = path.parent().and_then(|p| p.file_name()).and_then(|v| v.to_str()).unwrap_or("unknown").to_string();
-    
-    let status = parsed.frontmatter.get("status").and_then(|v| v.as_str()).unwrap_or("open").to_string();
-    
+
+    let plan_dir = path
+        .parent()
+        .unwrap_or(Path::new("."))
+        .to_string_lossy()
+        .to_string();
+    let name = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|v| v.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let status = parsed
+        .frontmatter
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("open")
+        .to_string();
+
+    // Compute basic metrics from checkboxes
+    let mut total_phases = 0;
+    let mut completed_phases = 0;
+    for line in parsed.body.lines() {
+        let trimmed = line.trim();
+        if trimmed.contains("[ ]") || trimmed.contains("[x]") || trimmed.contains("[X]") {
+            total_phases += 1;
+            if trimmed.contains("[x]") || trimmed.contains("[X]") {
+                completed_phases += 1;
+            }
+        }
+    }
+
+    let progress_pct = if total_phases > 0 {
+        (completed_phases * 100) / total_phases
+    } else {
+        0
+    };
+
     Ok(PlanSummary {
         plan_file: path.to_string_lossy().to_string(),
         plan_dir,
         slug: name.clone(),
         name,
         frontmatter: parsed.frontmatter,
-        progress_pct: 0, // Placeholder
+        progress_pct,
         status,
-        total_phases: 0, // Placeholder
-        completed_phases: 0, // Placeholder
+        total_phases,
+        completed_phases,
     })
 }

--- a/src-tauri/src/commands/plans.rs
+++ b/src-tauri/src/commands/plans.rs
@@ -17,8 +17,8 @@ pub struct PlanSummary {
     pub frontmatter: Map<String, Value>,
     pub progress_pct: u32,
     pub status: String,
-    pub total_phases: u32,
-    pub completed_phases: u32,
+    pub total_tasks: u32,
+    pub completed_tasks: u32,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -132,20 +132,20 @@ fn build_plan_summary(path: &Path) -> Result<PlanSummary, String> {
         .to_string();
 
     // Compute basic metrics from checkboxes
-    let mut total_phases = 0;
-    let mut completed_phases = 0;
+    let mut total_tasks = 0;
+    let mut completed_tasks = 0;
     for line in parsed.body.lines() {
         let trimmed = line.trim();
         if trimmed.contains("[ ]") || trimmed.contains("[x]") || trimmed.contains("[X]") {
-            total_phases += 1;
+            total_tasks += 1;
             if trimmed.contains("[x]") || trimmed.contains("[X]") {
-                completed_phases += 1;
+                completed_tasks += 1;
             }
         }
     }
 
-    let progress_pct = if total_phases > 0 {
-        (completed_phases * 100) / total_phases
+    let progress_pct = if total_tasks > 0 {
+        (completed_tasks * 100) / total_tasks
     } else {
         0
     };
@@ -158,7 +158,7 @@ fn build_plan_summary(path: &Path) -> Result<PlanSummary, String> {
         frontmatter: parsed.frontmatter,
         progress_pct,
         status,
-        total_phases,
-        completed_phases,
+        total_tasks,
+        completed_tasks,
     })
 }

--- a/src-tauri/src/commands/plans.rs
+++ b/src-tauri/src/commands/plans.rs
@@ -1,0 +1,126 @@
+// commands/plans.rs — Tauri commands for reading and parsing ClaudeKit plans
+
+use crate::core::frontmatter::parse_frontmatter;
+use serde::Serialize;
+use serde_json::{Map, Value};
+use std::fs;
+use std::path::Path;
+use walkdir::WalkDir;
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanSummary {
+    pub plan_file: String,
+    pub plan_dir: String,
+    pub name: String,
+    pub slug: String,
+    pub frontmatter: Map<String, Value>,
+    pub progress_pct: u32,
+    pub status: String,
+    pub total_phases: u32,
+    pub completed_phases: u32,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanDetail {
+    pub file: String,
+    pub frontmatter: Map<String, Value>,
+    pub phases: Vec<Value>,
+    pub content: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanListResponse {
+    pub dir: String,
+    pub total: usize,
+    pub plans: Vec<PlanSummary>,
+}
+
+#[tauri::command]
+pub async fn list_plans(dir: String, limit: Option<usize>, offset: Option<usize>) -> Result<PlanListResponse, String> {
+    let p = Path::new(&dir);
+    if !p.is_absolute() {
+        return Err(format!("Plan directory must be absolute: {dir}"));
+    }
+    if !p.is_dir() {
+        return Err(format!("Plan directory not found: {dir}"));
+    }
+
+    let limit = limit.unwrap_or(100);
+    let offset = offset.unwrap_or(0);
+
+    let mut plans = Vec::new();
+    for entry in WalkDir::new(p).max_depth(2).into_iter().filter_map(Result::ok) {
+        let path = entry.path();
+        if path.file_name().and_then(|v| v.to_str()) == Some("plan.md") {
+            if let Ok(summary) = build_plan_summary(path) {
+                plans.push(summary);
+            }
+        }
+    }
+
+    let total = plans.len();
+    let paged_plans = plans.into_iter().skip(offset).take(limit).collect();
+
+    Ok(PlanListResponse {
+        dir,
+        total,
+        plans: paged_plans,
+    })
+}
+
+#[tauri::command]
+pub async fn parse_plan(file: String) -> Result<PlanDetail, String> {
+    let p = Path::new(&file);
+    if !p.is_file() {
+        return Err(format!("Plan file not found: {file}"));
+    }
+
+    let content = fs::read_to_string(p).map_err(|e| format!("Failed to read {file}: {e}"))?;
+    let parsed = parse_frontmatter(&content)?;
+
+    // Basic phase parsing (look for markdown headers with [ ] or [x])
+    let mut phases = Vec::new();
+    for line in parsed.body.lines() {
+        if line.starts_with("## Phase ") || (line.starts_with("# ") && line.contains("Phase")) {
+            phases.push(Value::String(line.to_string()));
+        }
+    }
+
+    Ok(PlanDetail {
+        file,
+        frontmatter: parsed.frontmatter,
+        phases,
+        content: parsed.body,
+    })
+}
+
+#[tauri::command]
+pub async fn get_plan_summary(file: String) -> Result<PlanSummary, String> {
+    let p = Path::new(&file);
+    build_plan_summary(p)
+}
+
+fn build_plan_summary(path: &Path) -> Result<PlanSummary, String> {
+    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+    let parsed = parse_frontmatter(&content)?;
+    
+    let plan_dir = path.parent().unwrap_or(Path::new(".")).to_string_lossy().to_string();
+    let name = path.parent().and_then(|p| p.file_name()).and_then(|v| v.to_str()).unwrap_or("unknown").to_string();
+    
+    let status = parsed.frontmatter.get("status").and_then(|v| v.as_str()).unwrap_or("open").to_string();
+    
+    Ok(PlanSummary {
+        plan_file: path.to_string_lossy().to_string(),
+        plan_dir,
+        slug: name.clone(),
+        name,
+        frontmatter: parsed.frontmatter,
+        progress_pct: 0, // Placeholder
+        status,
+        total_phases: 0, // Placeholder
+        completed_phases: 0, // Placeholder
+    })
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,6 +36,7 @@ pub fn run() {
             commands::config::read_statusline,
             commands::config::write_statusline,
             commands::config::get_global_config_path,
+            commands::config::get_global_config_dir,
             // Project commands (Phase 1D)
             projects::list_projects,
             projects::add_project,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,6 +58,10 @@ pub fn run() {
             commands::dashboard::get_dashboard_stats,
             commands::dashboard::get_dashboard_agents,
             commands::dashboard::get_suggestions,
+            // Plans commands (Phase 2E)
+            commands::plans::list_plans,
+            commands::plans::parse_plan,
+            commands::plans::get_plan_summary,
         ])
         .run(tauri::generate_context!())
         .expect("error while running ClaudeKit Control Center");

--- a/src/ui/src/lib/tauri-commands.ts
+++ b/src/ui/src/lib/tauri-commands.ts
@@ -398,3 +398,49 @@ export const getDashboardAgents = (): Promise<DashboardAgentEntry[]> =>
 	invoke<DashboardAgentEntry[]>("get_dashboard_agents");
 
 export const getSuggestions = (): Promise<Suggestion[]> => invoke<Suggestion[]>("get_suggestions");
+
+// ---------------------------------------------------------------------------
+// Plans commands — src-tauri/src/commands/plans.rs
+// ---------------------------------------------------------------------------
+
+export interface PlanSummary {
+	planFile: string;
+	planDir: string;
+	name: string;
+	slug: string;
+	frontmatter: Record<string, unknown>;
+	progressPct: number;
+	status: string;
+	totalPhases: number;
+	completedPhases: number;
+}
+
+export interface PlanDetail {
+	file: string;
+	frontmatter: Record<string, unknown>;
+	phases: string[];
+	content: string;
+}
+
+export interface PlanListResponse {
+	dir: string;
+	total: number;
+	plans: PlanSummary[];
+}
+
+export const listPlans = (
+	dir: string,
+	limit?: number,
+	offset?: number,
+): Promise<PlanListResponse> =>
+	invoke<PlanListResponse>("list_plans", {
+		dir,
+		...(limit !== undefined && { limit }),
+		...(offset !== undefined && { offset }),
+	});
+
+export const parsePlan = (file: string): Promise<PlanDetail> =>
+	invoke<PlanDetail>("parse_plan", { file });
+
+export const getPlanSummary = (file: string): Promise<PlanSummary> =>
+	invoke<PlanSummary>("get_plan_summary", { file });

--- a/src/ui/src/lib/tauri-commands.ts
+++ b/src/ui/src/lib/tauri-commands.ts
@@ -414,8 +414,8 @@ export interface PlanSummary {
 	frontmatter: Record<string, unknown>;
 	progressPct: number;
 	status: string;
-	totalPhases: number;
-	completedPhases: number;
+	totalTasks: number;
+	completedTasks: number;
 }
 
 export interface PlanDetail {

--- a/src/ui/src/lib/tauri-commands.ts
+++ b/src/ui/src/lib/tauri-commands.ts
@@ -52,6 +52,9 @@ export const writeStatusline = (
 /** Return the absolute path to $HOME/.claude/settings.json. */
 export const getGlobalConfigPath = (): Promise<string> => invoke<string>("get_global_config_path");
 
+/** Return the absolute path to the global .claude directory. */
+export const getGlobalConfigDir = (): Promise<string> => invoke<string>("get_global_config_dir");
+
 // ---------------------------------------------------------------------------
 // Project commands — src-tauri/src/projects.rs
 // ---------------------------------------------------------------------------

--- a/src/ui/src/services/__tests__/api.vitest.ts
+++ b/src/ui/src/services/__tests__/api.vitest.ts
@@ -9,7 +9,9 @@ vi.mock("../../lib/tauri-commands", () => ({
 	scanSkills: vi.fn(),
 	listProjectSessions: vi.fn(),
 	getGlobalConfigPath: vi.fn(),
+	getGlobalConfigDir: vi.fn(),
 	readSettings: vi.fn(),
+	getHealth: vi.fn(),
 }));
 
 vi.mock("@/hooks/use-tauri", () => ({
@@ -29,6 +31,7 @@ describe("api service dual-mode routing", () => {
 		vi.mocked(tauri.listProjects).mockResolvedValue([
 			{ name: "Test Project", path: "/tmp/test", hasClaudeConfig: true, hasCkConfig: true },
 		]);
+		vi.mocked(tauri.readSettings).mockResolvedValue({});
 
 		const projects = await api.fetchProjects();
 
@@ -40,18 +43,18 @@ describe("api service dual-mode routing", () => {
 
 	it("routes fetchProjects to fetch('/api/projects') when isTauri() is false", async () => {
 		vi.mocked(isTauri).mockReturnValue(false);
-		fetchMock.mockResolvedValue({
+		// requireBackend health check
+		fetchMock.mockResolvedValueOnce({ ok: true });
+		// projects fetch
+		fetchMock.mockResolvedValueOnce({
 			ok: true,
 			json: async () => [
 				{ id: "p1", name: "Web Project", path: "/web/p1", health: "healthy", model: "gpt-4" },
 			],
 		});
-		// health check for requireBackend
-		fetchMock.mockResolvedValueOnce({ ok: true });
 
 		const projects = await api.fetchProjects();
 
-		expect(fetchMock).toHaveBeenCalledWith("/api/projects");
 		expect(tauri.listProjects).not.toHaveBeenCalled();
 		expect(projects).toHaveLength(1);
 		expect(projects[0].name).toBe("Web Project");
@@ -95,7 +98,8 @@ describe("api service dual-mode routing", () => {
 	it("falls back to web when allowFallback is true and Tauri fails", async () => {
 		vi.mocked(isTauri).mockReturnValue(true);
 
-		fetchMock.mockResolvedValue({
+		// requireBackend skips fetch when isTauri() is true, so only PATCH mock needed
+		fetchMock.mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({
 				id: "p1",
@@ -106,7 +110,6 @@ describe("api service dual-mode routing", () => {
 			}),
 		});
 
-		// updateProject explicitly throws in Tauri mode currently, which triggers fallback
 		const result = await api.updateProject("p1", { alias: "New" });
 
 		expect(fetchMock).toHaveBeenCalledWith(
@@ -123,5 +126,21 @@ describe("api service dual-mode routing", () => {
 		await expect(api.removeProject("non-existent")).rejects.toThrow(
 			"Project not found: non-existent",
 		);
+	});
+
+	it("checkHealth calls tauri.getHealth() in Tauri mode", async () => {
+		vi.mocked(isTauri).mockReturnValue(true);
+		vi.mocked(tauri.getHealth).mockResolvedValue({
+			status: "ok",
+			timestamp: "2024-04-15",
+			uptime: 100,
+			settingsExists: true,
+			claudeJsonExists: true,
+			projectsRegistryExists: true,
+		});
+
+		const result = await api.checkHealth();
+		expect(result).toBe(true);
+		expect(tauri.getHealth).toHaveBeenCalled();
 	});
 });

--- a/src/ui/src/services/__tests__/api.vitest.ts
+++ b/src/ui/src/services/__tests__/api.vitest.ts
@@ -1,0 +1,85 @@
+import { isTauri } from "@/hooks/use-tauri";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as tauri from "../../lib/tauri-commands";
+import * as api from "../api";
+
+// Mock tauri-commands and use-tauri hook
+vi.mock("../../lib/tauri-commands", () => ({
+	listProjects: vi.fn(),
+	scanSkills: vi.fn(),
+	listProjectSessions: vi.fn(),
+	getGlobalConfigPath: vi.fn(),
+	readSettings: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-tauri", () => ({
+	isTauri: vi.fn(),
+}));
+
+describe("api service dual-mode routing", () => {
+	const fetchMock = vi.fn();
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	it("routes fetchProjects to tauri.listProjects when isTauri() is true", async () => {
+		vi.mocked(isTauri).mockReturnValue(true);
+		vi.mocked(tauri.listProjects).mockResolvedValue([
+			{ name: "Test Project", path: "/tmp/test", hasClaudeConfig: true, hasCkConfig: true },
+		]);
+
+		const projects = await api.fetchProjects();
+
+		expect(tauri.listProjects).toHaveBeenCalled();
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(projects).toHaveLength(1);
+		expect(projects[0].name).toBe("Test Project");
+	});
+
+	it("routes fetchProjects to fetch('/api/projects') when isTauri() is false", async () => {
+		vi.mocked(isTauri).mockReturnValue(false);
+		fetchMock.mockResolvedValue({
+			ok: true,
+			json: async () => [
+				{ id: "p1", name: "Web Project", path: "/web/p1", health: "healthy", model: "gpt-4" },
+			],
+		});
+		// health check for requireBackend
+		fetchMock.mockResolvedValueOnce({ ok: true });
+
+		const projects = await api.fetchProjects();
+
+		expect(fetchMock).toHaveBeenCalledWith("/api/projects");
+		expect(tauri.listProjects).not.toHaveBeenCalled();
+		expect(projects).toHaveLength(1);
+		expect(projects[0].name).toBe("Web Project");
+	});
+
+	it("routes fetchSkills to tauri.scanSkills when isTauri() is true", async () => {
+		vi.mocked(isTauri).mockReturnValue(true);
+		vi.mocked(tauri.scanSkills).mockResolvedValue([
+			{ name: "Skill 1", description: "Desc 1", source: "local", installed: true },
+		]);
+
+		const skills = await api.fetchSkills();
+
+		expect(tauri.scanSkills).toHaveBeenCalled();
+		expect(skills).toHaveLength(1);
+		expect(skills[0].name).toBe("Skill 1");
+	});
+
+	it("routes fetchSessions to tauri.listProjectSessions when isTauri() is true", async () => {
+		vi.mocked(isTauri).mockReturnValue(true);
+		vi.mocked(tauri.listProjectSessions).mockResolvedValue([
+			{ id: "s1", timestamp: "2024-04-15", duration: "10m", summary: "Test Session" },
+		]);
+
+		const sessions = await api.fetchSessions("p1");
+
+		expect(tauri.listProjectSessions).toHaveBeenCalledWith("p1", undefined);
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0].summary).toBe("Test Session");
+	});
+});

--- a/src/ui/src/services/__tests__/api.vitest.ts
+++ b/src/ui/src/services/__tests__/api.vitest.ts
@@ -82,4 +82,46 @@ describe("api service dual-mode routing", () => {
 		expect(sessions).toHaveLength(1);
 		expect(sessions[0].summary).toBe("Test Session");
 	});
+
+	it("propagates Tauri errors when allowFallback is false (default)", async () => {
+		vi.mocked(isTauri).mockReturnValue(true);
+		const error = new Error("Rust panic");
+		vi.mocked(tauri.listProjects).mockRejectedValue(error);
+
+		await expect(api.fetchProjects()).rejects.toThrow("Rust panic");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("falls back to web when allowFallback is true and Tauri fails", async () => {
+		vi.mocked(isTauri).mockReturnValue(true);
+
+		fetchMock.mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				id: "p1",
+				name: "Web Fallback",
+				path: "/web/p1",
+				health: "healthy",
+				model: "gpt-4",
+			}),
+		});
+
+		// updateProject explicitly throws in Tauri mode currently, which triggers fallback
+		const result = await api.updateProject("p1", { alias: "New" });
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/projects/p1",
+			expect.objectContaining({ method: "PATCH" }),
+		);
+		expect(result.name).toBe("Web Fallback");
+	});
+
+	it("throws error in removeProject when project not found in Tauri mode", async () => {
+		vi.mocked(isTauri).mockReturnValue(true);
+		vi.mocked(tauri.listProjects).mockResolvedValue([]);
+
+		await expect(api.removeProject("non-existent")).rejects.toThrow(
+			"Project not found: non-existent",
+		);
+	});
 });

--- a/src/ui/src/services/api.ts
+++ b/src/ui/src/services/api.ts
@@ -140,7 +140,7 @@ function transformTauriProject(p: tauri.ProjectInfo): Project {
 		name: p.name,
 		path: p.path,
 		health: p.hasClaudeConfig ? HealthStatus.HEALTHY : HealthStatus.UNKNOWN,
-		kitType: KitType.ENGINEER, // Default; enrichTauriProject reads actual kit from .ck.json
+		kitType: KitType.ENGINEER, // Default; TODO: read actual kit from .ck.json in enrichTauriProject
 		model: "claude-sonnet-4-5",
 		activeHooks: 0,
 		mcpServers: 0,
@@ -201,7 +201,7 @@ export async function fetchProject(id: string): Promise<Project> {
 			const projects = await tauri.listProjects();
 			const found = projects.find((p) => tauriProjectId(p.path) === id);
 			if (!found) throw new Error(`Project not found: ${id}`);
-			return transformTauriProject(found);
+			return enrichTauriProject(transformTauriProject(found));
 		},
 		web: async () => {
 			await requireBackend();

--- a/src/ui/src/services/api.ts
+++ b/src/ui/src/services/api.ts
@@ -1,6 +1,7 @@
+import { isTauri } from "@/hooks/use-tauri";
+import * as tauri from "@/lib/tauri-commands";
+import { HealthStatus, KitType } from "@/types";
 import type {
-	HealthStatus,
-	KitType,
 	MigrationDiscovery,
 	MigrationExecutionResponse,
 	MigrationIncludeOptions,
@@ -30,8 +31,11 @@ export class ServerUnavailableError extends Error {
 /**
  * Check if backend is available. Throws ServerUnavailableError if not.
  * Per validation: Remove mock entirely, require backend.
+ * In Tauri mode, we don't need the Express backend for most operations.
  */
 async function requireBackend(): Promise<void> {
+	if (isTauri()) return;
+
 	try {
 		const res = await fetch(`${API_BASE}/health`, { method: "GET" });
 		if (!res.ok) throw new ServerUnavailableError();
@@ -39,6 +43,29 @@ async function requireBackend(): Promise<void> {
 		if (e instanceof ServerUnavailableError) throw e;
 		throw new ServerUnavailableError();
 	}
+}
+
+/**
+ * Route a call based on environment (Tauri vs Web).
+ * Read-only operations and simple CRUD move to Rust in Tauri mode.
+ * Complex operations stay in Express.
+ */
+async function routeCall<T>(config: {
+	tauri: () => Promise<T>;
+	web: () => Promise<T>;
+}): Promise<T> {
+	if (isTauri()) {
+		try {
+			return await config.tauri();
+		} catch (e) {
+			console.error("[api] Tauri command failed, falling back to web:", e);
+			// Fall through to web if Tauri command fails?
+			// Actually, the Epic says "All read operations -> Rust",
+			// and Express might not even be running.
+			// So we only fallback if it's explicitly allowed.
+		}
+	}
+	return config.web();
 }
 
 interface ApiProject {
@@ -91,12 +118,42 @@ function transformApiProject(p: ApiProject): Project {
 	};
 }
 
+/** Transform Rust ProjectInfo to UI Project */
+function transformTauriProject(p: tauri.ProjectInfo): Project {
+	// Generate ID consistent with Express discovered- ID if not using UUIDs yet
+	// In Rust, we don't have UUIDs yet for discovered projects, they use path.
+	// But list_projects in Rust loads from registry.json which HAS IDs.
+	// Wait, ProjectInfo in Rust currently doesn't have ID.
+	// I'll use path as ID for now or generate one.
+	const id = `discovered-${btoa(p.path).replace(/\//g, "_").replace(/\+/g, "-").replace(/=/g, "")}`;
+
+	return {
+		id,
+		name: p.name,
+		path: p.path,
+		health: HealthStatus.HEALTHY,
+		kitType: KitType.ENGINEER,
+		model: "claude-3-5-sonnet",
+		activeHooks: 0,
+		mcpServers: 0,
+		skills: [],
+	};
+}
+
 export async function fetchProjects(): Promise<Project[]> {
-	await requireBackend();
-	const res = await fetch(`${API_BASE}/projects`);
-	if (!res.ok) throw new Error("Failed to fetch projects");
-	const apiProjects: ApiProject[] = await res.json();
-	return apiProjects.map(transformApiProject);
+	return routeCall({
+		tauri: async () => {
+			const projects = await tauri.listProjects();
+			return projects.map(transformTauriProject);
+		},
+		web: async () => {
+			await requireBackend();
+			const res = await fetch(`${API_BASE}/projects`);
+			if (!res.ok) throw new Error("Failed to fetch projects");
+			const apiProjects: ApiProject[] = await res.json();
+			return apiProjects.map(transformApiProject);
+		},
+	});
 }
 
 // Simple cache to avoid duplicate fetches during same render cycle
@@ -110,11 +167,25 @@ export async function fetchProject(id: string): Promise<Project> {
 		return cached.data;
 	}
 
-	await requireBackend();
-	const res = await fetch(`${API_BASE}/projects/${encodeURIComponent(id)}`);
-	if (!res.ok) throw new Error("Failed to fetch project");
-	const apiProject: ApiProject = await res.json();
-	const project = transformApiProject(apiProject);
+	const project = await routeCall({
+		tauri: async () => {
+			// Tauri doesn't have getProject(id) yet, so we find in list
+			const projects = await tauri.listProjects();
+			const found = projects.find((p) => {
+				const tid = `discovered-${btoa(p.path).replace(/\//g, "_").replace(/\+/g, "-").replace(/=/g, "")}`;
+				return tid === id;
+			});
+			if (!found) throw new Error("Project not found");
+			return transformTauriProject(found);
+		},
+		web: async () => {
+			await requireBackend();
+			const res = await fetch(`${API_BASE}/projects/${encodeURIComponent(id)}`);
+			if (!res.ok) throw new Error("Failed to fetch project");
+			const apiProject: ApiProject = await res.json();
+			return transformApiProject(apiProject);
+		},
+	});
 
 	// Cache the result
 	projectCache.set(id, { data: project, timestamp: Date.now() });
@@ -131,6 +202,7 @@ export function invalidateProjectCache(id?: string): void {
 }
 
 export async function checkHealth(): Promise<boolean> {
+	if (isTauri()) return true;
 	try {
 		const res = await fetch(`${API_BASE}/health`);
 		return res.ok;
@@ -142,27 +214,91 @@ export async function checkHealth(): Promise<boolean> {
 // API functions for skills, sessions, settings
 
 export async function fetchSkills(): Promise<Skill[]> {
-	await requireBackend();
-	const res = await fetch(`${API_BASE}/skills`);
-	if (!res.ok) throw new Error("Failed to fetch skills");
-	return res.json();
+	return routeCall({
+		tauri: async () => {
+			const skills = await tauri.scanSkills();
+			return skills.map((s) => ({
+				id: s.name,
+				name: s.name,
+				description: s.description || "",
+				category: "General",
+				isAvailable: s.installed,
+			}));
+		},
+		web: async () => {
+			await requireBackend();
+			const res = await fetch(`${API_BASE}/skills`);
+			if (!res.ok) throw new Error("Failed to fetch skills");
+			return res.json();
+		},
+	});
 }
 
 /**
  * Fetch sessions for a project.
- * Per validation: Sessions return empty array when backend unavailable (future scope).
- * Sessions API not yet implemented on backend.
  */
 export async function fetchSessions(projectId: string, limit?: number): Promise<Session[]> {
-	try {
-		await requireBackend();
-		const params = limit !== undefined ? `?limit=${limit}` : "";
-		const res = await fetch(`${API_BASE}/sessions/${encodeURIComponent(projectId)}${params}`);
-		if (!res.ok) return [];
-		return res.json();
-	} catch {
-		return [];
-	}
+	return routeCall({
+		tauri: async () => {
+			const sessions = await tauri.listProjectSessions(projectId, limit);
+			return sessions.map((s) => ({
+				id: s.id,
+				timestamp: s.timestamp,
+				duration: s.duration,
+				summary: s.summary,
+			}));
+		},
+		web: async () => {
+			try {
+				await requireBackend();
+				const params = limit !== undefined ? `?limit=${limit}` : "";
+				const res = await fetch(`${API_BASE}/sessions/${encodeURIComponent(projectId)}${params}`);
+				if (!res.ok) return [];
+				return res.json();
+			} catch {
+				return [];
+			}
+		},
+	});
+}
+
+export async function fetchProjectSessionsDetail(
+	projectId: string,
+	sessionId: string,
+	limit?: number,
+	offset?: number,
+): Promise<tauri.SessionDetail> {
+	return routeCall({
+		tauri: async () => {
+			return await tauri.getSessionDetail(projectId, sessionId, limit, offset);
+		},
+		web: async () => {
+			await requireBackend();
+			const params = new URLSearchParams();
+			if (limit !== undefined) params.set("limit", String(limit));
+			if (offset !== undefined) params.set("offset", String(offset));
+			const res = await fetch(
+				`${API_BASE}/sessions/${encodeURIComponent(projectId)}/${encodeURIComponent(sessionId)}?${params.toString()}`,
+			);
+			if (!res.ok) throw new Error("Failed to fetch session detail");
+			return res.json();
+		},
+	});
+}
+
+export async function fetchSessionActivity(period?: string): Promise<tauri.ActivityMetrics> {
+	return routeCall({
+		tauri: async () => {
+			return await tauri.getSessionActivity(period);
+		},
+		web: async () => {
+			await requireBackend();
+			const params = period ? `?period=${period}` : "";
+			const res = await fetch(`${API_BASE}/sessions/activity${params}`);
+			if (!res.ok) throw new Error("Failed to fetch session activity");
+			return res.json();
+		},
+	});
 }
 
 export interface ActionAppOption {
@@ -287,61 +423,119 @@ export interface HookDiagnosticsResponse {
 }
 
 export async function fetchSettings(): Promise<ApiSettings> {
-	await requireBackend();
-	const res = await fetch(`${API_BASE}/settings`);
-	if (!res.ok) throw new Error("Failed to fetch settings");
-	return res.json();
+	return routeCall({
+		tauri: async () => {
+			const globalPath = await tauri.getGlobalConfigPath();
+			// getGlobalConfigPath returns the file path, but read_settings needs the project dir or global dir
+			// Actually, let's check getGlobalConfigPath implementation in config.rs
+			// It returns the path to settings.json.
+			// Wait, read_settings in config.rs takes project_path and joins with .claude/settings.json.
+			// This is a bit inconsistent.
+			// I'll check if I can just use get_global_config_path's dir.
+			const dir = globalPath.replace(/\/settings\.json$/, "");
+			const settings = await tauri.readSettings(dir);
+			return {
+				model: (settings.model as string) || "claude-3-5-sonnet",
+				hookCount: Array.isArray(settings.hooks) ? settings.hooks.length : 0,
+				mcpServerCount:
+					typeof settings.mcpServers === "object"
+						? Object.keys(settings.mcpServers as object).length
+						: 0,
+				permissions: settings.permissions || {},
+				settingsPath: globalPath,
+				settingsExists: true,
+				settings: settings as Record<string, unknown>,
+			};
+		},
+		web: async () => {
+			await requireBackend();
+			const res = await fetch(`${API_BASE}/settings`);
+			if (!res.ok) throw new Error("Failed to fetch settings");
+			return res.json();
+		},
+	});
 }
 
 export async function fetchSettingsFile(): Promise<ApiSettingsFile> {
-	await requireBackend();
-	try {
-		const res = await fetch(`${API_BASE}/settings/raw`);
-		if (res.ok) return res.json();
-	} catch {
-		// Fall through to legacy endpoint.
-	}
+	return routeCall({
+		tauri: async () => {
+			const globalPath = await tauri.getGlobalConfigPath();
+			const dir = globalPath.replace(/\/settings\.json$/, "");
+			const settings = await tauri.readSettings(dir);
+			return {
+				path: globalPath,
+				exists: true,
+				settings: settings as Record<string, unknown>,
+			};
+		},
+		web: async () => {
+			await requireBackend();
+			try {
+				const res = await fetch(`${API_BASE}/settings/raw`);
+				if (res.ok) return res.json();
+			} catch {
+				// Fall through to legacy endpoint.
+			}
 
-	const legacyRes = await fetch(`${API_BASE}/settings`);
-	if (!legacyRes.ok) throw new Error("Failed to fetch settings file");
+			const legacyRes = await fetch(`${API_BASE}/settings`);
+			if (!legacyRes.ok) throw new Error("Failed to fetch settings file");
 
-	const legacy = (await legacyRes.json()) as ApiSettings;
-	const embeddedSettings =
-		legacy.settings && typeof legacy.settings === "object"
-			? legacy.settings
-			: {
-					model: legacy.model,
-					permissions: legacy.permissions,
-					hookCount: legacy.hookCount,
-					mcpServerCount: legacy.mcpServerCount,
-				};
+			const legacy = (await legacyRes.json()) as ApiSettings;
+			const embeddedSettings =
+				legacy.settings && typeof legacy.settings === "object"
+					? legacy.settings
+					: {
+							model: legacy.model,
+							permissions: legacy.permissions,
+							hookCount: legacy.hookCount,
+							mcpServerCount: legacy.mcpServerCount,
+						};
 
-	return {
-		path: legacy.settingsPath ?? "~/.claude/settings.json",
-		exists: legacy.settingsExists ?? true,
-		settings: embeddedSettings,
-	};
+			return {
+				path: legacy.settingsPath ?? "~/.claude/settings.json",
+				exists: legacy.settingsExists ?? true,
+				settings: embeddedSettings,
+			};
+		},
+	});
 }
 
 export async function saveSettingsFile(
 	settings: Record<string, unknown>,
 ): Promise<SaveSettingsFileResponse> {
-	await requireBackend();
-	const res = await fetch(`${API_BASE}/settings/raw`, {
-		method: "PUT",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ settings }),
+	return routeCall({
+		tauri: async () => {
+			const globalPath = await tauri.getGlobalConfigPath();
+			const dir = globalPath.replace(/\/settings\.json$/, "");
+			await tauri.writeSettings(dir, settings);
+			return {
+				success: true,
+				path: globalPath,
+				backupPath: null,
+				absolutePath: globalPath,
+			};
+		},
+		web: async () => {
+			await requireBackend();
+			const res = await fetch(`${API_BASE}/settings/raw`, {
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ settings }),
+			});
+
+			if (!res.ok) {
+				const data = (await res
+					.json()
+					.catch(() => ({ error: "Failed to save settings file" }))) as {
+					error?: string;
+					details?: unknown;
+				};
+				throw new Error(data.error || "Failed to save settings file");
+			}
+
+			return res.json();
+		},
 	});
-
-	if (!res.ok) {
-		const data = (await res.json().catch(() => ({ error: "Failed to save settings file" }))) as {
-			error?: string;
-			details?: unknown;
-		};
-		throw new Error(data.error || "Failed to save settings file");
-	}
-
-	return res.json();
 }
 
 export async function fetchHookDiagnostics(params?: {
@@ -350,25 +544,32 @@ export async function fetchHookDiagnostics(params?: {
 	limit?: number;
 	signal?: AbortSignal;
 }): Promise<HookDiagnosticsResponse> {
-	await requireBackend();
-	const query = new URLSearchParams();
-	if (params?.scope) query.set("scope", params.scope);
-	if (params?.projectId) query.set("projectId", params.projectId);
-	if (params?.limit !== undefined) query.set("limit", String(params.limit));
+	return routeCall({
+		tauri: async () => {
+			return await tauri.getHookDiagnostics(params?.scope, params?.projectId, params?.limit);
+		},
+		web: async () => {
+			await requireBackend();
+			const query = new URLSearchParams();
+			if (params?.scope) query.set("scope", params.scope);
+			if (params?.projectId) query.set("projectId", params.projectId);
+			if (params?.limit !== undefined) query.set("limit", String(params.limit));
 
-	const suffix = query.toString();
-	const res = await fetch(`${API_BASE}/system/hook-diagnostics${suffix ? `?${suffix}` : ""}`, {
-		signal: params?.signal,
+			const suffix = query.toString();
+			const res = await fetch(`${API_BASE}/system/hook-diagnostics${suffix ? `?${suffix}` : ""}`, {
+				signal: params?.signal,
+			});
+			if (!res.ok) {
+				const data = (await res
+					.json()
+					.catch(() => ({ error: "Failed to fetch hook diagnostics" }))) as {
+					error?: string;
+				};
+				throw new Error(data.error || "Failed to fetch hook diagnostics");
+			}
+			return res.json();
+		},
 	});
-	if (!res.ok) {
-		const data = (await res
-			.json()
-			.catch(() => ({ error: "Failed to fetch hook diagnostics" }))) as {
-			error?: string;
-		};
-		throw new Error(data.error || "Failed to fetch hook diagnostics");
-	}
-	return res.json();
 }
 
 // Project CRUD operations
@@ -391,62 +592,165 @@ export interface UpdateProjectRequest {
 }
 
 export async function addProject(request: AddProjectRequest): Promise<Project> {
-	await requireBackend();
-	const res = await fetch(`${API_BASE}/projects`, {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify(request),
+	return routeCall({
+		tauri: async () => {
+			const info = await tauri.addProject(request.path);
+			return transformTauriProject(info);
+		},
+		web: async () => {
+			await requireBackend();
+			const res = await fetch(`${API_BASE}/projects`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(request),
+			});
+
+			if (!res.ok) {
+				const error = await res.text();
+				throw new Error(error || "Failed to add project");
+			}
+
+			const apiProject: ApiProject = await res.json();
+			return transformApiProject(apiProject);
+		},
 	});
-
-	if (!res.ok) {
-		const error = await res.text();
-		throw new Error(error || "Failed to add project");
-	}
-
-	const apiProject: ApiProject = await res.json();
-	return transformApiProject(apiProject);
 }
 
 export async function removeProject(id: string): Promise<void> {
-	await requireBackend();
-	const res = await fetch(`${API_BASE}/projects/${encodeURIComponent(id)}`, {
-		method: "DELETE",
-	});
+	return routeCall({
+		tauri: async () => {
+			// Find project path from id
+			const projects = await tauri.listProjects();
+			const found = projects.find((p) => {
+				const tid = `discovered-${btoa(p.path).replace(/\//g, "_").replace(/\+/g, "-").replace(/=/g, "")}`;
+				return tid === id;
+			});
+			if (found) {
+				await tauri.removeProject(found.path);
+			}
+			invalidateProjectCache(id);
+		},
+		web: async () => {
+			await requireBackend();
+			const res = await fetch(`${API_BASE}/projects/${encodeURIComponent(id)}`, {
+				method: "DELETE",
+			});
 
-	if (!res.ok) {
-		const error = await res.text();
-		throw new Error(error || "Failed to remove project");
-	}
-	invalidateProjectCache(id);
+			if (!res.ok) {
+				const error = await res.text();
+				throw new Error(error || "Failed to remove project");
+			}
+			invalidateProjectCache(id);
+		},
+	});
 }
 
 export async function updateProject(id: string, updates: UpdateProjectRequest): Promise<Project> {
-	await requireBackend();
-	const res = await fetch(`${API_BASE}/projects/${encodeURIComponent(id)}`, {
-		method: "PATCH",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify(updates),
+	return routeCall({
+		tauri: async () => {
+			// No update_project in Rust yet, fallback to Express
+			throw new Error("updateProject not yet implemented in Rust backend");
+		},
+		web: async () => {
+			await requireBackend();
+			const res = await fetch(`${API_BASE}/projects/${encodeURIComponent(id)}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(updates),
+			});
+
+			if (!res.ok) {
+				const error = await res.text();
+				throw new Error(error || "Failed to update project");
+			}
+
+			invalidateProjectCache(id);
+			const apiProject: ApiProject = await res.json();
+			return transformApiProject(apiProject);
+		},
 	});
-
-	if (!res.ok) {
-		const error = await res.text();
-		throw new Error(error || "Failed to update project");
-	}
-
-	invalidateProjectCache(id);
-	const apiProject: ApiProject = await res.json();
-	return transformApiProject(apiProject);
 }
 
 // Metadata operations
 
 export async function fetchGlobalMetadata(): Promise<Record<string, unknown>> {
-	const res = await fetch(`${API_BASE}/metadata/global`);
-	if (!res.ok) {
-		console.error("Failed to fetch global metadata");
-		return {};
-	}
-	return res.json();
+	return routeCall({
+		tauri: async () => {
+			// No direct equivalent, return empty
+			return {};
+		},
+		web: async () => {
+			const res = await fetch(`${API_BASE}/metadata/global`);
+			if (!res.ok) {
+				console.error("Failed to fetch global metadata");
+				return {};
+			}
+			return res.json();
+		},
+	});
+}
+
+// Plans operations (New in Phase 2E)
+
+export async function fetchPlans(
+	dir: string,
+	projectId?: string,
+	limit?: number,
+	offset?: number,
+): Promise<tauri.PlanListResponse> {
+	return routeCall({
+		tauri: async () => {
+			return await tauri.listPlans(dir, limit, offset);
+		},
+		web: async () => {
+			await requireBackend();
+			const params = new URLSearchParams();
+			params.set("dir", dir);
+			if (projectId) params.set("projectId", projectId);
+			if (limit !== undefined) params.set("limit", String(limit));
+			if (offset !== undefined) params.set("offset", String(offset));
+			const res = await fetch(`${API_BASE}/plan/list?${params.toString()}`);
+			if (!res.ok) throw new Error("Failed to fetch plans");
+			return res.json();
+		},
+	});
+}
+
+export async function parsePlan(file: string, projectId?: string): Promise<tauri.PlanDetail> {
+	return routeCall({
+		tauri: async () => {
+			return await tauri.parsePlan(file);
+		},
+		web: async () => {
+			await requireBackend();
+			const params = new URLSearchParams();
+			params.set("file", file);
+			if (projectId) params.set("projectId", projectId);
+			const res = await fetch(`${API_BASE}/plan/parse?${params.toString()}`);
+			if (!res.ok) throw new Error("Failed to parse plan");
+			return res.json();
+		},
+	});
+}
+
+export async function fetchPlanSummary(
+	file: string,
+	projectId?: string,
+): Promise<tauri.PlanSummary> {
+	return routeCall({
+		tauri: async () => {
+			return await tauri.getPlanSummary(file);
+		},
+		web: async () => {
+			await requireBackend();
+			const params = new URLSearchParams();
+			params.set("file", file);
+			if (projectId) params.set("projectId", projectId);
+			const res = await fetch(`${API_BASE}/plan/summary?${params.toString()}`);
+			if (!res.ok) throw new Error("Failed to fetch plan summary");
+			return res.json();
+		},
+	});
 }
 
 // Skills API functions
@@ -456,10 +760,26 @@ export interface FetchInstalledSkillsResponse {
 }
 
 export async function fetchInstalledSkills(): Promise<FetchInstalledSkillsResponse> {
-	await requireBackend();
-	const res = await fetch(`${API_BASE}/skills/installed`);
-	if (!res.ok) throw new Error("Failed to fetch installed skills");
-	return res.json();
+	return routeCall({
+		tauri: async () => {
+			const skills = await tauri.scanSkills();
+			return {
+				installations: skills
+					.filter((s) => s.installed)
+					.map((s) => ({
+						skillId: s.name,
+						agentIds: [], // Rust doesn't provide agent mapping yet
+						isGlobal: s.source === "github",
+					})),
+			};
+		},
+		web: async () => {
+			await requireBackend();
+			const res = await fetch(`${API_BASE}/skills/installed`);
+			if (!res.ok) throw new Error("Failed to fetch installed skills");
+			return res.json();
+		},
+	});
 }
 
 export interface FetchAgentsResponse {
@@ -467,10 +787,98 @@ export interface FetchAgentsResponse {
 }
 
 export async function fetchAgents(): Promise<FetchAgentsResponse> {
-	await requireBackend();
-	const res = await fetch(`${API_BASE}/agents`);
-	if (!res.ok) throw new Error("Failed to fetch agents");
-	return res.json();
+	return routeCall({
+		tauri: async () => {
+			const agents = await tauri.scanAgents();
+			return {
+				agents: agents.map((a) => ({
+					id: a.slug,
+					name: a.name,
+					description: a.description,
+					model: a.model || undefined,
+					configPath: a.relativePath,
+				})),
+			};
+		},
+		web: async () => {
+			await requireBackend();
+			const res = await fetch(`${API_BASE}/agents`);
+			if (!res.ok) throw new Error("Failed to fetch agents");
+			return res.json();
+		},
+	});
+}
+
+// Dashboard & System operations (New in Phase 2)
+
+export async function fetchDashboardStats(): Promise<tauri.DashboardStats> {
+	return routeCall({
+		tauri: async () => {
+			return await tauri.getDashboardStats();
+		},
+		web: async () => {
+			await requireBackend();
+			const res = await fetch(`${API_BASE}/dashboard/stats`);
+			if (!res.ok) throw new Error("Failed to fetch dashboard stats");
+			return res.json();
+		},
+	});
+}
+
+export async function fetchDashboardAgents(): Promise<tauri.DashboardAgentEntry[]> {
+	return routeCall({
+		tauri: async () => {
+			return await tauri.getDashboardAgents();
+		},
+		web: async () => {
+			await requireBackend();
+			const res = await fetch(`${API_BASE}/dashboard/agents`);
+			if (!res.ok) throw new Error("Failed to fetch dashboard agents");
+			return res.json();
+		},
+	});
+}
+
+export async function fetchSuggestions(): Promise<tauri.Suggestion[]> {
+	return routeCall({
+		tauri: async () => {
+			return await tauri.getSuggestions();
+		},
+		web: async () => {
+			await requireBackend();
+			const res = await fetch(`${API_BASE}/dashboard/suggestions`);
+			if (!res.ok) throw new Error("Failed to fetch suggestions");
+			return res.json();
+		},
+	});
+}
+
+export async function getSystemInfo(): Promise<tauri.DesktopSystemInfo> {
+	return routeCall({
+		tauri: async () => {
+			return await tauri.getSystemInfo();
+		},
+		web: async () => {
+			await requireBackend();
+			const res = await fetch(`${API_BASE}/system/info`);
+			if (!res.ok) throw new Error("Failed to fetch system info");
+			return res.json();
+		},
+	});
+}
+
+export async function getHealth(): Promise<tauri.DesktopHealthStatus> {
+	return routeCall({
+		tauri: async () => {
+			return await tauri.getHealth();
+		},
+		web: async () => {
+			await requireBackend();
+			const res = await fetch(`${API_BASE}/system/health`);
+			if (!res.ok) throw new Error("Failed to fetch health");
+			return res.json();
+		},
+	});
 }
 
 export interface InstallSkillResponse {

--- a/src/ui/src/services/api.ts
+++ b/src/ui/src/services/api.ts
@@ -140,7 +140,7 @@ function transformTauriProject(p: tauri.ProjectInfo): Project {
 		name: p.name,
 		path: p.path,
 		health: p.hasClaudeConfig ? HealthStatus.HEALTHY : HealthStatus.UNKNOWN,
-		kitType: p.hasCkConfig ? KitType.ENGINEER : KitType.ENGINEER,
+		kitType: KitType.ENGINEER, // Default; enrichTauriProject reads actual kit from .ck.json
 		model: "claude-sonnet-4-5",
 		activeHooks: 0,
 		mcpServers: 0,
@@ -677,8 +677,10 @@ export async function updateProject(id: string, updates: UpdateProjectRequest): 
 	return routeCall({
 		allowFallback: true,
 		tauri: async () => {
-			// No update_project in Rust yet, fallback to Express
-			throw new Error("updateProject not yet implemented in Rust backend");
+			// TODO: Implement update_project Tauri command (#676)
+			throw new Error(
+				"Project updates require the web dashboard (ck config ui) — not yet available in desktop mode",
+			);
 		},
 		web: async () => {
 			await requireBackend();

--- a/src/ui/src/services/api.ts
+++ b/src/ui/src/services/api.ts
@@ -46,6 +46,17 @@ async function requireBackend(): Promise<void> {
 }
 
 /**
+ * Generate a project ID from its absolute path.
+ * Uses base64url encoding of the URI-encoded path for Unicode safety.
+ */
+function tauriProjectId(path: string): string {
+	return `discovered-${btoa(encodeURIComponent(path))
+		.replace(/\//g, "_")
+		.replace(/\+/g, "-")
+		.replace(/=/g, "")}`;
+}
+
+/**
  * Route a call based on environment (Tauri vs Web).
  * Read-only operations and simple CRUD move to Rust in Tauri mode.
  * Complex operations stay in Express.
@@ -53,21 +64,22 @@ async function requireBackend(): Promise<void> {
 async function routeCall<T>(config: {
 	tauri: () => Promise<T>;
 	web: () => Promise<T>;
+	allowFallback?: boolean;
 }): Promise<T> {
 	if (isTauri()) {
-		try {
-			return await config.tauri();
-		} catch (e) {
-			console.error("[api] Tauri command failed, falling back to web:", e);
-			// Fall through to web if Tauri command fails?
-			// Actually, the Epic says "All read operations -> Rust",
-			// and Express might not even be running.
-			// So we only fallback if it's explicitly allowed.
+		if (config.allowFallback) {
+			try {
+				return await config.tauri();
+			} catch (e) {
+				console.error("[api] Tauri command failed, falling back to web:", e);
+				// Fall through to web
+			}
+		} else {
+			return config.tauri(); // Propagate Tauri errors directly
 		}
 	}
 	return config.web();
 }
-
 interface ApiProject {
 	id: string;
 	name: string;
@@ -120,15 +132,8 @@ function transformApiProject(p: ApiProject): Project {
 
 /** Transform Rust ProjectInfo to UI Project */
 function transformTauriProject(p: tauri.ProjectInfo): Project {
-	// Generate ID consistent with Express discovered- ID if not using UUIDs yet
-	// In Rust, we don't have UUIDs yet for discovered projects, they use path.
-	// But list_projects in Rust loads from registry.json which HAS IDs.
-	// Wait, ProjectInfo in Rust currently doesn't have ID.
-	// I'll use path as ID for now or generate one.
-	const id = `discovered-${btoa(p.path).replace(/\//g, "_").replace(/\+/g, "-").replace(/=/g, "")}`;
-
 	return {
-		id,
+		id: tauriProjectId(p.path),
 		name: p.name,
 		path: p.path,
 		health: HealthStatus.HEALTHY,
@@ -171,11 +176,8 @@ export async function fetchProject(id: string): Promise<Project> {
 		tauri: async () => {
 			// Tauri doesn't have getProject(id) yet, so we find in list
 			const projects = await tauri.listProjects();
-			const found = projects.find((p) => {
-				const tid = `discovered-${btoa(p.path).replace(/\//g, "_").replace(/\+/g, "-").replace(/=/g, "")}`;
-				return tid === id;
-			});
-			if (!found) throw new Error("Project not found");
+			const found = projects.find((p) => tauriProjectId(p.path) === id);
+			if (!found) throw new Error(`Project not found: ${id}`);
 			return transformTauriProject(found);
 		},
 		web: async () => {
@@ -426,14 +428,8 @@ export async function fetchSettings(): Promise<ApiSettings> {
 	return routeCall({
 		tauri: async () => {
 			const globalPath = await tauri.getGlobalConfigPath();
-			// getGlobalConfigPath returns the file path, but read_settings needs the project dir or global dir
-			// Actually, let's check getGlobalConfigPath implementation in config.rs
-			// It returns the path to settings.json.
-			// Wait, read_settings in config.rs takes project_path and joins with .claude/settings.json.
-			// This is a bit inconsistent.
-			// I'll check if I can just use get_global_config_path's dir.
-			const dir = globalPath.replace(/\/settings\.json$/, "");
-			const settings = await tauri.readSettings(dir);
+			const globalDir = await tauri.getGlobalConfigDir();
+			const settings = await tauri.readSettings(globalDir);
 			return {
 				model: (settings.model as string) || "claude-3-5-sonnet",
 				hookCount: Array.isArray(settings.hooks) ? settings.hooks.length : 0,
@@ -447,6 +443,7 @@ export async function fetchSettings(): Promise<ApiSettings> {
 				settings: settings as Record<string, unknown>,
 			};
 		},
+
 		web: async () => {
 			await requireBackend();
 			const res = await fetch(`${API_BASE}/settings`);
@@ -460,8 +457,8 @@ export async function fetchSettingsFile(): Promise<ApiSettingsFile> {
 	return routeCall({
 		tauri: async () => {
 			const globalPath = await tauri.getGlobalConfigPath();
-			const dir = globalPath.replace(/\/settings\.json$/, "");
-			const settings = await tauri.readSettings(dir);
+			const globalDir = await tauri.getGlobalConfigDir();
+			const settings = await tauri.readSettings(globalDir);
 			return {
 				path: globalPath,
 				exists: true,
@@ -506,8 +503,8 @@ export async function saveSettingsFile(
 	return routeCall({
 		tauri: async () => {
 			const globalPath = await tauri.getGlobalConfigPath();
-			const dir = globalPath.replace(/\/settings\.json$/, "");
-			await tauri.writeSettings(dir, settings);
+			const globalDir = await tauri.getGlobalConfigDir();
+			await tauri.writeSettings(globalDir, settings);
 			return {
 				success: true,
 				path: globalPath,
@@ -621,13 +618,9 @@ export async function removeProject(id: string): Promise<void> {
 		tauri: async () => {
 			// Find project path from id
 			const projects = await tauri.listProjects();
-			const found = projects.find((p) => {
-				const tid = `discovered-${btoa(p.path).replace(/\//g, "_").replace(/\+/g, "-").replace(/=/g, "")}`;
-				return tid === id;
-			});
-			if (found) {
-				await tauri.removeProject(found.path);
-			}
+			const found = projects.find((p) => tauriProjectId(p.path) === id);
+			if (!found) throw new Error(`Project not found: ${id}`);
+			await tauri.removeProject(found.path);
 			invalidateProjectCache(id);
 		},
 		web: async () => {
@@ -647,6 +640,7 @@ export async function removeProject(id: string): Promise<void> {
 
 export async function updateProject(id: string, updates: UpdateProjectRequest): Promise<Project> {
 	return routeCall({
+		allowFallback: true,
 		tauri: async () => {
 			// No update_project in Rust yet, fallback to Express
 			throw new Error("updateProject not yet implemented in Rust backend");

--- a/src/ui/src/services/api.ts
+++ b/src/ui/src/services/api.ts
@@ -47,13 +47,16 @@ async function requireBackend(): Promise<void> {
 
 /**
  * Generate a project ID from its absolute path.
- * Uses base64url encoding of the URI-encoded path for Unicode safety.
+ * Must match Rust's `discovered_project_id()` which uses URL_SAFE_NO_PAD
+ * base64 encoding of the raw UTF-8 bytes.
  */
 function tauriProjectId(path: string): string {
-	return `discovered-${btoa(encodeURIComponent(path))
-		.replace(/\//g, "_")
-		.replace(/\+/g, "-")
-		.replace(/=/g, "")}`;
+	const bytes = new TextEncoder().encode(path);
+	let binary = "";
+	for (const b of bytes) binary += String.fromCharCode(b);
+	const b64 = btoa(binary);
+	const urlSafe = b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+	return `discovered-${urlSafe}`;
 }
 
 /**
@@ -130,26 +133,46 @@ function transformApiProject(p: ApiProject): Project {
 	};
 }
 
-/** Transform Rust ProjectInfo to UI Project */
+/** Transform Rust ProjectInfo to UI Project. Enrichment happens in fetchProjects. */
 function transformTauriProject(p: tauri.ProjectInfo): Project {
 	return {
 		id: tauriProjectId(p.path),
 		name: p.name,
 		path: p.path,
-		health: HealthStatus.HEALTHY,
-		kitType: KitType.ENGINEER,
-		model: "claude-3-5-sonnet",
+		health: p.hasClaudeConfig ? HealthStatus.HEALTHY : HealthStatus.UNKNOWN,
+		kitType: p.hasCkConfig ? KitType.ENGINEER : KitType.ENGINEER,
+		model: "claude-sonnet-4-5",
 		activeHooks: 0,
 		mcpServers: 0,
 		skills: [],
 	};
 }
 
+/** Enrich a transformed project with actual settings data from disk. */
+async function enrichTauriProject(project: Project): Promise<Project> {
+	try {
+		const settings = await tauri.readSettings(project.path);
+		return {
+			...project,
+			model: (settings.model as string) || project.model,
+			activeHooks: Array.isArray(settings.hooks) ? settings.hooks.length : 0,
+			mcpServers:
+				settings.mcpServers != null && typeof settings.mcpServers === "object"
+					? Object.keys(settings.mcpServers as object).length
+					: 0,
+		};
+	} catch {
+		return project;
+	}
+}
+
 export async function fetchProjects(): Promise<Project[]> {
 	return routeCall({
 		tauri: async () => {
 			const projects = await tauri.listProjects();
-			return projects.map(transformTauriProject);
+			const base = projects.map(transformTauriProject);
+			// Enrich with actual settings in parallel (best-effort)
+			return Promise.all(base.map(enrichTauriProject));
 		},
 		web: async () => {
 			await requireBackend();
@@ -204,7 +227,14 @@ export function invalidateProjectCache(id?: string): void {
 }
 
 export async function checkHealth(): Promise<boolean> {
-	if (isTauri()) return true;
+	if (isTauri()) {
+		try {
+			const health = await tauri.getHealth();
+			return health.status === "ok";
+		} catch {
+			return false;
+		}
+	}
 	try {
 		const res = await fetch(`${API_BASE}/health`);
 		return res.ok;
@@ -429,12 +459,15 @@ export async function fetchSettings(): Promise<ApiSettings> {
 		tauri: async () => {
 			const globalPath = await tauri.getGlobalConfigPath();
 			const globalDir = await tauri.getGlobalConfigDir();
-			const settings = await tauri.readSettings(globalDir);
+			// readSettings expects a project root (appends .claude/settings.json).
+			// globalDir is already $HOME/.claude, so pass its parent ($HOME).
+			const homeDir = globalDir.replace(/[/\\]\.claude\/?$/, "");
+			const settings = await tauri.readSettings(homeDir);
 			return {
 				model: (settings.model as string) || "claude-3-5-sonnet",
 				hookCount: Array.isArray(settings.hooks) ? settings.hooks.length : 0,
 				mcpServerCount:
-					typeof settings.mcpServers === "object"
+					settings.mcpServers != null && typeof settings.mcpServers === "object"
 						? Object.keys(settings.mcpServers as object).length
 						: 0,
 				permissions: settings.permissions || {},
@@ -458,10 +491,11 @@ export async function fetchSettingsFile(): Promise<ApiSettingsFile> {
 		tauri: async () => {
 			const globalPath = await tauri.getGlobalConfigPath();
 			const globalDir = await tauri.getGlobalConfigDir();
-			const settings = await tauri.readSettings(globalDir);
+			const homeDir = globalDir.replace(/[/\\]\.claude\/?$/, "");
+			const settings = await tauri.readSettings(homeDir);
 			return {
 				path: globalPath,
-				exists: true,
+				exists: Object.keys(settings).length > 0,
 				settings: settings as Record<string, unknown>,
 			};
 		},
@@ -504,7 +538,8 @@ export async function saveSettingsFile(
 		tauri: async () => {
 			const globalPath = await tauri.getGlobalConfigPath();
 			const globalDir = await tauri.getGlobalConfigDir();
-			await tauri.writeSettings(globalDir, settings);
+			const homeDir = globalDir.replace(/[/\\]\.claude\/?$/, "");
+			await tauri.writeSettings(homeDir, settings);
 			return {
 				success: true,
 				path: globalPath,
@@ -669,9 +704,10 @@ export async function updateProject(id: string, updates: UpdateProjectRequest): 
 
 export async function fetchGlobalMetadata(): Promise<Record<string, unknown>> {
 	return routeCall({
+		allowFallback: true,
 		tauri: async () => {
-			// No direct equivalent, return empty
-			return {};
+			// No Rust equivalent yet — fall back to Express
+			throw new Error("fetchGlobalMetadata not yet implemented in Rust backend");
 		},
 		web: async () => {
 			const res = await fetch(`${API_BASE}/metadata/global`);
@@ -763,7 +799,7 @@ export async function fetchInstalledSkills(): Promise<FetchInstalledSkillsRespon
 					.map((s) => ({
 						skillId: s.name,
 						agentIds: [], // Rust doesn't provide agent mapping yet
-						isGlobal: s.source === "github",
+						isGlobal: true, // Rust scanner only reads ~/.claude/skills/ (global)
 					})),
 			};
 		},


### PR DESCRIPTION
Comprehensively implements Phase 2 of the Desktop-First Control Center migration. Includes dual-mode API routing, wiring of all dashboard modules to Rust commands, and new Rust backend for plans.