### PR TITLE
docs(claude): require desktop-v* tagging as final step for app-facing changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,26 @@ cd src-tauri && cargo check   # Type-check Rust only
 
 ### CI
 
-`.github/workflows/desktop-build.yml` builds on macOS/Ubuntu/Windows. Triggered by: PRs that touch `src-tauri/` or `src/ui/` (path filter), `desktop-v*` tag pushes (releases), and `workflow_dispatch` (manual). Release job creates GitHub release on `desktop-v*` tags.
+`.github/workflows/desktop-build.yml` builds on macOS/Ubuntu/Windows. Triggered by: PRs that touch `src-tauri/` or `src/ui/` (fast `check` gate only — typecheck + lint + test + ui:build + `cargo check`), `desktop-v*` tag pushes (full 3-platform matrix + release), and `workflow_dispatch` (manual). The heavy matrix is **skipped on PRs** — binaries only ship on tags.
+
+### Release tagging is MANDATORY for app-facing changes
+
+**A merged PR does NOT produce a usable app.** No `desktop-v*` tag = no binaries = `ck app` will 404. Any work that touches the desktop app surface (`src-tauri/`, `src/ui/`, `ck app` command, desktop release manifest, `desktop-build.yml`) MUST include a final tagging step after merge:
+
+```bash
+cd ~/claudekit/claudekit-cli && git checkout dev && git pull
+
+# Dev channel (safe: prerelease, updates desktop-latest-dev only)
+git tag desktop-v<version>-dev.<n> && git push origin desktop-v<version>-dev.<n>
+
+# Stable channel (ships to all end users via desktop-latest)
+git tag desktop-v<version> && git push origin desktop-v<version>
+```
+
+Rules:
+- Validate on the **dev channel first** (`-dev.<n>` suffix) before tagging a stable release. `ck app --dev` or a prerelease CLI auto-resolves to `desktop-latest-dev`.
+- Never promote to stable until dev has been smoke-tested on macOS + Windows + Linux.
+- The `/maintainer` skill's Step 9 covers branch/worktree cleanup but does NOT auto-tag — tagging is a conscious decision gated on smoke-test outcome.
 
 **TODO (pre-release):**
 - Generate updater key pair: `tauri signer generate`

--- a/src/__tests__/domains/plan-parser/plan-cli-arg-contract.test.ts
+++ b/src/__tests__/domains/plan-parser/plan-cli-arg-contract.test.ts
@@ -164,8 +164,9 @@ function extractInvocations(filePath: string): CkPlanInvocation[] {
 			continue;
 		}
 
-		// Only process lines with `ck plan`
-		if (!/ck\s+plan/.test(line)) continue;
+		// Only process lines with `ck plan` — word boundary prevents substring
+		// matches against words ending in "ck" (e.g. "fact-check plan claims").
+		if (!/\bck\s+plan\b/.test(line)) continue;
 
 		// Skip /ck:skill references (not CLI invocations)
 		if (/\/ck:[a-z]/.test(line)) continue;


### PR DESCRIPTION
## Summary

Two small, independent changes on one branch because the second unblocks the first's CI.

**1. `docs(claude)`** — add an explicit rule to `CLAUDE.md` → Desktop App → CI section stating that a merged PR does NOT produce usable binaries. Any work touching `src-tauri/`, `src/ui/`, `ck app`, or `desktop-build.yml` MUST end with a `desktop-v*` tag push (dev channel first, then stable after smoke-test). Surfaced during PR #706 post-merge: the pipeline is now channel-aware, but `ck app` still 404s because no release has ever been cut.

**2. `test(plan-parser)`** — anchor the `ck plan` regex in `plan-cli-arg-contract.test.ts` to a word boundary. The unanchored `/ck\s+plan/` substring-matched `fact-check plan claims` inside a fenced code block in `claudekit-engineer/claude/skills/ck-plan/references/red-team-personas.md:54`, extracting `claims` as a "subcommand" and failing the catch-all assertion. Switched to `/\bck\s+plan\b/` so word-internal `ck` sequences like the trailing `ck` in `check` no longer trip the parser. Valid invocations (backticked, leading whitespace, dollar-prompt) still match.

## Test plan

- [x] `bun test src/__tests__/domains/plan-parser/plan-cli-arg-contract.test.ts` → 52/52 pass (was 52 pass / 1 fail — the failing test was the false-positive one that no longer gets generated).
- [x] `bun run validate` — typecheck + lint + build clean.
- [x] Full hook pre-push suite — runs automatically on push; previously blocked by the same `claims` false positive on dev.

## Why bundle them

The failing test sits on `dev` (pre-existing, not introduced by me) and blocks the pre-push hook on every push to this repo — including a docs-only change. Splitting into two PRs means the first one can't be pushed without either fixing this test or bypassing the hook, so I just fixed it.
