### PR TITLE
test(migrate): reset route source-path mocks between cases

### DIFF
--- a/src/__tests__/domains/web-server/routes/migration-routes.test.ts
+++ b/src/__tests__/domains/web-server/routes/migration-routes.test.ts
@@ -183,10 +183,16 @@ describe("migration reconcile route", () => {
 		hasCtx = true;
 		discoverAgentsMock.mockReset();
 		discoverAgentsMock.mockResolvedValue([]);
+		getAgentSourcePathMock.mockReset();
+		getAgentSourcePathMock.mockReturnValue(null);
 		discoverCommandsMock.mockReset();
 		discoverCommandsMock.mockResolvedValue([]);
+		getCommandSourcePathMock.mockReset();
+		getCommandSourcePathMock.mockReturnValue(null);
 		discoverSkillsMock.mockReset();
 		discoverSkillsMock.mockResolvedValue([]);
+		getSkillSourcePathMock.mockReset();
+		getSkillSourcePathMock.mockReturnValue(null);
 		discoverConfigMock.mockReset();
 		discoverConfigMock.mockResolvedValue(null);
 		discoverRulesMock.mockReset();


### PR DESCRIPTION
## Summary

- reset the source-path mocks in `migration-routes.test.ts` before each test case
- remove suite-level state leakage that made the current `dev` tip fail the repo pre-push gate in clean worktrees
- unblock the `desktop-v0.1.0-dev.2` release tag push without bypassing hooks

## Validation

- [x] `bun test ./src/__tests__/domains/web-server/routes/migration-routes.test.ts`
- [x] pre-push hook on branch push (`lint`, `typecheck`, `build`, `ui:build`, `test`, `ui:test`)
