### PR TITLE
feat: Phase 6 — desktop distribution pipeline v2 (CI gating + dev channel)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Tests
+        run: bun test
+
   build:
     if: github.event_name != 'pull_request'
     strategy:
@@ -203,6 +206,16 @@ jobs:
       - name: Display downloaded artifacts
         run: find artifacts/ -type f | sort
 
+      - name: Detect release channel
+        id: channel
+        run: |
+          TAG="${{ github.ref_name }}"
+          if [[ "$TAG" == *"-dev."* ]]; then
+            echo "is_dev=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_dev=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Prepare release assets
         run: |
           set -euo pipefail
@@ -250,20 +263,14 @@ jobs:
         run: |
           TAG="${{ github.ref_name }}"
           VERSION="${TAG#desktop-v}"
-
-          # Detect dev channel: tag contains -dev. after version
-          if [[ "$TAG" == *"-dev."* ]]; then
-            IS_DEV_TAG=true
-          else
-            IS_DEV_TAG=false
-          fi
+          IS_DEV="${{ steps.channel.outputs.is_dev }}"
 
           ASSETS=()
           while IFS= read -r f; do
             ASSETS+=("$f")
           done < <(find release-assets/ -type f | sort)
 
-          if [ "$IS_DEV_TAG" = "true" ]; then
+          if [ "$IS_DEV" = "true" ]; then
             gh release create "$TAG" \
               --title "ClaudeKit Desktop v${VERSION} (dev)" \
               --generate-notes \
@@ -286,8 +293,8 @@ jobs:
 
           gh release upload "$TAG" desktop-manifest.json --clobber
 
-          # Route manifest to channel pointer based on tag convention
-          if [[ "$TAG" == *"-dev."* ]]; then
+          # Route manifest to channel pointer based on detected channel
+          if [ "${{ steps.channel.outputs.is_dev }}" = "true" ]; then
             # Dev channel pointer
             gh release create "desktop-latest-dev" \
               --title "Desktop Latest Dev (distribution manifest)" \

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -17,7 +17,57 @@ on:
   workflow_dispatch:
 
 jobs:
+  check:
+    name: PR Typecheck Gate
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libsecret-1-dev
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.2
+
+      - name: Install frontend dependencies
+        run: bun install --frozen-lockfile
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Rust typecheck
+        working-directory: src-tauri
+        run: cargo check
+
+      - name: TS typecheck
+        run: bun run typecheck
+
+      - name: UI build (strict TSC)
+        run: bun run ui:build
+
+      - name: Lint
+        run: bun run lint
+
   build:
+    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -201,16 +251,30 @@ jobs:
           TAG="${{ github.ref_name }}"
           VERSION="${TAG#desktop-v}"
 
-          # Collect all release assets
+          # Detect dev channel: tag contains -dev. after version
+          if [[ "$TAG" == *"-dev."* ]]; then
+            IS_DEV_TAG=true
+          else
+            IS_DEV_TAG=false
+          fi
+
           ASSETS=()
           while IFS= read -r f; do
             ASSETS+=("$f")
           done < <(find release-assets/ -type f | sort)
 
-          gh release create "$TAG" \
-            --title "ClaudeKit Desktop v${VERSION}" \
-            --generate-notes \
-            "${ASSETS[@]}"
+          if [ "$IS_DEV_TAG" = "true" ]; then
+            gh release create "$TAG" \
+              --title "ClaudeKit Desktop v${VERSION} (dev)" \
+              --generate-notes \
+              --prerelease \
+              "${ASSETS[@]}"
+          else
+            gh release create "$TAG" \
+              --title "ClaudeKit Desktop v${VERSION}" \
+              --generate-notes \
+              "${ASSETS[@]}"
+          fi
 
       - name: Generate desktop-manifest.json for desktop distribution
         env:
@@ -222,7 +286,19 @@ jobs:
 
           gh release upload "$TAG" desktop-manifest.json --clobber
 
-          gh release create "desktop-latest" --title "Desktop Latest (distribution manifest)" \
-            --notes "Auto-maintained by CI. Points to the latest desktop distribution manifest." \
-            --latest=false 2>/dev/null || true
-          gh release upload "desktop-latest" desktop-manifest.json --clobber
+          # Route manifest to channel pointer based on tag convention
+          if [[ "$TAG" == *"-dev."* ]]; then
+            # Dev channel pointer
+            gh release create "desktop-latest-dev" \
+              --title "Desktop Latest Dev (distribution manifest)" \
+              --notes "Auto-maintained by CI. Points to the latest dev desktop distribution manifest." \
+              --latest=false 2>/dev/null || true
+            gh release upload "desktop-latest-dev" desktop-manifest.json --clobber
+          else
+            # Stable channel pointer (unchanged behavior)
+            gh release create "desktop-latest" \
+              --title "Desktop Latest (distribution manifest)" \
+              --notes "Auto-maintained by CI. Points to the latest desktop distribution manifest." \
+              --latest=false 2>/dev/null || true
+            gh release upload "desktop-latest" desktop-manifest.json --clobber
+          fi

--- a/src/__tests__/commands/app/app-command.test.ts
+++ b/src/__tests__/commands/app/app-command.test.ts
@@ -1,5 +1,49 @@
 import { describe, expect, mock, test } from "bun:test";
 import { appCommand } from "@/commands/app/app-command.js";
+import type { AppCommandDependencies } from "@/commands/app/types.js";
+
+/** Minimal injectable stubs for channel resolution tests */
+function makeStubs(overrides: Partial<AppCommandDependencies> = {}): AppCommandDependencies {
+	return {
+		getBinaryPath: mock(() => null),
+		getInstallPath: mock(() => "/tmp/test-install"),
+		downloadBinary: mock(async () => "/tmp/test-binary"),
+		installBinary: mock(async (p: string) => p),
+		launchBinary: mock(() => {}),
+		uninstallBinary: mock(async () => ({ path: "/tmp/test-install", removed: false })),
+		info: mock(() => {}),
+		success: mock(() => {}),
+		printLine: mock(() => {}),
+		...overrides,
+	};
+}
+
+describe("appCommand channel resolution", () => {
+	test("--dev flag passes dev channel to downloadBinary", async () => {
+		const deps = makeStubs();
+		await appCommand({ dev: true }, deps);
+		expect(deps.downloadBinary).toHaveBeenCalledWith({ channel: "dev" });
+	});
+
+	test("--stable flag passes stable channel to downloadBinary", async () => {
+		const deps = makeStubs();
+		await appCommand({ stable: true }, deps);
+		expect(deps.downloadBinary).toHaveBeenCalledWith({ channel: "stable" });
+	});
+
+	test("--dev --stable together throws mutual exclusion error", async () => {
+		const deps = makeStubs();
+		await expect(appCommand({ dev: true, stable: true }, deps)).rejects.toThrow(/stable/i);
+	});
+
+	test("no flags causes downloadBinary to be called (auto-detect channel)", async () => {
+		// packageInfo.version in the test environment is the real package.json version.
+		// We only verify that downloadBinary is invoked — channel auto-detected.
+		const deps = makeStubs();
+		await appCommand({}, deps);
+		expect(deps.downloadBinary).toHaveBeenCalled();
+	});
+});
 
 describe("appCommand", () => {
 	test("launches the installed desktop binary when it already exists", async () => {

--- a/src/__tests__/domains/desktop/desktop-asset-selector.test.ts
+++ b/src/__tests__/domains/desktop/desktop-asset-selector.test.ts
@@ -8,6 +8,7 @@ import type { DesktopReleaseManifest } from "@/types/desktop.js";
 const manifest: DesktopReleaseManifest = {
 	version: "0.1.0",
 	date: "2026-04-15T21:00:00Z",
+	channel: "stable",
 	platforms: {
 		"darwin-aarch64": {
 			name: "mac-arm.zip",

--- a/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
+++ b/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
@@ -8,6 +8,7 @@ import type { DesktopReleaseManifest } from "@/types/desktop.js";
 const manifest: DesktopReleaseManifest = {
 	version: "0.1.0",
 	date: "2026-04-15T21:00:00Z",
+	channel: "stable",
 	platforms: {
 		"darwin-aarch64": {
 			name: "claudekit-control-center_0.1.0_macos-universal.app.zip",

--- a/src/__tests__/domains/desktop/desktop-release-manifest.test.ts
+++ b/src/__tests__/domains/desktop/desktop-release-manifest.test.ts
@@ -181,4 +181,73 @@ describe("desktop-release-manifest", () => {
 			}),
 		).toThrow();
 	});
+
+	test("parses manifest with explicit channel field", () => {
+		const parsed = parseDesktopReleaseManifest({
+			version: "0.1.0",
+			date: "2026-04-15T21:00:00Z",
+			channel: "dev",
+			platforms: {
+				"darwin-aarch64": {
+					name: "mac.zip",
+					url: "https://example.com/mac.zip",
+					size: 100,
+					assetType: "app-zip",
+				},
+				"darwin-x86_64": {
+					name: "mac.zip",
+					url: "https://example.com/mac.zip",
+					size: 100,
+					assetType: "app-zip",
+				},
+				"linux-x86_64": {
+					name: "linux.AppImage",
+					url: "https://example.com/linux.AppImage",
+					size: 200,
+					assetType: "appimage",
+				},
+				"windows-x86_64": {
+					name: "windows.exe",
+					url: "https://example.com/windows.exe",
+					size: 300,
+					assetType: "portable-exe",
+				},
+			},
+		});
+		expect(parsed.channel).toBe("dev");
+	});
+
+	test("defaults channel to stable when field is absent (backward compat)", () => {
+		const parsed = parseDesktopReleaseManifest({
+			version: "0.1.0",
+			date: "2026-04-15T21:00:00Z",
+			platforms: {
+				"darwin-aarch64": {
+					name: "mac.zip",
+					url: "https://example.com/mac.zip",
+					size: 100,
+					assetType: "app-zip",
+				},
+				"darwin-x86_64": {
+					name: "mac.zip",
+					url: "https://example.com/mac.zip",
+					size: 100,
+					assetType: "app-zip",
+				},
+				"linux-x86_64": {
+					name: "linux.AppImage",
+					url: "https://example.com/linux.AppImage",
+					size: 200,
+					assetType: "appimage",
+				},
+				"windows-x86_64": {
+					name: "windows.exe",
+					url: "https://example.com/windows.exe",
+					size: 300,
+					assetType: "portable-exe",
+				},
+			},
+		});
+		expect(parsed.channel).toBe("stable");
+	});
 });

--- a/src/__tests__/domains/desktop/desktop-release-service.test.ts
+++ b/src/__tests__/domains/desktop/desktop-release-service.test.ts
@@ -5,16 +5,29 @@ import {
 } from "@/domains/desktop/desktop-release-service.js";
 
 describe("desktop-release-service", () => {
-	test("builds latest and version-specific manifest URLs", () => {
+	test("builds stable latest URL (no args)", () => {
 		expect(getDesktopManifestUrl()).toBe(
 			"https://github.com/mrgoonie/claudekit-cli/releases/download/desktop-latest/desktop-manifest.json",
 		);
-		expect(getDesktopManifestUrl("0.1.0")).toBe(
+	});
+
+	test("builds dev latest URL (channel=dev)", () => {
+		expect(getDesktopManifestUrl({ channel: "dev" })).toBe(
+			"https://github.com/mrgoonie/claudekit-cli/releases/download/desktop-latest-dev/desktop-manifest.json",
+		);
+	});
+
+	test("builds version-specific URL (version overrides channel)", () => {
+		expect(getDesktopManifestUrl({ version: "0.1.0" })).toBe(
+			"https://github.com/mrgoonie/claudekit-cli/releases/download/desktop-v0.1.0/desktop-manifest.json",
+		);
+		// version + channel: version wins, channel is ignored (specific tag, not pointer)
+		expect(getDesktopManifestUrl({ version: "0.1.0", channel: "dev" })).toBe(
 			"https://github.com/mrgoonie/claudekit-cli/releases/download/desktop-v0.1.0/desktop-manifest.json",
 		);
 	});
 
-	test("fetches and parses the desktop manifest", async () => {
+	test("fetches and parses the desktop manifest (stable channel)", async () => {
 		const fetchFn = mock(async () => ({
 			ok: true,
 			json: async () => ({
@@ -60,6 +73,49 @@ describe("desktop-release-service", () => {
 		expect(manifest.platforms["windows-x86_64"]?.assetType).toBe("portable-exe");
 	});
 
+	test("fetchDesktopReleaseManifest calls dev URL when channel=dev", async () => {
+		const fetchFn = mock(async () => ({
+			ok: true,
+			json: async () => ({
+				version: "0.1.0",
+				date: "2026-04-15T21:00:00Z",
+				channel: "dev",
+				platforms: {
+					"darwin-aarch64": {
+						name: "mac.zip",
+						url: "https://example.com/mac.zip",
+						size: 100,
+						assetType: "app-zip",
+					},
+					"darwin-x86_64": {
+						name: "mac.zip",
+						url: "https://example.com/mac.zip",
+						size: 100,
+						assetType: "app-zip",
+					},
+					"linux-x86_64": {
+						name: "linux.AppImage",
+						url: "https://example.com/linux.AppImage",
+						size: 200,
+						assetType: "appimage",
+					},
+					"windows-x86_64": {
+						name: "windows.exe",
+						url: "https://example.com/windows.exe",
+						size: 300,
+						assetType: "portable-exe",
+					},
+				},
+			}),
+		}));
+
+		await fetchDesktopReleaseManifest({ channel: "dev" }, fetchFn as unknown as typeof fetch);
+
+		expect(fetchFn).toHaveBeenCalledWith(
+			"https://github.com/mrgoonie/claudekit-cli/releases/download/desktop-latest-dev/desktop-manifest.json",
+		);
+	});
+
 	test("throws when the manifest request fails", async () => {
 		const fetchFn = mock(async () => ({
 			ok: false,
@@ -68,7 +124,7 @@ describe("desktop-release-service", () => {
 		}));
 
 		await expect(
-			fetchDesktopReleaseManifest(undefined, fetchFn as unknown as typeof fetch),
+			fetchDesktopReleaseManifest({}, fetchFn as unknown as typeof fetch),
 		).rejects.toThrow(/404/i);
 	});
 });

--- a/src/commands/app/app-command.ts
+++ b/src/commands/app/app-command.ts
@@ -1,4 +1,5 @@
 import { configUICommand } from "@/commands/config/config-ui-command.js";
+import type { DesktopChannel } from "@/domains/desktop/desktop-release-service.js";
 import {
 	downloadDesktopBinary,
 	getDesktopBinaryPath,
@@ -7,12 +8,16 @@ import {
 	launchDesktopApp,
 	uninstallDesktopBinary,
 } from "@/domains/desktop/index.js";
+import { isPrereleaseVersion } from "@/domains/versioning/checking/version-utils.js";
 import { output } from "@/shared/output-manager.js";
 import type { cac } from "cac";
+import packageInfo from "../../../package.json" assert { type: "json" };
 import type { AppCommandDependencies, AppCommandOptions } from "./types.js";
 
 const APP_ACTION_CONFLICT_ERROR =
 	"Use only one of --web, --update, --path, or --uninstall per invocation.";
+
+const DEV_STABLE_CONFLICT_ERROR = "Use only one of --dev or --stable per invocation.";
 
 function ensureExclusiveAction(options: AppCommandOptions): void {
 	const enabledFlags = [options.web, options.update, options.path, options.uninstall].filter(
@@ -23,16 +28,30 @@ function ensureExclusiveAction(options: AppCommandOptions): void {
 	}
 }
 
+function resolveDesktopChannel(options: AppCommandOptions): DesktopChannel {
+	if (options.dev && options.stable) {
+		throw new Error(DEV_STABLE_CONFLICT_ERROR);
+	}
+	if (options.dev) return "dev";
+	if (options.stable) return "stable";
+	// Auto-detect: if the running CLI version is a prerelease, default to dev channel
+	return isPrereleaseVersion(packageInfo.version) ? "dev" : "stable";
+}
+
 export async function appCommand(
 	options: AppCommandOptions = {},
 	deps: AppCommandDependencies = {},
 ): Promise<void> {
 	ensureExclusiveAction(options);
+	const channel = resolveDesktopChannel(options);
 
 	const launchWeb = deps.launchWeb || configUICommand;
 	const getBinaryPath = deps.getBinaryPath || getDesktopBinaryPath;
 	const getInstallPath = deps.getInstallPath || getDesktopInstallPath;
-	const downloadBinary = deps.downloadBinary || downloadDesktopBinary;
+	const downloadBinary =
+		deps.downloadBinary ||
+		((opts?: { channel?: DesktopChannel }) =>
+			downloadDesktopBinary(undefined, { channel: opts?.channel }));
 	const installBinary = deps.installBinary || installDesktopBinary;
 	const launchBinary = deps.launchBinary || launchDesktopApp;
 	const uninstallBinary = deps.uninstallBinary || uninstallDesktopBinary;
@@ -78,7 +97,7 @@ export async function appCommand(
 			? "Downloading the latest ClaudeKit Control Center build..."
 			: "ClaudeKit Control Center not found. Downloading...",
 	);
-	const downloadedBinary = await downloadBinary();
+	const downloadedBinary = await downloadBinary({ channel });
 	const installedBinary = await installBinary(downloadedBinary);
 	success(`Installed ClaudeKit Control Center to ${installedBinary}`);
 	success("Launching ClaudeKit Control Center...");
@@ -92,6 +111,8 @@ export function registerAppCommand(cli: ReturnType<typeof cac>): void {
 		.option("--update", "Download and install the latest desktop build before launching")
 		.option("--path", "Print the current install path (or target path) and exit")
 		.option("--uninstall", "Remove the installed desktop app and exit")
+		.option("--dev", "Force dev channel for this invocation")
+		.option("--stable", "Force stable channel for this invocation")
 		.action(async (options: AppCommandOptions) => {
 			await appCommand(options);
 		});

--- a/src/commands/app/types.ts
+++ b/src/commands/app/types.ts
@@ -1,4 +1,5 @@
 import type { ConfigUIOptions } from "@/commands/config/types.js";
+import type { DesktopChannel } from "@/domains/desktop/desktop-release-service.js";
 import type { DesktopUninstallResult } from "@/domains/desktop/desktop-uninstaller.js";
 
 export interface AppCommandOptions {
@@ -6,13 +7,15 @@ export interface AppCommandOptions {
 	update?: boolean;
 	path?: boolean;
 	uninstall?: boolean;
+	dev?: boolean;
+	stable?: boolean;
 }
 
 export interface AppCommandDependencies {
 	launchWeb?: (options?: ConfigUIOptions) => Promise<void>;
 	getBinaryPath?: () => string | null;
 	getInstallPath?: () => string;
-	downloadBinary?: () => Promise<string>;
+	downloadBinary?: (opts?: { channel?: DesktopChannel }) => Promise<string>;
 	installBinary?: (downloadPath: string) => Promise<string>;
 	launchBinary?: (binaryPath: string) => void;
 	uninstallBinary?: () => Promise<DesktopUninstallResult>;

--- a/src/domains/desktop/desktop-binary-manager.ts
+++ b/src/domains/desktop/desktop-binary-manager.ts
@@ -6,7 +6,10 @@ import {
 	getDesktopInstallPath,
 } from "@/domains/desktop/desktop-install-path-resolver.js";
 import { installDesktopBinary } from "@/domains/desktop/desktop-installer.js";
-import { fetchDesktopReleaseManifest } from "@/domains/desktop/desktop-release-service.js";
+import {
+	type DesktopChannel,
+	fetchDesktopReleaseManifest,
+} from "@/domains/desktop/desktop-release-service.js";
 import { FileDownloader } from "@/domains/installation/download/file-downloader.js";
 
 export function getDesktopBinaryPath(
@@ -23,6 +26,7 @@ export function getDesktopBinaryPath(
 export async function downloadDesktopBinary(
 	version?: string,
 	options: {
+		channel?: DesktopChannel;
 		platform?: NodeJS.Platform;
 		arch?: string;
 		fetchManifest?: typeof fetchDesktopReleaseManifest;
@@ -37,7 +41,7 @@ export async function downloadDesktopBinary(
 	} = {},
 ): Promise<string> {
 	const fetchManifest = options.fetchManifest || fetchDesktopReleaseManifest;
-	const manifest = await fetchManifest(version);
+	const manifest = await fetchManifest({ version, channel: options.channel });
 	const entry = selectDesktopPlatformEntry(manifest, {
 		platform: options.platform,
 		arch: options.arch,

--- a/src/domains/desktop/desktop-release-service.ts
+++ b/src/domains/desktop/desktop-release-service.ts
@@ -3,16 +3,28 @@ import type { DesktopReleaseManifest } from "@/types/desktop.js";
 
 const DESKTOP_RELEASE_REPOSITORY = "https://github.com/mrgoonie/claudekit-cli/releases/download";
 
-export function getDesktopManifestUrl(version?: string): string {
-	const tag = version ? `desktop-v${version}` : "desktop-latest";
+export type DesktopChannel = "stable" | "dev";
+
+export function getDesktopManifestUrl(opts?: {
+	version?: string;
+	channel?: DesktopChannel;
+}): string {
+	const version = opts?.version;
+	const channel = opts?.channel ?? "stable";
+	let tag: string;
+	if (version) {
+		tag = `desktop-v${version}`;
+	} else {
+		tag = channel === "dev" ? "desktop-latest-dev" : "desktop-latest";
+	}
 	return `${DESKTOP_RELEASE_REPOSITORY}/${tag}/desktop-manifest.json`;
 }
 
 export async function fetchDesktopReleaseManifest(
-	version?: string,
+	opts?: { version?: string; channel?: DesktopChannel },
 	fetchFn: typeof fetch = globalThis.fetch,
 ): Promise<DesktopReleaseManifest> {
-	const response = await fetchFn(getDesktopManifestUrl(version));
+	const response = await fetchFn(getDesktopManifestUrl(opts));
 	if (!response.ok) {
 		throw new Error(`Failed to fetch desktop manifest: ${response.status} ${response.statusText}`);
 	}

--- a/src/types/desktop.ts
+++ b/src/types/desktop.ts
@@ -33,5 +33,6 @@ export const DesktopReleaseManifestSchema = z.object({
 		"linux-x86_64": DesktopPlatformAssetSchema,
 		"windows-x86_64": DesktopPlatformAssetSchema,
 	}),
+	channel: z.enum(["stable", "dev"]).default("stable"),
 });
 export type DesktopReleaseManifest = z.infer<typeof DesktopReleaseManifestSchema>;


### PR DESCRIPTION
## Summary

Follow-up to epic #676. Two linked improvements to the desktop distribution pipeline, landing together.

- PR CI now takes ~3-4 min instead of ~25 min: no full 3-platform Tauri bundle on PRs
- Dev-channel tags (`desktop-v*-dev.*`) route to `desktop-latest-dev`, keeping the stable pointer untouched
- `ck app --dev` / `--stable` flags with auto-detect from the installed CLI channel

Closes #703

## What changed

| File | Change |
|------|--------|
| `.github/workflows/desktop-build.yml` | PR trigger runs `cargo check` + `typecheck` + `ui:build` + `lint` on one Ubuntu runner; full matrix stays on `desktop-v*` tags. Release job routes `-dev.` tags to `desktop-latest-dev` prerelease, plain `desktop-v*` keeps upserting `desktop-latest` |
| `src/types/desktop.ts` | `channel: "stable" \| "dev"` added to `DesktopReleaseManifestSchema` with `.default("stable")` for back-compat |
| `src/domains/desktop/desktop-release-service.ts` | Resolver signature is now `{ version?, channel? }`; no version → `desktop-latest` or `desktop-latest-dev`; explicit version keeps existing behavior |
| `src/domains/desktop/desktop-binary-manager.ts` | Threads the selected channel into the manifest fetch |
| `src/commands/app/app-command.ts` | `--dev` / `--stable` flags, mutual exclusion, auto-detect via `isPrereleaseVersion` |
| `src/commands/app/types.ts` | `AppCommandOptions.dev`/`.stable`; `downloadBinary` accepts `{ channel? }` |
| Tests | 45 passing tests across service, manifest, binary-manager, asset-selector, app-command |

## Behavior matrix (CLI)

| Invocation | Channel used |
|------------|-------------|
| `ck app` (installed CLI is `@dev`) | dev |
| `ck app` (installed CLI is `@latest`) | stable |
| `ck app --dev` | dev (forced) |
| `ck app --stable` | stable (forced) |
| `ck app --dev --stable` | error, non-zero exit |

## Tag → manifest routing (CI)

| Tag pushed | Release tag | Manifest pointer |
|-----------|-------------|------------------|
| `desktop-v0.1.0` | `desktop-v0.1.0` (latest) | `desktop-latest` |
| `desktop-v0.2.0-dev.1` | `desktop-v0.2.0-dev.1` (prerelease) | `desktop-latest-dev` |

## Test plan

- [x] `bun run validate` passes (typecheck + lint + test + build, 112 vitest + 45 desktop/app tests)
- [x] Pre-commit quality gate passes on all 3 commits
- [x] `desktop-build.yml` YAML structurally valid; tag-match bash logic validated inline for both dev/stable tag shapes
- [ ] End-to-end verified after merge: push a `desktop-v*-dev.*` tag, confirm `desktop-latest-dev` populated and `desktop-latest` untouched
- [ ] End-to-end verified: `ck app --dev` resolves against the new pointer after first dev release exists

## Follow-ups (tracked separately)

- #704 Pre-stable blockers: Tauri updater signing key + macOS Gatekeeper warning

## Notes for review

The single remaining concern: the auto-detect unit test asserts `downloadBinary` was called but does not pin the channel value, because `packageInfo.version` is read at module load time and the test environment version varies. Reported as-is per plan; explicit pinning would require injecting the version through `deps` (noted for a future refactor).