### PR TITLE
feat(config): simplify-gate CLI parity (closes #705)

### DIFF
--- a/__tests__/domains/config/ck-config-manager.test.ts
+++ b/__tests__/domains/config/ck-config-manager.test.ts
@@ -366,7 +366,7 @@ describe("CkSimplifyConfigSchema", () => {
 		expect(result.simplify?.threshold?.locDelta).toBe(400);
 		expect(result.simplify?.threshold?.fileCount).toBe(8);
 		expect(result.simplify?.threshold?.singleFileLoc).toBe(200);
-		expect(result.simplify?.gate?.enabled).toBe(true);
+		expect(result.simplify?.gate?.enabled).toBe(false);
 		expect(result.simplify?.gate?.hardVerbs).toEqual(["ship", "merge", "pr", "deploy", "publish"]);
 		expect(result.simplify?.gate?.softVerbs).toEqual(["commit", "finalize", "release"]);
 	});

--- a/__tests__/domains/config/ck-config-manager.test.ts
+++ b/__tests__/domains/config/ck-config-manager.test.ts
@@ -11,6 +11,7 @@ import {
 	CkConfigSchema,
 	DEFAULT_CK_CONFIG,
 } from "../../../src/types/ck-config.js";
+// CkSimplifyConfigSchema is validated via CkConfigSchema.parse({ simplify: {...} })
 
 describe("CkConfigManager", () => {
 	let tempDir: string;
@@ -118,7 +119,7 @@ describe("CkConfigManager", () => {
 			}
 		});
 
-		it("should parse valid hooks config with all 9 hooks", async () => {
+		it("should parse valid hooks config with all 9 hooks (incl. simplify-gate)", async () => {
 			const hooksConfig = {
 				"session-init": true,
 				"subagent-init": true,
@@ -128,7 +129,7 @@ describe("CkConfigManager", () => {
 				"context-tracking": true,
 				"scout-block": true,
 				"privacy-block": true,
-				"post-edit-simplify-reminder": true,
+				"simplify-gate": true,
 			};
 
 			const testConfig: CkConfig = {
@@ -163,7 +164,7 @@ describe("CkConfigManager", () => {
 				"context-tracking",
 				"scout-block",
 				"privacy-block",
-				"post-edit-simplify-reminder",
+				"simplify-gate",
 			];
 
 			for (const hook of expectedHooks) {
@@ -181,7 +182,7 @@ describe("CkConfigManager", () => {
 				"context-tracking",
 				"scout-block",
 				"privacy-block",
-				"post-edit-simplify-reminder",
+				"simplify-gate",
 			]);
 
 			for (const hook of CK_HOOK_NAMES) {
@@ -356,5 +357,41 @@ describe("CkConfigManager", () => {
 			const projectContent = await readFile(projectPath, "utf-8");
 			expect(globalContent).not.toBe(projectContent);
 		});
+	});
+});
+
+describe("CkSimplifyConfigSchema", () => {
+	it("should apply defaults when simplify block is empty", () => {
+		const result = CkConfigSchema.parse({ simplify: {} });
+		expect(result.simplify?.threshold?.locDelta).toBe(400);
+		expect(result.simplify?.threshold?.fileCount).toBe(8);
+		expect(result.simplify?.threshold?.singleFileLoc).toBe(200);
+		expect(result.simplify?.gate?.enabled).toBe(true);
+		expect(result.simplify?.gate?.hardVerbs).toEqual(["ship", "merge", "pr", "deploy", "publish"]);
+		expect(result.simplify?.gate?.softVerbs).toEqual(["commit", "finalize", "release"]);
+	});
+
+	it("should reject unknown root keys under simplify (strict)", () => {
+		expect(() => CkConfigSchema.parse({ simplify: { unknownKey: "x" } })).toThrow();
+	});
+
+	it("should allow unknown nested keys under simplify.threshold and simplify.gate (passthrough)", () => {
+		const result = CkConfigSchema.parse({
+			simplify: {
+				threshold: { locDelta: 500, futureField: "ok" },
+				gate: { enabled: true, futureFlag: 1 },
+			},
+		});
+		expect(result.simplify?.threshold?.locDelta).toBe(500);
+	});
+
+	it("should accept user override of hardVerbs and softVerbs", () => {
+		const result = CkConfigSchema.parse({
+			simplify: {
+				gate: { hardVerbs: ["release"], softVerbs: ["push"] },
+			},
+		});
+		expect(result.simplify?.gate?.hardVerbs).toEqual(["release"]);
+		expect(result.simplify?.gate?.softVerbs).toEqual(["push"]);
 	});
 });

--- a/src/schemas/ck-config.schema.json
+++ b/src/schemas/ck-config.schema.json
@@ -484,10 +484,64 @@
 					"default": true,
 					"description": "PreToolUse hook - blocks sensitive files"
 				},
-				"post-edit-simplify-reminder": {
+				"simplify-gate": {
 					"type": "boolean",
 					"default": true,
-					"description": "PostToolUse hook - simplify reminder after edits"
+					"description": "UserPromptSubmit hook - hard-blocks ship/merge/pr/deploy/publish and soft-warns commit/finalize/release when live diff exceeds simplify thresholds. Bypass via CK_SIMPLIFY_DISABLED=1."
+				}
+			},
+			"additionalProperties": false
+		},
+		"simplify": {
+			"type": "object",
+			"description": "Signal-driven simplifier orchestration. Live git diff thresholds + verb-based gate.",
+			"properties": {
+				"threshold": {
+					"type": "object",
+					"description": "LOC/file thresholds that trip the gate. Nested object stays open for forward-compat fields.",
+					"properties": {
+						"locDelta": {
+							"type": "integer",
+							"minimum": 0,
+							"default": 400,
+							"description": "Total LOC change (across all files) above which the gate fires."
+						},
+						"fileCount": {
+							"type": "integer",
+							"minimum": 0,
+							"default": 8,
+							"description": "Number of changed files above which the gate fires."
+						},
+						"singleFileLoc": {
+							"type": "integer",
+							"minimum": 0,
+							"default": 200,
+							"description": "Per-file LOC change above which the gate fires."
+						}
+					}
+				},
+				"gate": {
+					"type": "object",
+					"description": "UserPromptSubmit gate behavior. Nested object stays open for forward-compat fields.",
+					"properties": {
+						"enabled": {
+							"type": "boolean",
+							"default": true,
+							"description": "Master toggle. Set false (or env CK_SIMPLIFY_DISABLED=1) to bypass entirely."
+						},
+						"hardVerbs": {
+							"type": "array",
+							"items": { "type": "string" },
+							"default": ["ship", "merge", "pr", "deploy", "publish"],
+							"description": "Verbs that hard-block (continue:false) when thresholds breached."
+						},
+						"softVerbs": {
+							"type": "array",
+							"items": { "type": "string" },
+							"default": ["commit", "finalize", "release"],
+							"description": "Verbs that soft-warn (additionalContext) when thresholds breached."
+						}
+					}
 				}
 			},
 			"additionalProperties": false

--- a/src/schemas/ck-config.schema.json
+++ b/src/schemas/ck-config.schema.json
@@ -526,8 +526,8 @@
 					"properties": {
 						"enabled": {
 							"type": "boolean",
-							"default": true,
-							"description": "Master toggle. Set false (or env CK_SIMPLIFY_DISABLED=1) to bypass entirely."
+							"default": false,
+							"description": "Master toggle. Off by default (opt-in). Set true to activate; env CK_SIMPLIFY_DISABLED=1 always bypasses."
 						},
 						"hardVerbs": {
 							"type": "array",

--- a/src/types/ck-config.ts
+++ b/src/types/ck-config.ts
@@ -439,7 +439,7 @@ export const CkSimplifyConfigSchema = z
 			.default({}),
 		gate: z
 			.object({
-				enabled: z.boolean().default(true),
+				enabled: z.boolean().default(false),
 				hardVerbs: z.array(z.string()).default(["ship", "merge", "pr", "deploy", "publish"]),
 				softVerbs: z.array(z.string()).default(["commit", "finalize", "release"]),
 			})

--- a/src/types/ck-config.ts
+++ b/src/types/ck-config.ts
@@ -408,7 +408,8 @@ export type CkAssertion = z.infer<typeof CkAssertionSchema>;
 
 // SYNC POINT: When adding/removing hooks in claudekit-engineer settings.json,
 // update ALL of: CkHooksConfigSchema, DEFAULT_CK_CONFIG.hooks, CK_HOOK_NAMES,
-// and src/schemas/ck-config.schema.json + GlobalConfigPage.tsx sections
+// src/schemas/ck-config.schema.json, GlobalConfigPage.tsx sections,
+// src/ui/src/services/configFieldDocs.ts, and src/ui/src/i18n/translations.ts (EN + VI)
 export const CkHooksConfigSchema = z.object({
 	"session-init": z.boolean().optional(),
 	"subagent-init": z.boolean().optional(),
@@ -418,9 +419,35 @@ export const CkHooksConfigSchema = z.object({
 	"context-tracking": z.boolean().optional(),
 	"scout-block": z.boolean().optional(),
 	"privacy-block": z.boolean().optional(),
-	"post-edit-simplify-reminder": z.boolean().optional(),
+	"simplify-gate": z.boolean().optional(),
 });
 export type CkHooksConfig = z.infer<typeof CkHooksConfigSchema>;
+
+// SYNC POINT: Simplify config block (mirrors claudekit-engineer simplify-gate hook).
+// Root .strict() to lock keys; nested blocks .passthrough() for forward-compat.
+// threshold and gate use .default({}) so Zod applies field-level defaults when the
+// sub-object is absent or empty — e.g. `simplify: {}` still yields full defaults.
+export const CkSimplifyConfigSchema = z
+	.object({
+		threshold: z
+			.object({
+				locDelta: z.number().int().nonnegative().default(400),
+				fileCount: z.number().int().nonnegative().default(8),
+				singleFileLoc: z.number().int().nonnegative().default(200),
+			})
+			.passthrough()
+			.default({}),
+		gate: z
+			.object({
+				enabled: z.boolean().default(true),
+				hardVerbs: z.array(z.string()).default(["ship", "merge", "pr", "deploy", "publish"]),
+				softVerbs: z.array(z.string()).default(["commit", "finalize", "release"]),
+			})
+			.passthrough()
+			.default({}),
+	})
+	.strict();
+export type CkSimplifyConfig = z.infer<typeof CkSimplifyConfigSchema>;
 
 // Full CkConfig schema
 export const CkConfigSchema = z
@@ -443,6 +470,7 @@ export const CkConfigSchema = z
 		skills: CkSkillsConfigSchema.optional(),
 		assertions: z.array(CkAssertionSchema).optional(),
 		hooks: CkHooksConfigSchema.optional(),
+		simplify: CkSimplifyConfigSchema.optional(),
 		updatePipeline: UpdatePipelineSchema.optional(),
 		modelTaxonomy: CkModelTaxonomySchema.optional(),
 	})
@@ -521,7 +549,15 @@ export const DEFAULT_CK_CONFIG: CkConfig = {
 		"context-tracking": true,
 		"scout-block": true,
 		"privacy-block": true,
-		"post-edit-simplify-reminder": true,
+		"simplify-gate": true,
+	},
+	simplify: {
+		threshold: { locDelta: 400, fileCount: 8, singleFileLoc: 200 },
+		gate: {
+			enabled: true,
+			hardVerbs: ["ship", "merge", "pr", "deploy", "publish"],
+			softVerbs: ["commit", "finalize", "release"],
+		},
 	},
 	updatePipeline: {
 		autoInitAfterUpdate: false,
@@ -540,7 +576,7 @@ export const CK_HOOK_NAMES = [
 	"context-tracking",
 	"scout-block",
 	"privacy-block",
-	"post-edit-simplify-reminder",
+	"simplify-gate",
 ] as const;
 
 export type CkHookName = (typeof CK_HOOK_NAMES)[number];

--- a/src/types/ck-config.ts
+++ b/src/types/ck-config.ts
@@ -554,7 +554,7 @@ export const DEFAULT_CK_CONFIG: CkConfig = {
 	simplify: {
 		threshold: { locDelta: 400, fileCount: 8, singleFileLoc: 200 },
 		gate: {
-			enabled: true,
+			enabled: false,
 			hardVerbs: ["ship", "merge", "pr", "deploy", "publish"],
 			softVerbs: ["commit", "finalize", "release"],
 		},

--- a/src/ui/src/i18n/translations.ts
+++ b/src/ui/src/i18n/translations.ts
@@ -467,7 +467,7 @@ export const translations = {
 		fieldHookPrivacyBlockDesc: "Block sensitive files from reading",
 		fieldHookSimplifyGate: "Simplify Gate",
 		fieldHookSimplifyGateDesc:
-			"UserPromptSubmit hook — hard-blocks ship/merge/pr/deploy/publish verbs and soft-warns commit/finalize/release when live diff exceeds simplify thresholds.",
+			"UserPromptSubmit hook — opt-in. When enabled (simplify.gate.enabled=true), hard-blocks ship/merge/pr/deploy/publish and soft-warns commit/finalize/release when live diff exceeds thresholds.",
 		sectionSimplify: "Simplify Gate",
 		fieldSimplifyThresholdLocDelta: "Total LOC threshold",
 		fieldSimplifyThresholdLocDeltaDesc:
@@ -480,7 +480,7 @@ export const translations = {
 			"Per-file LOC change above which the gate fires. Default: 200.",
 		fieldSimplifyGateEnabled: "Enabled",
 		fieldSimplifyGateEnabledDesc:
-			"Master toggle. Disable here OR set env CK_SIMPLIFY_DISABLED=1 to bypass.",
+			"Master toggle. Off by default (opt-in). Enable to activate the gate; env CK_SIMPLIFY_DISABLED=1 always bypasses.",
 		fieldSimplifyGateHardVerbs: "Hard-block verbs",
 		fieldSimplifyGateHardVerbsDesc:
 			"Verbs that hard-block when thresholds breached. Default: ship, merge, pr, deploy, publish.",
@@ -1556,7 +1556,7 @@ export const translations = {
 		fieldHookPrivacyBlockDesc: "Chặn đọc file nhạy cảm",
 		fieldHookSimplifyGate: "Cổng đơn giản hóa",
 		fieldHookSimplifyGateDesc:
-			"Hook UserPromptSubmit — chặn cứng các động từ ship/merge/pr/deploy/publish và cảnh báo nhẹ commit/finalize/release khi diff hiện tại vượt ngưỡng đơn giản hóa.",
+			"Hook UserPromptSubmit — opt-in. Khi bật (simplify.gate.enabled=true), chặn cứng ship/merge/pr/deploy/publish và cảnh báo nhẹ commit/finalize/release khi diff vượt ngưỡng.",
 		sectionSimplify: "Cổng đơn giản hóa",
 		fieldSimplifyThresholdLocDelta: "Ngưỡng tổng LOC",
 		fieldSimplifyThresholdLocDeltaDesc:
@@ -1569,7 +1569,7 @@ export const translations = {
 			"LOC thay đổi trong một file vượt ngưỡng này thì cổng kích hoạt. Mặc định: 200.",
 		fieldSimplifyGateEnabled: "Bật",
 		fieldSimplifyGateEnabledDesc:
-			"Công tắc chính. Tắt ở đây HOẶC đặt env CK_SIMPLIFY_DISABLED=1 để bỏ qua.",
+			"Công tắc chính. Tắt mặc định (opt-in). Bật để kích hoạt cổng; env CK_SIMPLIFY_DISABLED=1 luôn bỏ qua.",
 		fieldSimplifyGateHardVerbs: "Động từ chặn cứng",
 		fieldSimplifyGateHardVerbsDesc:
 			"Động từ chặn cứng khi vượt ngưỡng. Mặc định: ship, merge, pr, deploy, publish.",

--- a/src/ui/src/i18n/translations.ts
+++ b/src/ui/src/i18n/translations.ts
@@ -471,22 +471,18 @@ export const translations = {
 		sectionSimplify: "Simplify Gate",
 		fieldSimplifyThresholdLocDelta: "Total LOC threshold",
 		fieldSimplifyThresholdLocDeltaDesc:
-			"Total LOC change (across all files) above which the gate fires. Default: 400.",
+			"Total LOC change (across all files) above which the gate fires.",
 		fieldSimplifyThresholdFileCount: "File count threshold",
-		fieldSimplifyThresholdFileCountDesc:
-			"Number of changed files above which the gate fires. Default: 8.",
+		fieldSimplifyThresholdFileCountDesc: "Number of changed files above which the gate fires.",
 		fieldSimplifyThresholdSingleFileLoc: "Per-file LOC threshold",
-		fieldSimplifyThresholdSingleFileLocDesc:
-			"Per-file LOC change above which the gate fires. Default: 200.",
+		fieldSimplifyThresholdSingleFileLocDesc: "Per-file LOC change above which the gate fires.",
 		fieldSimplifyGateEnabled: "Enabled",
 		fieldSimplifyGateEnabledDesc:
 			"Master toggle. Off by default (opt-in). Enable to activate the gate; env CK_SIMPLIFY_DISABLED=1 always bypasses.",
 		fieldSimplifyGateHardVerbs: "Hard-block verbs",
-		fieldSimplifyGateHardVerbsDesc:
-			"Verbs that hard-block when thresholds breached. Default: ship, merge, pr, deploy, publish.",
+		fieldSimplifyGateHardVerbsDesc: "Verbs that hard-block when thresholds breached.",
 		fieldSimplifyGateSoftVerbs: "Soft-warn verbs",
-		fieldSimplifyGateSoftVerbsDesc:
-			"Verbs that emit a non-blocking warning. Default: commit, finalize, release.",
+		fieldSimplifyGateSoftVerbsDesc: "Verbs that emit a non-blocking warning.",
 
 		// Update Pipeline
 		sectionUpdatePipeline: "Update Pipeline",
@@ -1560,22 +1556,19 @@ export const translations = {
 		sectionSimplify: "Cổng đơn giản hóa",
 		fieldSimplifyThresholdLocDelta: "Ngưỡng tổng LOC",
 		fieldSimplifyThresholdLocDeltaDesc:
-			"Tổng LOC thay đổi (toàn bộ file) vượt ngưỡng này thì cổng kích hoạt. Mặc định: 400.",
+			"Tổng LOC thay đổi (toàn bộ file) vượt ngưỡng này thì cổng kích hoạt.",
 		fieldSimplifyThresholdFileCount: "Ngưỡng số file",
-		fieldSimplifyThresholdFileCountDesc:
-			"Số file thay đổi vượt ngưỡng này thì cổng kích hoạt. Mặc định: 8.",
+		fieldSimplifyThresholdFileCountDesc: "Số file thay đổi vượt ngưỡng này thì cổng kích hoạt.",
 		fieldSimplifyThresholdSingleFileLoc: "Ngưỡng LOC mỗi file",
 		fieldSimplifyThresholdSingleFileLocDesc:
-			"LOC thay đổi trong một file vượt ngưỡng này thì cổng kích hoạt. Mặc định: 200.",
+			"LOC thay đổi trong một file vượt ngưỡng này thì cổng kích hoạt.",
 		fieldSimplifyGateEnabled: "Bật",
 		fieldSimplifyGateEnabledDesc:
 			"Công tắc chính. Tắt mặc định (opt-in). Bật để kích hoạt cổng; env CK_SIMPLIFY_DISABLED=1 luôn bỏ qua.",
 		fieldSimplifyGateHardVerbs: "Động từ chặn cứng",
-		fieldSimplifyGateHardVerbsDesc:
-			"Động từ chặn cứng khi vượt ngưỡng. Mặc định: ship, merge, pr, deploy, publish.",
+		fieldSimplifyGateHardVerbsDesc: "Động từ chặn cứng khi vượt ngưỡng.",
 		fieldSimplifyGateSoftVerbs: "Động từ cảnh báo nhẹ",
-		fieldSimplifyGateSoftVerbsDesc:
-			"Động từ phát cảnh báo không chặn. Mặc định: commit, finalize, release.",
+		fieldSimplifyGateSoftVerbsDesc: "Động từ phát cảnh báo không chặn.",
 
 		// Update Pipeline
 		sectionUpdatePipeline: "Pipeline Cập nhật",

--- a/src/ui/src/i18n/translations.ts
+++ b/src/ui/src/i18n/translations.ts
@@ -465,8 +465,28 @@ export const translations = {
 		fieldHookScoutBlockDesc: "Block heavy directories from exploration",
 		fieldHookPrivacyBlock: "Privacy Block Hook",
 		fieldHookPrivacyBlockDesc: "Block sensitive files from reading",
-		fieldHookPostEditSimplify: "Post-Edit Simplify",
-		fieldHookPostEditSimplifyDesc: "Simplify reminder after edits",
+		fieldHookSimplifyGate: "Simplify Gate",
+		fieldHookSimplifyGateDesc:
+			"UserPromptSubmit hook — hard-blocks ship/merge/pr/deploy/publish verbs and soft-warns commit/finalize/release when live diff exceeds simplify thresholds.",
+		sectionSimplify: "Simplify Gate",
+		fieldSimplifyThresholdLocDelta: "Total LOC threshold",
+		fieldSimplifyThresholdLocDeltaDesc:
+			"Total LOC change (across all files) above which the gate fires. Default: 400.",
+		fieldSimplifyThresholdFileCount: "File count threshold",
+		fieldSimplifyThresholdFileCountDesc:
+			"Number of changed files above which the gate fires. Default: 8.",
+		fieldSimplifyThresholdSingleFileLoc: "Per-file LOC threshold",
+		fieldSimplifyThresholdSingleFileLocDesc:
+			"Per-file LOC change above which the gate fires. Default: 200.",
+		fieldSimplifyGateEnabled: "Enabled",
+		fieldSimplifyGateEnabledDesc:
+			"Master toggle. Disable here OR set env CK_SIMPLIFY_DISABLED=1 to bypass.",
+		fieldSimplifyGateHardVerbs: "Hard-block verbs",
+		fieldSimplifyGateHardVerbsDesc:
+			"Verbs that hard-block when thresholds breached. Default: ship, merge, pr, deploy, publish.",
+		fieldSimplifyGateSoftVerbs: "Soft-warn verbs",
+		fieldSimplifyGateSoftVerbsDesc:
+			"Verbs that emit a non-blocking warning. Default: commit, finalize, release.",
 
 		// Update Pipeline
 		sectionUpdatePipeline: "Update Pipeline",
@@ -1534,8 +1554,28 @@ export const translations = {
 		fieldHookScoutBlockDesc: "Chặn thư mục nặng khỏi việc khám phá",
 		fieldHookPrivacyBlock: "Hook chặn quyền riêng tư",
 		fieldHookPrivacyBlockDesc: "Chặn đọc file nhạy cảm",
-		fieldHookPostEditSimplify: "Đơn giản sau chỉnh sửa",
-		fieldHookPostEditSimplifyDesc: "Nhắc đơn giản sau khi chỉnh sửa",
+		fieldHookSimplifyGate: "Cổng đơn giản hóa",
+		fieldHookSimplifyGateDesc:
+			"Hook UserPromptSubmit — chặn cứng các động từ ship/merge/pr/deploy/publish và cảnh báo nhẹ commit/finalize/release khi diff hiện tại vượt ngưỡng đơn giản hóa.",
+		sectionSimplify: "Cổng đơn giản hóa",
+		fieldSimplifyThresholdLocDelta: "Ngưỡng tổng LOC",
+		fieldSimplifyThresholdLocDeltaDesc:
+			"Tổng LOC thay đổi (toàn bộ file) vượt ngưỡng này thì cổng kích hoạt. Mặc định: 400.",
+		fieldSimplifyThresholdFileCount: "Ngưỡng số file",
+		fieldSimplifyThresholdFileCountDesc:
+			"Số file thay đổi vượt ngưỡng này thì cổng kích hoạt. Mặc định: 8.",
+		fieldSimplifyThresholdSingleFileLoc: "Ngưỡng LOC mỗi file",
+		fieldSimplifyThresholdSingleFileLocDesc:
+			"LOC thay đổi trong một file vượt ngưỡng này thì cổng kích hoạt. Mặc định: 200.",
+		fieldSimplifyGateEnabled: "Bật",
+		fieldSimplifyGateEnabledDesc:
+			"Công tắc chính. Tắt ở đây HOẶC đặt env CK_SIMPLIFY_DISABLED=1 để bỏ qua.",
+		fieldSimplifyGateHardVerbs: "Động từ chặn cứng",
+		fieldSimplifyGateHardVerbsDesc:
+			"Động từ chặn cứng khi vượt ngưỡng. Mặc định: ship, merge, pr, deploy, publish.",
+		fieldSimplifyGateSoftVerbs: "Động từ cảnh báo nhẹ",
+		fieldSimplifyGateSoftVerbsDesc:
+			"Động từ phát cảnh báo không chặn. Mặc định: commit, finalize, release.",
 
 		// Update Pipeline
 		sectionUpdatePipeline: "Pipeline Cập nhật",

--- a/src/ui/src/pages/GlobalConfigPage.tsx
+++ b/src/ui/src/pages/GlobalConfigPage.tsx
@@ -266,9 +266,46 @@ const GlobalConfigPage: React.FC = () => {
 						description: t("fieldHookPrivacyBlockDesc"),
 					},
 					{
-						path: "hooks.post-edit-simplify-reminder",
-						label: t("fieldHookPostEditSimplify"),
-						description: t("fieldHookPostEditSimplifyDesc"),
+						path: "hooks.simplify-gate",
+						label: t("fieldHookSimplifyGate"),
+						description: t("fieldHookSimplifyGateDesc"),
+					},
+				],
+			},
+			{
+				id: "simplify",
+				title: t("sectionSimplify"),
+				defaultCollapsed: true,
+				fields: [
+					{
+						path: "simplify.threshold.locDelta",
+						label: t("fieldSimplifyThresholdLocDelta"),
+						description: t("fieldSimplifyThresholdLocDeltaDesc"),
+					},
+					{
+						path: "simplify.threshold.fileCount",
+						label: t("fieldSimplifyThresholdFileCount"),
+						description: t("fieldSimplifyThresholdFileCountDesc"),
+					},
+					{
+						path: "simplify.threshold.singleFileLoc",
+						label: t("fieldSimplifyThresholdSingleFileLoc"),
+						description: t("fieldSimplifyThresholdSingleFileLocDesc"),
+					},
+					{
+						path: "simplify.gate.enabled",
+						label: t("fieldSimplifyGateEnabled"),
+						description: t("fieldSimplifyGateEnabledDesc"),
+					},
+					{
+						path: "simplify.gate.hardVerbs",
+						label: t("fieldSimplifyGateHardVerbs"),
+						description: t("fieldSimplifyGateHardVerbsDesc"),
+					},
+					{
+						path: "simplify.gate.softVerbs",
+						label: t("fieldSimplifyGateSoftVerbs"),
+						description: t("fieldSimplifyGateSoftVerbsDesc"),
 					},
 				],
 			},

--- a/src/ui/src/services/configFieldDocs.ts
+++ b/src/ui/src/services/configFieldDocs.ts
@@ -610,16 +610,16 @@ export const CONFIG_FIELD_DOCS: Record<string, FieldDoc> = {
 	"simplify.gate.enabled": {
 		path: "simplify.gate.enabled",
 		type: "boolean",
-		default: "true",
+		default: "false",
 		description:
-			"Master toggle for the simplify gate. Set false to bypass entirely (or use env CK_SIMPLIFY_DISABLED=1 for one-off bypass).",
+			"Master toggle for the simplify gate. Off by default (opt-in). Set true to activate; env CK_SIMPLIFY_DISABLED=1 always bypasses.",
 		descriptionVi:
-			"Công tắc chính cho cổng simplify. Đặt false để bỏ qua hoàn toàn (hoặc dùng env CK_SIMPLIFY_DISABLED=1 để bỏ qua tạm thời).",
+			"Công tắc chính cho cổng simplify. Tắt mặc định (opt-in). Đặt true để kích hoạt; env CK_SIMPLIFY_DISABLED=1 luôn bỏ qua.",
 		effect:
-			"When false, the hook exits 0 immediately on every prompt. Equivalent to uninstalling the hook without removing it.",
+			"When false (default), the hook exits 0 immediately on every prompt. Set true to enforce thresholds against ship/merge/pr/deploy/publish verbs.",
 		effectVi:
-			"Khi false, hook thoát 0 ngay lập tức cho mọi prompt. Tương đương gỡ hook mà không xoá.",
-		example: '{\n  "simplify": {\n    "gate": { "enabled": false }\n  }\n}',
+			"Khi false (mặc định), hook thoát 0 ngay lập tức cho mọi prompt. Đặt true để áp dụng ngưỡng với động từ ship/merge/pr/deploy/publish.",
+		example: '{\n  "simplify": {\n    "gate": { "enabled": true }\n  }\n}',
 	},
 	"simplify.gate.hardVerbs": {
 		path: "simplify.gate.hardVerbs",

--- a/src/ui/src/services/configFieldDocs.ts
+++ b/src/ui/src/services/configFieldDocs.ts
@@ -555,19 +555,96 @@ export const CONFIG_FIELD_DOCS: Record<string, FieldDoc> = {
 			"Khi bật, nhắc người dùng cho phép trước khi truy cập tệp có thể chứa API keys, mật khẩu hoặc bí mật khác.",
 		example: '{\n  "hooks": {\n    "privacy-block": false\n  }\n}',
 	},
-	"hooks.post-edit-simplify-reminder": {
-		path: "hooks.post-edit-simplify-reminder",
+	"hooks.simplify-gate": {
+		path: "hooks.simplify-gate",
 		type: "boolean",
 		default: "true",
 		description:
-			"Reminds the agent to simplify code after file edits to maintain readability and prevent bloat.",
+			"UserPromptSubmit hook that hard-blocks ship/merge/pr/deploy/publish verbs and soft-warns commit/finalize/release when the live `git diff HEAD` plus untracked files exceed the simplify thresholds. Bypass with env CK_SIMPLIFY_DISABLED=1.",
 		descriptionVi:
-			"Nhắc nhở agent đơn giản hóa code sau khi chỉnh sửa tệp để duy trì khả năng đọc và ngăn phình to.",
+			"Hook UserPromptSubmit chặn cứng các động từ ship/merge/pr/deploy/publish và cảnh báo nhẹ commit/finalize/release khi `git diff HEAD` cộng file chưa track vượt ngưỡng simplify. Bỏ qua bằng env CK_SIMPLIFY_DISABLED=1.",
 		effect:
-			"After editing files, suggests reviewing for unnecessary complexity, redundant code, or opportunities to refactor.",
+			"Stateless hook. Recomputes signals from live git on every fire. Hard-block exits with code 2; soft-warn injects additionalContext. Verb matching uses word boundaries plus negation guards.",
 		effectVi:
-			"Sau khi chỉnh sửa tệp, đề xuất xem xét độ phức tạp không cần thiết, code dư thừa hoặc cơ hội refactor.",
-		example: '{\n  "hooks": {\n    "post-edit-simplify-reminder": false\n  }\n}',
+			"Hook không trạng thái. Tính lại tín hiệu từ git mỗi lần chạy. Chặn cứng thoát mã 2; cảnh báo nhẹ chèn additionalContext. So khớp động từ dùng word boundary và bảo vệ phủ định.",
+		example: '{\n  "hooks": {\n    "simplify-gate": false\n  }\n}',
+	},
+	"simplify.threshold.locDelta": {
+		path: "simplify.threshold.locDelta",
+		type: "integer",
+		default: "400",
+		description: "Total LOC change (across all files) above which the simplify gate fires.",
+		descriptionVi: "Tổng LOC thay đổi (toàn bộ file) vượt ngưỡng này thì cổng simplify kích hoạt.",
+		effect:
+			"Computed from `git diff --numstat HEAD --ignore-all-space` plus per-file line counts of untracked files.",
+		effectVi:
+			"Tính từ `git diff --numstat HEAD --ignore-all-space` cộng số dòng từng file chưa track.",
+		example: '{\n  "simplify": {\n    "threshold": { "locDelta": 800 }\n  }\n}',
+	},
+	"simplify.threshold.fileCount": {
+		path: "simplify.threshold.fileCount",
+		type: "integer",
+		default: "8",
+		description: "Number of changed files above which the simplify gate fires.",
+		descriptionVi: "Số file thay đổi vượt ngưỡng này thì cổng simplify kích hoạt.",
+		effect:
+			"Counts unique files in the union of `git diff HEAD` tracked changes and `git ls-files --others --exclude-standard` untracked files.",
+		effectVi:
+			"Đếm file duy nhất trong hợp của thay đổi đã track (`git diff HEAD`) và file chưa track (`git ls-files --others --exclude-standard`).",
+		example: '{\n  "simplify": {\n    "threshold": { "fileCount": 12 }\n  }\n}',
+	},
+	"simplify.threshold.singleFileLoc": {
+		path: "simplify.threshold.singleFileLoc",
+		type: "integer",
+		default: "200",
+		description:
+			"Per-file LOC change above which the simplify gate fires (matches CLAUDE.md 200-line modularization rule).",
+		descriptionVi:
+			"Thay đổi LOC mỗi file vượt ngưỡng này thì cổng simplify kích hoạt (khớp luật chia module 200 dòng trong CLAUDE.md).",
+		effect:
+			"Triggered if ANY single file's add+delete count crosses the threshold, even if total LOC and file count stay below their thresholds.",
+		effectVi:
+			"Kích hoạt nếu BẤT KỲ một file nào có tổng add+delete vượt ngưỡng, ngay cả khi tổng LOC và số file vẫn dưới ngưỡng.",
+		example: '{\n  "simplify": {\n    "threshold": { "singleFileLoc": 300 }\n  }\n}',
+	},
+	"simplify.gate.enabled": {
+		path: "simplify.gate.enabled",
+		type: "boolean",
+		default: "true",
+		description:
+			"Master toggle for the simplify gate. Set false to bypass entirely (or use env CK_SIMPLIFY_DISABLED=1 for one-off bypass).",
+		descriptionVi:
+			"Công tắc chính cho cổng simplify. Đặt false để bỏ qua hoàn toàn (hoặc dùng env CK_SIMPLIFY_DISABLED=1 để bỏ qua tạm thời).",
+		effect:
+			"When false, the hook exits 0 immediately on every prompt. Equivalent to uninstalling the hook without removing it.",
+		effectVi:
+			"Khi false, hook thoát 0 ngay lập tức cho mọi prompt. Tương đương gỡ hook mà không xoá.",
+		example: '{\n  "simplify": {\n    "gate": { "enabled": false }\n  }\n}',
+	},
+	"simplify.gate.hardVerbs": {
+		path: "simplify.gate.hardVerbs",
+		type: "array",
+		default: '["ship", "merge", "pr", "deploy", "publish"]',
+		description:
+			"Verbs that HARD-BLOCK the prompt (exit code 2) when simplify thresholds are breached.",
+		descriptionVi: "Động từ CHẶN CỨNG prompt (mã thoát 2) khi vượt ngưỡng simplify.",
+		effect:
+			"Matched case-insensitively with word boundaries (`\\b`) plus negation guards (`don't|never|not <verb>` and `ship on` idiom skip the match).",
+		effectVi:
+			"So khớp không phân biệt hoa thường với word boundary (`\\b`) cộng bảo vệ phủ định (`don't|never|not <verb>` và idiom `ship on` bỏ qua).",
+		example: '{\n  "simplify": {\n    "gate": { "hardVerbs": ["release"] }\n  }\n}',
+	},
+	"simplify.gate.softVerbs": {
+		path: "simplify.gate.softVerbs",
+		type: "array",
+		default: '["commit", "finalize", "release"]',
+		description:
+			"Verbs that emit a non-blocking warning (additionalContext) when simplify thresholds are breached.",
+		descriptionVi: "Động từ phát cảnh báo không chặn (additionalContext) khi vượt ngưỡng simplify.",
+		effect:
+			"Same matching rules as hardVerbs. The warning text points the user at `code-simplifier`.",
+		effectVi: "Quy tắc khớp giống hardVerbs. Cảnh báo trỏ người dùng đến `code-simplifier`.",
+		example: '{\n  "simplify": {\n    "gate": { "softVerbs": ["commit", "push"] }\n  }\n}',
 	},
 	"updatePipeline.autoInitAfterUpdate": {
 		path: "updatePipeline.autoInitAfterUpdate",


### PR DESCRIPTION
## Update (post-review pivot — 2026-04-18)

**`simplify.gate.enabled` default flipped `true` → `false` (opt-in).**

After UX review, opt-in + hard-block is the right posture:
- **Default-off** avoids surprising users with hard-blocks on first upgrade
- **Hard-block when on** matches the `/ck:plan → /ck:cook` handoff philosophy — opt-in users want enforcement
- Bypass paths preserved: `simplify.gate.enabled: false` OR env `CK_SIMPLIFY_DISABLED=1`

Changes:
- `src/types/ck-config.ts` — Zod default `false`
- `src/schemas/ck-config.schema.json` — JSON schema default `false`
- `src/ui/src/services/configFieldDocs.ts` — field doc + bilingual copy refresh
- `src/ui/src/i18n/translations.ts` — EN/VI copy reflects opt-in posture
- `__tests__/domains/config/ck-config-manager.test.ts` — assertion flipped

All 33 config tests + ui:build green.

Coordinated with engineer PR #676 (matching default flip on the hook side).

---

## Summary

CLI parity for the new `simplify-gate` hook shipped in claudekit-engineer PR #676. Coordinated dual-PR release so users never see a half-updated stack (engineer fires `simplify-gate`, CLI dashboard knows about it).

- **Hook rename:** `post-edit-simplify-reminder` → `simplify-gate` across all 4 SYNC POINT locations
- **New config block:** `simplify.{threshold,gate}` — Zod schema, JSON schema, dashboard panel, bilingual field docs
- **Schema posture:** root `.strict()` + nested `.passthrough()` so engineer can extend `threshold`/`gate` without bumping CLI
- **Defaults mirror engineer #676 exactly** — `locDelta: 400`, `fileCount: 8`, `singleFileLoc: 200`, `hardVerbs: [ship,merge,pr,deploy,publish]`, `softVerbs: [commit,finalize,release]`

## Files changed (6 / +305 / −24)

| File | Surface |
|---|---|
| `src/types/ck-config.ts` | CkHooksConfigSchema + DEFAULT_CK_CONFIG.hooks + CK_HOOK_NAMES + new CkSimplifyConfigSchema (4 sync points) |
| `src/schemas/ck-config.schema.json` | Hook toggle swap + new `simplify` block (3 thresholds + gate) |
| `src/ui/src/pages/GlobalConfigPage.tsx` | New collapsed Simplify Gate panel (6 controls) between Hooks and Advanced |
| `src/ui/src/services/configFieldDocs.ts` | 7 new bilingual field docs incl. bypass section |
| `src/ui/src/i18n/translations.ts` | 13 EN + 13 VI key pairs (TS \`as const\` enforces parity) |
| `__tests__/domains/config/ck-config-manager.test.ts` | Fixture swap + 4 new CkSimplifyConfigSchema tests |

## UI evidence

Verified live in dashboard (`bun run dashboard:dev` → http://localhost:3456/config/global → Simplify Gate panel). All 6 controls render with engineer-#676 defaults:

- **Total LOC threshold:** \`400\` (default badge)
- **File count threshold:** \`8\` (default badge)
- **Per-file LOC threshold:** \`200\` (default badge)
- **Enabled:** toggle ON (default badge)
- **Hard-block verbs:** \`ship\`, \`merge\`, \`pr\`, \`deploy\`, \`publish\` (chip editor — better than the planned v1 comma-input)
- **Soft-warn verbs:** \`commit\`, \`finalize\`, \`release\` (chip editor)

Each control shows the dotted JSON path (\`simplify.threshold.locDelta\`, \`simplify.gate.enabled\`, etc.) and the Default badge swaps to a dirty marker on user edit. EN ↔ VI toggle in the footer flips all labels and descriptions.

## Bypass mechanisms (documented)

- **Emergency:** \`CK_SIMPLIFY_DISABLED=1\` env var (per-process)
- **Persistent:** \`simplify.gate.enabled: false\` in \`.ck.json\` (per-project)

Both surface in \`configFieldDocs.ts\` so users find them in dashboard tooltips, not Discord.

## Test plan

- [x] \`bun run validate\` passes (typecheck + lint + test + build)
- [x] \`bun run ui:build\` passes (strict tsc -b)
- [x] 4 new CkSimplifyConfigSchema unit tests cover default cascade, root \`.strict()\` rejects unknown, nested \`.passthrough()\` accepts unknown, user override
- [x] Existing config-manager fixtures updated to use new hook name
- [x] EN ↔ VI parity enforced at compile time (TS \`as const\`)
- [x] Dashboard panel rendered + verified visually with engineer defaults

## Coordination

Targets \`dev\` (not main) — paired with engineer PR #676 for one-shot beta release. Once both merge to dev, users see hook + config + dashboard land together on next \`ck update\`.

## References

- Engineer PR: claudekit/claudekit-engineer#676
- Visual explanation: \`docs/visuals/705-simplify-gate-cli-parity.html\` (open in browser)
- Plan: \`plans/260416-2230-simplify-gate-cli-parity/plan.md\`

Closes #705
