### PR TITLE
feat(desktop): add first-run onboarding flow

### DIFF
--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,7 +1,7 @@
 # Project Roadmap: ClaudeKit CLI
 
-**Last Updated**: 2026-04-15
-**Version**: 3.41.4-dev.22
+**Last Updated**: 2026-04-16
+**Version**: 3.41.4-dev.26
 **Repository**: https://github.com/mrgoonie/claudekit-cli
 
 ---
@@ -19,6 +19,7 @@ ClaudeKit CLI (`ck`) is a command-line tool for bootstrapping and updating Claud
 - Phase 3 now adds unsigned desktop distribution plumbing: portable release assets, a plain `desktop-manifest.json` download manifest, and reusable desktop install/launch helpers.
 - Phase 4 now ships `ck app`, which detects an installed desktop binary, downloads and installs it on demand, and launches the native Control Center.
 - Phase 5A removes the Express boot requirement from Tauri desktop mode for supported native reads and routes unsupported flows back to CLI/web guidance.
+- Phase 5C adds a desktop-first first-run onboarding flow that scans common development folders, lets users register discovered projects, and persists onboarding completion in the native store.
 - Browser mode still uses the Express `/api` backend for `ck config` and the remaining server-backed flows.
 
 ---

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -90,6 +90,7 @@ Phase 5A changes the runtime split:
 - Tauri dev boots the frontend directly instead of shelling into `ck config ui`.
 - Supported desktop reads use Tauri commands or desktop-safe local adapters.
 - Unsupported server-backed flows such as migration, update orchestration, and onboarding install stay explicit CLI/web workflows instead of hidden `/api` calls.
+- Desktop first run now has its own native onboarding gate: if no projects are registered and no global `.ck.json` exists, the app redirects into a chromeless discovery flow that scans common home-directory workspaces and persists completion with `tauri-plugin-store`.
 
 ### skills/ - Skills Management
 Multi-select installation, registry tracking, uninstall per agent.

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -165,3 +165,10 @@ pub fn get_global_config_dir() -> Result<String, String> {
         paths::global_claude_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
     Ok(dir.to_string_lossy().into_owned())
 }
+
+/// Return the absolute path to the current user's home directory.
+#[tauri::command]
+pub fn get_home_dir() -> Result<String, String> {
+    let dir = paths::home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
+    Ok(dir.to_string_lossy().into_owned())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ pub fn run() {
             commands::config::write_statusline,
             commands::config::get_global_config_path,
             commands::config::get_global_config_dir,
+            commands::config::get_home_dir,
             // Project commands (Phase 1D)
             projects::list_projects,
             projects::add_project,

--- a/src/ui/src/hooks/__tests__/use-desktop-onboarding-gate.vitest.ts
+++ b/src/ui/src/hooks/__tests__/use-desktop-onboarding-gate.vitest.ts
@@ -1,0 +1,83 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchCkConfigScope } from "../../services/ck-config-api";
+import { getDesktopOnboardingCompleted } from "../../services/desktop-onboarding-state";
+import { useDesktopOnboardingGate } from "../use-desktop-onboarding-gate";
+import { isTauri } from "../use-tauri";
+
+vi.mock("../use-tauri", () => ({
+	isTauri: vi.fn(),
+}));
+
+vi.mock("../../services/ck-config-api", () => ({
+	fetchCkConfigScope: vi.fn(),
+}));
+
+vi.mock("../../services/desktop-onboarding-state", () => ({
+	getDesktopOnboardingCompleted: vi.fn(),
+}));
+
+describe("useDesktopOnboardingGate", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+		vi.mocked(isTauri).mockReturnValue(true);
+		vi.mocked(getDesktopOnboardingCompleted).mockResolvedValue(false);
+		vi.mocked(fetchCkConfigScope).mockResolvedValue({
+			config: {},
+			sources: {},
+			globalPath: "",
+			projectPath: null,
+		});
+	});
+
+	it("shows onboarding for desktop first run when projects and global config are absent", async () => {
+		const { result } = renderHook(() =>
+			useDesktopOnboardingGate({ projectCount: 0, projectsLoading: false }),
+		);
+
+		await waitFor(() => expect(result.current.checking).toBe(false));
+
+		expect(result.current.shouldShowOnboarding).toBe(true);
+	});
+
+	it("skips onboarding when projects already exist", async () => {
+		const { result } = renderHook(() =>
+			useDesktopOnboardingGate({ projectCount: 2, projectsLoading: false }),
+		);
+
+		await waitFor(() => expect(result.current.checking).toBe(false));
+
+		expect(fetchCkConfigScope).not.toHaveBeenCalled();
+		expect(result.current.shouldShowOnboarding).toBe(false);
+	});
+
+	it("skips onboarding when it was previously completed", async () => {
+		vi.mocked(getDesktopOnboardingCompleted).mockResolvedValue(true);
+
+		const { result } = renderHook(() =>
+			useDesktopOnboardingGate({ projectCount: 0, projectsLoading: false }),
+		);
+
+		await waitFor(() => expect(result.current.checking).toBe(false));
+
+		expect(fetchCkConfigScope).not.toHaveBeenCalled();
+		expect(result.current.shouldShowOnboarding).toBe(false);
+	});
+
+	it("skips onboarding when a global config already exists", async () => {
+		vi.mocked(fetchCkConfigScope).mockResolvedValue({
+			config: { codingLevel: 3 },
+			sources: {},
+			globalPath: "",
+			projectPath: null,
+		});
+
+		const { result } = renderHook(() =>
+			useDesktopOnboardingGate({ projectCount: 0, projectsLoading: false }),
+		);
+
+		await waitFor(() => expect(result.current.checking).toBe(false));
+
+		expect(result.current.shouldShowOnboarding).toBe(false);
+	});
+});

--- a/src/ui/src/hooks/__tests__/use-desktop-onboarding-gate.vitest.ts
+++ b/src/ui/src/hooks/__tests__/use-desktop-onboarding-gate.vitest.ts
@@ -40,6 +40,20 @@ describe("useDesktopOnboardingGate", () => {
 		expect(result.current.shouldShowOnboarding).toBe(true);
 	});
 
+	it("disables the gate immediately outside Tauri mode", async () => {
+		vi.mocked(isTauri).mockReturnValue(false);
+
+		const { result } = renderHook(() =>
+			useDesktopOnboardingGate({ projectCount: 0, projectsLoading: false }),
+		);
+
+		await waitFor(() => expect(result.current.checking).toBe(false));
+
+		expect(getDesktopOnboardingCompleted).not.toHaveBeenCalled();
+		expect(fetchCkConfigScope).not.toHaveBeenCalled();
+		expect(result.current.shouldShowOnboarding).toBe(false);
+	});
+
 	it("skips onboarding when projects already exist", async () => {
 		const { result } = renderHook(() =>
 			useDesktopOnboardingGate({ projectCount: 2, projectsLoading: false }),
@@ -79,5 +93,17 @@ describe("useDesktopOnboardingGate", () => {
 		await waitFor(() => expect(result.current.checking).toBe(false));
 
 		expect(result.current.shouldShowOnboarding).toBe(false);
+	});
+
+	it("falls back to onboarding when gate evaluation fails and there are no projects", async () => {
+		vi.mocked(fetchCkConfigScope).mockRejectedValue(new Error("boom"));
+
+		const { result } = renderHook(() =>
+			useDesktopOnboardingGate({ projectCount: 0, projectsLoading: false }),
+		);
+
+		await waitFor(() => expect(result.current.checking).toBe(false));
+
+		expect(result.current.shouldShowOnboarding).toBe(true);
 	});
 });

--- a/src/ui/src/hooks/use-desktop-onboarding-gate.ts
+++ b/src/ui/src/hooks/use-desktop-onboarding-gate.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import { fetchCkConfigScope } from "../services/ck-config-api";
+import { getDesktopOnboardingCompleted } from "../services/desktop-onboarding-state";
+import { isTauri } from "./use-tauri";
+
+interface UseDesktopOnboardingGateOptions {
+	projectCount: number;
+	projectsLoading: boolean;
+}
+
+interface UseDesktopOnboardingGateResult {
+	checking: boolean;
+	shouldShowOnboarding: boolean;
+}
+
+export function useDesktopOnboardingGate({
+	projectCount,
+	projectsLoading,
+}: UseDesktopOnboardingGateOptions): UseDesktopOnboardingGateResult {
+	const desktopMode = isTauri();
+	const [checking, setChecking] = useState(desktopMode);
+	const [shouldShowOnboarding, setShouldShowOnboarding] = useState(false);
+
+	useEffect(() => {
+		let cancelled = false;
+
+		if (!desktopMode) {
+			setChecking(false);
+			setShouldShowOnboarding(false);
+			return;
+		}
+
+		if (projectsLoading) {
+			setChecking(true);
+			return;
+		}
+
+		async function load(): Promise<void> {
+			setChecking(true);
+			try {
+				const completed = await getDesktopOnboardingCompleted();
+				if (completed || projectCount > 0) {
+					if (!cancelled) {
+						setShouldShowOnboarding(false);
+					}
+					return;
+				}
+
+				const globalConfig = await fetchCkConfigScope("global");
+				const hasGlobalConfig = Object.keys(globalConfig.config).length > 0;
+
+				if (!cancelled) {
+					setShouldShowOnboarding(!hasGlobalConfig);
+				}
+			} catch (error) {
+				console.error("[desktop-onboarding] Failed to evaluate first-run state", error);
+				if (!cancelled) {
+					setShouldShowOnboarding(projectCount === 0);
+				}
+			} finally {
+				if (!cancelled) {
+					setChecking(false);
+				}
+			}
+		}
+
+		void load();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [desktopMode, projectCount, projectsLoading]);
+
+	return { checking, shouldShowOnboarding };
+}

--- a/src/ui/src/hooks/use-desktop-onboarding-gate.ts
+++ b/src/ui/src/hooks/use-desktop-onboarding-gate.ts
@@ -11,6 +11,7 @@ interface UseDesktopOnboardingGateOptions {
 interface UseDesktopOnboardingGateResult {
 	checking: boolean;
 	shouldShowOnboarding: boolean;
+	dismissOnboarding: () => void;
 }
 
 export function useDesktopOnboardingGate({
@@ -20,11 +21,18 @@ export function useDesktopOnboardingGate({
 	const desktopMode = isTauri();
 	const [checking, setChecking] = useState(desktopMode);
 	const [shouldShowOnboarding, setShouldShowOnboarding] = useState(false);
+	const [dismissed, setDismissed] = useState(false);
 
 	useEffect(() => {
 		let cancelled = false;
 
 		if (!desktopMode) {
+			setChecking(false);
+			setShouldShowOnboarding(false);
+			return;
+		}
+
+		if (dismissed) {
 			setChecking(false);
 			setShouldShowOnboarding(false);
 			return;
@@ -69,7 +77,15 @@ export function useDesktopOnboardingGate({
 		return () => {
 			cancelled = true;
 		};
-	}, [desktopMode, projectCount, projectsLoading]);
+	}, [desktopMode, dismissed, projectCount, projectsLoading]);
 
-	return { checking, shouldShowOnboarding };
+	return {
+		checking,
+		shouldShowOnboarding,
+		dismissOnboarding: () => {
+			setDismissed(true);
+			setChecking(false);
+			setShouldShowOnboarding(false);
+		},
+	};
 }

--- a/src/ui/src/i18n/translations.ts
+++ b/src/ui/src/i18n/translations.ts
@@ -120,6 +120,8 @@ export const translations = {
 		desktopOnboardingScanningHint:
 			"This checks your home, ~/projects, ~/code, and ~/dev directories for Claude workspaces.",
 		desktopOnboardingScanFailed: "Failed to scan for Claude projects",
+		desktopOnboardingScanPartialWarning:
+			"{count} scan target(s) could not be read. Showing the projects that were discovered successfully.",
 		desktopOnboardingSelectTitle: "Choose projects to add",
 		desktopOnboardingSelectDescription:
 			"Pick the projects you want ClaudeKit Control Center to register now.",
@@ -135,6 +137,8 @@ export const translations = {
 			"Your onboarding preferences are saved. ClaudeKit Control Center will open the dashboard from here on out.",
 		desktopOnboardingOpenDashboard: "Open Dashboard",
 		desktopOnboardingKitDetected: "ClaudeKit detected",
+		desktopOnboardingPartialAddWarning:
+			"{failed} of {total} selected projects could not be added. You can register them manually later.",
 		desktopModePlansTitle: "Plans dashboard stays in the web workflow for now",
 		desktopModePlansDescription:
 			"Phase 5A removes the Express runtime from desktop mode. The rich plans dashboard still depends on backend-only plan analytics and actions that are being handled in later work.",
@@ -1186,6 +1190,8 @@ export const translations = {
 		desktopOnboardingScanningHint:
 			"Ứng dụng sẽ kiểm tra home, ~/projects, ~/code và ~/dev để tìm workspace Claude.",
 		desktopOnboardingScanFailed: "Không thể quét dự án Claude",
+		desktopOnboardingScanPartialWarning:
+			"Có {count} vị trí quét không thể đọc được. Ứng dụng đang hiển thị các dự án đã tìm thấy thành công.",
 		desktopOnboardingSelectTitle: "Chọn dự án để thêm",
 		desktopOnboardingSelectDescription:
 			"Hãy chọn các dự án bạn muốn ClaudeKit Control Center đăng ký ngay bây giờ.",
@@ -1201,6 +1207,8 @@ export const translations = {
 			"Tùy chọn onboarding đã được lưu. Từ bây giờ ClaudeKit Control Center sẽ mở thẳng vào dashboard.",
 		desktopOnboardingOpenDashboard: "Mở Dashboard",
 		desktopOnboardingKitDetected: "Đã phát hiện ClaudeKit",
+		desktopOnboardingPartialAddWarning:
+			"{failed} trong số {total} dự án đã chọn không thể được thêm vào. Bạn có thể đăng ký thủ công sau.",
 		desktopModePlansTitle: "Bảng điều khiển kế hoạch hiện vẫn ở web workflow",
 		desktopModePlansDescription:
 			"Phase 5A loại bỏ runtime Express khỏi chế độ desktop. Bảng điều khiển kế hoạch đầy đủ vẫn phụ thuộc vào phân tích và thao tác kế hoạch ở backend, sẽ được xử lý ở các bước sau.",

--- a/src/ui/src/i18n/translations.ts
+++ b/src/ui/src/i18n/translations.ts
@@ -109,6 +109,32 @@ export const translations = {
 			"The current onboarding flow installs kits through the web backend, which is intentionally not part of desktop mode anymore.",
 		desktopModeOnboardingHint:
 			"Use ck init or ck config in the terminal or web dashboard for onboarding today.",
+		desktopOnboardingEyebrow: "First Run",
+		desktopOnboardingTitle: "Welcome to ClaudeKit Control Center",
+		desktopOnboardingDescription:
+			"Let's get your desktop app ready by finding the Claude projects you want to manage here.",
+		desktopOnboardingWelcomeBody:
+			"We'll scan your home, projects, code, and dev folders for Claude-ready workspaces, then let you choose what to register.",
+		desktopOnboardingStart: "Find My Projects",
+		desktopOnboardingScanning: "Scanning common development folders...",
+		desktopOnboardingScanningHint:
+			"This checks your home, ~/projects, ~/code, and ~/dev directories for Claude workspaces.",
+		desktopOnboardingScanFailed: "Failed to scan for Claude projects",
+		desktopOnboardingSelectTitle: "Choose projects to add",
+		desktopOnboardingSelectDescription:
+			"Pick the projects you want ClaudeKit Control Center to register now.",
+		desktopOnboardingNoProjects:
+			"No Claude projects were found in the common development folders. You can continue to the dashboard and add one manually later.",
+		desktopOnboardingSelectedCount: "{count} selected",
+		desktopOnboardingContinue: "Continue",
+		desktopOnboardingSkip: "Skip for now",
+		desktopOnboardingSaving: "Saving...",
+		desktopOnboardingAddFailed: "Failed to add the selected projects",
+		desktopOnboardingDoneTitle: "You're ready to go",
+		desktopOnboardingDoneDescription:
+			"Your onboarding preferences are saved. ClaudeKit Control Center will open the dashboard from here on out.",
+		desktopOnboardingOpenDashboard: "Open Dashboard",
+		desktopOnboardingKitDetected: "ClaudeKit detected",
 		desktopModePlansTitle: "Plans dashboard stays in the web workflow for now",
 		desktopModePlansDescription:
 			"Phase 5A removes the Express runtime from desktop mode. The rich plans dashboard still depends on backend-only plan analytics and actions that are being handled in later work.",
@@ -1149,6 +1175,32 @@ export const translations = {
 			"Luồng onboarding hiện tại cài kit thông qua web backend, và phần đó đã được chủ động loại khỏi chế độ desktop.",
 		desktopModeOnboardingHint:
 			"Dùng ck init hoặc ck config trong terminal hoặc web dashboard để onboarding lúc này.",
+		desktopOnboardingEyebrow: "Lần mở đầu",
+		desktopOnboardingTitle: "Chào mừng đến ClaudeKit Control Center",
+		desktopOnboardingDescription:
+			"Hãy chuẩn bị ứng dụng desktop bằng cách tìm các dự án Claude mà bạn muốn quản lý tại đây.",
+		desktopOnboardingWelcomeBody:
+			"Ứng dụng sẽ quét thư mục home, projects, code và dev để tìm workspace Claude, sau đó cho bạn chọn các dự án cần đăng ký.",
+		desktopOnboardingStart: "Tìm dự án của tôi",
+		desktopOnboardingScanning: "Đang quét các thư mục phát triển phổ biến...",
+		desktopOnboardingScanningHint:
+			"Ứng dụng sẽ kiểm tra home, ~/projects, ~/code và ~/dev để tìm workspace Claude.",
+		desktopOnboardingScanFailed: "Không thể quét dự án Claude",
+		desktopOnboardingSelectTitle: "Chọn dự án để thêm",
+		desktopOnboardingSelectDescription:
+			"Hãy chọn các dự án bạn muốn ClaudeKit Control Center đăng ký ngay bây giờ.",
+		desktopOnboardingNoProjects:
+			"Không tìm thấy dự án Claude nào trong các thư mục phát triển phổ biến. Bạn vẫn có thể vào dashboard và thêm thủ công sau.",
+		desktopOnboardingSelectedCount: "Đã chọn {count}",
+		desktopOnboardingContinue: "Tiếp tục",
+		desktopOnboardingSkip: "Bỏ qua lúc này",
+		desktopOnboardingSaving: "Đang lưu...",
+		desktopOnboardingAddFailed: "Không thể thêm các dự án đã chọn",
+		desktopOnboardingDoneTitle: "Mọi thứ đã sẵn sàng",
+		desktopOnboardingDoneDescription:
+			"Tùy chọn onboarding đã được lưu. Từ bây giờ ClaudeKit Control Center sẽ mở thẳng vào dashboard.",
+		desktopOnboardingOpenDashboard: "Mở Dashboard",
+		desktopOnboardingKitDetected: "Đã phát hiện ClaudeKit",
 		desktopModePlansTitle: "Bảng điều khiển kế hoạch hiện vẫn ở web workflow",
 		desktopModePlansDescription:
 			"Phase 5A loại bỏ runtime Express khỏi chế độ desktop. Bảng điều khiển kế hoạch đầy đủ vẫn phụ thuộc vào phân tích và thao tác kế hoạch ở backend, sẽ được xử lý ở các bước sau.",

--- a/src/ui/src/layouts/AppLayout.tsx
+++ b/src/ui/src/layouts/AppLayout.tsx
@@ -10,6 +10,8 @@ import ResizeHandle from "../components/ResizeHandle";
 import SearchPalette from "../components/SearchPalette";
 import Sidebar from "../components/Sidebar";
 import { useProjects } from "../hooks";
+import { useDesktopOnboardingGate } from "../hooks/use-desktop-onboarding-gate";
+import { isTauri } from "../hooks/use-tauri";
 import { useUpdater } from "../hooks/use-updater";
 import { useResizable } from "../hooks/useResizable";
 import { useI18n } from "../i18n";
@@ -19,6 +21,7 @@ const AppLayout: React.FC = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
 	const { projectId: urlProjectId } = useParams<{ projectId?: string }>();
+	const desktopMode = isTauri();
 
 	// Wire updater listener for Tauri desktop mode.
 	// No visible UI yet — update badge will be added in a future phase.
@@ -80,6 +83,10 @@ const AppLayout: React.FC = () => {
 		error: projectsError,
 		addProject: addProjectOriginal,
 	} = useProjects();
+	const { checking: onboardingChecking, shouldShowOnboarding } = useDesktopOnboardingGate({
+		projectCount: projects.length,
+		projectsLoading,
+	});
 
 	const handleAddProject = async (request: Parameters<typeof addProjectOriginal>[0]) => {
 		await addProjectOriginal(request);
@@ -92,6 +99,17 @@ const AppLayout: React.FC = () => {
 		if (projects.length === 0 || urlProjectId || !isProjectRoute) return;
 		navigate(`/project/${projects[0].id}`, { replace: true });
 	}, [projects, urlProjectId, navigate, location.pathname]);
+
+	useEffect(() => {
+		if (!desktopMode || onboardingChecking) return;
+		if (shouldShowOnboarding && location.pathname !== "/onboarding") {
+			navigate("/onboarding", { replace: true });
+			return;
+		}
+		if (!shouldShowOnboarding && location.pathname === "/onboarding") {
+			navigate("/", { replace: true });
+		}
+	}, [desktopMode, location.pathname, navigate, onboardingChecking, shouldShowOnboarding]);
 
 	useEffect(() => {
 		const root = window.document.documentElement;
@@ -121,7 +139,7 @@ const AppLayout: React.FC = () => {
 		setSidebarWidth(isSidebarCollapsed ? 288 : 56);
 	};
 
-	if (projectsLoading) {
+	if (projectsLoading || (desktopMode && onboardingChecking)) {
 		return (
 			<div className="flex h-screen w-full bg-dash-bg text-dash-text items-center justify-center">
 				<div className="animate-pulse text-dash-text-muted">{t("loading")}</div>
@@ -135,6 +153,20 @@ const AppLayout: React.FC = () => {
 				<div className="text-red-500">
 					{t("error")}: {projectsError}
 				</div>
+			</div>
+		);
+	}
+
+	const showChromelessOnboarding = desktopMode && location.pathname === "/onboarding";
+
+	if (showChromelessOnboarding) {
+		return (
+			<div className="flex h-screen w-full bg-dash-bg text-dash-text overflow-hidden font-sans transition-colors duration-300">
+				<main className="flex flex-1 flex-col overflow-hidden p-4 md:p-6">
+					<Outlet
+						context={{ project: currentProject, isConnected, theme, onToggleTheme: toggleTheme }}
+					/>
+				</main>
 			</div>
 		);
 	}

--- a/src/ui/src/layouts/AppLayout.tsx
+++ b/src/ui/src/layouts/AppLayout.tsx
@@ -15,6 +15,7 @@ import { isTauri } from "../hooks/use-tauri";
 import { useUpdater } from "../hooks/use-updater";
 import { useResizable } from "../hooks/useResizable";
 import { useI18n } from "../i18n";
+import type { AppLayoutContext } from "./app-layout-context";
 
 const AppLayout: React.FC = () => {
 	const { t } = useI18n();
@@ -82,11 +83,13 @@ const AppLayout: React.FC = () => {
 		loading: projectsLoading,
 		error: projectsError,
 		addProject: addProjectOriginal,
+		reload: reloadProjects,
 	} = useProjects();
-	const { checking: onboardingChecking, shouldShowOnboarding } = useDesktopOnboardingGate({
-		projectCount: projects.length,
-		projectsLoading,
-	});
+	const {
+		checking: onboardingChecking,
+		shouldShowOnboarding,
+		dismissOnboarding,
+	} = useDesktopOnboardingGate({ projectCount: projects.length, projectsLoading });
 
 	const handleAddProject = async (request: Parameters<typeof addProjectOriginal>[0]) => {
 		await addProjectOriginal(request);
@@ -104,10 +107,6 @@ const AppLayout: React.FC = () => {
 		if (!desktopMode || onboardingChecking) return;
 		if (shouldShowOnboarding && location.pathname !== "/onboarding") {
 			navigate("/onboarding", { replace: true });
-			return;
-		}
-		if (!shouldShowOnboarding && location.pathname === "/onboarding") {
-			navigate("/", { replace: true });
 		}
 	}, [desktopMode, location.pathname, navigate, onboardingChecking, shouldShowOnboarding]);
 
@@ -158,14 +157,20 @@ const AppLayout: React.FC = () => {
 	}
 
 	const showChromelessOnboarding = desktopMode && location.pathname === "/onboarding";
+	const outletContext: AppLayoutContext = {
+		project: currentProject,
+		isConnected,
+		theme,
+		onToggleTheme: toggleTheme,
+		reloadProjects,
+		dismissDesktopOnboarding: dismissOnboarding,
+	};
 
 	if (showChromelessOnboarding) {
 		return (
 			<div className="flex h-screen w-full bg-dash-bg text-dash-text overflow-hidden font-sans transition-colors duration-300">
 				<main className="flex flex-1 flex-col overflow-hidden p-4 md:p-6">
-					<Outlet
-						context={{ project: currentProject, isConnected, theme, onToggleTheme: toggleTheme }}
-					/>
+					<Outlet context={outletContext} />
 				</main>
 			</div>
 		);
@@ -196,9 +201,7 @@ const AppLayout: React.FC = () => {
 			<div className="flex-1 flex flex-col min-w-0 h-full relative">
 				<main className="flex-1 flex flex-col overflow-hidden p-4 md:p-6">
 					{/* Always render Outlet - pages handle their own project requirements */}
-					<Outlet
-						context={{ project: currentProject, isConnected, theme, onToggleTheme: toggleTheme }}
-					/>
+					<Outlet context={outletContext} />
 				</main>
 			</div>
 		</div>

--- a/src/ui/src/layouts/app-layout-context.ts
+++ b/src/ui/src/layouts/app-layout-context.ts
@@ -5,6 +5,6 @@ export interface AppLayoutContext {
 	isConnected: boolean;
 	theme: "light" | "dark";
 	onToggleTheme: () => void;
-	reloadProjects: () => Promise<void>;
-	dismissDesktopOnboarding: () => void;
+	reloadProjects?: () => Promise<void>;
+	dismissDesktopOnboarding?: () => void;
 }

--- a/src/ui/src/layouts/app-layout-context.ts
+++ b/src/ui/src/layouts/app-layout-context.ts
@@ -1,0 +1,10 @@
+import type { Project } from "../types";
+
+export interface AppLayoutContext {
+	project: Project | null;
+	isConnected: boolean;
+	theme: "light" | "dark";
+	onToggleTheme: () => void;
+	reloadProjects: () => Promise<void>;
+	dismissDesktopOnboarding: () => void;
+}

--- a/src/ui/src/lib/tauri-commands.ts
+++ b/src/ui/src/lib/tauri-commands.ts
@@ -55,6 +55,9 @@ export const getGlobalConfigPath = (): Promise<string> => invoke<string>("get_gl
 /** Return the absolute path to the global .claude directory. */
 export const getGlobalConfigDir = (): Promise<string> => invoke<string>("get_global_config_dir");
 
+/** Return the absolute path to the current user's home directory. */
+export const getHomeDir = (): Promise<string> => invoke<string>("get_home_dir");
+
 // ---------------------------------------------------------------------------
 // Project commands — src-tauri/src/projects.rs
 // ---------------------------------------------------------------------------

--- a/src/ui/src/pages/OnboardingPage.tsx
+++ b/src/ui/src/pages/OnboardingPage.tsx
@@ -7,13 +7,13 @@ import { useNavigate } from "react-router-dom";
 import FeaturePreviewCard from "../components/FeaturePreviewCard";
 import InstallWizard from "../components/InstallWizard";
 import SuccessScreen from "../components/SuccessScreen";
-import DesktopModeNotice from "../components/desktop-mode-notice";
 import { KIT_COMPARISONS, getKitFeatures } from "../data/kit-comparison";
 import type { KitComparison as KitComparisonType, KitFeature } from "../data/kit-comparison";
 import { isTauri } from "../hooks/use-tauri";
 import { useI18n } from "../i18n";
 import type { TranslationKey } from "../i18n";
 import { KitType } from "../types";
+import DesktopOnboardingPage from "./onboarding/desktop-onboarding-page";
 
 // Internal component for kit cards
 interface KitCardProps {
@@ -146,13 +146,7 @@ const OnboardingPageContent: React.FC = () => {
 
 const OnboardingPage: React.FC = () => {
 	if (isTauri()) {
-		return (
-			<DesktopModeNotice
-				titleKey="desktopModeOnboardingTitle"
-				descriptionKey="desktopModeOnboardingDescription"
-				commandHintKey="desktopModeOnboardingHint"
-			/>
-		);
+		return <DesktopOnboardingPage />;
 	}
 
 	return <OnboardingPageContent />;

--- a/src/ui/src/pages/ProjectDashboardPage.tsx
+++ b/src/ui/src/pages/ProjectDashboardPage.tsx
@@ -6,16 +6,13 @@ import { useEffect, useState } from "react";
 import { useOutletContext } from "react-router-dom";
 import ProjectDashboard from "../components/ProjectDashboard";
 import { useI18n } from "../i18n";
+import type { AppLayoutContext } from "../layouts/app-layout-context";
 import { fetchProject } from "../services/api";
 import type { Project } from "../types";
 
-interface OutletContext {
-	project: Project | null;
-}
-
 const ProjectDashboardPage: React.FC = () => {
 	const { t } = useI18n();
-	const { project } = useOutletContext<OutletContext>();
+	const { project } = useOutletContext<AppLayoutContext>();
 	const [detailedProject, setDetailedProject] = useState<Project | null>(null);
 
 	useEffect(() => {

--- a/src/ui/src/pages/onboarding/__tests__/desktop-onboarding-page.vitest.tsx
+++ b/src/ui/src/pages/onboarding/__tests__/desktop-onboarding-page.vitest.tsx
@@ -157,11 +157,6 @@ describe("DesktopOnboardingPage", () => {
 			</MemoryRouter>,
 		);
 
-		await userEvent.click(screen.getByRole("button", { name: "Find My Projects" }));
-		await waitFor(() =>
-			expect(screen.getByRole("button", { name: "Skip for now" })).toBeInTheDocument(),
-		);
-
 		await userEvent.click(screen.getByRole("button", { name: "Skip for now" }));
 
 		await waitFor(() =>
@@ -172,6 +167,37 @@ describe("DesktopOnboardingPage", () => {
 		expect(outletContext.reloadProjects).not.toHaveBeenCalled();
 		expect(outletContext.dismissDesktopOnboarding).toHaveBeenCalledTimes(1);
 		expect(setDesktopOnboardingCompleted).toHaveBeenCalledWith(true);
+	});
+
+	it("does not warn when optional scan roots are simply missing", async () => {
+		vi.mocked(tauri.scanForProjects).mockReset();
+		vi.mocked(tauri.scanForProjects)
+			.mockResolvedValueOnce([])
+			.mockRejectedValueOnce(
+				new Error("Scan root is not a directory or does not exist: /Users/test/projects"),
+			)
+			.mockRejectedValueOnce(
+				new Error("Scan root is not a directory or does not exist: /Users/test/code"),
+			)
+			.mockRejectedValueOnce(
+				new Error("Scan root is not a directory or does not exist: /Users/test/dev"),
+			);
+
+		render(
+			<MemoryRouter>
+				<DesktopOnboardingPage />
+			</MemoryRouter>,
+		);
+
+		await userEvent.click(screen.getByRole("button", { name: "Find My Projects" }));
+
+		await waitFor(() => expect(screen.getByText("No projects found")).toBeInTheDocument());
+
+		expect(
+			screen.queryByText(
+				"1 scan target(s) could not be read. Showing the projects that were discovered successfully.",
+			),
+		).not.toBeInTheDocument();
 	});
 
 	it("keeps Continue disabled when nothing is selected", async () => {

--- a/src/ui/src/pages/onboarding/__tests__/desktop-onboarding-page.vitest.tsx
+++ b/src/ui/src/pages/onboarding/__tests__/desktop-onboarding-page.vitest.tsx
@@ -1,0 +1,132 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as tauri from "../../../lib/tauri-commands";
+import { addProject } from "../../../services/api";
+import { setDesktopOnboardingCompleted } from "../../../services/desktop-onboarding-state";
+import DesktopOnboardingPage from "../desktop-onboarding-page";
+
+const navigateMock = vi.fn();
+const onboardingTranslations: Record<string, string> = {
+	desktopOnboardingEyebrow: "First Run",
+	desktopOnboardingTitle: "Welcome to ClaudeKit Control Center",
+	desktopOnboardingDescription: "Welcome description",
+	desktopOnboardingWelcomeBody: "Welcome body",
+	desktopOnboardingStart: "Find My Projects",
+	desktopOnboardingScanning: "Scanning common development folders...",
+	desktopOnboardingScanningHint: "Scan hint",
+	desktopOnboardingSelectTitle: "Choose projects to add",
+	desktopOnboardingSelectDescription: "Pick projects",
+	desktopOnboardingNoProjects: "No projects found",
+	desktopOnboardingSelectedCount: "{count} selected",
+	desktopOnboardingContinue: "Continue",
+	desktopOnboardingSkip: "Skip for now",
+	desktopOnboardingSaving: "Saving...",
+	desktopOnboardingDoneTitle: "You're ready to go",
+	desktopOnboardingDoneDescription: "Saved",
+	desktopOnboardingOpenDashboard: "Open Dashboard",
+	desktopOnboardingKitDetected: "ClaudeKit detected",
+	desktopOnboardingAddFailed: "Failed to add the selected projects",
+};
+
+vi.mock("react-router-dom", async () => {
+	const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+	return {
+		...actual,
+		useNavigate: () => navigateMock,
+	};
+});
+
+vi.mock("../../../lib/tauri-commands", () => ({
+	getGlobalConfigDir: vi.fn(),
+	scanForProjects: vi.fn(),
+}));
+
+vi.mock("../../../services/api", () => ({
+	addProject: vi.fn(),
+}));
+
+vi.mock("../../../services/desktop-onboarding-state", () => ({
+	setDesktopOnboardingCompleted: vi.fn(),
+}));
+
+vi.mock("../../../i18n", () => ({
+	useI18n: () => ({
+		t: (key: string) => onboardingTranslations[key] ?? key,
+	}),
+}));
+
+describe("DesktopOnboardingPage", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+		vi.mocked(tauri.getGlobalConfigDir).mockResolvedValue("/Users/test/.claude");
+		vi.mocked(tauri.scanForProjects)
+			.mockResolvedValueOnce([
+				{
+					name: "alpha",
+					path: "/Users/test/projects/alpha",
+					hasClaudeConfig: true,
+					hasCkConfig: true,
+				},
+			])
+			.mockResolvedValueOnce([
+				{
+					name: "alpha",
+					path: "/Users/test/projects/alpha",
+					hasClaudeConfig: true,
+					hasCkConfig: true,
+				},
+				{
+					name: "beta",
+					path: "/Users/test/code/beta",
+					hasClaudeConfig: true,
+					hasCkConfig: false,
+				},
+			])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([]);
+		vi.mocked(addProject)
+			.mockResolvedValueOnce({
+				id: "project-alpha",
+			} as never)
+			.mockResolvedValueOnce({
+				id: "project-beta",
+			} as never);
+	});
+
+	it("scans common roots, lets the user pick projects, and persists completion", async () => {
+		render(
+			<MemoryRouter>
+				<DesktopOnboardingPage />
+			</MemoryRouter>,
+		);
+
+		await userEvent.click(screen.getByRole("button", { name: "Find My Projects" }));
+
+		await waitFor(() =>
+			expect(screen.getByRole("heading", { name: "Choose projects to add" })).toBeInTheDocument(),
+		);
+
+		expect(tauri.scanForProjects).toHaveBeenCalledTimes(4);
+		expect(tauri.scanForProjects).toHaveBeenNthCalledWith(1, "/Users/test", 3);
+		expect(tauri.scanForProjects).toHaveBeenNthCalledWith(2, "/Users/test/projects", 3);
+		expect(tauri.scanForProjects).toHaveBeenNthCalledWith(3, "/Users/test/code", 3);
+		expect(tauri.scanForProjects).toHaveBeenNthCalledWith(4, "/Users/test/dev", 3);
+		expect(screen.getAllByRole("checkbox")).toHaveLength(2);
+
+		await userEvent.click(screen.getByLabelText(/\/Users\/test\/code\/beta/i));
+		await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: "Open Dashboard" })).toBeInTheDocument(),
+		);
+
+		expect(addProject).toHaveBeenCalledTimes(1);
+		expect(addProject).toHaveBeenCalledWith({ path: "/Users/test/projects/alpha" });
+		expect(setDesktopOnboardingCompleted).toHaveBeenCalledWith(true);
+
+		await userEvent.click(screen.getByRole("button", { name: "Open Dashboard" }));
+		expect(navigateMock).toHaveBeenCalledWith("/project/project-alpha", { replace: true });
+	});
+});

--- a/src/ui/src/pages/onboarding/__tests__/desktop-onboarding-page.vitest.tsx
+++ b/src/ui/src/pages/onboarding/__tests__/desktop-onboarding-page.vitest.tsx
@@ -19,6 +19,8 @@ const onboardingTranslations: Record<string, string> = {
 	desktopOnboardingSelectTitle: "Choose projects to add",
 	desktopOnboardingSelectDescription: "Pick projects",
 	desktopOnboardingNoProjects: "No projects found",
+	desktopOnboardingScanPartialWarning:
+		"{count} scan target(s) could not be read. Showing the projects that were discovered successfully.",
 	desktopOnboardingSelectedCount: "{count} selected",
 	desktopOnboardingContinue: "Continue",
 	desktopOnboardingSkip: "Skip for now",
@@ -28,18 +30,12 @@ const onboardingTranslations: Record<string, string> = {
 	desktopOnboardingOpenDashboard: "Open Dashboard",
 	desktopOnboardingKitDetected: "ClaudeKit detected",
 	desktopOnboardingAddFailed: "Failed to add the selected projects",
+	desktopOnboardingPartialAddWarning:
+		"{failed} of {total} selected projects could not be added. You can register them manually later.",
 };
 
-vi.mock("react-router-dom", async () => {
-	const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
-	return {
-		...actual,
-		useNavigate: () => navigateMock,
-	};
-});
-
 vi.mock("../../../lib/tauri-commands", () => ({
-	getGlobalConfigDir: vi.fn(),
+	getHomeDir: vi.fn(),
 	scanForProjects: vi.fn(),
 }));
 
@@ -51,16 +47,38 @@ vi.mock("../../../services/desktop-onboarding-state", () => ({
 	setDesktopOnboardingCompleted: vi.fn(),
 }));
 
+const outletContext = {
+	project: null,
+	isConnected: true,
+	theme: "dark" as const,
+	onToggleTheme: vi.fn(),
+	reloadProjects: vi.fn().mockResolvedValue(undefined),
+	dismissDesktopOnboarding: vi.fn(),
+};
+
 vi.mock("../../../i18n", () => ({
 	useI18n: () => ({
 		t: (key: string) => onboardingTranslations[key] ?? key,
 	}),
 }));
 
+vi.mock("react-router-dom", async () => {
+	const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+	return {
+		...actual,
+		useNavigate: () => navigateMock,
+		useOutletContext: () => outletContext,
+	};
+});
+
 describe("DesktopOnboardingPage", () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
-		vi.mocked(tauri.getGlobalConfigDir).mockResolvedValue("/Users/test/.claude");
+		navigateMock.mockReset();
+		outletContext.reloadProjects.mockResolvedValue(undefined);
+		outletContext.reloadProjects.mockClear();
+		outletContext.dismissDesktopOnboarding.mockClear();
+		vi.mocked(tauri.getHomeDir).mockResolvedValue("/Users/test");
 		vi.mocked(tauri.scanForProjects)
 			.mockResolvedValueOnce([
 				{
@@ -109,7 +127,7 @@ describe("DesktopOnboardingPage", () => {
 		);
 
 		expect(tauri.scanForProjects).toHaveBeenCalledTimes(4);
-		expect(tauri.scanForProjects).toHaveBeenNthCalledWith(1, "/Users/test", 3);
+		expect(tauri.scanForProjects).toHaveBeenNthCalledWith(1, "/Users/test", 1);
 		expect(tauri.scanForProjects).toHaveBeenNthCalledWith(2, "/Users/test/projects", 3);
 		expect(tauri.scanForProjects).toHaveBeenNthCalledWith(3, "/Users/test/code", 3);
 		expect(tauri.scanForProjects).toHaveBeenNthCalledWith(4, "/Users/test/dev", 3);
@@ -124,9 +142,79 @@ describe("DesktopOnboardingPage", () => {
 
 		expect(addProject).toHaveBeenCalledTimes(1);
 		expect(addProject).toHaveBeenCalledWith({ path: "/Users/test/projects/alpha" });
+		expect(outletContext.reloadProjects).toHaveBeenCalledTimes(1);
+		expect(outletContext.dismissDesktopOnboarding).toHaveBeenCalledTimes(1);
 		expect(setDesktopOnboardingCompleted).toHaveBeenCalledWith(true);
 
 		await userEvent.click(screen.getByRole("button", { name: "Open Dashboard" }));
 		expect(navigateMock).toHaveBeenCalledWith("/project/project-alpha", { replace: true });
+	});
+
+	it("lets the user skip onboarding without adding projects", async () => {
+		render(
+			<MemoryRouter>
+				<DesktopOnboardingPage />
+			</MemoryRouter>,
+		);
+
+		await userEvent.click(screen.getByRole("button", { name: "Find My Projects" }));
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: "Skip for now" })).toBeInTheDocument(),
+		);
+
+		await userEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: "Open Dashboard" })).toBeInTheDocument(),
+		);
+
+		expect(addProject).not.toHaveBeenCalled();
+		expect(outletContext.reloadProjects).not.toHaveBeenCalled();
+		expect(outletContext.dismissDesktopOnboarding).toHaveBeenCalledTimes(1);
+		expect(setDesktopOnboardingCompleted).toHaveBeenCalledWith(true);
+	});
+
+	it("keeps Continue disabled when nothing is selected", async () => {
+		render(
+			<MemoryRouter>
+				<DesktopOnboardingPage />
+			</MemoryRouter>,
+		);
+
+		await userEvent.click(screen.getByRole("button", { name: "Find My Projects" }));
+		await waitFor(() =>
+			expect(screen.getByRole("heading", { name: "Choose projects to add" })).toBeInTheDocument(),
+		);
+
+		await userEvent.click(screen.getByLabelText(/\/Users\/test\/projects\/alpha/i));
+		await userEvent.click(screen.getByLabelText(/\/Users\/test\/code\/beta/i));
+
+		expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+	});
+
+	it("shows a warning when some scan targets fail and still allows skipping", async () => {
+		vi.mocked(tauri.scanForProjects).mockReset();
+		vi.mocked(tauri.scanForProjects)
+			.mockRejectedValueOnce(new Error("bad root"))
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([]);
+
+		render(
+			<MemoryRouter>
+				<DesktopOnboardingPage />
+			</MemoryRouter>,
+		);
+
+		await userEvent.click(screen.getByRole("button", { name: "Find My Projects" }));
+
+		await waitFor(() =>
+			expect(
+				screen.getByText(
+					"1 scan target(s) could not be read. Showing the projects that were discovered successfully.",
+				),
+			).toBeInTheDocument(),
+		);
+		expect(screen.getByRole("button", { name: "Skip for now" })).toBeInTheDocument();
 	});
 });

--- a/src/ui/src/pages/onboarding/desktop-onboarding-page.tsx
+++ b/src/ui/src/pages/onboarding/desktop-onboarding-page.tsx
@@ -1,0 +1,200 @@
+import type React from "react";
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useI18n } from "../../i18n";
+import * as tauri from "../../lib/tauri-commands";
+import { addProject } from "../../services/api";
+import { setDesktopOnboardingCompleted } from "../../services/desktop-onboarding-state";
+import { buildDesktopScanRoots, dedupeDiscoveredProjects } from "./desktop-onboarding-utils";
+import DesktopProjectSelectionList from "./desktop-project-selection-list";
+
+type Step = "welcome" | "discovering" | "selection" | "done";
+
+const SCAN_DEPTH = 3;
+
+const DesktopOnboardingPage: React.FC = () => {
+	const { t } = useI18n();
+	const navigate = useNavigate();
+	const [step, setStep] = useState<Step>("welcome");
+	const [projects, setProjects] = useState<tauri.ProjectInfo[]>([]);
+	const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set());
+	const [error, setError] = useState<string | null>(null);
+	const [saving, setSaving] = useState(false);
+	const [targetProjectId, setTargetProjectId] = useState<string | null>(null);
+
+	const selectedCount = selectedPaths.size;
+	const discoveredCount = projects.length;
+	const finishTarget = useMemo(
+		() => (targetProjectId ? `/project/${targetProjectId}` : "/"),
+		[targetProjectId],
+	);
+
+	const togglePath = (path: string) => {
+		setSelectedPaths((current) => {
+			const next = new Set(current);
+			if (next.has(path)) {
+				next.delete(path);
+			} else {
+				next.add(path);
+			}
+			return next;
+		});
+	};
+
+	const startDiscovery = async () => {
+		setError(null);
+		setStep("discovering");
+
+		try {
+			const globalConfigDir = await tauri.getGlobalConfigDir();
+			const roots = buildDesktopScanRoots(globalConfigDir);
+			const scanned = await Promise.allSettled(
+				roots.map((root) => tauri.scanForProjects(root, SCAN_DEPTH)),
+			);
+			const discovered = dedupeDiscoveredProjects(
+				scanned.flatMap((result) => (result.status === "fulfilled" ? result.value : [])),
+			);
+
+			setProjects(discovered);
+			setSelectedPaths(new Set(discovered.map((project) => project.path)));
+			setStep("selection");
+		} catch (scanError) {
+			setError(scanError instanceof Error ? scanError.message : t("desktopOnboardingScanFailed"));
+			setStep("selection");
+		}
+	};
+
+	const completeOnboarding = async (paths: string[]) => {
+		setSaving(true);
+		setError(null);
+
+		try {
+			const results = await Promise.allSettled(paths.map((path) => addProject({ path })));
+			const added = results.flatMap((result) =>
+				result.status === "fulfilled" ? [result.value] : [],
+			);
+			if (paths.length > 0 && added.length === 0) {
+				throw new Error(t("desktopOnboardingAddFailed"));
+			}
+
+			await setDesktopOnboardingCompleted(true);
+			setTargetProjectId(added[0]?.id ?? null);
+			setStep("done");
+		} catch (saveError) {
+			setError(saveError instanceof Error ? saveError.message : t("desktopOnboardingAddFailed"));
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	return (
+		<div className="mx-auto flex h-full w-full max-w-4xl flex-col justify-center px-4 py-8">
+			<div className="rounded-[2rem] border border-dash-border bg-dash-surface p-8 shadow-sm">
+				<div className="mb-8 text-center">
+					<div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-dash-accent-subtle text-3xl">
+						CK
+					</div>
+					<p className="mt-4 text-[10px] font-bold uppercase tracking-[0.3em] text-dash-accent">
+						{t("desktopOnboardingEyebrow")}
+					</p>
+					<h1 className="mt-3 text-3xl font-bold text-dash-text">{t("desktopOnboardingTitle")}</h1>
+					<p className="mt-3 text-sm leading-relaxed text-dash-text-muted">
+						{step === "done"
+							? t("desktopOnboardingDoneDescription")
+							: t("desktopOnboardingDescription")}
+					</p>
+				</div>
+
+				{error ? (
+					<div className="mb-6 rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+						{error}
+					</div>
+				) : null}
+
+				{step === "welcome" ? (
+					<div className="space-y-6 text-center">
+						<p className="text-sm text-dash-text-muted">{t("desktopOnboardingWelcomeBody")}</p>
+						<button
+							type="button"
+							onClick={() => void startDiscovery()}
+							className="rounded-xl bg-dash-accent px-5 py-3 text-sm font-semibold text-white transition hover:bg-dash-accent/90"
+						>
+							{t("desktopOnboardingStart")}
+						</button>
+					</div>
+				) : null}
+
+				{step === "discovering" ? (
+					<div className="space-y-4 text-center">
+						<div className="mx-auto h-12 w-12 animate-spin rounded-full border-2 border-dash-accent border-t-transparent" />
+						<p className="text-sm font-medium text-dash-text">{t("desktopOnboardingScanning")}</p>
+						<p className="text-xs text-dash-text-muted">{t("desktopOnboardingScanningHint")}</p>
+					</div>
+				) : null}
+
+				{step === "selection" ? (
+					<div className="space-y-6">
+						<div className="flex flex-wrap items-center justify-between gap-3">
+							<div>
+								<h2 className="text-lg font-semibold text-dash-text">
+									{t("desktopOnboardingSelectTitle")}
+								</h2>
+								<p className="mt-1 text-sm text-dash-text-muted">
+									{discoveredCount > 0
+										? t("desktopOnboardingSelectDescription")
+										: t("desktopOnboardingNoProjects")}
+								</p>
+							</div>
+							<span className="rounded-full border border-dash-border px-3 py-1 text-xs font-semibold text-dash-text-secondary">
+								{t("desktopOnboardingSelectedCount").replace("{count}", String(selectedCount))}
+							</span>
+						</div>
+
+						{discoveredCount > 0 ? (
+							<DesktopProjectSelectionList
+								projects={projects}
+								selectedPaths={selectedPaths}
+								onToggle={togglePath}
+							/>
+						) : null}
+
+						<div className="flex flex-wrap justify-end gap-3">
+							<button
+								type="button"
+								onClick={() => void completeOnboarding([])}
+								className="rounded-xl border border-dash-border px-4 py-2 text-sm font-medium text-dash-text-secondary transition hover:bg-dash-bg"
+							>
+								{t("desktopOnboardingSkip")}
+							</button>
+							<button
+								type="button"
+								onClick={() => void completeOnboarding(Array.from(selectedPaths))}
+								disabled={saving || (discoveredCount > 0 && selectedCount === 0)}
+								className="rounded-xl bg-dash-accent px-4 py-2 text-sm font-semibold text-white transition hover:bg-dash-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+							>
+								{saving ? t("desktopOnboardingSaving") : t("desktopOnboardingContinue")}
+							</button>
+						</div>
+					</div>
+				) : null}
+
+				{step === "done" ? (
+					<div className="space-y-4 text-center">
+						<p className="text-lg font-semibold text-dash-text">
+							{t("desktopOnboardingDoneTitle")}
+						</p>
+						<button
+							type="button"
+							onClick={() => navigate(finishTarget, { replace: true })}
+							className="rounded-xl bg-dash-accent px-5 py-3 text-sm font-semibold text-white transition hover:bg-dash-accent/90"
+						>
+							{t("desktopOnboardingOpenDashboard")}
+						</button>
+					</div>
+				) : null}
+			</div>
+		</div>
+	);
+};
+
+export default DesktopOnboardingPage;

--- a/src/ui/src/pages/onboarding/desktop-onboarding-page.tsx
+++ b/src/ui/src/pages/onboarding/desktop-onboarding-page.tsx
@@ -11,6 +11,11 @@ import DesktopProjectSelectionList from "./desktop-project-selection-list";
 
 type Step = "welcome" | "discovering" | "selection" | "done";
 
+function isMissingScanTargetError(reason: unknown): boolean {
+	const message = reason instanceof Error ? reason.message : String(reason);
+	return message.includes("does not exist");
+}
+
 const DesktopOnboardingPage: React.FC = () => {
 	const { t } = useI18n();
 	const navigate = useNavigate();
@@ -55,7 +60,9 @@ const DesktopOnboardingPage: React.FC = () => {
 			const scanned = await Promise.allSettled(
 				targets.map((target) => tauri.scanForProjects(target.rootPath, target.maxDepth)),
 			);
-			const failedScans = scanned.filter((result) => result.status === "rejected").length;
+			const failedScans = scanned.filter(
+				(result) => result.status === "rejected" && !isMissingScanTargetError(result.reason),
+			).length;
 			const discovered = dedupeDiscoveredProjects(
 				scanned.flatMap((result) => (result.status === "fulfilled" ? result.value : [])),
 			);
@@ -90,10 +97,10 @@ const DesktopOnboardingPage: React.FC = () => {
 			}
 
 			if (paths.length > 0) {
-				await reloadProjects();
+				await reloadProjects?.();
 			}
 			await setDesktopOnboardingCompleted(true);
-			dismissDesktopOnboarding();
+			dismissDesktopOnboarding?.();
 			setTargetProjectId(added[0]?.id ?? null);
 			setPartialFailures(failedCount);
 			setStep("done");
@@ -136,13 +143,22 @@ const DesktopOnboardingPage: React.FC = () => {
 				{step === "welcome" ? (
 					<div className="space-y-6 text-center">
 						<p className="text-sm text-dash-text-muted">{t("desktopOnboardingWelcomeBody")}</p>
-						<button
-							type="button"
-							onClick={() => void startDiscovery()}
-							className="rounded-xl bg-dash-accent px-5 py-3 text-sm font-semibold text-white transition hover:bg-dash-accent/90"
-						>
-							{t("desktopOnboardingStart")}
-						</button>
+						<div className="flex flex-wrap justify-center gap-3">
+							<button
+								type="button"
+								onClick={() => void completeOnboarding([])}
+								className="rounded-xl border border-dash-border px-5 py-3 text-sm font-medium text-dash-text-secondary transition hover:bg-dash-bg"
+							>
+								{t("desktopOnboardingSkip")}
+							</button>
+							<button
+								type="button"
+								onClick={() => void startDiscovery()}
+								className="rounded-xl bg-dash-accent px-5 py-3 text-sm font-semibold text-white transition hover:bg-dash-accent/90"
+							>
+								{t("desktopOnboardingStart")}
+							</button>
+						</div>
 					</div>
 				) : null}
 

--- a/src/ui/src/pages/onboarding/desktop-onboarding-page.tsx
+++ b/src/ui/src/pages/onboarding/desktop-onboarding-page.tsx
@@ -1,26 +1,28 @@
 import type React from "react";
 import { useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useOutletContext } from "react-router-dom";
 import { useI18n } from "../../i18n";
+import type { AppLayoutContext } from "../../layouts/app-layout-context";
 import * as tauri from "../../lib/tauri-commands";
 import { addProject } from "../../services/api";
 import { setDesktopOnboardingCompleted } from "../../services/desktop-onboarding-state";
-import { buildDesktopScanRoots, dedupeDiscoveredProjects } from "./desktop-onboarding-utils";
+import { buildDesktopScanTargets, dedupeDiscoveredProjects } from "./desktop-onboarding-utils";
 import DesktopProjectSelectionList from "./desktop-project-selection-list";
 
 type Step = "welcome" | "discovering" | "selection" | "done";
 
-const SCAN_DEPTH = 3;
-
 const DesktopOnboardingPage: React.FC = () => {
 	const { t } = useI18n();
 	const navigate = useNavigate();
+	const { reloadProjects, dismissDesktopOnboarding } = useOutletContext<AppLayoutContext>();
 	const [step, setStep] = useState<Step>("welcome");
 	const [projects, setProjects] = useState<tauri.ProjectInfo[]>([]);
 	const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set());
 	const [error, setError] = useState<string | null>(null);
+	const [warning, setWarning] = useState<string | null>(null);
 	const [saving, setSaving] = useState(false);
 	const [targetProjectId, setTargetProjectId] = useState<string | null>(null);
+	const [partialFailures, setPartialFailures] = useState(0);
 
 	const selectedCount = selectedPaths.size;
 	const discoveredCount = projects.length;
@@ -43,20 +45,28 @@ const DesktopOnboardingPage: React.FC = () => {
 
 	const startDiscovery = async () => {
 		setError(null);
+		setWarning(null);
+		setPartialFailures(0);
 		setStep("discovering");
 
 		try {
-			const globalConfigDir = await tauri.getGlobalConfigDir();
-			const roots = buildDesktopScanRoots(globalConfigDir);
+			const homeDir = await tauri.getHomeDir();
+			const targets = buildDesktopScanTargets(homeDir);
 			const scanned = await Promise.allSettled(
-				roots.map((root) => tauri.scanForProjects(root, SCAN_DEPTH)),
+				targets.map((target) => tauri.scanForProjects(target.rootPath, target.maxDepth)),
 			);
+			const failedScans = scanned.filter((result) => result.status === "rejected").length;
 			const discovered = dedupeDiscoveredProjects(
 				scanned.flatMap((result) => (result.status === "fulfilled" ? result.value : [])),
 			);
 
 			setProjects(discovered);
 			setSelectedPaths(new Set(discovered.map((project) => project.path)));
+			if (failedScans > 0) {
+				setWarning(
+					t("desktopOnboardingScanPartialWarning").replace("{count}", String(failedScans)),
+				);
+			}
 			setStep("selection");
 		} catch (scanError) {
 			setError(scanError instanceof Error ? scanError.message : t("desktopOnboardingScanFailed"));
@@ -67,18 +77,25 @@ const DesktopOnboardingPage: React.FC = () => {
 	const completeOnboarding = async (paths: string[]) => {
 		setSaving(true);
 		setError(null);
+		setPartialFailures(0);
 
 		try {
 			const results = await Promise.allSettled(paths.map((path) => addProject({ path })));
 			const added = results.flatMap((result) =>
 				result.status === "fulfilled" ? [result.value] : [],
 			);
+			const failedCount = results.length - added.length;
 			if (paths.length > 0 && added.length === 0) {
 				throw new Error(t("desktopOnboardingAddFailed"));
 			}
 
+			if (paths.length > 0) {
+				await reloadProjects();
+			}
 			await setDesktopOnboardingCompleted(true);
+			dismissDesktopOnboarding();
 			setTargetProjectId(added[0]?.id ?? null);
+			setPartialFailures(failedCount);
 			setStep("done");
 		} catch (saveError) {
 			setError(saveError instanceof Error ? saveError.message : t("desktopOnboardingAddFailed"));
@@ -108,6 +125,11 @@ const DesktopOnboardingPage: React.FC = () => {
 				{error ? (
 					<div className="mb-6 rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
 						{error}
+					</div>
+				) : null}
+				{warning ? (
+					<div className="mb-6 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+						{warning}
 					</div>
 				) : null}
 
@@ -183,6 +205,13 @@ const DesktopOnboardingPage: React.FC = () => {
 						<p className="text-lg font-semibold text-dash-text">
 							{t("desktopOnboardingDoneTitle")}
 						</p>
+						{partialFailures > 0 ? (
+							<p className="text-sm text-amber-300">
+								{t("desktopOnboardingPartialAddWarning")
+									.replace("{failed}", String(partialFailures))
+									.replace("{total}", String(selectedCount))}
+							</p>
+						) : null}
 						<button
 							type="button"
 							onClick={() => navigate(finishTarget, { replace: true })}

--- a/src/ui/src/pages/onboarding/desktop-onboarding-utils.ts
+++ b/src/ui/src/pages/onboarding/desktop-onboarding-utils.ts
@@ -1,0 +1,20 @@
+import { dirname, join } from "pathe";
+import type { ProjectInfo } from "../../lib/tauri-commands";
+
+export function buildDesktopScanRoots(globalConfigDir: string): string[] {
+	const homeDir = dirname(globalConfigDir);
+
+	return [homeDir, join(homeDir, "projects"), join(homeDir, "code"), join(homeDir, "dev")];
+}
+
+export function dedupeDiscoveredProjects(projects: ProjectInfo[]): ProjectInfo[] {
+	const byPath = new Map<string, ProjectInfo>();
+
+	for (const project of projects) {
+		if (!byPath.has(project.path)) {
+			byPath.set(project.path, project);
+		}
+	}
+
+	return Array.from(byPath.values()).sort((left, right) => left.path.localeCompare(right.path));
+}

--- a/src/ui/src/pages/onboarding/desktop-onboarding-utils.ts
+++ b/src/ui/src/pages/onboarding/desktop-onboarding-utils.ts
@@ -1,10 +1,18 @@
-import { dirname, join } from "pathe";
+import { join } from "pathe";
 import type { ProjectInfo } from "../../lib/tauri-commands";
 
-export function buildDesktopScanRoots(globalConfigDir: string): string[] {
-	const homeDir = dirname(globalConfigDir);
+export interface DesktopScanTarget {
+	rootPath: string;
+	maxDepth: number;
+}
 
-	return [homeDir, join(homeDir, "projects"), join(homeDir, "code"), join(homeDir, "dev")];
+export function buildDesktopScanTargets(homeDir: string): DesktopScanTarget[] {
+	return [
+		{ rootPath: homeDir, maxDepth: 1 },
+		{ rootPath: join(homeDir, "projects"), maxDepth: 3 },
+		{ rootPath: join(homeDir, "code"), maxDepth: 3 },
+		{ rootPath: join(homeDir, "dev"), maxDepth: 3 },
+	];
 }
 
 export function dedupeDiscoveredProjects(projects: ProjectInfo[]): ProjectInfo[] {

--- a/src/ui/src/pages/onboarding/desktop-project-selection-list.tsx
+++ b/src/ui/src/pages/onboarding/desktop-project-selection-list.tsx
@@ -1,0 +1,56 @@
+import type React from "react";
+import { useI18n } from "../../i18n";
+import type { ProjectInfo } from "../../lib/tauri-commands";
+
+interface DesktopProjectSelectionListProps {
+	projects: ProjectInfo[];
+	selectedPaths: Set<string>;
+	onToggle: (path: string) => void;
+}
+
+const DesktopProjectSelectionList: React.FC<DesktopProjectSelectionListProps> = ({
+	projects,
+	selectedPaths,
+	onToggle,
+}) => {
+	const { t } = useI18n();
+
+	return (
+		<div className="space-y-3">
+			{projects.map((project) => {
+				const selected = selectedPaths.has(project.path);
+
+				return (
+					<label
+						key={project.path}
+						className={`flex cursor-pointer items-start gap-3 rounded-xl border p-4 transition-colors ${
+							selected
+								? "border-dash-accent bg-dash-accent-subtle/60"
+								: "border-dash-border bg-dash-surface hover:border-dash-accent/40"
+						}`}
+					>
+						<input
+							type="checkbox"
+							checked={selected}
+							onChange={() => onToggle(project.path)}
+							className="mt-1 h-4 w-4 accent-[var(--dash-accent)]"
+						/>
+						<div className="min-w-0">
+							<div className="flex flex-wrap items-center gap-2">
+								<p className="text-sm font-semibold text-dash-text">{project.name}</p>
+								{project.hasCkConfig ? (
+									<span className="rounded-full border border-dash-accent/40 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-dash-accent">
+										{t("desktopOnboardingKitDetected")}
+									</span>
+								) : null}
+							</div>
+							<p className="mt-1 break-all text-xs text-dash-text-muted">{project.path}</p>
+						</div>
+					</label>
+				);
+			})}
+		</div>
+	);
+};
+
+export default DesktopProjectSelectionList;

--- a/src/ui/src/services/desktop-onboarding-state.ts
+++ b/src/ui/src/services/desktop-onboarding-state.ts
@@ -1,0 +1,19 @@
+import { LazyStore } from "@tauri-apps/plugin-store";
+
+const STORE_PATH = "control-center-state.json";
+const ONBOARDING_COMPLETED_KEY = "desktopOnboardingCompleted";
+
+const desktopStateStore = new LazyStore(STORE_PATH, {
+	defaults: {
+		[ONBOARDING_COMPLETED_KEY]: false,
+	},
+});
+
+export async function getDesktopOnboardingCompleted(): Promise<boolean> {
+	return Boolean(await desktopStateStore.get<boolean>(ONBOARDING_COMPLETED_KEY));
+}
+
+export async function setDesktopOnboardingCompleted(completed: boolean): Promise<void> {
+	await desktopStateStore.set(ONBOARDING_COMPLETED_KEY, completed);
+	await desktopStateStore.save();
+}


### PR DESCRIPTION
## Summary
- add a desktop-only first-run onboarding gate that redirects Tauri users into onboarding when no projects are registered and no global `.ck.json` exists
- add a native onboarding flow that scans common development folders, lets users select discovered projects, registers them, and persists completion with `tauri-plugin-store`
- render desktop onboarding without the normal sidebar chrome and keep the existing web onboarding route intact
- add desktop onboarding tests plus small roadmap/architecture doc updates for the new Phase 5C behavior

Closes #693
Part of #676

## Validation
- `bun run validate`
- targeted UI tests for the desktop onboarding gate and onboarding page flow
- pre-commit quality gate
- pre-push quality gate