### PR TITLE
feat(desktop): add Phase 3 distribution pipeline

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'src-tauri/**'
       - 'src/ui/**'
+      - 'src/domains/desktop/**'
+      - 'src/types/desktop.ts'
+      - 'scripts/generate-desktop-release-manifest.ts'
       - '.github/workflows/desktop-build.yml'
   workflow_dispatch:
 
@@ -68,10 +71,45 @@ jobs:
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # TODO: add TAURI_SIGNING_PRIVATE_KEY secret for update signatures
         with:
           args: ${{ matrix.args }}
           # tagName/releaseName only set on desktop-v* tags — see release job below
+
+      - name: Prepare portable desktop assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p desktop-portable
+
+          case "${{ matrix.platform }}" in
+            macos-latest)
+              APP_PATH="$(find src-tauri/target -type d -name '*.app' | head -1)"
+              if [ -z "$APP_PATH" ]; then
+                echo "Portable macOS app bundle not found"
+                exit 1
+              fi
+              ditto -c -k --keepParent "$APP_PATH" \
+                "desktop-portable/claudekit-control-center_macos-universal.app.zip"
+              ;;
+            ubuntu-22.04)
+              APPIMAGE_PATH="$(find src-tauri/target -type f -name '*.AppImage' | head -1)"
+              if [ -z "$APPIMAGE_PATH" ]; then
+                echo "Portable Linux AppImage not found"
+                exit 1
+              fi
+              cp "$APPIMAGE_PATH" \
+                "desktop-portable/claudekit-control-center_linux-x86_64.AppImage"
+              ;;
+            windows-latest)
+              EXE_PATH="src-tauri/target/release/claudekit-control-center.exe"
+              if [ ! -f "$EXE_PATH" ]; then
+                echo "Portable Windows executable not found at $EXE_PATH"
+                exit 1
+              fi
+              cp "$EXE_PATH" \
+                "desktop-portable/claudekit-control-center_windows-x86_64-portable.exe"
+              ;;
+          esac
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -79,6 +117,7 @@ jobs:
           name: desktop-${{ matrix.platform }}
           if-no-files-found: warn
           path: |
+            desktop-portable/*
             src-tauri/target/release/bundle/**/*.dmg
             src-tauri/target/release/bundle/**/*.app
             src-tauri/target/release/bundle/**/*.msi
@@ -99,6 +138,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.2
+
+      - name: Install release job dependencies
+        run: bun install --frozen-lockfile
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -106,6 +152,30 @@ jobs:
 
       - name: Display downloaded artifacts
         run: find artifacts/ -type f | sort
+
+      - name: Prepare release assets
+        run: |
+          set -euo pipefail
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#desktop-v}"
+          mkdir -p release-assets
+
+          cp "$(find artifacts/ -type f -name '*.dmg' | head -1)" release-assets/
+          cp "$(find artifacts/ -type f -name '*.msi' | head -1)" release-assets/
+          cp "$(find artifacts/ -type f -name '*.deb' | head -1)" release-assets/
+
+          cp "$(find artifacts/ -type f -name 'claudekit-control-center_macos-universal.app.zip' | head -1)" \
+            "release-assets/claudekit-control-center_${VERSION}_macos-universal.app.zip"
+          cp "$(find artifacts/ -type f -name 'claudekit-control-center_linux-x86_64.AppImage' | head -1)" \
+            "release-assets/claudekit-control-center_${VERSION}_linux-x86_64.AppImage"
+          cp "$(find artifacts/ -type f -name 'claudekit-control-center_windows-x86_64-portable.exe' | head -1)" \
+            "release-assets/claudekit-control-center_${VERSION}_windows-x86_64-portable.exe"
+
+          if find artifacts/ -type f -name '*.exe' ! -name 'claudekit-control-center_windows-x86_64-portable.exe' | grep -q .; then
+            cp "$(find artifacts/ -type f -name '*.exe' ! -name 'claudekit-control-center_windows-x86_64-portable.exe' | head -1)" release-assets/
+          fi
+
+          find release-assets/ -type f | sort
 
       - name: Create GitHub Release
         env:
@@ -118,58 +188,24 @@ jobs:
           ASSETS=()
           while IFS= read -r f; do
             ASSETS+=("$f")
-          done < <(find artifacts/ -type f \( \
-            -name "*.dmg" -o -name "*.msi" -o -name "*.exe" \
-            -o -name "*.AppImage" -o -name "*.deb" \
-          \))
+          done < <(find release-assets/ -type f | sort)
 
           gh release create "$TAG" \
             --title "ClaudeKit Desktop v${VERSION}" \
-            --notes "Desktop release v${VERSION} for macOS, Windows, and Linux." \
+            --generate-notes \
             "${ASSETS[@]}"
 
-      - name: Check updater signing key
-        run: |
-          if [ -z "${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" ]; then
-            echo "::warning::TAURI_SIGNING_PRIVATE_KEY not configured — skipping updater manifest"
-            echo "SKIP_UPDATER=true" >> "$GITHUB_ENV"
-          fi
-
-      - name: Generate latest.json for auto-updater
-        if: env.SKIP_UPDATER != 'true'
+      - name: Generate desktop-manifest.json for desktop distribution
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ github.ref_name }}"
-          VERSION="${TAG#desktop-v}"
+          gh api "repos/${{ github.repository }}/releases/tags/${TAG}" > release.json
+          bun scripts/generate-desktop-release-manifest.ts release.json > desktop-manifest.json
 
-          # Build platform url map from uploaded assets
-          DARWIN_URL=$(gh release view "$TAG" --json assets --jq \
-            '.assets[] | select(.name | endswith(".dmg")) | .browserDownloadUrl' | head -1)
-          LINUX_URL=$(gh release view "$TAG" --json assets --jq \
-            '.assets[] | select(.name | endswith(".AppImage")) | .browserDownloadUrl' | head -1)
-          WIN_URL=$(gh release view "$TAG" --json assets --jq \
-            '.assets[] | select(.name | endswith(".msi")) | .browserDownloadUrl' | head -1)
+          gh release upload "$TAG" desktop-manifest.json --clobber
 
-          # TODO: populate signatures from .sig files once TAURI_SIGNING_PRIVATE_KEY is set
-          cat > latest.json <<EOF
-          {
-            "version": "${VERSION}",
-            "notes": "ClaudeKit Desktop v${VERSION}",
-            "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "platforms": {
-              "darwin-aarch64": { "url": "${DARWIN_URL}", "signature": "" },
-              "darwin-x86_64": { "url": "${DARWIN_URL}", "signature": "" },
-              "linux-x86_64": { "url": "${LINUX_URL}", "signature": "" },
-              "windows-x86_64": { "url": "${WIN_URL}", "signature": "" }
-            }
-          }
-          EOF
-
-          # Upload to desktop-specific stable tag for updater endpoint
-          gh release upload "$TAG" latest.json --clobber
-          # Also maintain a floating 'desktop-latest' release for the updater endpoint
-          gh release create "desktop-latest" --title "Desktop Latest (auto-updater)" \
-            --notes "Auto-maintained by CI. Points to latest desktop release." \
+          gh release create "desktop-latest" --title "Desktop Latest (distribution manifest)" \
+            --notes "Auto-maintained by CI. Points to the latest desktop distribution manifest." \
             --latest=false 2>/dev/null || true
-          gh release upload "desktop-latest" latest.json --clobber
+          gh release upload "desktop-latest" desktop-manifest.json --clobber

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -83,7 +83,7 @@ jobs:
 
           case "${{ matrix.platform }}" in
             macos-latest)
-              APP_PATH="$(find src-tauri/target -type d -name '*.app' | head -1)"
+              APP_PATH="$(find src-tauri/target/universal-apple-darwin -type d -name '*.app' | head -1)"
               if [ -z "$APP_PATH" ]; then
                 echo "Portable macOS app bundle not found"
                 exit 1
@@ -115,7 +115,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: desktop-${{ matrix.platform }}
-          if-no-files-found: warn
+          if-no-files-found: error
           path: |
             desktop-portable/*
             src-tauri/target/release/bundle/**/*.dmg

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -160,9 +160,26 @@ jobs:
           VERSION="${TAG#desktop-v}"
           mkdir -p release-assets
 
-          cp "$(find artifacts/ -type f -name '*.dmg' | head -1)" release-assets/
-          cp "$(find artifacts/ -type f -name '*.msi' | head -1)" release-assets/
-          cp "$(find artifacts/ -type f -name '*.deb' | head -1)" release-assets/
+          DMG_PATH="$(find artifacts/ -type f -name '*.dmg' | head -1)"
+          if [ -z "$DMG_PATH" ]; then
+            echo "Desktop DMG asset not found"
+            exit 1
+          fi
+          cp "$DMG_PATH" release-assets/
+
+          MSI_PATH="$(find artifacts/ -type f -name '*.msi' | head -1)"
+          if [ -z "$MSI_PATH" ]; then
+            echo "Desktop MSI asset not found"
+            exit 1
+          fi
+          cp "$MSI_PATH" release-assets/
+
+          DEB_PATH="$(find artifacts/ -type f -name '*.deb' | head -1)"
+          if [ -z "$DEB_PATH" ]; then
+            echo "Desktop DEB asset not found"
+            exit 1
+          fi
+          cp "$DEB_PATH" release-assets/
 
           cp "$(find artifacts/ -type f -name 'claudekit-control-center_macos-universal.app.zip' | head -1)" \
             "release-assets/claudekit-control-center_${VERSION}_macos-universal.app.zip"

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -54,6 +54,8 @@ The codebase underwent a major modularization refactor, reducing 24 large files 
 - `src-tauri/` now contains Phase 1 native read-side coverage for sessions, agents, commands, skills, MCP discovery, dashboard aggregates, and system diagnostics.
 - `src-tauri/src/core/` now includes shared helpers for frontmatter parsing and Claude project/session path resolution.
 - `src/ui/src/lib/tauri-commands.ts` now exposes the expanded typed invoke surface for native mode.
+- `src/domains/desktop/` now owns the Phase 3 desktop distribution contract: manifest parsing/building, platform asset selection, install-path resolution, install helpers, and detached app launch helpers.
+- `.github/workflows/desktop-build.yml` now prepares portable desktop assets and publishes a plain `desktop-latest/desktop-manifest.json` manifest for CLI-side binary discovery; signed Tauri updater support remains a later phase.
 - Browser mode still uses the Express `/api` backend for live UI data flow; the desktop routing switchover remains a later phase.
 
 ### Development Tools

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,9 +1,7 @@
 # Project Roadmap: ClaudeKit CLI
 
-**Last Updated**: 2026-03-05
-**Version**: 3.36.0-dev.11
-**Last Updated**: 2026-03-02
-**Version**: 3.36.0-dev.7 (next stable: 3.36.0)
+**Last Updated**: 2026-04-15
+**Version**: 3.41.4-dev.22
 **Repository**: https://github.com/mrgoonie/claudekit-cli
 
 ---
@@ -18,6 +16,7 @@ ClaudeKit CLI (`ck`) is a command-line tool for bootstrapping and updating Claud
 
 - Tauri v2 native shell now has Phase 1 backend coverage for sessions, entity browsers, MCP discovery, dashboard aggregates, and system diagnostics.
 - Typed invoke wrappers in `src/ui/src/lib/tauri-commands.ts` cover the expanded native command surface.
+- Phase 3 now adds unsigned desktop distribution plumbing: portable release assets, a plain `desktop-manifest.json` download manifest, and reusable desktop install/launch helpers for the future `ck app` command.
 - Browser mode still uses the Express `/api` backend today; the dual-mode routing switchover is still pending follow-up phases.
 
 ---

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -80,6 +80,12 @@ Commands maintain context object threaded through phases. Enables shared state, 
 ### desktop/ - Tauri Control Center (native mode)
 Native shell for the shared dashboard. The Phase 1 invoke bridge now covers config/statusline, project registry, sessions, entity browsers, MCP discovery, dashboard aggregates, and system diagnostics. Pure helpers live in `src-tauri/src/core/`. Browser mode still uses the Express `/api` backend for the actual dashboard routing.
 
+Phase 3 adds the unsigned desktop distribution layer around that shell:
+- `.github/workflows/desktop-build.yml` now prepares portable desktop assets alongside the user-facing bundles.
+- `scripts/generate-desktop-release-manifest.ts` emits a plain `desktop-manifest.json` download manifest from the tagged GitHub Release assets.
+- `src/domains/desktop/` provides the reusable TypeScript install/launch surface that Phase 4 can wire into `ck app`.
+- Signed in-app updater support remains deferred until a dedicated signing-key phase ships a real Tauri updater contract.
+
 ### skills/ - Skills Management
 Multi-select installation, registry tracking, uninstall per agent.
 

--- a/scripts/generate-desktop-release-manifest.ts
+++ b/scripts/generate-desktop-release-manifest.ts
@@ -1,13 +1,7 @@
 #!/usr/bin/env bun
 import { readFile } from "node:fs/promises";
 import { buildDesktopReleaseManifest } from "../src/domains/desktop/desktop-release-manifest.js";
-import type { GitHubReleaseAsset } from "../src/types";
-
-interface ReleasePayload {
-	tag_name: string;
-	published_at?: string;
-	assets: GitHubReleaseAsset[];
-}
+import { parseDesktopReleasePayload } from "../src/domains/desktop/desktop-release-payload.js";
 
 function getVersionFromTag(tag: string): string {
 	if (!tag.startsWith("desktop-v")) {
@@ -23,7 +17,7 @@ async function main(): Promise<void> {
 	}
 
 	const raw = await readFile(inputPath, "utf-8");
-	const payload = JSON.parse(raw) as ReleasePayload;
+	const payload = parseDesktopReleasePayload(JSON.parse(raw));
 	const manifest = buildDesktopReleaseManifest({
 		version: getVersionFromTag(payload.tag_name),
 		publishedAt: payload.published_at || new Date().toISOString(),

--- a/scripts/generate-desktop-release-manifest.ts
+++ b/scripts/generate-desktop-release-manifest.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env bun
+import { readFile } from "node:fs/promises";
+import { buildDesktopReleaseManifest } from "../src/domains/desktop/desktop-release-manifest.js";
+import type { GitHubReleaseAsset } from "../src/types";
+
+interface ReleasePayload {
+	tag_name: string;
+	published_at?: string;
+	assets: GitHubReleaseAsset[];
+}
+
+function getVersionFromTag(tag: string): string {
+	if (!tag.startsWith("desktop-v")) {
+		throw new Error(`Expected desktop release tag, received: ${tag}`);
+	}
+	return tag.slice("desktop-v".length);
+}
+
+async function main(): Promise<void> {
+	const inputPath = process.argv[2];
+	if (!inputPath) {
+		throw new Error("Usage: bun scripts/generate-desktop-release-manifest.ts <release-json>");
+	}
+
+	const raw = await readFile(inputPath, "utf-8");
+	const payload = JSON.parse(raw) as ReleasePayload;
+	const manifest = buildDesktopReleaseManifest({
+		version: getVersionFromTag(payload.tag_name),
+		publishedAt: payload.published_at || new Date().toISOString(),
+		assets: payload.assets,
+	});
+
+	process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+main().catch((error) => {
+	const message = error instanceof Error ? error.message : String(error);
+	console.error(message);
+	process.exit(1);
+});

--- a/src/__tests__/domains/desktop/desktop-app-launcher.test.ts
+++ b/src/__tests__/domains/desktop/desktop-app-launcher.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+	buildDesktopLaunchCommand,
+	launchDesktopApp,
+} from "@/domains/desktop/desktop-app-launcher.js";
+
+describe("desktop-app-launcher", () => {
+	test("builds platform-specific launch commands", () => {
+		expect(
+			buildDesktopLaunchCommand("/tmp/ClaudeKit Control Center.app", { platform: "darwin" }),
+		).toEqual({
+			command: "open",
+			args: ["/tmp/ClaudeKit Control Center.app"],
+		});
+		expect(
+			buildDesktopLaunchCommand("/tmp/claudekit-control-center", { platform: "linux" }),
+		).toEqual({
+			command: "/tmp/claudekit-control-center",
+			args: [],
+		});
+		expect(
+			buildDesktopLaunchCommand("C:\\ClaudeKit\\ClaudeKit Control Center.exe", {
+				platform: "win32",
+			}),
+		).toEqual({
+			command: "C:\\ClaudeKit\\ClaudeKit Control Center.exe",
+			args: [],
+		});
+	});
+
+	test("launches the app with detached ignored stdio", () => {
+		const unref = mock(() => {});
+		const spawnFn = mock(() => ({ unref }));
+
+		launchDesktopApp("/tmp/claudekit-control-center", {
+			platform: "linux",
+			spawnFn,
+		});
+
+		expect(spawnFn).toHaveBeenCalledWith("/tmp/claudekit-control-center", [], {
+			detached: true,
+			stdio: "ignore",
+			windowsHide: false,
+		});
+		expect(unref).toHaveBeenCalled();
+	});
+});

--- a/src/__tests__/domains/desktop/desktop-asset-selector.test.ts
+++ b/src/__tests__/domains/desktop/desktop-asset-selector.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import {
+	getCurrentDesktopPlatformKey,
+	selectDesktopPlatformEntry,
+} from "@/domains/desktop/desktop-asset-selector.js";
+import type { DesktopReleaseManifest } from "@/types/desktop.js";
+
+const manifest: DesktopReleaseManifest = {
+	version: "0.1.0",
+	date: "2026-04-15T21:00:00Z",
+	platforms: {
+		"darwin-aarch64": {
+			name: "mac-arm.zip",
+			url: "https://example.com/mac-arm.zip",
+			size: 100,
+			assetType: "app-zip",
+		},
+		"darwin-x86_64": {
+			name: "mac-x64.zip",
+			url: "https://example.com/mac-x64.zip",
+			size: 110,
+			assetType: "app-zip",
+		},
+		"linux-x86_64": {
+			name: "linux.AppImage",
+			url: "https://example.com/linux.AppImage",
+			size: 120,
+			assetType: "appimage",
+		},
+		"windows-x86_64": {
+			name: "windows.exe",
+			url: "https://example.com/windows.exe",
+			size: 130,
+			assetType: "portable-exe",
+		},
+	},
+};
+
+describe("desktop-asset-selector", () => {
+	test("maps supported runtime platforms to manifest keys", () => {
+		expect(getCurrentDesktopPlatformKey("darwin", "arm64")).toBe("darwin-aarch64");
+		expect(getCurrentDesktopPlatformKey("darwin", "x64")).toBe("darwin-x86_64");
+		expect(getCurrentDesktopPlatformKey("linux", "x64")).toBe("linux-x86_64");
+		expect(getCurrentDesktopPlatformKey("win32", "x64")).toBe("windows-x86_64");
+	});
+
+	test("throws on unsupported platform combinations", () => {
+		expect(() => getCurrentDesktopPlatformKey("linux", "arm64")).toThrow(/unsupported/i);
+		expect(() => getCurrentDesktopPlatformKey("freebsd", "x64")).toThrow(/unsupported/i);
+	});
+
+	test("selects the correct manifest entry for the current platform", () => {
+		const entry = selectDesktopPlatformEntry(manifest, {
+			platform: "linux",
+			arch: "x64",
+		});
+
+		expect(entry.assetType).toBe("appimage");
+		expect(entry.name).toBe("linux.AppImage");
+	});
+});

--- a/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
+++ b/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	downloadDesktopBinary,
+	getDesktopBinaryPath,
+} from "@/domains/desktop/desktop-binary-manager.js";
+import type { DesktopReleaseManifest } from "@/types/desktop.js";
+
+const manifest: DesktopReleaseManifest = {
+	version: "0.1.0",
+	date: "2026-04-15T21:00:00Z",
+	platforms: {
+		"darwin-aarch64": {
+			name: "claudekit-control-center_0.1.0_macos-universal.app.zip",
+			url: "https://example.com/mac.zip",
+			size: 101,
+			assetType: "app-zip",
+		},
+		"darwin-x86_64": {
+			name: "claudekit-control-center_0.1.0_macos-universal.app.zip",
+			url: "https://example.com/mac.zip",
+			size: 101,
+			assetType: "app-zip",
+		},
+		"linux-x86_64": {
+			name: "claudekit-control-center_0.1.0_linux-x86_64.AppImage",
+			url: "https://example.com/linux.AppImage",
+			size: 202,
+			assetType: "appimage",
+		},
+		"windows-x86_64": {
+			name: "claudekit-control-center_0.1.0_windows-x86_64-portable.exe",
+			url: "https://example.com/windows.exe",
+			size: 303,
+			assetType: "portable-exe",
+		},
+	},
+};
+
+describe("desktop-binary-manager", () => {
+	const originalTestHome = process.env.CK_TEST_HOME;
+
+	beforeEach(() => {
+		process.env.CK_TEST_HOME = "/tmp/ck-phase-3-home";
+	});
+
+	afterEach(() => {
+		process.env.CK_TEST_HOME = originalTestHome;
+	});
+
+	test("returns null when the installed binary is missing", () => {
+		const result = getDesktopBinaryPath({
+			platform: "linux",
+			existsFn: () => false,
+		});
+
+		expect(result).toBeNull();
+	});
+
+	test("returns the install path when the binary exists", () => {
+		const result = getDesktopBinaryPath({
+			platform: "linux",
+			existsFn: () => true,
+		});
+
+		expect(result).toBe("/tmp/ck-phase-3-home/.local/bin/claudekit-control-center");
+	});
+
+	test("downloads the current platform asset from the manifest", async () => {
+		const fetchManifest = mock(async () => manifest);
+		const downloadFile = mock(async () => "/tmp/downloads/linux.AppImage");
+		const getDownloadDirectory = mock(() => "/tmp/downloads");
+
+		const result = await downloadDesktopBinary(undefined, {
+			platform: "linux",
+			arch: "x64",
+			fetchManifest,
+			downloadFile,
+			getDownloadDirectory,
+		});
+
+		expect(fetchManifest).toHaveBeenCalled();
+		expect(downloadFile).toHaveBeenCalledWith({
+			url: "https://example.com/linux.AppImage",
+			name: "claudekit-control-center_0.1.0_linux-x86_64.AppImage",
+			size: 202,
+			destDir: "/tmp/downloads",
+		});
+		expect(result).toBe("/tmp/downloads/linux.AppImage");
+	});
+});

--- a/src/__tests__/domains/desktop/desktop-install-path-resolver.test.ts
+++ b/src/__tests__/domains/desktop/desktop-install-path-resolver.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import {
+	getDesktopDownloadDirectory,
+	getDesktopInstallPath,
+} from "@/domains/desktop/desktop-install-path-resolver.js";
+import { PathResolver } from "@/shared/path-resolver.js";
+
+describe("desktop-install-path-resolver", () => {
+	const originalTestHome = process.env.CK_TEST_HOME;
+	const originalLocalAppData = process.env.LOCALAPPDATA;
+
+	beforeEach(() => {
+		process.env.CK_TEST_HOME = "/tmp/ck-phase-3-home";
+		process.env.LOCALAPPDATA = "C:\\Users\\Kai\\AppData\\Local";
+	});
+
+	afterEach(() => {
+		process.env.CK_TEST_HOME = originalTestHome;
+		process.env.LOCALAPPDATA = originalLocalAppData;
+	});
+
+	test("resolves per-platform install targets inside the user profile", () => {
+		expect(getDesktopInstallPath({ platform: "darwin" })).toBe(
+			"/tmp/ck-phase-3-home/Applications/ClaudeKit Control Center.app",
+		);
+		expect(getDesktopInstallPath({ platform: "linux" })).toBe(
+			"/tmp/ck-phase-3-home/.local/bin/claudekit-control-center",
+		);
+		expect(getDesktopInstallPath({ platform: "win32" })).toBe(
+			"C:\\Users\\Kai\\AppData\\Local\\ClaudeKit\\ClaudeKit Control Center.exe",
+		);
+	});
+
+	test("uses the shared cache directory for downloads", () => {
+		expect(getDesktopDownloadDirectory()).toBe(
+			join(PathResolver.getCacheDir(false), "desktop-downloads"),
+		);
+	});
+});

--- a/src/__tests__/domains/desktop/desktop-installer.test.ts
+++ b/src/__tests__/domains/desktop/desktop-installer.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { chmod, mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { installDesktopBinary } from "@/domains/desktop/desktop-installer.js";
+
+describe("desktop-installer", () => {
+	const originalTestHome = process.env.CK_TEST_HOME;
+
+	beforeEach(() => {
+		process.env.CK_TEST_HOME = "/tmp/ck-phase-3-installer-home";
+	});
+
+	afterEach(async () => {
+		process.env.CK_TEST_HOME = originalTestHome;
+		await rm("/tmp/ck-phase-3-installer-home", { recursive: true, force: true });
+		await rm("/tmp/ck-phase-3-installer-fixtures", { recursive: true, force: true });
+	});
+
+	test("installs a linux AppImage into the user-local bin directory", async () => {
+		const fixturesDir = "/tmp/ck-phase-3-installer-fixtures";
+		await mkdir(fixturesDir, { recursive: true });
+		const sourcePath = join(fixturesDir, "claudekit-control-center.AppImage");
+		await writeFile(sourcePath, "linux-binary");
+		await chmod(sourcePath, 0o644);
+
+		const installedPath = await installDesktopBinary(sourcePath, {
+			platform: "linux",
+		});
+
+		expect(installedPath).toBe(
+			"/tmp/ck-phase-3-installer-home/.local/bin/claudekit-control-center",
+		);
+		expect(await Bun.file(installedPath).text()).toBe("linux-binary");
+		expect((await stat(installedPath)).mode & 0o111).toBeGreaterThan(0);
+	});
+
+	test("installs a macOS app bundle from a zip staging directory and clears quarantine", async () => {
+		const fixturesDir = "/tmp/ck-phase-3-installer-fixtures";
+		await mkdir(fixturesDir, { recursive: true });
+		const downloadPath = join(fixturesDir, "claudekit-control-center.app.zip");
+		await writeFile(downloadPath, "placeholder");
+		const removeQuarantineFn = mock(async (_path: string) => {});
+
+		const installedPath = await installDesktopBinary(downloadPath, {
+			platform: "darwin",
+			extractZipFn: async (_source, config) => {
+				const appDir = join(config.dir, "ClaudeKit Control Center.app", "Contents");
+				await mkdir(appDir, { recursive: true });
+				await writeFile(join(appDir, "Info.plist"), "<plist />");
+			},
+			removeQuarantineFn,
+		});
+
+		expect(installedPath).toBe(
+			"/tmp/ck-phase-3-installer-home/Applications/ClaudeKit Control Center.app",
+		);
+		expect(await Bun.file(join(installedPath, "Contents", "Info.plist")).text()).toContain("plist");
+		expect(removeQuarantineFn).toHaveBeenCalledWith(`${installedPath}.new`);
+	});
+
+	test("preserves the existing macOS install when quarantine removal fails before swap", async () => {
+		const currentInstallPath =
+			"/tmp/ck-phase-3-installer-home/Applications/ClaudeKit Control Center.app/Contents";
+		await mkdir(currentInstallPath, { recursive: true });
+		await writeFile(join(currentInstallPath, "Info.plist"), "old-version");
+
+		const fixturesDir = "/tmp/ck-phase-3-installer-fixtures";
+		await mkdir(fixturesDir, { recursive: true });
+		const downloadPath = join(fixturesDir, "claudekit-control-center.app.zip");
+		await writeFile(downloadPath, "placeholder");
+
+		await expect(
+			installDesktopBinary(downloadPath, {
+				platform: "darwin",
+				extractZipFn: async (_source, config) => {
+					const appDir = join(config.dir, "ClaudeKit Control Center.app", "Contents");
+					await mkdir(appDir, { recursive: true });
+					await writeFile(join(appDir, "Info.plist"), "new-version");
+				},
+				removeQuarantineFn: async () => {
+					throw new Error("quarantine failed");
+				},
+			}),
+		).rejects.toThrow(/quarantine failed/);
+
+		expect(
+			await Bun.file(
+				"/tmp/ck-phase-3-installer-home/Applications/ClaudeKit Control Center.app/Contents/Info.plist",
+			).text(),
+		).toBe("old-version");
+	});
+});

--- a/src/__tests__/domains/desktop/desktop-release-manifest.test.ts
+++ b/src/__tests__/domains/desktop/desktop-release-manifest.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildDesktopReleaseManifest,
+	parseDesktopReleaseManifest,
+} from "@/domains/desktop/desktop-release-manifest.js";
+import type { GitHubReleaseAsset } from "@/types";
+
+function createAsset(
+	name: string,
+	size: number,
+	browserDownloadUrl = `https://example.com/${name}`,
+): GitHubReleaseAsset {
+	return {
+		id: size,
+		name,
+		url: `https://api.example.com/assets/${size}`,
+		browser_download_url: browserDownloadUrl,
+		size,
+		content_type: "application/octet-stream",
+	};
+}
+
+describe("desktop-release-manifest", () => {
+	test("builds a plain desktop manifest from portable release assets", () => {
+		const manifest = buildDesktopReleaseManifest({
+			version: "0.1.0",
+			publishedAt: "2026-04-15T21:00:00Z",
+			assets: [
+				createAsset("claudekit-control-center_0.1.0_macos-universal.app.zip", 101),
+				createAsset("claudekit-control-center_0.1.0_linux-x86_64.AppImage", 202),
+				createAsset("claudekit-control-center_0.1.0_windows-x86_64-portable.exe", 303),
+			],
+		});
+		const macArm = manifest.platforms["darwin-aarch64"];
+		const macIntel = manifest.platforms["darwin-x86_64"];
+		const linux = manifest.platforms["linux-x86_64"];
+		const windows = manifest.platforms["windows-x86_64"];
+
+		expect(manifest.version).toBe("0.1.0");
+		expect(manifest.date).toBe("2026-04-15T21:00:00Z");
+		expect(macArm).toBeDefined();
+		expect(macIntel).toBeDefined();
+		expect(linux).toBeDefined();
+		expect(windows).toBeDefined();
+		expect(macArm?.assetType).toBe("app-zip");
+		expect(macIntel?.url).toContain("macos-universal.app.zip");
+		expect(linux).toEqual({
+			name: "claudekit-control-center_0.1.0_linux-x86_64.AppImage",
+			url: "https://example.com/claudekit-control-center_0.1.0_linux-x86_64.AppImage",
+			size: 202,
+			assetType: "appimage",
+		});
+		expect(windows?.assetType).toBe("portable-exe");
+	});
+
+	test("parses a valid manifest payload", () => {
+		const parsed = parseDesktopReleaseManifest({
+			version: "0.1.0",
+			date: "2026-04-15T21:00:00Z",
+			platforms: {
+				"darwin-aarch64": {
+					name: "mac.zip",
+					url: "https://example.com/mac.zip",
+					size: 100,
+					assetType: "app-zip",
+				},
+				"darwin-x86_64": {
+					name: "mac.zip",
+					url: "https://example.com/mac.zip",
+					size: 100,
+					assetType: "app-zip",
+				},
+				"linux-x86_64": {
+					name: "linux.AppImage",
+					url: "https://example.com/linux.AppImage",
+					size: 200,
+					assetType: "appimage",
+				},
+				"windows-x86_64": {
+					name: "windows.exe",
+					url: "https://example.com/windows.exe",
+					size: 300,
+					assetType: "portable-exe",
+				},
+			},
+		});
+
+		expect(parsed.platforms["windows-x86_64"]?.name).toBe("windows.exe");
+	});
+
+	test("throws when a required portable asset is missing", () => {
+		expect(() =>
+			buildDesktopReleaseManifest({
+				version: "0.1.0",
+				publishedAt: "2026-04-15T21:00:00Z",
+				assets: [
+					createAsset("claudekit-control-center_0.1.0_macos-universal.app.zip", 101),
+					createAsset("claudekit-control-center_0.1.0_linux-x86_64.AppImage", 202),
+				],
+			}),
+		).toThrow(/windows/i);
+	});
+
+	test("throws on malformed manifest payload", () => {
+		expect(() =>
+			parseDesktopReleaseManifest({
+				version: "0.1.0",
+				date: "2026-04-15T21:00:00Z",
+				platforms: {
+					"darwin-aarch64": {
+						name: "mac.zip",
+						url: "not-a-url",
+						size: 100,
+						assetType: "app-zip",
+					},
+				},
+			}),
+		).toThrow();
+	});
+
+	test("rejects non-HTTPS asset URLs", () => {
+		expect(() =>
+			parseDesktopReleaseManifest({
+				version: "0.1.0",
+				date: "2026-04-15T21:00:00Z",
+				platforms: {
+					"darwin-aarch64": {
+						name: "mac.zip",
+						url: "http://example.com/mac.zip",
+						size: 100,
+						assetType: "app-zip",
+					},
+					"darwin-x86_64": {
+						name: "mac.zip",
+						url: "https://example.com/mac.zip",
+						size: 100,
+						assetType: "app-zip",
+					},
+					"linux-x86_64": {
+						name: "linux.AppImage",
+						url: "https://example.com/linux.AppImage",
+						size: 200,
+						assetType: "appimage",
+					},
+					"windows-x86_64": {
+						name: "windows.exe",
+						url: "https://example.com/windows.exe",
+						size: 300,
+						assetType: "portable-exe",
+					},
+				},
+			}),
+		).toThrow(/https/i);
+	});
+
+	test("throws when a platform entry is missing from the manifest payload", () => {
+		expect(() =>
+			parseDesktopReleaseManifest({
+				version: "0.1.0",
+				date: "2026-04-15T21:00:00Z",
+				platforms: {
+					"darwin-aarch64": {
+						name: "mac.zip",
+						url: "https://example.com/mac.zip",
+						size: 100,
+						assetType: "app-zip",
+					},
+					"darwin-x86_64": {
+						name: "mac.zip",
+						url: "https://example.com/mac.zip",
+						size: 100,
+						assetType: "app-zip",
+					},
+					"linux-x86_64": {
+						name: "linux.AppImage",
+						url: "https://example.com/linux.AppImage",
+						size: 200,
+						assetType: "appimage",
+					},
+				},
+			}),
+		).toThrow();
+	});
+});

--- a/src/__tests__/domains/desktop/desktop-release-payload.test.ts
+++ b/src/__tests__/domains/desktop/desktop-release-payload.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { parseDesktopReleasePayload } from "@/domains/desktop/desktop-release-payload.js";
+
+describe("desktop-release-payload", () => {
+	test("parses a valid GitHub release payload", () => {
+		const payload = parseDesktopReleasePayload({
+			id: 1,
+			tag_name: "desktop-v0.1.0",
+			name: "ClaudeKit Desktop v0.1.0",
+			draft: false,
+			prerelease: false,
+			published_at: "2026-04-16T00:00:00Z",
+			tarball_url: "https://example.com/tarball",
+			zipball_url: "https://example.com/zipball",
+			assets: [
+				{
+					id: 10,
+					name: "claudekit-control-center_0.1.0_macos-universal.app.zip",
+					url: "https://api.example.com/assets/10",
+					browser_download_url: "https://example.com/mac.zip",
+					size: 100,
+					content_type: "application/zip",
+				},
+			],
+		});
+
+		expect(payload.tag_name).toBe("desktop-v0.1.0");
+	});
+
+	test("rejects malformed release payloads", () => {
+		expect(() =>
+			parseDesktopReleasePayload({
+				tag_name: "desktop-v0.1.0",
+				assets: [],
+			}),
+		).toThrow();
+	});
+
+	test("rejects empty asset lists with a clear error", () => {
+		expect(() =>
+			parseDesktopReleasePayload({
+				id: 1,
+				tag_name: "desktop-v0.1.0",
+				name: "ClaudeKit Desktop v0.1.0",
+				draft: false,
+				prerelease: false,
+				published_at: "2026-04-16T00:00:00Z",
+				tarball_url: "https://example.com/tarball",
+				zipball_url: "https://example.com/zipball",
+				assets: [],
+			}),
+		).toThrow(/no assets/i);
+	});
+});

--- a/src/__tests__/domains/desktop/desktop-release-service.test.ts
+++ b/src/__tests__/domains/desktop/desktop-release-service.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+	fetchDesktopReleaseManifest,
+	getDesktopManifestUrl,
+} from "@/domains/desktop/desktop-release-service.js";
+
+describe("desktop-release-service", () => {
+	test("builds latest and version-specific manifest URLs", () => {
+		expect(getDesktopManifestUrl()).toBe(
+			"https://github.com/mrgoonie/claudekit-cli/releases/download/desktop-latest/desktop-manifest.json",
+		);
+		expect(getDesktopManifestUrl("0.1.0")).toBe(
+			"https://github.com/mrgoonie/claudekit-cli/releases/download/desktop-v0.1.0/desktop-manifest.json",
+		);
+	});
+
+	test("fetches and parses the desktop manifest", async () => {
+		const fetchFn = mock(async () => ({
+			ok: true,
+			json: async () => ({
+				version: "0.1.0",
+				date: "2026-04-15T21:00:00Z",
+				platforms: {
+					"darwin-aarch64": {
+						name: "mac.zip",
+						url: "https://example.com/mac.zip",
+						size: 100,
+						assetType: "app-zip",
+					},
+					"darwin-x86_64": {
+						name: "mac.zip",
+						url: "https://example.com/mac.zip",
+						size: 100,
+						assetType: "app-zip",
+					},
+					"linux-x86_64": {
+						name: "linux.AppImage",
+						url: "https://example.com/linux.AppImage",
+						size: 200,
+						assetType: "appimage",
+					},
+					"windows-x86_64": {
+						name: "windows.exe",
+						url: "https://example.com/windows.exe",
+						size: 300,
+						assetType: "portable-exe",
+					},
+				},
+			}),
+		}));
+
+		const manifest = await fetchDesktopReleaseManifest(
+			undefined,
+			fetchFn as unknown as typeof fetch,
+		);
+
+		expect(fetchFn).toHaveBeenCalledWith(
+			"https://github.com/mrgoonie/claudekit-cli/releases/download/desktop-latest/desktop-manifest.json",
+		);
+		expect(manifest.platforms["windows-x86_64"]?.assetType).toBe("portable-exe");
+	});
+
+	test("throws when the manifest request fails", async () => {
+		const fetchFn = mock(async () => ({
+			ok: false,
+			status: 404,
+			statusText: "Not Found",
+		}));
+
+		await expect(
+			fetchDesktopReleaseManifest(undefined, fetchFn as unknown as typeof fetch),
+		).rejects.toThrow(/404/i);
+	});
+});

--- a/src/domains/desktop/desktop-app-launcher.ts
+++ b/src/domains/desktop/desktop-app-launcher.ts
@@ -1,0 +1,48 @@
+import { spawn } from "node:child_process";
+
+export interface DesktopLaunchCommand {
+	command: string;
+	args: string[];
+}
+
+export function buildDesktopLaunchCommand(
+	binaryPath: string,
+	options: { platform?: NodeJS.Platform } = {},
+): DesktopLaunchCommand {
+	const platform = options.platform || process.platform;
+	if (platform === "darwin") {
+		return {
+			command: "open",
+			args: [binaryPath],
+		};
+	}
+	return {
+		command: binaryPath,
+		args: [],
+	};
+}
+
+export function launchDesktopApp(
+	binaryPath: string,
+	options: {
+		platform?: NodeJS.Platform;
+		spawnFn?: (
+			command: string,
+			args: string[],
+			options: {
+				detached: boolean;
+				stdio: "ignore";
+				windowsHide: boolean;
+			},
+		) => { unref: () => void };
+	} = {},
+): void {
+	const command = buildDesktopLaunchCommand(binaryPath, options);
+	const spawnFn = options.spawnFn || spawn;
+	const child = spawnFn(command.command, command.args, {
+		detached: true,
+		stdio: "ignore",
+		windowsHide: (options.platform || process.platform) === "win32",
+	});
+	child.unref();
+}

--- a/src/domains/desktop/desktop-asset-selector.ts
+++ b/src/domains/desktop/desktop-asset-selector.ts
@@ -1,0 +1,28 @@
+import type {
+	DesktopPlatformAsset,
+	DesktopPlatformKey,
+	DesktopReleaseManifest,
+} from "@/types/desktop.js";
+
+export function getCurrentDesktopPlatformKey(
+	platform: NodeJS.Platform = process.platform,
+	arch: string = process.arch,
+): DesktopPlatformKey {
+	if (platform === "darwin" && arch === "arm64") return "darwin-aarch64";
+	if (platform === "darwin" && arch === "x64") return "darwin-x86_64";
+	if (platform === "linux" && arch === "x64") return "linux-x86_64";
+	if (platform === "win32" && arch === "x64") return "windows-x86_64";
+	throw new Error(`Unsupported desktop platform: ${platform}/${arch}`);
+}
+
+export function selectDesktopPlatformEntry(
+	manifest: DesktopReleaseManifest,
+	options: { platform?: NodeJS.Platform; arch?: string } = {},
+): DesktopPlatformAsset {
+	const key = getCurrentDesktopPlatformKey(options.platform, options.arch);
+	const entry = manifest.platforms[key];
+	if (!entry) {
+		throw new Error(`Desktop release manifest is missing platform entry: ${key}`);
+	}
+	return entry;
+}

--- a/src/domains/desktop/desktop-binary-manager.ts
+++ b/src/domains/desktop/desktop-binary-manager.ts
@@ -1,0 +1,57 @@
+import { existsSync } from "node:fs";
+import { launchDesktopApp } from "@/domains/desktop/desktop-app-launcher.js";
+import { selectDesktopPlatformEntry } from "@/domains/desktop/desktop-asset-selector.js";
+import {
+	getDesktopDownloadDirectory,
+	getDesktopInstallPath,
+} from "@/domains/desktop/desktop-install-path-resolver.js";
+import { installDesktopBinary } from "@/domains/desktop/desktop-installer.js";
+import { fetchDesktopReleaseManifest } from "@/domains/desktop/desktop-release-service.js";
+import { FileDownloader } from "@/domains/installation/download/file-downloader.js";
+
+export function getDesktopBinaryPath(
+	options: {
+		platform?: NodeJS.Platform;
+		existsFn?: (path: string) => boolean;
+	} = {},
+): string | null {
+	const installPath = getDesktopInstallPath({ platform: options.platform });
+	const existsFn = options.existsFn || existsSync;
+	return existsFn(installPath) ? installPath : null;
+}
+
+export async function downloadDesktopBinary(
+	version?: string,
+	options: {
+		platform?: NodeJS.Platform;
+		arch?: string;
+		fetchManifest?: typeof fetchDesktopReleaseManifest;
+		downloadFile?: (params: {
+			url: string;
+			name: string;
+			size?: number;
+			destDir: string;
+			token?: string;
+		}) => Promise<string>;
+		getDownloadDirectory?: () => string;
+	} = {},
+): Promise<string> {
+	const fetchManifest = options.fetchManifest || fetchDesktopReleaseManifest;
+	const manifest = await fetchManifest(version);
+	const entry = selectDesktopPlatformEntry(manifest, {
+		platform: options.platform,
+		arch: options.arch,
+	});
+	const downloadFile =
+		options.downloadFile || ((params) => new FileDownloader().downloadFile(params));
+	const getDownloadDirectory = options.getDownloadDirectory || getDesktopDownloadDirectory;
+
+	return downloadFile({
+		url: entry.url,
+		name: entry.name,
+		size: entry.size,
+		destDir: getDownloadDirectory(),
+	});
+}
+
+export { installDesktopBinary, launchDesktopApp };

--- a/src/domains/desktop/desktop-install-path-resolver.ts
+++ b/src/domains/desktop/desktop-install-path-resolver.ts
@@ -1,0 +1,33 @@
+import { homedir } from "node:os";
+import { dirname, join, win32 } from "node:path";
+import { PathResolver } from "@/shared/path-resolver.js";
+
+function getDesktopHomeDirectory(): string {
+	return process.env.CK_TEST_HOME || process.env.HOME || process.env.USERPROFILE || homedir();
+}
+
+export function getDesktopInstallPath(options: { platform?: NodeJS.Platform } = {}): string {
+	const platform = options.platform || process.platform;
+	const homeDir = getDesktopHomeDirectory();
+
+	if (platform === "darwin") {
+		return join(homeDir, "Applications", "ClaudeKit Control Center.app");
+	}
+	if (platform === "linux") {
+		return join(homeDir, ".local", "bin", "claudekit-control-center");
+	}
+	if (platform === "win32") {
+		const localAppData = process.env.LOCALAPPDATA || join(homeDir, "AppData", "Local");
+		return win32.join(localAppData, "ClaudeKit", "ClaudeKit Control Center.exe");
+	}
+
+	throw new Error(`Unsupported install platform: ${platform}`);
+}
+
+export function getDesktopInstallDirectory(options: { platform?: NodeJS.Platform } = {}): string {
+	return dirname(getDesktopInstallPath(options));
+}
+
+export function getDesktopDownloadDirectory(): string {
+	return join(PathResolver.getCacheDir(false), "desktop-downloads");
+}

--- a/src/domains/desktop/desktop-installer.ts
+++ b/src/domains/desktop/desktop-installer.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { chmod, mkdtemp, readdir, rename } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { promisify } from "node:util";
 import {
 	getDesktopInstallDirectory,
@@ -54,8 +54,8 @@ export async function installDesktopBinary(
 				await execFileAsync("xattr", ["-dr", "com.apple.quarantine", path]);
 			});
 		const stagingDir = await mkdtemp(join(tmpdir(), "ck-desktop-app-"));
-		const stagedInstallPath = `${targetPath}.new`;
-		const backupInstallPath = `${targetPath}.backup`;
+		const stagedInstallPath = join(dirname(targetPath), `${basename(targetPath)}.new`);
+		const backupInstallPath = join(dirname(targetPath), `${basename(targetPath)}.backup`);
 		try {
 			await extractZipFn(downloadPath, { dir: stagingDir });
 			const appBundlePath = await findAppBundle(stagingDir);

--- a/src/domains/desktop/desktop-installer.ts
+++ b/src/domains/desktop/desktop-installer.ts
@@ -72,7 +72,6 @@ export async function installDesktopBinary(
 			if ((await pathExists(backupInstallPath)) && !(await pathExists(targetPath))) {
 				await rename(backupInstallPath, targetPath);
 			}
-			await remove(stagedInstallPath);
 			throw error;
 		} finally {
 			await remove(stagingDir);

--- a/src/domains/desktop/desktop-installer.ts
+++ b/src/domains/desktop/desktop-installer.ts
@@ -1,0 +1,96 @@
+import { execFile } from "node:child_process";
+import { chmod, mkdtemp, readdir, rename } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import {
+	getDesktopInstallDirectory,
+	getDesktopInstallPath,
+} from "@/domains/desktop/desktop-install-path-resolver.js";
+import { copy, copyFile, ensureDir, pathExists, remove } from "fs-extra";
+
+const execFileAsync = promisify(execFile);
+
+async function findAppBundle(rootDir: string): Promise<string> {
+	const entries = await readdir(rootDir, { withFileTypes: true });
+	for (const entry of entries) {
+		const fullPath = join(rootDir, entry.name);
+		if (entry.isDirectory() && entry.name.endsWith(".app")) {
+			return fullPath;
+		}
+		if (entry.isDirectory()) {
+			try {
+				return await findAppBundle(fullPath);
+			} catch {
+				// Keep searching.
+			}
+		}
+	}
+	throw new Error("Extracted macOS asset did not contain an .app bundle");
+}
+
+export async function installDesktopBinary(
+	downloadPath: string,
+	options: {
+		platform?: NodeJS.Platform;
+		extractZipFn?: (source: string, config: { dir: string }) => Promise<void>;
+		removeQuarantineFn?: (path: string) => Promise<void>;
+	} = {},
+): Promise<string> {
+	const platform = options.platform || process.platform;
+	const targetPath = getDesktopInstallPath({ platform });
+	await ensureDir(getDesktopInstallDirectory({ platform }));
+
+	if (platform === "darwin") {
+		const extractZipFn =
+			options.extractZipFn ||
+			(async (source: string, config: { dir: string }) => {
+				const { default: extractZip } = await import("extract-zip");
+				await extractZip(source, config);
+			});
+		const removeQuarantineFn =
+			options.removeQuarantineFn ||
+			(async (path: string) => {
+				await execFileAsync("xattr", ["-dr", "com.apple.quarantine", path]);
+			});
+		const stagingDir = await mkdtemp(join(tmpdir(), "ck-desktop-app-"));
+		const stagedInstallPath = `${targetPath}.new`;
+		const backupInstallPath = `${targetPath}.backup`;
+		try {
+			await extractZipFn(downloadPath, { dir: stagingDir });
+			const appBundlePath = await findAppBundle(stagingDir);
+			await remove(stagedInstallPath);
+			await remove(backupInstallPath);
+			await copy(appBundlePath, stagedInstallPath);
+			await removeQuarantineFn(stagedInstallPath);
+			if (await pathExists(targetPath)) {
+				await rename(targetPath, backupInstallPath);
+			}
+			await rename(stagedInstallPath, targetPath);
+			await remove(backupInstallPath);
+		} catch (error) {
+			if ((await pathExists(backupInstallPath)) && !(await pathExists(targetPath))) {
+				await rename(backupInstallPath, targetPath);
+			}
+			await remove(stagedInstallPath);
+			throw error;
+		} finally {
+			await remove(stagingDir);
+			await remove(stagedInstallPath);
+		}
+		return targetPath;
+	}
+
+	if (platform === "linux") {
+		await copyFile(downloadPath, targetPath);
+		await chmod(targetPath, 0o755);
+		return targetPath;
+	}
+
+	if (platform === "win32") {
+		await copyFile(downloadPath, targetPath);
+		return targetPath;
+	}
+
+	throw new Error(`Unsupported install platform: ${platform}`);
+}

--- a/src/domains/desktop/desktop-release-manifest.ts
+++ b/src/domains/desktop/desktop-release-manifest.ts
@@ -1,0 +1,59 @@
+import type { GitHubReleaseAsset } from "@/types";
+import { type DesktopReleaseManifest, DesktopReleaseManifestSchema } from "@/types/desktop.js";
+
+function findAsset(
+	assets: GitHubReleaseAsset[],
+	pattern: RegExp,
+	label: string,
+): GitHubReleaseAsset {
+	const asset = assets.find((entry) => pattern.test(entry.name));
+	if (!asset) {
+		throw new Error(`Missing required desktop release asset for ${label}`);
+	}
+	return asset;
+}
+
+export function parseDesktopReleaseManifest(input: unknown): DesktopReleaseManifest {
+	return DesktopReleaseManifestSchema.parse(input);
+}
+
+export function buildDesktopReleaseManifest(input: {
+	version: string;
+	publishedAt: string;
+	assets: GitHubReleaseAsset[];
+}): DesktopReleaseManifest {
+	const macAsset = findAsset(input.assets, /macos-universal\.app\.zip$/i, "macOS");
+	const linuxAsset = findAsset(input.assets, /linux-x86_64\.AppImage$/i, "Linux");
+	const windowsAsset = findAsset(input.assets, /windows-x86_64-portable\.exe$/i, "Windows");
+
+	return parseDesktopReleaseManifest({
+		version: input.version,
+		date: input.publishedAt,
+		platforms: {
+			"darwin-aarch64": {
+				name: macAsset.name,
+				url: macAsset.browser_download_url,
+				size: macAsset.size,
+				assetType: "app-zip",
+			},
+			"darwin-x86_64": {
+				name: macAsset.name,
+				url: macAsset.browser_download_url,
+				size: macAsset.size,
+				assetType: "app-zip",
+			},
+			"linux-x86_64": {
+				name: linuxAsset.name,
+				url: linuxAsset.browser_download_url,
+				size: linuxAsset.size,
+				assetType: "appimage",
+			},
+			"windows-x86_64": {
+				name: windowsAsset.name,
+				url: windowsAsset.browser_download_url,
+				size: windowsAsset.size,
+				assetType: "portable-exe",
+			},
+		},
+	});
+}

--- a/src/domains/desktop/desktop-release-payload.ts
+++ b/src/domains/desktop/desktop-release-payload.ts
@@ -1,0 +1,9 @@
+import { type GitHubRelease, GitHubReleaseSchema } from "@/types";
+
+export function parseDesktopReleasePayload(input: unknown): GitHubRelease {
+	const payload = GitHubReleaseSchema.parse(input);
+	if (payload.assets.length === 0) {
+		throw new Error("Desktop release payload contains no assets");
+	}
+	return payload;
+}

--- a/src/domains/desktop/desktop-release-service.ts
+++ b/src/domains/desktop/desktop-release-service.ts
@@ -1,0 +1,20 @@
+import { parseDesktopReleaseManifest } from "@/domains/desktop/desktop-release-manifest.js";
+import type { DesktopReleaseManifest } from "@/types/desktop.js";
+
+const DESKTOP_RELEASE_REPOSITORY = "https://github.com/mrgoonie/claudekit-cli/releases/download";
+
+export function getDesktopManifestUrl(version?: string): string {
+	const tag = version ? `desktop-v${version}` : "desktop-latest";
+	return `${DESKTOP_RELEASE_REPOSITORY}/${tag}/desktop-manifest.json`;
+}
+
+export async function fetchDesktopReleaseManifest(
+	version?: string,
+	fetchFn: typeof fetch = globalThis.fetch,
+): Promise<DesktopReleaseManifest> {
+	const response = await fetchFn(getDesktopManifestUrl(version));
+	if (!response.ok) {
+		throw new Error(`Failed to fetch desktop manifest: ${response.status} ${response.statusText}`);
+	}
+	return parseDesktopReleaseManifest(await response.json());
+}

--- a/src/domains/desktop/index.ts
+++ b/src/domains/desktop/index.ts
@@ -1,0 +1,20 @@
+export {
+	buildDesktopReleaseManifest,
+	parseDesktopReleaseManifest,
+} from "./desktop-release-manifest.js";
+export {
+	getCurrentDesktopPlatformKey,
+	selectDesktopPlatformEntry,
+} from "./desktop-asset-selector.js";
+export {
+	getDesktopDownloadDirectory,
+	getDesktopInstallDirectory,
+	getDesktopInstallPath,
+} from "./desktop-install-path-resolver.js";
+export { buildDesktopLaunchCommand, launchDesktopApp } from "./desktop-app-launcher.js";
+export { fetchDesktopReleaseManifest, getDesktopManifestUrl } from "./desktop-release-service.js";
+export {
+	downloadDesktopBinary,
+	getDesktopBinaryPath,
+	installDesktopBinary,
+} from "./desktop-binary-manager.js";

--- a/src/types/desktop.ts
+++ b/src/types/desktop.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+export const DesktopPlatformKeySchema = z.enum([
+	"darwin-aarch64",
+	"darwin-x86_64",
+	"linux-x86_64",
+	"windows-x86_64",
+]);
+export type DesktopPlatformKey = z.infer<typeof DesktopPlatformKeySchema>;
+
+export const DesktopAssetTypeSchema = z.enum(["app-zip", "appimage", "portable-exe"]);
+export type DesktopAssetType = z.infer<typeof DesktopAssetTypeSchema>;
+
+export const DesktopPlatformAssetSchema = z.object({
+	name: z.string().min(1),
+	url: z
+		.string()
+		.url()
+		.refine((value) => value.startsWith("https://"), {
+			message: "Desktop asset URLs must use HTTPS",
+		}),
+	size: z.number().int().nonnegative(),
+	assetType: DesktopAssetTypeSchema,
+});
+export type DesktopPlatformAsset = z.infer<typeof DesktopPlatformAssetSchema>;
+
+export const DesktopReleaseManifestSchema = z.object({
+	version: z.string().min(1),
+	date: z.string().min(1),
+	platforms: z.object({
+		"darwin-aarch64": DesktopPlatformAssetSchema,
+		"darwin-x86_64": DesktopPlatformAssetSchema,
+		"linux-x86_64": DesktopPlatformAssetSchema,
+		"windows-x86_64": DesktopPlatformAssetSchema,
+	}),
+});
+export type DesktopReleaseManifest = z.infer<typeof DesktopReleaseManifestSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,6 +48,18 @@ export {
 	type CacheEntry,
 } from "./github.js";
 
+// Desktop distribution types
+export {
+	DesktopPlatformKeySchema,
+	type DesktopPlatformKey,
+	DesktopAssetTypeSchema,
+	type DesktopAssetType,
+	DesktopPlatformAssetSchema,
+	type DesktopPlatformAsset,
+	DesktopReleaseManifestSchema,
+	type DesktopReleaseManifest,
+} from "./desktop.js";
+
 // Metadata types
 export {
 	type FileOwnership,

--- a/src/ui/src/hooks/use-updater.ts
+++ b/src/ui/src/hooks/use-updater.ts
@@ -23,6 +23,8 @@
 import { useEffect, useState } from "react";
 import { isTauri } from "./use-tauri";
 
+const SIGNED_UPDATER_ENABLED = false;
+
 export interface UseUpdaterResult {
 	/** True when the updater confirmed a newer version is available */
 	updateAvailable: boolean;
@@ -33,7 +35,10 @@ export function useUpdater(): UseUpdaterResult {
 
 	useEffect(() => {
 		// Only activate in Tauri desktop mode — web mode has no updater
-		if (!isTauri()) return;
+		// Phase 3 ships a plain desktop download manifest (`desktop-manifest.json`) for `ck app`, not the
+		// signed Tauri updater contract. Keep the updater hook disabled until the
+		// signing-key phase reintroduces a real updater payload and pubkey.
+		if (!isTauri() || !SIGNED_UPDATER_ENABLED) return;
 
 		let cancelled = false;
 		let unlisten: (() => void) | undefined;


### PR DESCRIPTION
## Summary

- add Phase 3 desktop distribution infrastructure for issue #676
- publish portable desktop assets plus a plain `desktop-manifest.json` for CLI-side binary discovery
- add reusable desktop manifest, asset selection, install, and launch modules with TDD coverage
- disable the dormant Tauri updater hook until a signed updater phase exists
- update internal roadmap and architecture docs for the Phase 3 rollout

Closes #687
Closes #688
Closes #689
Part of #676

## Validation

- [x] `bun run validate`
- [x] pre-commit hook passed on both commits
- [x] pre-push hook passed before branch push

## Notes

- The remaining non-blocking risk is runner-side GitHub Actions behavior for a real `desktop-v*` tag, which still needs one live release execution to verify artifact discovery end to end.
- Internal docs were updated in this repo; no `claudekit-docs` update is needed.
