### PR TITLE
feat: Phase 5B - system tray enhancements

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,17 @@
 {
 	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
 	"files": {
-		"ignore": ["dist", "node_modules", "*.log", ".claude", ".opencode", "package.json", "bin/**"]
+		"ignore": [
+			"dist",
+			"node_modules",
+			"*.log",
+			".claude",
+			".opencode",
+			"package.json",
+			"bin/**",
+			"src-tauri/gen/schemas/**",
+			"src-tauri/target/**"
+		]
 	},
 	"organizeImports": {
 		"enabled": true

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -57,6 +57,7 @@ The codebase underwent a major modularization refactor, reducing 24 large files 
 - `src/domains/desktop/` now owns the desktop distribution contract used by `ck app`: manifest parsing/building, platform asset selection, install-path resolution, install/uninstall helpers, and detached app launch helpers.
 - `.github/workflows/desktop-build.yml` now prepares portable desktop assets and publishes a plain `desktop-latest/desktop-manifest.json` manifest for CLI-side binary discovery; signed Tauri updater support remains a later phase.
 - Tauri desktop mode now boots without the Express dashboard server for supported native reads, while browser mode keeps the Express `/api` backend for the remaining server-backed flows.
+- Phase 5B adds native tray orchestration on top of that runtime: recent projects come from the desktop registry, tray clicks update project recency in Rust, and the React shell handles a semantic `tray-open` event for dashboard/settings/project navigation.
 
 ### Development Tools
 - **Biome**: Fast linting and formatting

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -19,6 +19,7 @@ ClaudeKit CLI (`ck`) is a command-line tool for bootstrapping and updating Claud
 - Phase 3 now adds unsigned desktop distribution plumbing: portable release assets, a plain `desktop-manifest.json` download manifest, and reusable desktop install/launch helpers.
 - Phase 4 now ships `ck app`, which detects an installed desktop binary, downloads and installs it on demand, and launches the native Control Center.
 - Phase 5A removes the Express boot requirement from Tauri desktop mode for supported native reads and routes unsupported flows back to CLI/web guidance.
+- Phase 5B expands the native tray with recent projects, dashboard/settings shortcuts, project recency tracking, and system-terminal launch for the most recent project.
 - Phase 5C adds a desktop-first first-run onboarding flow that scans common development folders, lets users register discovered projects, and persists onboarding completion in the native store.
 - Browser mode still uses the Express `/api` backend for `ck config` and the remaining server-backed flows.
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -92,6 +92,11 @@ Phase 5A changes the runtime split:
 - Unsupported server-backed flows such as migration, update orchestration, and onboarding install stay explicit CLI/web workflows instead of hidden `/api` calls.
 - Desktop first run now has its own native onboarding gate: if no projects are registered and no global `.ck.json` exists, the app redirects into a chromeless discovery flow that scans common home-directory workspaces and persists completion with `tauri-plugin-store`.
 
+Phase 5B extends the native shell instead of the shared web backend:
+- The tray menu now renders recent projects from `~/.claudekit/projects.json`, sorted by `last_opened` then `added_at`.
+- Rust-side tray handlers own project recency updates and system-terminal launch, so tray actions work without Express.
+- The shared React app listens for a semantic `tray-open` event and translates it into `/project/:projectId`, `/dashboard`, or settings navigation.
+
 ### skills/ - Skills Management
 Multi-select installation, registry tracking, uninstall per agent.
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ pub fn run() {
             projects::list_projects,
             projects::add_project,
             projects::remove_project,
+            projects::touch_project,
             projects::scan_for_projects,
             // Session commands (Phase 1A)
             commands::sessions::scan_sessions,

--- a/src-tauri/src/projects.rs
+++ b/src-tauri/src/projects.rs
@@ -455,7 +455,6 @@ fn build_recent_project_info(project: &RegisteredProject) -> RecentProjectInfo {
 fn current_timestamp_iso() -> String {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration)
         .unwrap_or_default();
     let secs = now.as_secs();
     let millis = now.subsec_millis();

--- a/src-tauri/src/projects.rs
+++ b/src-tauri/src/projects.rs
@@ -3,10 +3,15 @@
 // Uses the same ~/.claudekit/projects.json registry as the CLI/web backend so
 // desktop project actions and desktop read commands share one source of truth.
 
-use crate::core::paths;
+use crate::core::{paths, project_ids};
+use crate::tray;
 use serde::{Deserialize, Serialize};
-use std::fs;
+use std::cmp::Ordering;
+use std::fs::{self, File, OpenOptions};
 use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -18,7 +23,26 @@ pub struct ProjectInfo {
     pub has_ck_config: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RecentProjectInfo {
+    pub project_id: String,
+    pub name: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_opened: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct ProjectActionPreferences {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    terminal_app: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    editor_app: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct RegisteredProject {
     id: String,
@@ -27,6 +51,12 @@ struct RegisteredProject {
     added_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     last_opened: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pinned: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    preferences: Option<ProjectActionPreferences>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -36,56 +66,105 @@ struct ProjectsRegistry {
 }
 
 const REGISTRY_VERSION: u32 = 1;
+const REGISTRY_LOCK_RETRY_MS: u64 = 100;
+const REGISTRY_LOCK_MAX_RETRIES: usize = 50;
+const REGISTRY_STALE_LOCK_MS: u64 = 30_000;
 
 #[tauri::command]
 pub fn list_projects(_app: tauri::AppHandle) -> Result<Vec<ProjectInfo>, String> {
-    let registry = load_registry()?;
-    Ok(registry
-        .projects
-        .iter()
-        .filter(|project| Path::new(&project.path).is_dir())
-        .map(|project| build_project_info(&project.path))
-        .collect())
+    with_registry_lock(|| {
+        let registry = load_registry()?;
+        Ok(registry
+            .projects
+            .iter()
+            .filter(|project| Path::new(&project.path).is_dir())
+            .map(|project| build_project_info(&project.path))
+            .collect())
+    })
 }
 
 #[tauri::command]
-pub fn add_project(_app: tauri::AppHandle, path: String) -> Result<ProjectInfo, String> {
+pub fn add_project(app: tauri::AppHandle, path: String) -> Result<ProjectInfo, String> {
     let canonical_path = canonical_project_path(&path)?;
-    let mut registry = load_registry()?;
+    let (project_info, should_refresh) = with_registry_lock(|| {
+        let mut registry = load_registry()?;
 
-    if !registry
-        .projects
-        .iter()
-        .any(|project| project.path == canonical_path)
-    {
-        let project_name = Path::new(&canonical_path)
-            .file_name()
-            .and_then(|value| value.to_str())
-            .unwrap_or(&canonical_path)
-            .to_string();
+        if !registry
+            .projects
+            .iter()
+            .any(|project| project.path == canonical_path)
+        {
+            let project_name = Path::new(&canonical_path)
+                .file_name()
+                .and_then(|value| value.to_str())
+                .unwrap_or(&canonical_path)
+                .to_string();
 
-        registry.projects.push(RegisteredProject {
-            id: Uuid::new_v4().to_string(),
-            path: canonical_path.clone(),
-            alias: project_name,
-            added_at: current_timestamp_iso(),
-            last_opened: None,
-        });
-        save_registry(&registry)?;
+            registry.projects.push(RegisteredProject {
+                id: Uuid::new_v4().to_string(),
+                path: canonical_path.clone(),
+                alias: project_name,
+                added_at: current_timestamp_iso(),
+                last_opened: None,
+                pinned: None,
+                tags: None,
+                preferences: None,
+            });
+            save_registry(&registry)?;
+            return Ok((build_project_info(&canonical_path), true));
+        }
+
+        Ok((build_project_info(&canonical_path), false))
+    })?;
+
+    if should_refresh {
+        refresh_tray_best_effort(&app);
     }
 
-    Ok(build_project_info(&canonical_path))
+    Ok(project_info)
 }
 
 #[tauri::command]
-pub fn remove_project(_app: tauri::AppHandle, path: String) -> Result<(), String> {
+pub fn remove_project(app: tauri::AppHandle, path: String) -> Result<(), String> {
     let normalized_path = normalize_input_path(&path);
-    let mut registry = load_registry()?;
-    registry.projects.retain(|project| {
-        let project_path = normalize_input_path(&project.path);
-        project_path != normalized_path && project.path != path
-    });
-    save_registry(&registry)
+    let should_refresh = with_registry_lock(|| {
+        let mut registry = load_registry()?;
+        let original_len = registry.projects.len();
+
+        registry.projects.retain(|project| {
+            let project_path = normalize_input_path(&project.path);
+            project_path != normalized_path && project.path != path
+        });
+
+        if registry.projects.len() != original_len {
+            save_registry(&registry)?;
+            return Ok(true);
+        }
+
+        Ok(false)
+    })?;
+
+    if should_refresh {
+        refresh_tray_best_effort(&app);
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
+pub fn touch_project(app: tauri::AppHandle, path: String) -> Result<(), String> {
+    let canonical_path = canonical_project_path(&path)?;
+    with_registry_lock(|| {
+        let mut registry = load_registry()?;
+
+        if !set_project_last_opened(&mut registry, &canonical_path, current_timestamp_iso()) {
+            return Err(format!("Project is not registered: {canonical_path}"));
+        }
+
+        save_registry(&registry)
+    })?;
+    refresh_tray_best_effort(&app);
+    Ok(())
 }
 
 #[tauri::command]
@@ -113,6 +192,45 @@ pub async fn scan_for_projects(
     .map_err(|e| format!("Scan failed: {e}"))
 }
 
+pub(crate) fn list_recent_projects(limit: usize) -> Result<Vec<RecentProjectInfo>, String> {
+    with_registry_lock(|| {
+        let registry = load_registry()?;
+        Ok(recent_projects_from_registry(&registry, limit)
+            .into_iter()
+            .map(|project| build_recent_project_info(&project))
+            .collect())
+    })
+}
+
+pub(crate) fn primary_recent_project() -> Result<Option<RecentProjectInfo>, String> {
+    Ok(list_recent_projects(1)?.into_iter().next())
+}
+
+pub(crate) fn touch_project_path(
+    app: &tauri::AppHandle,
+    path: &str,
+) -> Result<RecentProjectInfo, String> {
+    let canonical_path = canonical_project_path(path)?;
+    let updated = with_registry_lock(|| {
+        let mut registry = load_registry()?;
+
+        if !set_project_last_opened(&mut registry, &canonical_path, current_timestamp_iso()) {
+            return Err(format!("Project is not registered: {canonical_path}"));
+        }
+
+        let updated = recent_projects_from_registry(&registry, usize::MAX)
+            .into_iter()
+            .find(|project| project.path == canonical_path)
+            .map(|project| build_recent_project_info(&project))
+            .ok_or_else(|| format!("Project is not registered: {canonical_path}"))?;
+
+        save_registry(&registry)?;
+        Ok(updated)
+    })?;
+    refresh_tray_best_effort(app);
+    Ok(updated)
+}
+
 fn registry_path() -> Result<std::path::PathBuf, String> {
     paths::projects_registry_path()
         .ok_or_else(|| "Cannot determine projects registry path".to_string())
@@ -129,8 +247,29 @@ fn load_registry() -> Result<ProjectsRegistry, String> {
 
     let content = fs::read_to_string(&path)
         .map_err(|err| format!("Failed to read {}: {err}", path.display()))?;
-    serde_json::from_str::<ProjectsRegistry>(&content)
-        .map_err(|err| format!("Failed to parse {}: {err}", path.display()))
+    match serde_json::from_str::<ProjectsRegistry>(&content) {
+        Ok(registry) => Ok(registry),
+        Err(err) => {
+            let backup_path = std::path::PathBuf::from(format!(
+                "{}.backup-{}",
+                path.display(),
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|duration| duration.as_millis())
+                    .unwrap_or_default()
+            ));
+            let _ = fs::copy(&path, &backup_path);
+            eprintln!(
+                "[projects] failed to parse registry, backed up {} to {}: {err}",
+                path.display(),
+                backup_path.display()
+            );
+            Ok(ProjectsRegistry {
+                version: REGISTRY_VERSION,
+                projects: Vec::new(),
+            })
+        }
+    }
 }
 
 fn save_registry(registry: &ProjectsRegistry) -> Result<(), String> {
@@ -142,7 +281,94 @@ fn save_registry(registry: &ProjectsRegistry) -> Result<(), String> {
 
     let content = serde_json::to_string_pretty(registry)
         .map_err(|err| format!("Failed to serialize projects registry: {err}"))?;
-    fs::write(&path, content).map_err(|err| format!("Failed to write {}: {err}", path.display()))
+    let temp_path = std::path::PathBuf::from(format!("{}.tmp", path.display()));
+    fs::write(&temp_path, content)
+        .map_err(|err| format!("Failed to write {}: {err}", temp_path.display()))?;
+    fs::rename(&temp_path, &path)
+        .map_err(|err| format!("Failed to replace {}: {err}", path.display()))
+}
+
+fn refresh_tray_best_effort(app: &tauri::AppHandle) {
+    if let Err(err) = tray::refresh_tray(app) {
+        eprintln!("[projects] failed to refresh tray: {err}");
+    }
+}
+
+fn with_registry_lock<T>(operation: impl FnOnce() -> Result<T, String>) -> Result<T, String> {
+    static PROJECTS_REGISTRY_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let lock = PROJECTS_REGISTRY_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock
+        .lock()
+        .map_err(|_| "Projects registry lock poisoned".to_string())?;
+    let _file_lock = acquire_registry_file_lock()?;
+    operation()
+}
+
+struct RegistryFileLock {
+    _file: File,
+    path: std::path::PathBuf,
+}
+
+impl Drop for RegistryFileLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn acquire_registry_file_lock() -> Result<RegistryFileLock, String> {
+    let registry_path = registry_path()?;
+    let lock_path = std::path::PathBuf::from(format!("{}.lock", registry_path.display()));
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|err| format!("Failed to create {}: {err}", parent.display()))?;
+    }
+
+    for attempt in 0..=REGISTRY_LOCK_MAX_RETRIES {
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&lock_path)
+        {
+            Ok(file) => {
+                return Ok(RegistryFileLock {
+                    _file: file,
+                    path: lock_path,
+                })
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                if let Ok(metadata) = fs::metadata(&lock_path) {
+                    if let Ok(modified) = metadata.modified() {
+                        if let Ok(age) = SystemTime::now().duration_since(modified) {
+                            if age.as_millis() as u64 > REGISTRY_STALE_LOCK_MS {
+                                let _ = fs::remove_file(&lock_path);
+                                continue;
+                            }
+                        }
+                    }
+                }
+
+                if attempt == REGISTRY_LOCK_MAX_RETRIES {
+                    return Err(format!(
+                        "Failed to acquire registry lock at {}",
+                        lock_path.display()
+                    ));
+                }
+
+                thread::sleep(Duration::from_millis(REGISTRY_LOCK_RETRY_MS));
+            }
+            Err(err) => {
+                return Err(format!(
+                    "Failed to acquire registry lock at {}: {err}",
+                    lock_path.display()
+                ))
+            }
+        }
+    }
+
+    Err(format!(
+        "Failed to acquire registry lock at {}",
+        lock_path.display()
+    ))
 }
 
 fn canonical_project_path(path: &str) -> Result<String, String> {
@@ -164,13 +390,77 @@ fn normalize_input_path(path: &str) -> String {
         .into_owned()
 }
 
+fn recent_projects_from_registry(
+    registry: &ProjectsRegistry,
+    limit: usize,
+) -> Vec<RegisteredProject> {
+    let mut projects = registry
+        .projects
+        .iter()
+        .filter(|project| Path::new(&project.path).is_dir())
+        .cloned()
+        .collect::<Vec<_>>();
+
+    projects.sort_by(compare_recent_projects);
+    projects.truncate(limit);
+    projects
+}
+
+fn compare_recent_projects(left: &RegisteredProject, right: &RegisteredProject) -> Ordering {
+    normalize_timestamp(right.last_opened.as_deref())
+        .cmp(&normalize_timestamp(left.last_opened.as_deref()))
+        .then_with(|| normalize_timestamp(Some(&right.added_at)).cmp(&normalize_timestamp(Some(&left.added_at))))
+        .then_with(|| left.alias.cmp(&right.alias))
+}
+
+fn normalize_timestamp(timestamp: Option<&str>) -> String {
+    let Some(timestamp) = timestamp else {
+        return String::new();
+    };
+    if let Some(base) = timestamp.strip_suffix('Z') {
+        if base.contains('.') {
+            return timestamp.to_string();
+        }
+        return format!("{base}.000Z");
+    }
+    timestamp.to_string()
+}
+
+fn set_project_last_opened(
+    registry: &mut ProjectsRegistry,
+    canonical_path: &str,
+    timestamp: String,
+) -> bool {
+    if let Some(project) = registry
+        .projects
+        .iter_mut()
+        .find(|project| normalize_input_path(&project.path) == canonical_path)
+    {
+        project.last_opened = Some(timestamp);
+        return true;
+    }
+
+    false
+}
+
+fn build_recent_project_info(project: &RegisteredProject) -> RecentProjectInfo {
+    RecentProjectInfo {
+        project_id: project_ids::discovered_project_id(&project.path),
+        name: project.alias.clone(),
+        path: project.path.clone(),
+        last_opened: project.last_opened.clone(),
+    }
+}
+
 fn current_timestamp_iso() -> String {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_secs())
+        .map(|duration| duration)
         .unwrap_or_default();
-    let days = (now / 86_400) as i64;
-    let secs_of_day = (now % 86_400) as i64;
+    let secs = now.as_secs();
+    let millis = now.subsec_millis();
+    let days = (secs / 86_400) as i64;
+    let secs_of_day = (secs % 86_400) as i64;
     let z = days + 719_468;
     let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
     let doe = z - era * 146_097;
@@ -184,7 +474,7 @@ fn current_timestamp_iso() -> String {
     let hour = secs_of_day / 3_600;
     let minute = (secs_of_day % 3_600) / 60;
     let second = secs_of_day % 60;
-    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z")
 }
 
 fn scan_recursive(dir: &Path, depth: u32, results: &mut Vec<ProjectInfo>) {
@@ -229,5 +519,142 @@ fn build_project_info(path: &str) -> ProjectInfo {
         path: path.to_string(),
         has_claude_config: p.join(".claude").is_dir(),
         has_ck_config: p.join(".claude/.ck.json").is_file(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        compare_recent_projects, current_timestamp_iso, recent_projects_from_registry,
+        set_project_last_opened, ProjectsRegistry, RegisteredProject, REGISTRY_VERSION,
+    };
+    use std::cmp::Ordering;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be valid")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("ck-projects-{name}-{unique}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+
+    fn registered_project(path: &PathBuf, alias: &str, added_at: &str) -> RegisteredProject {
+        RegisteredProject {
+            id: format!("id-{alias}"),
+            path: path.to_string_lossy().into_owned(),
+            alias: alias.to_string(),
+            added_at: added_at.to_string(),
+            last_opened: None,
+            pinned: None,
+            tags: None,
+            preferences: None,
+        }
+    }
+
+    #[test]
+    fn recent_projects_sort_by_last_opened_then_added_at() {
+        let alpha = temp_dir("alpha");
+        let beta = temp_dir("beta");
+        let gamma = temp_dir("gamma");
+
+        let mut alpha_project = registered_project(&alpha, "alpha", "2026-04-10T09:00:00Z");
+        alpha_project.last_opened = Some("2026-04-16T10:00:00Z".to_string());
+
+        let mut beta_project = registered_project(&beta, "beta", "2026-04-15T09:00:00Z");
+        beta_project.last_opened = Some("2026-04-15T11:00:00Z".to_string());
+
+        let gamma_project = registered_project(&gamma, "gamma", "2026-04-16T08:00:00Z");
+        let missing_project = RegisteredProject {
+            id: "id-missing".to_string(),
+            path: "/tmp/does-not-exist".to_string(),
+            alias: "missing".to_string(),
+            added_at: "2026-04-20T00:00:00Z".to_string(),
+            last_opened: Some("2026-04-20T00:00:00Z".to_string()),
+            pinned: None,
+            tags: None,
+            preferences: None,
+        };
+
+        let registry = ProjectsRegistry {
+            version: REGISTRY_VERSION,
+            projects: vec![beta_project, missing_project, gamma_project, alpha_project],
+        };
+
+        let recent = recent_projects_from_registry(&registry, 3);
+        let aliases = recent
+            .iter()
+            .map(|project| project.alias.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(aliases, vec!["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
+    fn touch_updates_matching_project_timestamp() {
+        let alpha = temp_dir("touch-alpha");
+        let beta = temp_dir("touch-beta");
+        let canonical_alpha = alpha
+            .canonicalize()
+            .expect("alpha path should canonicalize")
+            .to_string_lossy()
+            .into_owned();
+
+        let mut registry = ProjectsRegistry {
+            version: REGISTRY_VERSION,
+            projects: vec![
+                registered_project(&alpha, "alpha", "2026-04-10T09:00:00Z"),
+                registered_project(&beta, "beta", "2026-04-15T09:00:00Z"),
+            ],
+        };
+
+        let touched = set_project_last_opened(
+            &mut registry,
+            &canonical_alpha,
+            "2026-04-16T11:22:33Z".to_string(),
+        );
+
+        assert!(touched);
+        assert_eq!(
+            registry.projects[0].last_opened.as_deref(),
+            Some("2026-04-16T11:22:33Z")
+        );
+        assert_eq!(registry.projects[1].last_opened, None);
+    }
+
+    #[test]
+    fn compare_recent_projects_prefers_newer_timestamps() {
+        let alpha = temp_dir("cmp-alpha");
+        let beta = temp_dir("cmp-beta");
+        let mut left = registered_project(&alpha, "alpha", "2026-04-10T09:00:00Z");
+        let mut right = registered_project(&beta, "beta", "2026-04-15T09:00:00Z");
+        left.last_opened = Some("2026-04-16T08:00:00Z".to_string());
+        right.last_opened = Some("2026-04-16T09:00:00Z".to_string());
+
+        assert_eq!(compare_recent_projects(&left, &right), Ordering::Greater);
+    }
+
+    #[test]
+    fn compare_recent_projects_normalizes_second_precision_timestamps() {
+        let alpha = temp_dir("cmp-ms-alpha");
+        let beta = temp_dir("cmp-ms-beta");
+        let mut left = registered_project(&alpha, "alpha", "2026-04-10T09:00:00Z");
+        let mut right = registered_project(&beta, "beta", "2026-04-15T09:00:00Z");
+        left.last_opened = Some("2026-04-16T08:00:00Z".to_string());
+        right.last_opened = Some("2026-04-16T08:00:00.123Z".to_string());
+
+        assert_eq!(compare_recent_projects(&left, &right), Ordering::Greater);
+    }
+
+    #[test]
+    fn timestamp_generator_returns_iso_shape() {
+        let timestamp = current_timestamp_iso();
+        assert_eq!(timestamp.len(), 24);
+        assert!(timestamp.contains('.'));
+        assert!(timestamp.ends_with('Z'));
     }
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -389,17 +389,22 @@ mod tests {
         assert!(error.contains("does not exist"));
     }
 
-    #[test]
-    fn builds_platform_terminal_command() {
-        let dir = temp_dir("terminal");
-        let command = build_system_terminal_command(&dir.to_string_lossy())
-            .expect("command should build");
+	#[test]
+	fn builds_platform_terminal_command() {
+		let dir = temp_dir("terminal");
+		let result = build_system_terminal_command(&dir.to_string_lossy());
 
-        #[cfg(target_os = "macos")]
-        assert_eq!(command.command, "open");
-        #[cfg(target_os = "windows")]
-        assert_eq!(command.command, "cmd.exe");
-        #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
-        assert_eq!(command.command, "x-terminal-emulator");
-    }
+		#[cfg(target_os = "macos")]
+		assert_eq!(result.expect("command should build").command, "open");
+		#[cfg(target_os = "windows")]
+		assert_eq!(result.expect("command should build").command, "cmd.exe");
+		#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+		match result {
+			Ok(command) => assert!(!command.command.is_empty(), "should resolve a Linux terminal"),
+			Err(error) => assert!(
+				error.contains("No supported system terminal was found on PATH"),
+				"unexpected Linux terminal error: {error}",
+			),
+		}
+	}
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,34 +1,80 @@
-// ClaudeKit Control Center — System tray setup and menu handlers
-//
-// Creates a persistent tray icon with:
-//   - "Open Control Center" — shows and focuses the main window
-//   - "Check for Updates" — emits "check-updates" event to frontend
-//   - "Quit" — exits the application
-//
-// Left-click on the tray icon also shows and focuses the main window.
+// ClaudeKit Control Center — System tray setup and menu handlers.
 
+use crate::core::project_ids;
+use crate::projects;
+use serde::Serialize;
+use std::process::{Command, Stdio};
 use tauri::{
-    menu::{Menu, MenuItem},
+    menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    Emitter, Manager, Runtime,
+    Emitter, Manager,
 };
 
-/// Register the system tray icon and context menu for the given app handle.
-/// Must be called from the `setup` closure in `tauri::Builder`.
-pub fn create_tray<R: Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
-    let show = MenuItem::with_id(app, "show", "Open Control Center", true, None::<&str>)?;
-    let check_updates = MenuItem::with_id(
-        app,
-        "check_updates",
-        "Check for Updates",
-        true,
-        None::<&str>,
-    )?;
+const TRAY_ID: &str = "control-center-tray";
+const RECENT_LIMIT: usize = 3;
+const RECENT_PROJECT_PREFIX: &str = "recent_project:";
+
+#[derive(Clone)]
+struct TrayState {
+    recent_projects: Submenu<tauri::Wry>,
+    open_terminal: MenuItem<tauri::Wry>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct TrayOpenPayload {
+    destination: &'static str,
+    project_id: Option<String>,
+}
+
+#[derive(Debug)]
+struct TerminalCommand {
+    command: &'static str,
+    args: Vec<String>,
+    cwd: Option<String>,
+}
+
+pub fn create_tray(app: &tauri::AppHandle) -> tauri::Result<()> {
+    let title = MenuItem::with_id(app, "tray_title", "ClaudeKit Control Center", false, None::<&str>)?;
+    let recent_projects = Submenu::with_id(app, "recent_projects", "Recent Projects", true)?;
+    let open_dashboard =
+        MenuItem::with_id(app, "open_dashboard", "Open Dashboard", true, None::<&str>)?;
+    let open_terminal =
+        MenuItem::with_id(app, "open_terminal", "Open in Terminal", false, None::<&str>)?;
+    let check_updates =
+        MenuItem::with_id(app, "check_updates", "Check for Updates", true, None::<&str>)?;
+    let settings = MenuItem::with_id(app, "settings", "Settings", true, None::<&str>)?;
     let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
+    let separator_1 = PredefinedMenuItem::separator(app)?;
+    let separator_2 = PredefinedMenuItem::separator(app)?;
+    let separator_3 = PredefinedMenuItem::separator(app)?;
 
-    let menu = Menu::with_items(app, &[&show, &check_updates, &quit])?;
+    refresh_recent_projects_menu(app, &recent_projects, &open_terminal)
+        .map_err(|err| tauri::Error::Io(std::io::Error::other(err)))?;
 
-    TrayIconBuilder::new()
+    let menu = Menu::with_id_and_items(
+        app,
+        "control_center_tray_menu",
+        &[
+            &title,
+            &separator_1,
+            &recent_projects,
+            &separator_2,
+            &open_dashboard,
+            &open_terminal,
+            &separator_3,
+            &check_updates,
+            &settings,
+            &quit,
+        ],
+    )?;
+
+    app.manage(TrayState {
+        recent_projects: recent_projects.clone(),
+        open_terminal: open_terminal.clone(),
+    });
+
+    TrayIconBuilder::with_id(TRAY_ID)
         .icon(
             app.default_window_icon()
                 .cloned()
@@ -37,31 +83,30 @@ pub fn create_tray<R: Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
         .menu(&menu)
         .tooltip("ClaudeKit Control Center")
         .on_menu_event(|app, event| match event.id.as_ref() {
-            "show" => {
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.show();
-                    let _ = window.set_focus();
+            "open_dashboard" => emit_tray_open(app, "dashboard", None),
+            "open_terminal" => {
+                if let Some(project) = projects::primary_recent_project().ok().flatten() {
+                    if let Err(err) = open_system_terminal(&project.path) {
+                        eprintln!("[tray] failed to open terminal: {err}");
+                    } else if let Err(err) = projects::touch_project_path(app, &project.path) {
+                        eprintln!("[tray] failed to update recent project: {err}");
+                    }
                 }
             }
             "check_updates" => {
-                // Delegate update check to the frontend via tauri-plugin-updater JS API.
-                // Emit an event so the React/TS side can call `checkUpdate()`.
-                // TODO(Phase 2): Add listen("check-updates") handler in frontend
-                // once @tauri-apps/api + @tauri-apps/plugin-updater are installed
-                // and the updater signing key is configured.
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.show();
-                    let _ = window.set_focus();
+                if let Some(window) = focus_main_window(app) {
                     let _ = window.emit("check-updates", ());
                 }
             }
-            "quit" => {
-                app.exit(0);
+            "settings" => emit_tray_open(app, "settings", None),
+            "quit" => app.exit(0),
+            _ => {
+                if let Some(project_id) = event.id.as_ref().strip_prefix(RECENT_PROJECT_PREFIX) {
+                    handle_recent_project_click(app, project_id);
+                }
             }
-            _ => {}
         })
         .on_tray_icon_event(|tray, event| {
-            // Left-click opens the main window (standard macOS/Windows tray behaviour)
             if let TrayIconEvent::Click {
                 button: MouseButton::Left,
                 button_state: MouseButtonState::Up,
@@ -69,13 +114,252 @@ pub fn create_tray<R: Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
             } = event
             {
                 let app = tray.app_handle();
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.show();
-                    let _ = window.set_focus();
-                }
+                let _ = focus_main_window(&app);
             }
         })
         .build(app)?;
 
     Ok(())
+}
+
+pub fn refresh_tray(app: &tauri::AppHandle) -> Result<(), String> {
+    let Some(state) = app.try_state::<TrayState>() else {
+        return Ok(());
+    };
+
+    refresh_recent_projects_menu(app, &state.recent_projects, &state.open_terminal)
+}
+
+fn refresh_recent_projects_menu(
+    app: &tauri::AppHandle,
+    recent_projects_menu: &Submenu<tauri::Wry>,
+    open_terminal: &MenuItem<tauri::Wry>,
+) -> Result<(), String> {
+    while recent_projects_menu
+        .remove_at(0)
+        .map_err(|err| err.to_string())?
+        .is_some()
+    {}
+
+    let recent_projects = projects::list_recent_projects(RECENT_LIMIT)?;
+    open_terminal
+        .set_enabled(!recent_projects.is_empty())
+        .map_err(|err| err.to_string())?;
+
+    if recent_projects.is_empty() {
+        let empty = MenuItem::with_id(
+            app,
+            "recent_projects_empty",
+            "No recent projects",
+            false,
+            None::<&str>,
+        )
+        .map_err(|err| err.to_string())?;
+        recent_projects_menu
+            .append(&empty)
+            .map_err(|err| err.to_string())?;
+        return Ok(());
+    }
+
+    for project in recent_projects {
+        let item = MenuItem::with_id(
+            app,
+            format!("{RECENT_PROJECT_PREFIX}{}", project.project_id),
+            project.name,
+            true,
+            None::<&str>,
+        )
+        .map_err(|err| err.to_string())?;
+        recent_projects_menu
+            .append(&item)
+            .map_err(|err| err.to_string())?;
+    }
+
+    Ok(())
+}
+
+fn handle_recent_project_click(app: &tauri::AppHandle, project_id: &str) {
+    let Ok(path) = project_ids::decode_discovered_project_id(project_id) else {
+        eprintln!("[tray] failed to decode project id: {project_id}");
+        return;
+    };
+    let Ok(project) = projects::touch_project_path(app, &path) else {
+        eprintln!("[tray] failed to update recent project for path: {path}");
+        return;
+    };
+    emit_tray_open(app, "project", Some(project.project_id));
+}
+
+fn emit_tray_open(app: &tauri::AppHandle, destination: &'static str, project_id: Option<String>) {
+    if let Some(window) = focus_main_window(app) {
+        let _ = window.emit(
+            "tray-open",
+            TrayOpenPayload {
+                destination,
+                project_id,
+            },
+        );
+    }
+}
+
+fn focus_main_window(app: &tauri::AppHandle) -> Option<tauri::WebviewWindow> {
+    let window = app.get_webview_window("main")?;
+    let _ = window.show();
+    let _ = window.set_focus();
+    Some(window)
+}
+
+fn open_system_terminal(path: &str) -> Result<(), String> {
+    let command = build_system_terminal_command(path)?;
+    let mut process = Command::new(command.command);
+    process
+        .args(command.args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    if let Some(cwd) = command.cwd {
+        process.current_dir(cwd);
+    }
+
+    process
+        .spawn()
+        .map(|_| ())
+        .map_err(|err| format!("Failed to open system terminal: {err}"))
+}
+
+fn build_system_terminal_command(path: &str) -> Result<TerminalCommand, String> {
+    if !std::path::Path::new(path).is_dir() {
+        return Err(format!("Project path does not exist: {path}"));
+    }
+
+    if cfg!(target_os = "macos") {
+        return Ok(TerminalCommand {
+            command: "open",
+            args: vec!["-a".to_string(), "Terminal".to_string(), path.to_string()],
+            cwd: None,
+        });
+    }
+
+    if cfg!(target_os = "windows") {
+        return Ok(TerminalCommand {
+            command: "cmd.exe",
+            args: vec![
+                "/c".to_string(),
+                "start".to_string(),
+                "cmd".to_string(),
+                "/k".to_string(),
+            ],
+            cwd: Some(path.to_string()),
+        });
+    }
+
+    for candidate in [
+        TerminalCommand {
+            command: "x-terminal-emulator",
+            args: vec!["--working-directory".to_string(), path.to_string()],
+            cwd: None,
+        },
+        TerminalCommand {
+            command: "gnome-terminal",
+            args: vec![format!("--working-directory={path}")],
+            cwd: Some(path.to_string()),
+        },
+        TerminalCommand {
+            command: "konsole",
+            args: vec!["--workdir".to_string(), path.to_string()],
+            cwd: Some(path.to_string()),
+        },
+        TerminalCommand {
+            command: "tilix",
+            args: vec![format!("--working-directory={path}")],
+            cwd: Some(path.to_string()),
+        },
+        TerminalCommand {
+            command: "xfce4-terminal",
+            args: vec![format!("--working-directory={path}")],
+            cwd: Some(path.to_string()),
+        },
+        TerminalCommand {
+            command: "kitty",
+            args: vec!["--directory".to_string(), path.to_string()],
+            cwd: Some(path.to_string()),
+        },
+        TerminalCommand {
+            command: "alacritty",
+            args: vec!["--working-directory".to_string(), path.to_string()],
+            cwd: Some(path.to_string()),
+        },
+        TerminalCommand {
+            command: "wezterm",
+            args: vec!["start".to_string(), "--cwd".to_string(), path.to_string()],
+            cwd: Some(path.to_string()),
+        },
+        TerminalCommand {
+            command: "terminator",
+            args: vec![format!("--working-directory={path}")],
+            cwd: Some(path.to_string()),
+        },
+    ] {
+        if command_exists(candidate.command) {
+            return Ok(candidate);
+        }
+    }
+
+    Err("No supported system terminal was found on PATH".to_string())
+}
+
+fn command_exists(command: &str) -> bool {
+    let checker = if cfg!(target_os = "windows") {
+        "where"
+    } else {
+        "which"
+    };
+
+    Command::new(checker)
+        .arg(command)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_system_terminal_command;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be valid")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("ck-tray-{name}-{unique}"));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+
+    #[test]
+    fn rejects_missing_terminal_paths() {
+        let error = build_system_terminal_command("/tmp/ck-tray-missing")
+            .expect_err("missing path should fail");
+        assert!(error.contains("does not exist"));
+    }
+
+    #[test]
+    fn builds_platform_terminal_command() {
+        let dir = temp_dir("terminal");
+        let command = build_system_terminal_command(&dir.to_string_lossy())
+            .expect("command should build");
+
+        #[cfg(target_os = "macos")]
+        assert_eq!(command.command, "open");
+        #[cfg(target_os = "windows")]
+        assert_eq!(command.command, "cmd.exe");
+        #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+        assert_eq!(command.command, "x-terminal-emulator");
+    }
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -4,6 +4,7 @@ use crate::core::project_ids;
 use crate::projects;
 use serde::Serialize;
 use std::process::{Command, Stdio};
+use std::sync::OnceLock;
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
@@ -29,9 +30,22 @@ struct TrayOpenPayload {
 
 #[derive(Debug)]
 struct TerminalCommand {
-    command: &'static str,
-    args: Vec<String>,
-    cwd: Option<String>,
+	command: &'static str,
+	args: Vec<String>,
+	cwd: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum LinuxTerminalKind {
+	XTerminalEmulator,
+	GnomeTerminal,
+	Konsole,
+	Tilix,
+	Xfce4Terminal,
+	Kitty,
+	Alacritty,
+	Wezterm,
+	Terminator,
 }
 
 pub fn create_tray(app: &tauri::AppHandle) -> tauri::Result<()> {
@@ -141,10 +155,10 @@ fn refresh_recent_projects_menu(
         .is_some()
     {}
 
-    let recent_projects = projects::list_recent_projects(RECENT_LIMIT)?;
-    open_terminal
-        .set_enabled(!recent_projects.is_empty())
-        .map_err(|err| err.to_string())?;
+	let recent_projects = projects::list_recent_projects(RECENT_LIMIT)?;
+	open_terminal
+		.set_enabled(!recent_projects.is_empty() && system_terminal_supported())
+		.map_err(|err| err.to_string())?;
 
     if recent_projects.is_empty() {
         let empty = MenuItem::with_id(
@@ -241,8 +255,8 @@ fn build_system_terminal_command(path: &str) -> Result<TerminalCommand, String> 
         });
     }
 
-    if cfg!(target_os = "windows") {
-        return Ok(TerminalCommand {
+	if cfg!(target_os = "windows") {
+		return Ok(TerminalCommand {
             command: "cmd.exe",
             args: vec![
                 "/c".to_string(),
@@ -251,62 +265,57 @@ fn build_system_terminal_command(path: &str) -> Result<TerminalCommand, String> 
                 "/k".to_string(),
             ],
             cwd: Some(path.to_string()),
-        });
-    }
+		});
+	}
 
-    for candidate in [
-        TerminalCommand {
-            command: "x-terminal-emulator",
-            args: vec!["--working-directory".to_string(), path.to_string()],
-            cwd: None,
-        },
-        TerminalCommand {
-            command: "gnome-terminal",
-            args: vec![format!("--working-directory={path}")],
-            cwd: Some(path.to_string()),
-        },
-        TerminalCommand {
-            command: "konsole",
-            args: vec!["--workdir".to_string(), path.to_string()],
-            cwd: Some(path.to_string()),
-        },
-        TerminalCommand {
-            command: "tilix",
-            args: vec![format!("--working-directory={path}")],
-            cwd: Some(path.to_string()),
-        },
-        TerminalCommand {
-            command: "xfce4-terminal",
-            args: vec![format!("--working-directory={path}")],
-            cwd: Some(path.to_string()),
-        },
-        TerminalCommand {
-            command: "kitty",
-            args: vec!["--directory".to_string(), path.to_string()],
-            cwd: Some(path.to_string()),
-        },
-        TerminalCommand {
-            command: "alacritty",
-            args: vec!["--working-directory".to_string(), path.to_string()],
-            cwd: Some(path.to_string()),
-        },
-        TerminalCommand {
-            command: "wezterm",
-            args: vec!["start".to_string(), "--cwd".to_string(), path.to_string()],
-            cwd: Some(path.to_string()),
-        },
-        TerminalCommand {
-            command: "terminator",
-            args: vec![format!("--working-directory={path}")],
-            cwd: Some(path.to_string()),
-        },
-    ] {
-        if command_exists(candidate.command) {
-            return Ok(candidate);
-        }
-    }
-
-    Err("No supported system terminal was found on PATH".to_string())
+	match cached_linux_terminal_kind() {
+		Some(LinuxTerminalKind::XTerminalEmulator) => Ok(TerminalCommand {
+			command: "x-terminal-emulator",
+			args: vec!["--working-directory".to_string(), path.to_string()],
+			cwd: None,
+		}),
+		Some(LinuxTerminalKind::GnomeTerminal) => Ok(TerminalCommand {
+			command: "gnome-terminal",
+			args: vec![format!("--working-directory={path}")],
+			cwd: Some(path.to_string()),
+		}),
+		Some(LinuxTerminalKind::Konsole) => Ok(TerminalCommand {
+			command: "konsole",
+			args: vec!["--workdir".to_string(), path.to_string()],
+			cwd: Some(path.to_string()),
+		}),
+		Some(LinuxTerminalKind::Tilix) => Ok(TerminalCommand {
+			command: "tilix",
+			args: vec![format!("--working-directory={path}")],
+			cwd: Some(path.to_string()),
+		}),
+		Some(LinuxTerminalKind::Xfce4Terminal) => Ok(TerminalCommand {
+			command: "xfce4-terminal",
+			args: vec![format!("--working-directory={path}")],
+			cwd: Some(path.to_string()),
+		}),
+		Some(LinuxTerminalKind::Kitty) => Ok(TerminalCommand {
+			command: "kitty",
+			args: vec!["--directory".to_string(), path.to_string()],
+			cwd: Some(path.to_string()),
+		}),
+		Some(LinuxTerminalKind::Alacritty) => Ok(TerminalCommand {
+			command: "alacritty",
+			args: vec!["--working-directory".to_string(), path.to_string()],
+			cwd: Some(path.to_string()),
+		}),
+		Some(LinuxTerminalKind::Wezterm) => Ok(TerminalCommand {
+			command: "wezterm",
+			args: vec!["start".to_string(), "--cwd".to_string(), path.to_string()],
+			cwd: Some(path.to_string()),
+		}),
+		Some(LinuxTerminalKind::Terminator) => Ok(TerminalCommand {
+			command: "terminator",
+			args: vec![format!("--working-directory={path}")],
+			cwd: Some(path.to_string()),
+		}),
+		None => Err("No supported system terminal was found on PATH".to_string()),
+	}
 }
 
 fn command_exists(command: &str) -> bool {
@@ -321,8 +330,39 @@ fn command_exists(command: &str) -> bool {
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .status()
-        .is_ok_and(|status| status.success())
+		.status()
+		.is_ok_and(|status| status.success())
+}
+
+fn system_terminal_supported() -> bool {
+	if cfg!(target_os = "macos") || cfg!(target_os = "windows") {
+		return true;
+	}
+	cached_linux_terminal_kind().is_some()
+}
+
+fn cached_linux_terminal_kind() -> Option<LinuxTerminalKind> {
+	static LINUX_TERMINAL_KIND: OnceLock<Option<LinuxTerminalKind>> = OnceLock::new();
+	*LINUX_TERMINAL_KIND.get_or_init(detect_linux_terminal_kind)
+}
+
+fn detect_linux_terminal_kind() -> Option<LinuxTerminalKind> {
+	for candidate in [
+		(LinuxTerminalKind::XTerminalEmulator, "x-terminal-emulator"),
+		(LinuxTerminalKind::GnomeTerminal, "gnome-terminal"),
+		(LinuxTerminalKind::Konsole, "konsole"),
+		(LinuxTerminalKind::Tilix, "tilix"),
+		(LinuxTerminalKind::Xfce4Terminal, "xfce4-terminal"),
+		(LinuxTerminalKind::Kitty, "kitty"),
+		(LinuxTerminalKind::Alacritty, "alacritty"),
+		(LinuxTerminalKind::Wezterm, "wezterm"),
+		(LinuxTerminalKind::Terminator, "terminator"),
+	] {
+		if command_exists(candidate.1) {
+			return Some(candidate.0);
+		}
+	}
+	None
 }
 
 #[cfg(test)]

--- a/src/ui/src/layouts/AppLayout.tsx
+++ b/src/ui/src/layouts/AppLayout.tsx
@@ -63,6 +63,8 @@ const AppLayout: React.FC = () => {
 						return;
 					}
 					if (payload.destination === "settings") {
+						// TODO: tray.rs currently emits settings with no projectId.
+						// Keep the project-scoped branch ready for a future tray shortcut.
 						if (payload.projectId) {
 							navigate(`/config/project/${encodeURIComponent(payload.projectId)}`);
 							return;
@@ -183,14 +185,15 @@ const AppLayout: React.FC = () => {
 	useEffect(() => {
 		if (!desktopMode || !urlProjectId) return;
 		const encodedProjectId = encodeURIComponent(urlProjectId);
-		const isProjectScopedRoute = [
-			`/project/${urlProjectId}`,
-			`/project/${encodedProjectId}`,
-			`/config/project/${urlProjectId}`,
-			`/config/project/${encodedProjectId}`,
-			`/sessions/${urlProjectId}/`,
-			`/sessions/${encodedProjectId}/`,
-		].some((prefix) => location.pathname.startsWith(prefix));
+		const matchesProjectRoute = (prefix: string) =>
+			location.pathname === prefix || location.pathname.startsWith(`${prefix}/`);
+		const isProjectScopedRoute =
+			matchesProjectRoute(`/project/${urlProjectId}`) ||
+			matchesProjectRoute(`/project/${encodedProjectId}`) ||
+			matchesProjectRoute(`/config/project/${urlProjectId}`) ||
+			matchesProjectRoute(`/config/project/${encodedProjectId}`) ||
+			matchesProjectRoute(`/sessions/${urlProjectId}`) ||
+			matchesProjectRoute(`/sessions/${encodedProjectId}`);
 		if (!isProjectScopedRoute) {
 			return;
 		}

--- a/src/ui/src/layouts/AppLayout.tsx
+++ b/src/ui/src/layouts/AppLayout.tsx
@@ -15,7 +15,13 @@ import { isTauri } from "../hooks/use-tauri";
 import { useUpdater } from "../hooks/use-updater";
 import { useResizable } from "../hooks/useResizable";
 import { useI18n } from "../i18n";
+import { touchProject } from "../services/api";
 import type { AppLayoutContext } from "./app-layout-context";
+
+interface TrayOpenPayload {
+	destination: "dashboard" | "project" | "settings";
+	projectId?: string | null;
+}
 
 const AppLayout: React.FC = () => {
 	const { t } = useI18n();
@@ -38,6 +44,51 @@ const AppLayout: React.FC = () => {
 			setSelectedProjectId(urlProjectId);
 		}
 	}, [urlProjectId]);
+
+	useEffect(() => {
+		if (!desktopMode) return;
+
+		let cancelled = false;
+		let unlisten: (() => void) | undefined;
+
+		void (async () => {
+			try {
+				const { listen } = await import("@tauri-apps/api/event");
+				if (cancelled) return;
+				const nextUnlisten = await listen<TrayOpenPayload>("tray-open", (event) => {
+					const payload = event.payload;
+					if (!payload) return;
+					if (payload.destination === "project" && payload.projectId) {
+						navigate(`/project/${encodeURIComponent(payload.projectId)}`);
+						return;
+					}
+					if (payload.destination === "settings") {
+						if (payload.projectId) {
+							navigate(`/config/project/${encodeURIComponent(payload.projectId)}`);
+							return;
+						}
+						navigate("/config/global");
+						return;
+					}
+					navigate("/dashboard");
+				});
+				if (cancelled) {
+					nextUnlisten();
+					return;
+				}
+				unlisten = nextUnlisten;
+			} catch (error) {
+				if (!cancelled) {
+					console.error("[desktop-tray] Failed to register tray-open listener", error);
+				}
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+			unlisten?.();
+		};
+	}, [desktopMode, navigate]);
 
 	const [theme, setTheme] = useState<"light" | "dark">(() => {
 		if (typeof window !== "undefined") {
@@ -128,6 +179,22 @@ const AppLayout: React.FC = () => {
 		() => projects.find((p) => p.id === selectedProjectId) || null,
 		[projects, selectedProjectId],
 	);
+
+	useEffect(() => {
+		if (!desktopMode || !urlProjectId) return;
+		const encodedProjectId = encodeURIComponent(urlProjectId);
+		const isProjectScopedRoute = location.pathname
+			.split("/")
+			.some((segment) => segment === urlProjectId || segment === encodedProjectId);
+		if (!isProjectScopedRoute) {
+			return;
+		}
+		const routeProject = projects.find((project) => project.id === urlProjectId);
+		if (!routeProject?.path) return;
+		void touchProject(routeProject.path).catch((error) => {
+			console.error("[desktop-tray] Failed to touch project recency", error);
+		});
+	}, [desktopMode, location.pathname, projects, urlProjectId]);
 
 	const handleSwitchProject = (id: string) => {
 		navigate(`/project/${id}`);

--- a/src/ui/src/layouts/AppLayout.tsx
+++ b/src/ui/src/layouts/AppLayout.tsx
@@ -183,9 +183,14 @@ const AppLayout: React.FC = () => {
 	useEffect(() => {
 		if (!desktopMode || !urlProjectId) return;
 		const encodedProjectId = encodeURIComponent(urlProjectId);
-		const isProjectScopedRoute = location.pathname
-			.split("/")
-			.some((segment) => segment === urlProjectId || segment === encodedProjectId);
+		const isProjectScopedRoute = [
+			`/project/${urlProjectId}`,
+			`/project/${encodedProjectId}`,
+			`/config/project/${urlProjectId}`,
+			`/config/project/${encodedProjectId}`,
+			`/sessions/${urlProjectId}/`,
+			`/sessions/${encodedProjectId}/`,
+		].some((prefix) => location.pathname.startsWith(prefix));
 		if (!isProjectScopedRoute) {
 			return;
 		}

--- a/src/ui/src/layouts/__tests__/app-layout.vitest.tsx
+++ b/src/ui/src/layouts/__tests__/app-layout.vitest.tsx
@@ -1,0 +1,168 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const navigateMock = vi.fn();
+const listenMock = vi.fn();
+const touchProjectMock = vi.fn();
+const routeState = {
+	pathname: "/project/project-alpha",
+	projectId: "project-alpha" as string | undefined,
+};
+
+vi.mock("react-router-dom", () => ({
+	Outlet: () => <div>outlet</div>,
+	useLocation: () => ({ pathname: routeState.pathname }),
+	useNavigate: () => navigateMock,
+	useParams: () => ({ projectId: routeState.projectId }),
+}));
+
+vi.mock("../../components/SearchPalette", () => ({
+	default: () => null,
+}));
+
+vi.mock("../../components/Sidebar", () => ({
+	default: () => null,
+}));
+
+vi.mock("../../components/ResizeHandle", () => ({
+	default: () => null,
+}));
+
+vi.mock("../../hooks", () => ({
+	useProjects: () => ({
+		projects: [
+			{
+				id: "project-alpha",
+				name: "Alpha",
+				path: "/tmp/alpha",
+				health: "healthy",
+				kitType: "engineer",
+				model: "gpt-5",
+				activeHooks: 0,
+				mcpServers: 0,
+				skills: [],
+			},
+		],
+		loading: false,
+		error: null,
+		addProject: vi.fn(),
+		reload: vi.fn(),
+	}),
+}));
+
+vi.mock("../../hooks/use-desktop-onboarding-gate", () => ({
+	useDesktopOnboardingGate: () => ({
+		checking: false,
+		shouldShowOnboarding: false,
+		dismissOnboarding: vi.fn(),
+	}),
+}));
+
+vi.mock("../../hooks/use-tauri", () => ({
+	isTauri: () => true,
+}));
+
+vi.mock("../../hooks/use-updater", () => ({
+	useUpdater: () => ({ updateAvailable: false }),
+}));
+
+vi.mock("../../hooks/useResizable", () => ({
+	useResizable: () => ({
+		size: 288,
+		isDragging: false,
+		startDrag: vi.fn(),
+		setSize: vi.fn(),
+	}),
+}));
+
+vi.mock("../../i18n", () => ({
+	useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("../../services/api", () => ({
+	touchProject: (...args: unknown[]) => touchProjectMock(...args),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+	listen: (...args: unknown[]) => listenMock(...args),
+}));
+
+describe("AppLayout tray integration", () => {
+	beforeEach(() => {
+		navigateMock.mockReset();
+		touchProjectMock.mockReset();
+		listenMock.mockReset();
+		routeState.pathname = "/project/project-alpha";
+		routeState.projectId = "project-alpha";
+		Object.defineProperty(window, "localStorage", {
+			configurable: true,
+			value: {
+				getItem: vi.fn().mockReturnValue(null),
+				setItem: vi.fn(),
+				removeItem: vi.fn(),
+				clear: vi.fn(),
+			},
+		});
+	});
+
+	it("touches the current desktop project on mount", async () => {
+		listenMock.mockResolvedValue(vi.fn());
+		touchProjectMock.mockResolvedValue(undefined);
+		const { default: AppLayout } = await import("../AppLayout");
+
+		render(<AppLayout />);
+
+		await waitFor(() => expect(touchProjectMock).toHaveBeenCalledWith("/tmp/alpha"));
+	});
+
+	it("touches the same project again when re-entering its route", async () => {
+		listenMock.mockResolvedValue(vi.fn());
+		touchProjectMock.mockResolvedValue(undefined);
+		const { default: AppLayout } = await import("../AppLayout");
+
+		const { rerender } = render(<AppLayout />);
+		await waitFor(() => expect(touchProjectMock).toHaveBeenCalled());
+		const initialCalls = touchProjectMock.mock.calls.length;
+
+		touchProjectMock.mockClear();
+		routeState.pathname = "/dashboard";
+		routeState.projectId = undefined;
+		rerender(<AppLayout />);
+
+		routeState.pathname = "/project/project-alpha";
+		routeState.projectId = "project-alpha";
+		rerender(<AppLayout />);
+
+		await waitFor(() => expect(touchProjectMock).toHaveBeenCalledWith("/tmp/alpha"));
+		expect(initialCalls).toBeGreaterThan(0);
+	});
+
+	it("navigates to tray-selected routes from tray-open events", async () => {
+		let trayHandler:
+			| ((event: { payload: { destination: string; projectId?: string | null } }) => void)
+			| undefined;
+		const unlistenMock = vi.fn();
+		listenMock.mockImplementation((_event, handler) => {
+			trayHandler = handler;
+			return Promise.resolve(unlistenMock);
+		});
+		touchProjectMock.mockResolvedValue(undefined);
+		const { default: AppLayout } = await import("../AppLayout");
+
+		const { unmount } = render(<AppLayout />);
+
+		await waitFor(() => expect(listenMock).toHaveBeenCalledWith("tray-open", expect.any(Function)));
+
+		trayHandler?.({ payload: { destination: "project", projectId: "project-beta" } });
+		expect(navigateMock).toHaveBeenCalledWith("/project/project-beta");
+
+		trayHandler?.({ payload: { destination: "settings" } });
+		expect(navigateMock).toHaveBeenCalledWith("/config/global");
+
+		trayHandler?.({ payload: { destination: "dashboard" } });
+		expect(navigateMock).toHaveBeenCalledWith("/dashboard");
+
+		unmount();
+		expect(unlistenMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/ui/src/layouts/__tests__/app-layout.vitest.tsx
+++ b/src/ui/src/layouts/__tests__/app-layout.vitest.tsx
@@ -32,7 +32,7 @@ vi.mock("../../hooks", () => ({
 	useProjects: () => ({
 		projects: [
 			{
-				id: "project-alpha",
+				id: routeState.projectId ?? "project-alpha",
 				name: "Alpha",
 				path: "/tmp/alpha",
 				health: "healthy",
@@ -79,9 +79,13 @@ vi.mock("../../i18n", () => ({
 	useI18n: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock("../../services/api", () => ({
-	touchProject: (...args: unknown[]) => touchProjectMock(...args),
-}));
+vi.mock("../../services/api", async () => {
+	const actual = await vi.importActual<typeof import("../../services/api")>("../../services/api");
+	return {
+		...actual,
+		touchProject: (...args: unknown[]) => touchProjectMock(...args),
+	};
+});
 
 vi.mock("@tauri-apps/api/event", () => ({
 	listen: (...args: unknown[]) => listenMock(...args),
@@ -108,6 +112,9 @@ describe("AppLayout tray integration", () => {
 	it("touches the current desktop project on mount", async () => {
 		listenMock.mockResolvedValue(vi.fn());
 		touchProjectMock.mockResolvedValue(undefined);
+		const { tauriProjectId } = await import("../../services/api");
+		routeState.projectId = tauriProjectId("/tmp/alpha");
+		routeState.pathname = `/project/${routeState.projectId}`;
 		const { default: AppLayout } = await import("../AppLayout");
 
 		render(<AppLayout />);
@@ -118,6 +125,9 @@ describe("AppLayout tray integration", () => {
 	it("touches the same project again when re-entering its route", async () => {
 		listenMock.mockResolvedValue(vi.fn());
 		touchProjectMock.mockResolvedValue(undefined);
+		const { tauriProjectId } = await import("../../services/api");
+		routeState.projectId = tauriProjectId("/tmp/alpha");
+		routeState.pathname = `/project/${routeState.projectId}`;
 		const { default: AppLayout } = await import("../AppLayout");
 
 		const { rerender } = render(<AppLayout />);
@@ -129,8 +139,8 @@ describe("AppLayout tray integration", () => {
 		routeState.projectId = undefined;
 		rerender(<AppLayout />);
 
-		routeState.pathname = "/project/project-alpha";
-		routeState.projectId = "project-alpha";
+		routeState.projectId = tauriProjectId("/tmp/alpha");
+		routeState.pathname = `/project/${routeState.projectId}`;
 		rerender(<AppLayout />);
 
 		await waitFor(() => expect(touchProjectMock).toHaveBeenCalledWith("/tmp/alpha"));
@@ -147,14 +157,18 @@ describe("AppLayout tray integration", () => {
 			return Promise.resolve(unlistenMock);
 		});
 		touchProjectMock.mockResolvedValue(undefined);
+		const { tauriProjectId } = await import("../../services/api");
+		routeState.projectId = tauriProjectId("/tmp/alpha");
+		routeState.pathname = `/project/${routeState.projectId}`;
 		const { default: AppLayout } = await import("../AppLayout");
 
 		const { unmount } = render(<AppLayout />);
 
 		await waitFor(() => expect(listenMock).toHaveBeenCalledWith("tray-open", expect.any(Function)));
 
-		trayHandler?.({ payload: { destination: "project", projectId: "project-beta" } });
-		expect(navigateMock).toHaveBeenCalledWith("/project/project-beta");
+		const betaProjectId = tauriProjectId("/tmp/beta");
+		trayHandler?.({ payload: { destination: "project", projectId: betaProjectId } });
+		expect(navigateMock).toHaveBeenCalledWith(`/project/${betaProjectId}`);
 
 		trayHandler?.({ payload: { destination: "settings" } });
 		expect(navigateMock).toHaveBeenCalledWith("/config/global");

--- a/src/ui/src/lib/tauri-commands.ts
+++ b/src/ui/src/lib/tauri-commands.ts
@@ -94,6 +94,10 @@ export const addProject = (path: string): Promise<ProjectInfo> =>
 export const removeProject = (path: string): Promise<void> =>
 	invoke<void>("remove_project", { path });
 
+/** Update a project's last-opened timestamp in the desktop registry. */
+export const touchProject = (path: string): Promise<void> =>
+	invoke<void>("touch_project", { path });
+
 /**
  * Recursively scan a root directory for ClaudeKit projects (.claude/ presence).
  * `maxDepth` caps recursion depth (default 3 on Rust side).

--- a/src/ui/src/services/__tests__/api.vitest.ts
+++ b/src/ui/src/services/__tests__/api.vitest.ts
@@ -148,7 +148,7 @@ describe("api service dual-mode routing", () => {
 	it("touchProject invalidates the cached project lookup in Tauri mode", async () => {
 		vi.mocked(isTauri).mockReturnValue(true);
 		const projectPath = "/tmp/test";
-		const projectId = `discovered-${Buffer.from(projectPath).toString("base64url")}`;
+		const projectId = api.tauriProjectId(projectPath);
 		vi.mocked(tauri.listProjects).mockResolvedValue([
 			{ name: "Test Project", path: projectPath, hasClaudeConfig: true, hasCkConfig: true },
 		]);

--- a/src/ui/src/services/__tests__/api.vitest.ts
+++ b/src/ui/src/services/__tests__/api.vitest.ts
@@ -12,6 +12,7 @@ vi.mock("../../lib/tauri-commands", () => ({
 	getGlobalConfigDir: vi.fn(),
 	readSettings: vi.fn(),
 	getHealth: vi.fn(),
+	touchProject: vi.fn(),
 }));
 
 vi.mock("@/hooks/use-tauri", () => ({
@@ -142,5 +143,29 @@ describe("api service dual-mode routing", () => {
 		const result = await api.checkHealth();
 		expect(result).toBe(true);
 		expect(tauri.getHealth).toHaveBeenCalled();
+	});
+
+	it("touchProject invalidates the cached project lookup in Tauri mode", async () => {
+		vi.mocked(isTauri).mockReturnValue(true);
+		const projectPath = "/tmp/test";
+		const projectId = `discovered-${Buffer.from(projectPath).toString("base64url")}`;
+		vi.mocked(tauri.listProjects).mockResolvedValue([
+			{ name: "Test Project", path: projectPath, hasClaudeConfig: true, hasCkConfig: true },
+		]);
+		vi.mocked(tauri.readSettings).mockResolvedValue({});
+		vi.mocked(tauri.touchProject).mockResolvedValue();
+
+		await api.fetchProject(projectId);
+		expect(tauri.listProjects).toHaveBeenCalledTimes(1);
+
+		await api.fetchProject(projectId);
+		expect(tauri.listProjects).toHaveBeenCalledTimes(1);
+
+		await api.touchProject(projectPath);
+		await api.fetchProject(projectId);
+
+		expect(tauri.touchProject).toHaveBeenCalledWith(projectPath);
+		expect(tauri.listProjects).toHaveBeenCalledTimes(2);
+		expect(fetchMock).not.toHaveBeenCalled();
 	});
 });

--- a/src/ui/src/services/api.ts
+++ b/src/ui/src/services/api.ts
@@ -712,6 +712,12 @@ export async function updateProject(id: string, updates: UpdateProjectRequest): 
 	});
 }
 
+export async function touchProject(path: string): Promise<void> {
+	if (!isTauri()) return;
+	await tauri.touchProject(path);
+	invalidateProjectCache();
+}
+
 // Metadata operations
 
 export async function fetchGlobalMetadata(): Promise<Record<string, unknown>> {

--- a/src/ui/src/services/api.ts
+++ b/src/ui/src/services/api.ts
@@ -50,7 +50,7 @@ async function requireBackend(): Promise<void> {
  * Must match Rust's `discovered_project_id()` which uses URL_SAFE_NO_PAD
  * base64 encoding of the raw UTF-8 bytes.
  */
-function tauriProjectId(path: string): string {
+export function tauriProjectId(path: string): string {
 	const bytes = new TextEncoder().encode(path);
 	let binary = "";
 	for (const b of bytes) binary += String.fromCharCode(b);


### PR DESCRIPTION
## Summary
- add native tray recent-project actions for the desktop Control Center
- route tray-open events into the React shell and refresh recency on project-scoped desktop routes
- preserve shared project-registry metadata while hardening desktop registry writes with locking and atomic saves
- add desktop tray regression tests and update desktop roadmap/architecture docs

Closes #692

## Validation
- bun run validate
- cargo test --manifest-path src-tauri/Cargo.toml
- parallel red-team/code-review pass completed and findings addressed
