### PR TITLE
fix(desktop): harden Windows desktop release and dev update flow

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Quality gate (pre-commit): typecheck + lint + build
+# Quality gate (pre-commit): lint + typecheck + desktop config + build
 # Catches the top 3 CI failure categories BEFORE code leaves the machine.
 # Works in both normal repos and worktrees.
 
@@ -44,7 +44,14 @@ bun run typecheck || {
   exit 1
 }
 
-echo "  [3/3] Build..."
+echo "  [3/4] Desktop Config..."
+bun run desktop:validate-config || {
+  echo ""
+  echo "  [X] Desktop bundle config invalid. Fix src-tauri/tauri.conf.json before committing."
+  exit 1
+}
+
+echo "  [4/4] Build..."
 bun run build || {
   echo ""
   echo "  [X] Build failed. Fix errors before committing."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,7 +17,7 @@ echo "  Quality Gate (pre-commit)"
 echo "  ========================="
 echo ""
 
-echo "  [1/3] Lint (auto-fix)..."
+echo "  [1/4] Lint (auto-fix)..."
 # Snapshot diff before lint to isolate lint-caused changes from pre-existing
 # unstaged work. Both snapshots include pre-existing changes, so comparing
 # them detects ONLY what lint modified (pre-existing diffs cancel out).
@@ -37,7 +37,7 @@ if [ "$DIFF_BEFORE" != "$DIFF_AFTER" ]; then
   exit 1
 fi
 
-echo "  [2/3] Typecheck..."
+echo "  [2/4] Typecheck..."
 bun run typecheck || {
   echo ""
   echo "  [X] Typecheck failed. Fix type errors before committing."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -17,14 +17,14 @@ echo "  Quality Gate (pre-push)"
 echo "  ========================"
 echo ""
 
-echo "  [1/6] Lint..."
+echo "  [1/7] Lint..."
 bun run lint || {
   echo ""
   echo "  [X] Lint failed. Run 'bun run lint:fix' to auto-fix, then re-stage."
   exit 1
 }
 
-echo "  [2/6] Typecheck..."
+echo "  [2/7] Typecheck..."
 bun run typecheck || {
   echo ""
   echo "  [X] Typecheck failed. Run 'bun run typecheck' to see errors."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Quality gate (pre-push): lint + typecheck + build + ui:build + tests + ui tests
+# Quality gate (pre-push): lint + typecheck + desktop config + build + ui:build + tests + ui tests
 # Full CI parity — nothing reaches upstream that wouldn't pass CI.
 # Works in both normal repos and worktrees.
 
@@ -31,14 +31,21 @@ bun run typecheck || {
   exit 1
 }
 
-echo "  [3/6] Build..."
+echo "  [3/7] Desktop Config..."
+bun run desktop:validate-config || {
+  echo ""
+  echo "  [X] Desktop bundle config invalid. Fix src-tauri/tauri.conf.json before pushing."
+  exit 1
+}
+
+echo "  [4/7] Build..."
 bun run build || {
   echo ""
   echo "  [X] Build failed. Run 'bun run build' to see errors."
   exit 1
 }
 
-echo "  [4/6] UI Build (tsc -b + vite)..."
+echo "  [5/7] UI Build (tsc -b + vite)..."
 bun run ui:build || {
   echo ""
   echo "  [X] UI build failed. Run 'bun run ui:build' to see errors."
@@ -46,7 +53,7 @@ bun run ui:build || {
   exit 1
 }
 
-echo "  [5/6] Tests..."
+echo "  [6/7] Tests..."
 # Suppress interactive prompts and enable CI-safe test behavior (matches ci.yml env vars)
 NON_INTERACTIVE=true CI_SAFE_MODE=true bun test || {
   echo ""
@@ -54,7 +61,7 @@ NON_INTERACTIVE=true CI_SAFE_MODE=true bun test || {
   exit 1
 }
 
-echo "  [6/6] UI Tests..."
+echo "  [7/7] UI Tests..."
 bun run ui:test || {
   echo ""
   echo "  [X] UI tests failed. Run 'bun run ui:test' to see failures."

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -8,9 +8,14 @@ on:
   # Dev builds: only when desktop-related files change
   pull_request:
     paths:
+      - '.githooks/**'
+      - 'package.json'
+      - 'scripts/validate-desktop-bundle-config.ts'
       - 'src-tauri/**'
+      - 'src/commands/app/**'
       - 'src/ui/**'
       - 'src/domains/desktop/**'
+      - 'src/domains/help/commands/app-command-help.ts'
       - 'src/types/desktop.ts'
       - 'scripts/generate-desktop-release-manifest.ts'
       - '.github/workflows/desktop-build.yml'
@@ -40,6 +45,9 @@ jobs:
 
       - name: Install frontend dependencies
         run: bun install --frozen-lockfile
+
+      - name: Validate desktop bundle config
+        run: bun run desktop:validate-config
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -118,6 +126,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
+
+      - name: Validate desktop bundle config
+        run: bun run desktop:validate-config
 
       # tauri-action runs beforeBuildCommand (bun run ui:build) automatically
       - name: Build Tauri app

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -15,6 +15,7 @@ on:
       - 'src/commands/app/**'
       - 'src/ui/**'
       - 'src/domains/desktop/**'
+      - 'src/domains/versioning/checking/**'
       - 'src/domains/help/commands/app-command-help.ts'
       - 'src/types/desktop.ts'
       - 'scripts/generate-desktop-release-manifest.ts'
@@ -76,6 +77,42 @@ jobs:
 
       - name: Tests
         run: bun test
+
+  pr-windows-build:
+    name: PR Windows Bundle Check
+    runs-on: windows-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.2
+
+      - name: Install frontend dependencies
+        run: bun install --frozen-lockfile
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Validate desktop bundle config
+        run: bun run desktop:validate-config
+
+      - name: Build Tauri app on Windows
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: ''
 
   build:
     if: github.event_name != 'pull_request'

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"dev:quick": "./scripts/dev-quick-start.sh",
 		"dev:all": "./scripts/dev-quick-start.sh all",
 		"metrics": "bun run scripts/workflow-metrics.ts",
-		"validate": "bun run typecheck && bun run lint && bun test && bun run ui:test && bun run build",
+		"validate": "bun run typecheck && bun run lint && bun run desktop:validate-config && bun test && bun run ui:test && bun run build",
 		"install:hooks": "./.githooks/install.sh",
 		"prepare": "node -e \"try{require('child_process').execSync('git rev-parse --git-dir',{stdio:'ignore'});require('child_process').execSync('bash .githooks/install.sh',{stdio:'inherit'})}catch(e){console.warn('[i] Hook install skipped:',e.message)}\""
 	},

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"tauri": "tauri",
 		"tauri:dev": "tauri dev",
 		"tauri:build": "tauri build",
+		"desktop:validate-config": "bun scripts/validate-desktop-bundle-config.ts",
 		"dev": "bun run src/index.ts",
 		"dashboard:dev": "cd src/ui && bun install --silent && cd ../.. && bun run src/index.ts config ui --dev",
 		"dashboard:tauri": "bun run ui:dev:tauri",

--- a/scripts/generate-desktop-release-manifest.ts
+++ b/scripts/generate-desktop-release-manifest.ts
@@ -22,6 +22,7 @@ async function main(): Promise<void> {
 		version: getVersionFromTag(payload.tag_name),
 		publishedAt: payload.published_at || new Date().toISOString(),
 		assets: payload.assets,
+		channel: payload.prerelease ? "dev" : "stable",
 	});
 
 	process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);

--- a/scripts/validate-desktop-bundle-config.ts
+++ b/scripts/validate-desktop-bundle-config.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath } from "node:url";
+import {
+	loadDesktopBundleConfig,
+	validateDesktopBundleConfig,
+} from "../src/domains/desktop/desktop-bundle-version.js";
+
+const CONFIG_PATH = fileURLToPath(new URL("../src-tauri/tauri.conf.json", import.meta.url));
+
+try {
+	const config = await loadDesktopBundleConfig(CONFIG_PATH);
+	const result = validateDesktopBundleConfig(config);
+	console.log(
+		`[desktop-config] app version ${result.appVersion} -> wix.version ${result.expectedWixVersion}`,
+	);
+} catch (error) {
+	const message = error instanceof Error ? error.message : String(error);
+	console.error(`[desktop-config] ${message}`);
+	process.exitCode = 1;
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,6 +35,11 @@
 	"bundle": {
 		"active": true,
 		"targets": "all",
+		"windows": {
+			"wix": {
+				"version": "0.1.0.2"
+			}
+		},
 		"icon": [
 			"icons/32x32.png",
 			"icons/128x128.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,7 +37,7 @@
 		"targets": "all",
 		"windows": {
 			"wix": {
-				"version": "0.1.0.2"
+				"version": "0.1.2"
 			}
 		},
 		"icon": [

--- a/src/__tests__/commands/app/app-command-update.test.ts
+++ b/src/__tests__/commands/app/app-command-update.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, mock, test } from "bun:test";
+import { appCommand } from "@/commands/app/app-command.js";
+
+describe("appCommand update short-circuit", () => {
+	test("skips download when the installed desktop build is already up to date", async () => {
+		const downloadBinary = mock(async () => "/tmp/download.zip");
+		const launchBinary = mock(() => {});
+		const success = mock(() => {});
+
+		await appCommand(
+			{ dev: true, update: true },
+			{
+				getBinaryPath: () => "/Applications/ClaudeKit Control Center.app",
+				getInstallPath: () => "/Applications/ClaudeKit Control Center.app",
+				getUpdateStatus: async () => ({
+					currentVersion: "0.1.0-dev.2",
+					latestVersion: "0.1.0-dev.2",
+					updateAvailable: false,
+					reason: "up-to-date",
+				}),
+				downloadBinary,
+				installBinary: async (path) => path,
+				launchBinary,
+				uninstallBinary: async () => ({ path: "/unused", removed: false }),
+				info: () => {},
+				success,
+				printLine: () => {},
+			},
+		);
+
+		expect(downloadBinary).not.toHaveBeenCalled();
+		expect(launchBinary).toHaveBeenCalledWith("/Applications/ClaudeKit Control Center.app");
+		expect(success).toHaveBeenCalledWith(
+			"ClaudeKit Control Center is already up to date (0.1.0-dev.2)",
+		);
+	});
+
+	test("downloads when update metadata is missing or stale", async () => {
+		const downloadBinary = mock(async () => "/tmp/download.zip");
+		const installBinary = mock(async () => "/Applications/ClaudeKit Control Center.app");
+
+		await appCommand(
+			{ dev: true, update: true },
+			{
+				getBinaryPath: () => "/Applications/ClaudeKit Control Center.app",
+				getInstallPath: () => "/Applications/ClaudeKit Control Center.app",
+				getUpdateStatus: async () => ({
+					currentVersion: null,
+					latestVersion: "0.1.0-dev.2",
+					updateAvailable: true,
+					reason: "unknown-installed-version",
+				}),
+				downloadBinary,
+				installBinary,
+				launchBinary: () => {},
+				uninstallBinary: async () => ({ path: "/unused", removed: false }),
+				info: () => {},
+				success: () => {},
+				printLine: () => {},
+			},
+		);
+
+		expect(downloadBinary).toHaveBeenCalledWith({ channel: "dev" });
+		expect(installBinary).toHaveBeenCalledWith("/tmp/download.zip");
+	});
+});

--- a/src/__tests__/commands/app/app-command.test.ts
+++ b/src/__tests__/commands/app/app-command.test.ts
@@ -102,7 +102,7 @@ describe("appCommand", () => {
 		);
 	});
 
-	test("forces a reinstall when --update is used", async () => {
+	test("downloads and reinstalls when --update finds a newer desktop build", async () => {
 		const downloadBinary = mock(async () => "/tmp/download.zip");
 		const installBinary = mock(async () => "/Applications/ClaudeKit Control Center.app");
 
@@ -111,6 +111,12 @@ describe("appCommand", () => {
 			{
 				getBinaryPath: () => "/Applications/ClaudeKit Control Center.app",
 				getInstallPath: () => "/Applications/ClaudeKit Control Center.app",
+				getUpdateStatus: async () => ({
+					currentVersion: "0.1.0-dev.1",
+					latestVersion: "0.1.0-dev.2",
+					updateAvailable: true,
+					reason: "update-available",
+				}),
 				downloadBinary,
 				installBinary,
 				launchBinary: () => {},

--- a/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
+++ b/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
@@ -112,6 +112,8 @@ describe("desktop-binary-manager", () => {
 			platform: "linux",
 			arch: "x64",
 			fetchManifest: async () => manifest,
+			binaryPath: "/tmp/ck-phase-3-home/.local/bin/claudekit-control-center",
+			validateInstalledArtifact: async () => true,
 		});
 
 		expect(status).toEqual({
@@ -128,6 +130,8 @@ describe("desktop-binary-manager", () => {
 			platform: "linux",
 			arch: "x64",
 			fetchManifest: async () => manifest,
+			binaryPath: "/tmp/ck-phase-3-home/.local/bin/claudekit-control-center",
+			validateInstalledArtifact: async () => true,
 		});
 
 		expect(status).toEqual({
@@ -157,6 +161,8 @@ describe("desktop-binary-manager", () => {
 			platform: "linux",
 			arch: "x64",
 			fetchManifest: async () => manifest,
+			binaryPath: "/tmp/ck-phase-3-home/.local/bin/claudekit-control-center",
+			validateInstalledArtifact: async () => true,
 		});
 
 		expect(status).toEqual({
@@ -164,6 +170,33 @@ describe("desktop-binary-manager", () => {
 			latestVersion: "0.1.0",
 			updateAvailable: false,
 			reason: "installed-newer",
+		});
+	});
+
+	test("forces a reinstall when the installed artifact does not match the recorded metadata", async () => {
+		const status = await getDesktopUpdateStatus({
+			channel: "stable",
+			platform: "linux",
+			arch: "x64",
+			fetchManifest: async () => manifest,
+			readInstallMetadata: async () => ({
+				version: "0.1.0",
+				manifestDate: "2026-04-15T21:00:00Z",
+				channel: "stable",
+				platformKey: "linux-x86_64",
+				assetName: "claudekit-control-center_0.1.0_linux-x86_64.AppImage",
+				assetSize: 202,
+				installedAt: "2026-04-15T21:05:00Z",
+			}),
+			binaryPath: "/tmp/ck-phase-3-home/.local/bin/claudekit-control-center",
+			validateInstalledArtifact: async () => false,
+		});
+
+		expect(status).toEqual({
+			currentVersion: "0.1.0",
+			latestVersion: "0.1.0",
+			updateAvailable: true,
+			reason: "update-available",
 		});
 	});
 });

--- a/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
+++ b/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { rm } from "node:fs/promises";
 import {
 	downloadDesktopBinary,
 	getDesktopBinaryPath,
+	getDesktopUpdateStatus,
 } from "@/domains/desktop/desktop-binary-manager.js";
+import { writeDesktopInstallMetadata } from "@/domains/desktop/desktop-install-metadata.js";
 import type { DesktopReleaseManifest } from "@/types/desktop.js";
 
 const manifest: DesktopReleaseManifest = {
@@ -46,6 +49,7 @@ describe("desktop-binary-manager", () => {
 
 	afterEach(() => {
 		process.env.CK_TEST_HOME = originalTestHome;
+		return rm("/tmp/ck-phase-3-home", { recursive: true, force: true });
 	});
 
 	test("returns null when the installed binary is missing", () => {
@@ -87,5 +91,79 @@ describe("desktop-binary-manager", () => {
 			destDir: "/tmp/downloads",
 		});
 		expect(result).toBe("/tmp/downloads/linux.AppImage");
+	});
+
+	test("reports no update when installed desktop metadata matches the latest manifest", async () => {
+		await writeDesktopInstallMetadata(
+			{
+				version: "0.1.0",
+				manifestDate: "2026-04-15T21:00:00Z",
+				channel: "stable",
+				platformKey: "linux-x86_64",
+				assetName: "claudekit-control-center_0.1.0_linux-x86_64.AppImage",
+				assetSize: 202,
+				installedAt: "2026-04-15T21:05:00Z",
+			},
+			{ platform: "linux" },
+		);
+
+		const status = await getDesktopUpdateStatus({
+			channel: "stable",
+			platform: "linux",
+			arch: "x64",
+			fetchManifest: async () => manifest,
+		});
+
+		expect(status).toEqual({
+			currentVersion: "0.1.0",
+			latestVersion: "0.1.0",
+			updateAvailable: false,
+			reason: "up-to-date",
+		});
+	});
+
+	test("reports an update when installed metadata is missing", async () => {
+		const status = await getDesktopUpdateStatus({
+			channel: "stable",
+			platform: "linux",
+			arch: "x64",
+			fetchManifest: async () => manifest,
+		});
+
+		expect(status).toEqual({
+			currentVersion: null,
+			latestVersion: "0.1.0",
+			updateAvailable: true,
+			reason: "unknown-installed-version",
+		});
+	});
+
+	test("reports installed-newer when the installed build is newer on the same channel", async () => {
+		await writeDesktopInstallMetadata(
+			{
+				version: "0.1.1",
+				manifestDate: "2026-04-20T00:00:00Z",
+				channel: "stable",
+				platformKey: "linux-x86_64",
+				assetName: "claudekit-control-center_0.1.1_linux-x86_64.AppImage",
+				assetSize: 999,
+				installedAt: "2026-04-20T00:05:00Z",
+			},
+			{ platform: "linux" },
+		);
+
+		const status = await getDesktopUpdateStatus({
+			channel: "stable",
+			platform: "linux",
+			arch: "x64",
+			fetchManifest: async () => manifest,
+		});
+
+		expect(status).toEqual({
+			currentVersion: "0.1.1",
+			latestVersion: "0.1.0",
+			updateAvailable: false,
+			reason: "installed-newer",
+		});
 	});
 });

--- a/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
+++ b/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
@@ -199,4 +199,31 @@ describe("desktop-binary-manager", () => {
 			reason: "update-available",
 		});
 	});
+
+	test("forces an update when the installed desktop metadata is for a different channel", async () => {
+		const status = await getDesktopUpdateStatus({
+			channel: "stable",
+			platform: "linux",
+			arch: "x64",
+			fetchManifest: async () => manifest,
+			readInstallMetadata: async () => ({
+				version: "0.1.0-dev.2",
+				manifestDate: "2026-04-15T21:00:00Z",
+				channel: "dev",
+				platformKey: "linux-x86_64",
+				assetName: "claudekit-control-center_0.1.0-dev.2_linux-x86_64.AppImage",
+				assetSize: 202,
+				installedAt: "2026-04-15T21:05:00Z",
+			}),
+			binaryPath: "/tmp/ck-phase-3-home/.local/bin/claudekit-control-center",
+			validateInstalledArtifact: async () => true,
+		});
+
+		expect(status).toEqual({
+			currentVersion: "0.1.0-dev.2",
+			latestVersion: "0.1.0",
+			updateAvailable: true,
+			reason: "update-available",
+		});
+	});
 });

--- a/src/__tests__/domains/desktop/desktop-bundle-version.test.ts
+++ b/src/__tests__/domains/desktop/desktop-bundle-version.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import {
+	deriveWindowsWixVersion,
+	validateDesktopBundleConfig,
+} from "@/domains/desktop/desktop-bundle-version.js";
+
+describe("desktop-bundle-version", () => {
+	test("derives a numeric MSI-safe version from a prerelease app version", () => {
+		expect(deriveWindowsWixVersion("0.1.0-dev.2")).toBe("0.1.0.2");
+		expect(deriveWindowsWixVersion("1.2.3-rc.12")).toBe("1.2.3.12");
+	});
+
+	test("derives a four-part MSI version from a stable app version", () => {
+		expect(deriveWindowsWixVersion("0.1.0")).toBe("0.1.0.0");
+	});
+
+	test("rejects prerelease versions without a numeric suffix", () => {
+		expect(() => deriveWindowsWixVersion("0.1.0-dev")).toThrow(/numeric prerelease segment/i);
+	});
+
+	test("validates matching wix.version in desktop bundle config", () => {
+		expect(() =>
+			validateDesktopBundleConfig({
+				version: "0.1.0-dev.2",
+				bundle: {
+					windows: {
+						wix: {
+							version: "0.1.0.2",
+						},
+					},
+				},
+			}),
+		).not.toThrow();
+	});
+
+	test("rejects mismatched wix.version in desktop bundle config", () => {
+		expect(() =>
+			validateDesktopBundleConfig({
+				version: "0.1.0-dev.2",
+				bundle: {
+					windows: {
+						wix: {
+							version: "0.1.0.1",
+						},
+					},
+				},
+			}),
+		).toThrow(/requires bundle\.windows\.wix\.version 0\.1\.0\.2/i);
+	});
+});

--- a/src/__tests__/domains/desktop/desktop-bundle-version.test.ts
+++ b/src/__tests__/domains/desktop/desktop-bundle-version.test.ts
@@ -3,19 +3,32 @@ import {
 	deriveWindowsWixVersion,
 	validateDesktopBundleConfig,
 } from "@/domains/desktop/desktop-bundle-version.js";
+import { compareVersions } from "compare-versions";
 
 describe("desktop-bundle-version", () => {
-	test("derives a numeric MSI-safe version from a prerelease app version", () => {
-		expect(deriveWindowsWixVersion("0.1.0-dev.2")).toBe("0.1.0.2");
-		expect(deriveWindowsWixVersion("1.2.3-rc.12")).toBe("1.2.3.12");
+	test("derives a monotonic MSI-safe version from a prerelease app version", () => {
+		expect(deriveWindowsWixVersion("0.1.0-dev.2")).toBe("0.1.2");
+		expect(deriveWindowsWixVersion("1.2.3-rc.12")).toBe("1.2.1932");
 	});
 
-	test("derives a four-part MSI version from a stable app version", () => {
-		expect(deriveWindowsWixVersion("0.1.0")).toBe("0.1.0.0");
+	test("derives a stable MSI version that sorts after same-base prereleases", () => {
+		expect(deriveWindowsWixVersion("0.1.0")).toBe("0.1.511");
+		expect(
+			compareVersions(deriveWindowsWixVersion("0.1.0"), deriveWindowsWixVersion("0.1.0-dev.2")),
+		).toBe(1);
+		expect(
+			compareVersions(deriveWindowsWixVersion("0.1.1-dev.1"), deriveWindowsWixVersion("0.1.0")),
+		).toBe(1);
 	});
 
 	test("rejects prerelease versions without a numeric suffix", () => {
 		expect(() => deriveWindowsWixVersion("0.1.0-dev")).toThrow(/numeric prerelease segment/i);
+	});
+
+	test("rejects unsupported prerelease labels for Windows MSI", () => {
+		expect(() => deriveWindowsWixVersion("0.1.0-preview.1")).toThrow(
+			/unsupported prerelease label/i,
+		);
 	});
 
 	test("validates matching wix.version in desktop bundle config", () => {
@@ -25,7 +38,22 @@ describe("desktop-bundle-version", () => {
 				bundle: {
 					windows: {
 						wix: {
-							version: "0.1.0.2",
+							version: "0.1.2",
+						},
+					},
+				},
+			}),
+		).not.toThrow();
+	});
+
+	test("accepts an equivalent four-part wix.version that ends in .0", () => {
+		expect(() =>
+			validateDesktopBundleConfig({
+				version: "0.1.0",
+				bundle: {
+					windows: {
+						wix: {
+							version: "0.1.511.0",
 						},
 					},
 				},
@@ -40,11 +68,11 @@ describe("desktop-bundle-version", () => {
 				bundle: {
 					windows: {
 						wix: {
-							version: "0.1.0.1",
+							version: "0.1.1",
 						},
 					},
 				},
 			}),
-		).toThrow(/requires bundle\.windows\.wix\.version 0\.1\.0\.2/i);
+		).toThrow(/requires bundle\.windows\.wix\.version 0\.1\.2/i);
 	});
 });

--- a/src/__tests__/domains/desktop/desktop-installed-artifact-validator.test.ts
+++ b/src/__tests__/domains/desktop/desktop-installed-artifact-validator.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { validateInstalledDesktopArtifact } from "@/domains/desktop/desktop-installed-artifact-validator.js";
+
+describe("desktop-installed-artifact-validator", () => {
+	test("matches the exact CFBundleShortVersionString value on macOS", async () => {
+		const isValid = await validateInstalledDesktopArtifact(
+			"/Applications/ClaudeKit Control Center.app",
+			{
+				version: "1.2.3",
+				manifestDate: "2026-04-19T00:00:00Z",
+				channel: "stable",
+				platformKey: "darwin-aarch64",
+				assetName: "claudekit-control-center_1.2.3_macos-universal.app.zip",
+				assetSize: 123,
+				installedAt: "2026-04-19T00:00:00Z",
+			},
+			{
+				platform: "darwin",
+				readFileFn: async () => `<?xml version="1.0"?>
+<plist>
+  <dict>
+    <key>CFBundleShortVersionString</key>
+    <string>1.2.3</string>
+  </dict>
+</plist>`,
+			},
+		);
+
+		expect(isValid).toBe(true);
+	});
+
+	test("rejects substring-only matches on macOS", async () => {
+		const isValid = await validateInstalledDesktopArtifact(
+			"/Applications/ClaudeKit Control Center.app",
+			{
+				version: "1.2",
+				manifestDate: "2026-04-19T00:00:00Z",
+				channel: "stable",
+				platformKey: "darwin-aarch64",
+				assetName: "claudekit-control-center_1.2_macos-universal.app.zip",
+				assetSize: 123,
+				installedAt: "2026-04-19T00:00:00Z",
+			},
+			{
+				platform: "darwin",
+				readFileFn: async () => `<?xml version="1.0"?>
+<plist>
+  <dict>
+    <key>CFBundleShortVersionString</key>
+    <string>1.20</string>
+  </dict>
+</plist>`,
+			},
+		);
+
+		expect(isValid).toBe(false);
+	});
+});

--- a/src/__tests__/domains/desktop/desktop-installer.test.ts
+++ b/src/__tests__/domains/desktop/desktop-installer.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { chmod, mkdir, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { readDesktopInstallMetadata } from "@/domains/desktop/desktop-install-metadata.js";
 import { installDesktopBinary } from "@/domains/desktop/desktop-installer.js";
 
 describe("desktop-installer", () => {
@@ -22,6 +23,18 @@ describe("desktop-installer", () => {
 		const sourcePath = join(fixturesDir, "claudekit-control-center.AppImage");
 		await writeFile(sourcePath, "linux-binary");
 		await chmod(sourcePath, 0o644);
+		await writeFile(
+			`${sourcePath}.metadata.json`,
+			JSON.stringify({
+				version: "0.1.0-dev.2",
+				manifestDate: "2026-04-19T00:00:00Z",
+				channel: "dev",
+				platformKey: "linux-x86_64",
+				assetName: "claudekit-control-center_0.1.0-dev.2_linux-x86_64.AppImage",
+				assetSize: 111,
+				installedAt: "2026-04-19T00:00:00Z",
+			}),
+		);
 
 		const installedPath = await installDesktopBinary(sourcePath, {
 			platform: "linux",
@@ -32,6 +45,15 @@ describe("desktop-installer", () => {
 		);
 		expect(await Bun.file(installedPath).text()).toBe("linux-binary");
 		expect((await stat(installedPath)).mode & 0o111).toBeGreaterThan(0);
+		expect(await readDesktopInstallMetadata({ platform: "linux" })).toEqual({
+			version: "0.1.0-dev.2",
+			manifestDate: "2026-04-19T00:00:00Z",
+			channel: "dev",
+			platformKey: "linux-x86_64",
+			assetName: "claudekit-control-center_0.1.0-dev.2_linux-x86_64.AppImage",
+			assetSize: 111,
+			installedAt: "2026-04-19T00:00:00Z",
+		});
 	});
 
 	test("installs a macOS app bundle from a zip staging directory and clears quarantine", async () => {

--- a/src/__tests__/domains/desktop/desktop-installer.test.ts
+++ b/src/__tests__/domains/desktop/desktop-installer.test.ts
@@ -80,6 +80,34 @@ describe("desktop-installer", () => {
 		expect(removeQuarantineFn).toHaveBeenCalledWith(`${installedPath}.new`);
 	});
 
+	test("does not fail the install when metadata persistence fails after a successful copy", async () => {
+		const fixturesDir = "/tmp/ck-phase-3-installer-fixtures";
+		await mkdir(fixturesDir, { recursive: true });
+		const sourcePath = join(fixturesDir, "claudekit-control-center.AppImage");
+		await writeFile(sourcePath, "linux-binary");
+
+		const installedPath = await installDesktopBinary(sourcePath, {
+			platform: "linux",
+			readDownloadedMetadataFn: async () => ({
+				version: "0.1.0-dev.2",
+				manifestDate: "2026-04-19T00:00:00Z",
+				channel: "dev",
+				platformKey: "linux-x86_64",
+				assetName: "claudekit-control-center_0.1.0-dev.2_linux-x86_64.AppImage",
+				assetSize: 111,
+				installedAt: "2026-04-19T00:00:00Z",
+			}),
+			persistInstallMetadataFn: async () => {
+				throw new Error("metadata write failed");
+			},
+		});
+
+		expect(installedPath).toBe(
+			"/tmp/ck-phase-3-installer-home/.local/bin/claudekit-control-center",
+		);
+		expect(await Bun.file(installedPath).text()).toBe("linux-binary");
+	});
+
 	test("preserves the existing macOS install when quarantine removal fails before swap", async () => {
 		const currentInstallPath =
 			"/tmp/ck-phase-3-installer-home/Applications/ClaudeKit Control Center.app/Contents";

--- a/src/__tests__/domains/desktop/desktop-release-manifest-dev-channel.test.ts
+++ b/src/__tests__/domains/desktop/desktop-release-manifest-dev-channel.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { buildDesktopReleaseManifest } from "@/domains/desktop/desktop-release-manifest.js";
+
+describe("desktop-release-manifest dev channel", () => {
+	test("marks dev releases with channel=dev for update metadata", () => {
+		const manifest = buildDesktopReleaseManifest({
+			version: "0.1.0-dev.2",
+			publishedAt: "2026-04-19T00:00:00Z",
+			channel: "dev",
+			assets: [
+				{
+					id: 1,
+					name: "claudekit-control-center_0.1.0-dev.2_macos-universal.app.zip",
+					url: "https://api.example.com/assets/1",
+					browser_download_url:
+						"https://example.com/claudekit-control-center_0.1.0-dev.2_macos-universal.app.zip",
+					size: 100,
+					content_type: "application/zip",
+				},
+				{
+					id: 2,
+					name: "claudekit-control-center_0.1.0-dev.2_linux-x86_64.AppImage",
+					url: "https://api.example.com/assets/2",
+					browser_download_url:
+						"https://example.com/claudekit-control-center_0.1.0-dev.2_linux-x86_64.AppImage",
+					size: 200,
+					content_type: "application/octet-stream",
+				},
+				{
+					id: 3,
+					name: "claudekit-control-center_0.1.0-dev.2_windows-x86_64-portable.exe",
+					url: "https://api.example.com/assets/3",
+					browser_download_url:
+						"https://example.com/claudekit-control-center_0.1.0-dev.2_windows-x86_64-portable.exe",
+					size: 300,
+					content_type: "application/octet-stream",
+				},
+			],
+		});
+
+		expect(manifest.channel).toBe("dev");
+	});
+});

--- a/src/__tests__/domains/desktop/desktop-release-manifest.test.ts
+++ b/src/__tests__/domains/desktop/desktop-release-manifest.test.ts
@@ -38,6 +38,7 @@ describe("desktop-release-manifest", () => {
 
 		expect(manifest.version).toBe("0.1.0");
 		expect(manifest.date).toBe("2026-04-15T21:00:00Z");
+		expect(manifest.channel).toBe("stable");
 		expect(macArm).toBeDefined();
 		expect(macIntel).toBeDefined();
 		expect(linux).toBeDefined();
@@ -215,6 +216,21 @@ describe("desktop-release-manifest", () => {
 			},
 		});
 		expect(parsed.channel).toBe("dev");
+	});
+
+	test("builds a dev manifest when requested", () => {
+		const manifest = buildDesktopReleaseManifest({
+			version: "0.1.0-dev.2",
+			publishedAt: "2026-04-15T21:00:00Z",
+			channel: "dev",
+			assets: [
+				createAsset("claudekit-control-center_0.1.0-dev.2_macos-universal.app.zip", 101),
+				createAsset("claudekit-control-center_0.1.0-dev.2_linux-x86_64.AppImage", 202),
+				createAsset("claudekit-control-center_0.1.0-dev.2_windows-x86_64-portable.exe", 303),
+			],
+		});
+
+		expect(manifest.channel).toBe("dev");
 	});
 
 	test("defaults channel to stable when field is absent (backward compat)", () => {

--- a/src/__tests__/domains/desktop/desktop-release-service.test.ts
+++ b/src/__tests__/domains/desktop/desktop-release-service.test.ts
@@ -70,6 +70,7 @@ describe("desktop-release-service", () => {
 		expect(fetchFn).toHaveBeenCalledWith(
 			"https://github.com/mrgoonie/claudekit-cli/releases/download/desktop-latest/desktop-manifest.json",
 		);
+		expect(manifest.channel).toBe("stable");
 		expect(manifest.platforms["windows-x86_64"]?.assetType).toBe("portable-exe");
 	});
 
@@ -114,6 +115,92 @@ describe("desktop-release-service", () => {
 		expect(fetchFn).toHaveBeenCalledWith(
 			"https://github.com/mrgoonie/claudekit-cli/releases/download/desktop-latest-dev/desktop-manifest.json",
 		);
+	});
+
+	test("backfills channel=dev for legacy dev manifests that predate the channel field", async () => {
+		const fetchFn = mock(async () => ({
+			ok: true,
+			json: async () => ({
+				version: "0.1.0-dev.2",
+				date: "2026-04-15T21:00:00Z",
+				platforms: {
+					"darwin-aarch64": {
+						name: "mac.zip",
+						url: "https://example.com/mac.zip",
+						size: 100,
+						assetType: "app-zip",
+					},
+					"darwin-x86_64": {
+						name: "mac.zip",
+						url: "https://example.com/mac.zip",
+						size: 100,
+						assetType: "app-zip",
+					},
+					"linux-x86_64": {
+						name: "linux.AppImage",
+						url: "https://example.com/linux.AppImage",
+						size: 200,
+						assetType: "appimage",
+					},
+					"windows-x86_64": {
+						name: "windows.exe",
+						url: "https://example.com/windows.exe",
+						size: 300,
+						assetType: "portable-exe",
+					},
+				},
+			}),
+		}));
+
+		const manifest = await fetchDesktopReleaseManifest(
+			{ channel: "dev" },
+			fetchFn as unknown as typeof fetch,
+		);
+
+		expect(manifest.channel).toBe("dev");
+	});
+
+	test("infers channel=dev for version-specific prerelease manifests that lack the channel field", async () => {
+		const fetchFn = mock(async () => ({
+			ok: true,
+			json: async () => ({
+				version: "0.1.0-dev.2",
+				date: "2026-04-15T21:00:00Z",
+				platforms: {
+					"darwin-aarch64": {
+						name: "mac.zip",
+						url: "https://example.com/mac.zip",
+						size: 100,
+						assetType: "app-zip",
+					},
+					"darwin-x86_64": {
+						name: "mac.zip",
+						url: "https://example.com/mac.zip",
+						size: 100,
+						assetType: "app-zip",
+					},
+					"linux-x86_64": {
+						name: "linux.AppImage",
+						url: "https://example.com/linux.AppImage",
+						size: 200,
+						assetType: "appimage",
+					},
+					"windows-x86_64": {
+						name: "windows.exe",
+						url: "https://example.com/windows.exe",
+						size: 300,
+						assetType: "portable-exe",
+					},
+				},
+			}),
+		}));
+
+		const manifest = await fetchDesktopReleaseManifest(
+			{ version: "0.1.0-dev.2" },
+			fetchFn as unknown as typeof fetch,
+		);
+
+		expect(manifest.channel).toBe("dev");
 	});
 
 	test("throws when the manifest request fails", async () => {

--- a/src/__tests__/domains/desktop/desktop-uninstaller.test.ts
+++ b/src/__tests__/domains/desktop/desktop-uninstaller.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { getDesktopInstallMetadataPath } from "@/domains/desktop/desktop-install-path-resolver.js";
 import { uninstallDesktopBinary } from "@/domains/desktop/desktop-uninstaller.js";
 
 describe("desktop-uninstaller", () => {
@@ -10,6 +13,7 @@ describe("desktop-uninstaller", () => {
 
 	afterEach(() => {
 		process.env.CK_TEST_HOME = originalTestHome;
+		return rm("/tmp/ck-phase-4-home", { recursive: true, force: true });
 	});
 
 	test("returns a no-op result when the desktop binary is missing", async () => {
@@ -44,5 +48,20 @@ describe("desktop-uninstaller", () => {
 			path: "/tmp/ck-phase-4-home/.local/bin/claudekit-control-center",
 			removed: true,
 		});
+	});
+
+	test("removes install metadata when uninstalling the desktop binary", async () => {
+		const installDir = "/tmp/ck-phase-4-home/.local/bin";
+		await mkdir(installDir, { recursive: true });
+		await writeFile(join(installDir, "claudekit-control-center"), "binary");
+		await writeFile(getDesktopInstallMetadataPath({ platform: "linux" }), "{}");
+
+		await uninstallDesktopBinary({
+			platform: "linux",
+		});
+
+		await expect(
+			Bun.file(getDesktopInstallMetadataPath({ platform: "linux" })).text(),
+		).rejects.toThrow();
 	});
 });

--- a/src/__tests__/domains/desktop/desktop-uninstaller.test.ts
+++ b/src/__tests__/domains/desktop/desktop-uninstaller.test.ts
@@ -64,4 +64,25 @@ describe("desktop-uninstaller", () => {
 			Bun.file(getDesktopInstallMetadataPath({ platform: "linux" })).text(),
 		).rejects.toThrow();
 	});
+
+	test("does not fail the uninstall when metadata cleanup throws after removal", async () => {
+		const removeFn = mock(async () => {});
+
+		const result = await uninstallDesktopBinary({
+			platform: "linux",
+			pathExistsFn: async () => true,
+			removeFn,
+			clearInstallMetadataFn: async () => {
+				throw new Error("metadata cleanup failed");
+			},
+		});
+
+		expect(removeFn).toHaveBeenCalledWith(
+			"/tmp/ck-phase-4-home/.local/bin/claudekit-control-center",
+		);
+		expect(result).toEqual({
+			path: "/tmp/ck-phase-4-home/.local/bin/claudekit-control-center",
+			removed: true,
+		});
+	});
 });

--- a/src/commands/app/app-command.ts
+++ b/src/commands/app/app-command.ts
@@ -95,7 +95,7 @@ export async function appCommand(
 	}
 
 	if (options.update && existingBinary) {
-		const updateStatus = await getUpdateStatus({ channel });
+		const updateStatus = await getUpdateStatus({ channel, binaryPath: existingBinary });
 		if (!updateStatus.updateAvailable) {
 			success(
 				updateStatus.reason === "installed-newer"

--- a/src/commands/app/app-command.ts
+++ b/src/commands/app/app-command.ts
@@ -4,6 +4,7 @@ import {
 	downloadDesktopBinary,
 	getDesktopBinaryPath,
 	getDesktopInstallPath,
+	getDesktopUpdateStatus,
 	installDesktopBinary,
 	launchDesktopApp,
 	uninstallDesktopBinary,
@@ -48,6 +49,7 @@ export async function appCommand(
 	const launchWeb = deps.launchWeb || configUICommand;
 	const getBinaryPath = deps.getBinaryPath || getDesktopBinaryPath;
 	const getInstallPath = deps.getInstallPath || getDesktopInstallPath;
+	const getUpdateStatus = deps.getUpdateStatus || getDesktopUpdateStatus;
 	const downloadBinary =
 		deps.downloadBinary ||
 		((opts?: { channel?: DesktopChannel }) =>
@@ -85,16 +87,30 @@ export async function appCommand(
 		return;
 	}
 
-	const existingBinary = options.update ? null : getBinaryPath();
-	if (existingBinary) {
+	const existingBinary = getBinaryPath();
+	if (existingBinary && !options.update) {
 		success("Launching ClaudeKit Control Center...");
 		launchBinary(existingBinary);
 		return;
 	}
 
+	if (options.update && existingBinary) {
+		const updateStatus = await getUpdateStatus({ channel });
+		if (!updateStatus.updateAvailable) {
+			success(
+				updateStatus.reason === "installed-newer"
+					? `Installed desktop build (${updateStatus.currentVersion}) is newer than the latest published build (${updateStatus.latestVersion})`
+					: `ClaudeKit Control Center is already up to date (${updateStatus.latestVersion})`,
+			);
+			success("Launching ClaudeKit Control Center...");
+			launchBinary(existingBinary);
+			return;
+		}
+	}
+
 	info(
 		options.update
-			? "Downloading the latest ClaudeKit Control Center build..."
+			? "Downloading and installing the latest ClaudeKit Control Center build..."
 			: "ClaudeKit Control Center not found. Downloading...",
 	);
 	const downloadedBinary = await downloadBinary({ channel });
@@ -108,7 +124,7 @@ export function registerAppCommand(cli: ReturnType<typeof cac>): void {
 	cli
 		.command("app", "Launch ClaudeKit Control Center desktop app")
 		.option("--web", "Open the web dashboard instead of the desktop app")
-		.option("--update", "Download and install the latest desktop build before launching")
+		.option("--update", "Check for a newer desktop build and install it before launching")
 		.option("--path", "Print the current install path (or target path) and exit")
 		.option("--uninstall", "Remove the installed desktop app and exit")
 		.option("--dev", "Force dev channel for this invocation")

--- a/src/commands/app/types.ts
+++ b/src/commands/app/types.ts
@@ -1,4 +1,5 @@
 import type { ConfigUIOptions } from "@/commands/config/types.js";
+import type { DesktopUpdateStatus } from "@/domains/desktop/desktop-binary-manager.js";
 import type { DesktopChannel } from "@/domains/desktop/desktop-release-service.js";
 import type { DesktopUninstallResult } from "@/domains/desktop/desktop-uninstaller.js";
 
@@ -15,6 +16,7 @@ export interface AppCommandDependencies {
 	launchWeb?: (options?: ConfigUIOptions) => Promise<void>;
 	getBinaryPath?: () => string | null;
 	getInstallPath?: () => string;
+	getUpdateStatus?: (opts?: { channel?: DesktopChannel }) => Promise<DesktopUpdateStatus>;
 	downloadBinary?: (opts?: { channel?: DesktopChannel }) => Promise<string>;
 	installBinary?: (downloadPath: string) => Promise<string>;
 	launchBinary?: (binaryPath: string) => void;

--- a/src/commands/app/types.ts
+++ b/src/commands/app/types.ts
@@ -16,7 +16,10 @@ export interface AppCommandDependencies {
 	launchWeb?: (options?: ConfigUIOptions) => Promise<void>;
 	getBinaryPath?: () => string | null;
 	getInstallPath?: () => string;
-	getUpdateStatus?: (opts?: { channel?: DesktopChannel }) => Promise<DesktopUpdateStatus>;
+	getUpdateStatus?: (opts?: {
+		channel?: DesktopChannel;
+		binaryPath?: string | null;
+	}) => Promise<DesktopUpdateStatus>;
 	downloadBinary?: (opts?: { channel?: DesktopChannel }) => Promise<string>;
 	installBinary?: (downloadPath: string) => Promise<string>;
 	launchBinary?: (binaryPath: string) => void;

--- a/src/domains/desktop/desktop-binary-manager.ts
+++ b/src/domains/desktop/desktop-binary-manager.ts
@@ -12,6 +12,7 @@ import {
 	getDesktopDownloadDirectory,
 	getDesktopInstallPath,
 } from "@/domains/desktop/desktop-install-path-resolver.js";
+import { validateInstalledDesktopArtifact } from "@/domains/desktop/desktop-installed-artifact-validator.js";
 import { installDesktopBinary } from "@/domains/desktop/desktop-installer.js";
 import {
 	type DesktopChannel,
@@ -91,11 +92,15 @@ export async function getDesktopUpdateStatus(
 		arch?: string;
 		fetchManifest?: typeof fetchDesktopReleaseManifest;
 		readInstallMetadata?: typeof readDesktopInstallMetadata;
+		binaryPath?: string | null;
+		validateInstalledArtifact?: typeof validateInstalledDesktopArtifact;
 	} = {},
 ): Promise<DesktopUpdateStatus> {
 	const { manifest, entry, platformKey } = await resolveDesktopReleaseAsset(undefined, options);
 	const latestVersion = normalizeVersion(manifest.version);
 	const readInstallMetadata = options.readInstallMetadata || readDesktopInstallMetadata;
+	const validateInstalledArtifact =
+		options.validateInstalledArtifact || validateInstalledDesktopArtifact;
 	const installed = await readInstallMetadata({ platform: options.platform });
 	const requestedChannel = options.channel ?? "stable";
 
@@ -105,6 +110,25 @@ export async function getDesktopUpdateStatus(
 			latestVersion,
 			updateAvailable: true,
 			reason: "unknown-installed-version",
+		};
+	}
+
+	const binaryPath = options.binaryPath || getDesktopBinaryPath({ platform: options.platform });
+	if (!binaryPath) {
+		return {
+			currentVersion: installed.version,
+			latestVersion,
+			updateAvailable: true,
+			reason: "unknown-installed-version",
+		};
+	}
+
+	if (!(await validateInstalledArtifact(binaryPath, installed, { platform: options.platform }))) {
+		return {
+			currentVersion: installed.version,
+			latestVersion,
+			updateAvailable: true,
+			reason: "update-available",
 		};
 	}
 

--- a/src/domains/desktop/desktop-binary-manager.ts
+++ b/src/domains/desktop/desktop-binary-manager.ts
@@ -140,8 +140,10 @@ export async function getDesktopUpdateStatus(
 		installed.assetName === entry.name &&
 		installed.assetSize === entry.size &&
 		installed.manifestDate === manifest.date;
+	const installedIsNewer =
+		sameChannel && samePlatform && isNewerVersion(latestVersion, installed.version);
 
-	if (sameChannel && samePlatform && isNewerVersion(latestVersion, installed.version)) {
+	if (installedIsNewer) {
 		return {
 			currentVersion: installed.version,
 			latestVersion,

--- a/src/domains/desktop/desktop-binary-manager.ts
+++ b/src/domains/desktop/desktop-binary-manager.ts
@@ -1,6 +1,13 @@
 import { existsSync } from "node:fs";
 import { launchDesktopApp } from "@/domains/desktop/desktop-app-launcher.js";
-import { selectDesktopPlatformEntry } from "@/domains/desktop/desktop-asset-selector.js";
+import {
+	getCurrentDesktopPlatformKey,
+	selectDesktopPlatformEntry,
+} from "@/domains/desktop/desktop-asset-selector.js";
+import {
+	readDesktopInstallMetadata,
+	writeDownloadedDesktopMetadata,
+} from "@/domains/desktop/desktop-install-metadata.js";
 import {
 	getDesktopDownloadDirectory,
 	getDesktopInstallPath,
@@ -11,6 +18,12 @@ import {
 	fetchDesktopReleaseManifest,
 } from "@/domains/desktop/desktop-release-service.js";
 import { FileDownloader } from "@/domains/installation/download/file-downloader.js";
+import {
+	isNewerVersion,
+	normalizeVersion,
+	versionsMatch,
+} from "@/domains/versioning/checking/version-utils.js";
+import type { DesktopInstallMetadata } from "@/types/desktop.js";
 
 export function getDesktopBinaryPath(
 	options: {
@@ -21,6 +34,113 @@ export function getDesktopBinaryPath(
 	const installPath = getDesktopInstallPath({ platform: options.platform });
 	const existsFn = options.existsFn || existsSync;
 	return existsFn(installPath) ? installPath : null;
+}
+
+function resolveDesktopMetadata(
+	manifestVersion: string,
+	manifestDate: string,
+	channel: DesktopChannel,
+	platformKey: ReturnType<typeof getCurrentDesktopPlatformKey>,
+	entry: { name: string; size: number },
+): DesktopInstallMetadata {
+	return {
+		version: normalizeVersion(manifestVersion),
+		manifestDate,
+		channel,
+		platformKey,
+		assetName: entry.name,
+		assetSize: entry.size,
+		installedAt: new Date().toISOString(),
+	};
+}
+
+async function resolveDesktopReleaseAsset(
+	version: string | undefined,
+	options: {
+		channel?: DesktopChannel;
+		platform?: NodeJS.Platform;
+		arch?: string;
+		fetchManifest?: typeof fetchDesktopReleaseManifest;
+	},
+) {
+	const fetchManifest = options.fetchManifest || fetchDesktopReleaseManifest;
+	const manifest = await fetchManifest({ version, channel: options.channel });
+	const entry = selectDesktopPlatformEntry(manifest, {
+		platform: options.platform,
+		arch: options.arch,
+	});
+	const platformKey = getCurrentDesktopPlatformKey(options.platform, options.arch);
+	return {
+		manifest,
+		entry,
+		platformKey,
+	};
+}
+
+export interface DesktopUpdateStatus {
+	currentVersion: string | null;
+	latestVersion: string;
+	updateAvailable: boolean;
+	reason: "up-to-date" | "update-available" | "installed-newer" | "unknown-installed-version";
+}
+
+export async function getDesktopUpdateStatus(
+	options: {
+		channel?: DesktopChannel;
+		platform?: NodeJS.Platform;
+		arch?: string;
+		fetchManifest?: typeof fetchDesktopReleaseManifest;
+		readInstallMetadata?: typeof readDesktopInstallMetadata;
+	} = {},
+): Promise<DesktopUpdateStatus> {
+	const { manifest, entry, platformKey } = await resolveDesktopReleaseAsset(undefined, options);
+	const latestVersion = normalizeVersion(manifest.version);
+	const readInstallMetadata = options.readInstallMetadata || readDesktopInstallMetadata;
+	const installed = await readInstallMetadata({ platform: options.platform });
+	const requestedChannel = options.channel ?? "stable";
+
+	if (!installed) {
+		return {
+			currentVersion: null,
+			latestVersion,
+			updateAvailable: true,
+			reason: "unknown-installed-version",
+		};
+	}
+
+	const sameChannel = installed.channel === requestedChannel;
+	const samePlatform = installed.platformKey === platformKey;
+	const metadataMatchesRelease =
+		sameChannel &&
+		installed.platformKey === platformKey &&
+		installed.assetName === entry.name &&
+		installed.assetSize === entry.size &&
+		installed.manifestDate === manifest.date;
+
+	if (sameChannel && samePlatform && isNewerVersion(latestVersion, installed.version)) {
+		return {
+			currentVersion: installed.version,
+			latestVersion,
+			updateAvailable: false,
+			reason: "installed-newer",
+		};
+	}
+
+	if (metadataMatchesRelease && versionsMatch(installed.version, latestVersion)) {
+		return {
+			currentVersion: installed.version,
+			latestVersion,
+			updateAvailable: false,
+			reason: "up-to-date",
+		};
+	}
+
+	return {
+		currentVersion: installed.version,
+		latestVersion,
+		updateAvailable: true,
+		reason: "update-available",
+	};
 }
 
 export async function downloadDesktopBinary(
@@ -38,24 +158,29 @@ export async function downloadDesktopBinary(
 			token?: string;
 		}) => Promise<string>;
 		getDownloadDirectory?: () => string;
+		writeDownloadedMetadata?: (
+			downloadPath: string,
+			metadata: DesktopInstallMetadata,
+		) => Promise<void>;
 	} = {},
 ): Promise<string> {
-	const fetchManifest = options.fetchManifest || fetchDesktopReleaseManifest;
-	const manifest = await fetchManifest({ version, channel: options.channel });
-	const entry = selectDesktopPlatformEntry(manifest, {
-		platform: options.platform,
-		arch: options.arch,
-	});
+	const { manifest, entry, platformKey } = await resolveDesktopReleaseAsset(version, options);
 	const downloadFile =
 		options.downloadFile || ((params) => new FileDownloader().downloadFile(params));
 	const getDownloadDirectory = options.getDownloadDirectory || getDesktopDownloadDirectory;
+	const writeDownloadedMetadata = options.writeDownloadedMetadata || writeDownloadedDesktopMetadata;
 
-	return downloadFile({
+	const downloadPath = await downloadFile({
 		url: entry.url,
 		name: entry.name,
 		size: entry.size,
 		destDir: getDownloadDirectory(),
 	});
+	await writeDownloadedMetadata(
+		downloadPath,
+		resolveDesktopMetadata(manifest.version, manifest.date, manifest.channel, platformKey, entry),
+	);
+	return downloadPath;
 }
 
 export { installDesktopBinary, launchDesktopApp };

--- a/src/domains/desktop/desktop-bundle-version.ts
+++ b/src/domains/desktop/desktop-bundle-version.ts
@@ -2,6 +2,17 @@ import { readFile } from "node:fs/promises";
 import semver from "semver";
 import { z } from "zod";
 
+const WINDOWS_MSI_PATCH_STRIDE = 512;
+const WINDOWS_MSI_STABLE_SLOT = 511;
+const WINDOWS_MSI_PATCH_LIMIT = 127;
+const WINDOWS_MSI_PRERELEASE_LIMIT = 126;
+const WINDOWS_MSI_PRERELEASE_BASES = {
+	dev: 0,
+	alpha: 128,
+	beta: 256,
+	rc: 384,
+} as const;
+
 const DesktopBundleConfigSchema = z.object({
 	version: z.string().min(1),
 	bundle: z
@@ -21,33 +32,49 @@ const DesktopBundleConfigSchema = z.object({
 
 type DesktopBundleConfig = z.infer<typeof DesktopBundleConfigSchema>;
 
+function normalizeWindowsWixVersion(version: string): string {
+	return version.endsWith(".0") ? version.slice(0, -2) : version;
+}
+
 export function deriveWindowsWixVersion(appVersion: string): string {
 	const parsed = semver.parse(appVersion);
 	if (!parsed) {
 		throw new Error(`Desktop app version must be valid semver: ${appVersion}`);
 	}
 
-	if (parsed.major > 255 || parsed.minor > 255 || parsed.patch > 65_535) {
+	if (parsed.major > 255 || parsed.minor > 255 || parsed.patch > WINDOWS_MSI_PATCH_LIMIT) {
 		throw new Error(
-			`Desktop app version ${appVersion} exceeds Windows MSI numeric limits (255.255.65535)`,
+			`Desktop app version ${appVersion} exceeds the supported Windows MSI range (major <= 255, minor <= 255, patch <= ${WINDOWS_MSI_PATCH_LIMIT})`,
 		);
 	}
 
+	const patchWindow = parsed.patch * WINDOWS_MSI_PATCH_STRIDE;
+
 	if (parsed.prerelease.length === 0) {
-		return `${parsed.major}.${parsed.minor}.${parsed.patch}.0`;
+		return `${parsed.major}.${parsed.minor}.${patchWindow + WINDOWS_MSI_STABLE_SLOT}`;
 	}
 
+	const prereleaseLabel =
+		parsed.prerelease.find((segment): segment is string => typeof segment === "string") ?? "dev";
 	const numericSegment = [...parsed.prerelease]
 		.reverse()
 		.find((segment): segment is number => typeof segment === "number");
+	const prereleaseBase =
+		WINDOWS_MSI_PRERELEASE_BASES[prereleaseLabel as keyof typeof WINDOWS_MSI_PRERELEASE_BASES];
 
-	if (numericSegment === undefined || numericSegment > 65_535) {
+	if (!prereleaseBase && prereleaseBase !== 0) {
 		throw new Error(
-			`Desktop app version ${appVersion} needs a numeric prerelease segment <= 65535 for Windows MSI`,
+			`Desktop app version ${appVersion} uses unsupported prerelease label "${prereleaseLabel}" for Windows MSI (supported: dev, alpha, beta, rc)`,
 		);
 	}
 
-	return `${parsed.major}.${parsed.minor}.${parsed.patch}.${numericSegment}`;
+	if (numericSegment === undefined || numericSegment > WINDOWS_MSI_PRERELEASE_LIMIT) {
+		throw new Error(
+			`Desktop app version ${appVersion} needs a numeric prerelease segment <= ${WINDOWS_MSI_PRERELEASE_LIMIT} for Windows MSI`,
+		);
+	}
+
+	return `${parsed.major}.${parsed.minor}.${patchWindow + prereleaseBase + numericSegment}`;
 }
 
 export function validateDesktopBundleConfig(config: DesktopBundleConfig): {
@@ -59,9 +86,12 @@ export function validateDesktopBundleConfig(config: DesktopBundleConfig): {
 	const expectedWixVersion = deriveWindowsWixVersion(appVersion);
 	const actualWixVersion = config.bundle?.windows?.wix?.version ?? null;
 
-	if (actualWixVersion !== expectedWixVersion) {
+	if (
+		actualWixVersion === null ||
+		normalizeWindowsWixVersion(actualWixVersion) !== expectedWixVersion
+	) {
 		throw new Error(
-			`Desktop Windows MSI version mismatch: tauri.conf version ${appVersion} requires bundle.windows.wix.version ${expectedWixVersion}, found ${actualWixVersion ?? "missing"}`,
+			`Desktop Windows MSI version mismatch: tauri.conf version ${appVersion} requires bundle.windows.wix.version ${expectedWixVersion} (or ${expectedWixVersion}.0), found ${actualWixVersion ?? "missing"}`,
 		);
 	}
 

--- a/src/domains/desktop/desktop-bundle-version.ts
+++ b/src/domains/desktop/desktop-bundle-version.ts
@@ -1,0 +1,78 @@
+import { readFile } from "node:fs/promises";
+import semver from "semver";
+import { z } from "zod";
+
+const DesktopBundleConfigSchema = z.object({
+	version: z.string().min(1),
+	bundle: z
+		.object({
+			windows: z
+				.object({
+					wix: z
+						.object({
+							version: z.string().min(1),
+						})
+						.optional(),
+				})
+				.optional(),
+		})
+		.optional(),
+});
+
+type DesktopBundleConfig = z.infer<typeof DesktopBundleConfigSchema>;
+
+export function deriveWindowsWixVersion(appVersion: string): string {
+	const parsed = semver.parse(appVersion);
+	if (!parsed) {
+		throw new Error(`Desktop app version must be valid semver: ${appVersion}`);
+	}
+
+	if (parsed.major > 255 || parsed.minor > 255 || parsed.patch > 65_535) {
+		throw new Error(
+			`Desktop app version ${appVersion} exceeds Windows MSI numeric limits (255.255.65535)`,
+		);
+	}
+
+	if (parsed.prerelease.length === 0) {
+		return `${parsed.major}.${parsed.minor}.${parsed.patch}.0`;
+	}
+
+	const numericSegment = [...parsed.prerelease]
+		.reverse()
+		.find((segment): segment is number => typeof segment === "number");
+
+	if (numericSegment === undefined || numericSegment > 65_535) {
+		throw new Error(
+			`Desktop app version ${appVersion} needs a numeric prerelease segment <= 65535 for Windows MSI`,
+		);
+	}
+
+	return `${parsed.major}.${parsed.minor}.${parsed.patch}.${numericSegment}`;
+}
+
+export function validateDesktopBundleConfig(config: DesktopBundleConfig): {
+	appVersion: string;
+	expectedWixVersion: string;
+	actualWixVersion: string | null;
+} {
+	const appVersion = config.version;
+	const expectedWixVersion = deriveWindowsWixVersion(appVersion);
+	const actualWixVersion = config.bundle?.windows?.wix?.version ?? null;
+
+	if (actualWixVersion !== expectedWixVersion) {
+		throw new Error(
+			`Desktop Windows MSI version mismatch: tauri.conf version ${appVersion} requires bundle.windows.wix.version ${expectedWixVersion}, found ${actualWixVersion ?? "missing"}`,
+		);
+	}
+
+	return {
+		appVersion,
+		expectedWixVersion,
+		actualWixVersion,
+	};
+}
+
+export async function loadDesktopBundleConfig(configPath: string): Promise<DesktopBundleConfig> {
+	const raw = await readFile(configPath, "utf8");
+	return DesktopBundleConfigSchema.parse(JSON.parse(raw));
+}

--- a/src/domains/desktop/desktop-bundle-version.ts
+++ b/src/domains/desktop/desktop-bundle-version.ts
@@ -15,19 +15,13 @@ const WINDOWS_MSI_PRERELEASE_BASES = {
 
 const DesktopBundleConfigSchema = z.object({
 	version: z.string().min(1),
-	bundle: z
-		.object({
-			windows: z
-				.object({
-					wix: z
-						.object({
-							version: z.string().min(1),
-						})
-						.optional(),
-				})
-				.optional(),
-		})
-		.optional(),
+	bundle: z.object({
+		windows: z.object({
+			wix: z.object({
+				version: z.string().min(1),
+			}),
+		}),
+	}),
 });
 
 type DesktopBundleConfig = z.infer<typeof DesktopBundleConfigSchema>;
@@ -84,14 +78,11 @@ export function validateDesktopBundleConfig(config: DesktopBundleConfig): {
 } {
 	const appVersion = config.version;
 	const expectedWixVersion = deriveWindowsWixVersion(appVersion);
-	const actualWixVersion = config.bundle?.windows?.wix?.version ?? null;
+	const actualWixVersion = config.bundle.windows.wix.version;
 
-	if (
-		actualWixVersion === null ||
-		normalizeWindowsWixVersion(actualWixVersion) !== expectedWixVersion
-	) {
+	if (normalizeWindowsWixVersion(actualWixVersion) !== expectedWixVersion) {
 		throw new Error(
-			`Desktop Windows MSI version mismatch: tauri.conf version ${appVersion} requires bundle.windows.wix.version ${expectedWixVersion} (or ${expectedWixVersion}.0), found ${actualWixVersion ?? "missing"}`,
+			`Desktop Windows MSI version mismatch: tauri.conf version ${appVersion} requires bundle.windows.wix.version ${expectedWixVersion} (or ${expectedWixVersion}.0), found ${actualWixVersion}`,
 		);
 	}
 

--- a/src/domains/desktop/desktop-install-metadata.ts
+++ b/src/domains/desktop/desktop-install-metadata.ts
@@ -1,10 +1,46 @@
-import { dirname } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { getDesktopInstallMetadataPath } from "@/domains/desktop/desktop-install-path-resolver.js";
 import { type DesktopInstallMetadata, DesktopInstallMetadataSchema } from "@/types/desktop.js";
 import { ensureDir, pathExists, readJson, remove, writeJson } from "fs-extra";
 
 export function getDesktopDownloadMetadataPath(downloadPath: string): string {
-	return `${downloadPath}.metadata.json`;
+	return join(dirname(downloadPath), `${basename(downloadPath)}.metadata.json`);
+}
+
+async function readMetadataAt(
+	metadataPath: string,
+	options: {
+		readJsonFn?: (path: string) => Promise<unknown>;
+		pathExistsFn?: (path: string) => Promise<boolean>;
+	} = {},
+): Promise<DesktopInstallMetadata | null> {
+	const pathExistsFn = options.pathExistsFn || pathExists;
+	const readJsonFn = options.readJsonFn || readJson;
+
+	if (!(await pathExistsFn(metadataPath))) {
+		return null;
+	}
+
+	try {
+		return DesktopInstallMetadataSchema.parse(await readJsonFn(metadataPath));
+	} catch {
+		return null;
+	}
+}
+
+async function writeMetadataAt(
+	metadataPath: string,
+	metadata: DesktopInstallMetadata,
+	options: {
+		writeJsonFn?: (path: string, value: unknown, opts: { spaces: number }) => Promise<void>;
+		ensureDirFn?: (path: string) => Promise<void>;
+	} = {},
+): Promise<void> {
+	const ensureDirFn = options.ensureDirFn || ensureDir;
+	const writeJsonFn = options.writeJsonFn || writeJson;
+
+	await ensureDirFn(dirname(metadataPath));
+	await writeJsonFn(metadataPath, metadata, { spaces: 2 });
 }
 
 export async function readDesktopInstallMetadata(
@@ -15,18 +51,7 @@ export async function readDesktopInstallMetadata(
 	} = {},
 ): Promise<DesktopInstallMetadata | null> {
 	const metadataPath = getDesktopInstallMetadataPath({ platform: options.platform });
-	const pathExistsFn = options.pathExistsFn || pathExists;
-	const readJsonFn = options.readJsonFn || readJson;
-
-	if (!(await pathExistsFn(metadataPath))) {
-		return null;
-	}
-
-	try {
-		return DesktopInstallMetadataSchema.parse(await readJsonFn(metadataPath));
-	} catch {
-		return null;
-	}
+	return readMetadataAt(metadataPath, options);
 }
 
 export async function readDownloadedDesktopMetadata(
@@ -37,18 +62,7 @@ export async function readDownloadedDesktopMetadata(
 	} = {},
 ): Promise<DesktopInstallMetadata | null> {
 	const metadataPath = getDesktopDownloadMetadataPath(downloadPath);
-	const pathExistsFn = options.pathExistsFn || pathExists;
-	const readJsonFn = options.readJsonFn || readJson;
-
-	if (!(await pathExistsFn(metadataPath))) {
-		return null;
-	}
-
-	try {
-		return DesktopInstallMetadataSchema.parse(await readJsonFn(metadataPath));
-	} catch {
-		return null;
-	}
+	return readMetadataAt(metadataPath, options);
 }
 
 export async function writeDesktopInstallMetadata(
@@ -60,11 +74,7 @@ export async function writeDesktopInstallMetadata(
 	} = {},
 ): Promise<void> {
 	const metadataPath = getDesktopInstallMetadataPath({ platform: options.platform });
-	const ensureDirFn = options.ensureDirFn || ensureDir;
-	const writeJsonFn = options.writeJsonFn || writeJson;
-
-	await ensureDirFn(dirname(metadataPath));
-	await writeJsonFn(metadataPath, metadata, { spaces: 2 });
+	await writeMetadataAt(metadataPath, metadata, options);
 }
 
 export async function writeDownloadedDesktopMetadata(
@@ -76,11 +86,7 @@ export async function writeDownloadedDesktopMetadata(
 	} = {},
 ): Promise<void> {
 	const metadataPath = getDesktopDownloadMetadataPath(downloadPath);
-	const ensureDirFn = options.ensureDirFn || ensureDir;
-	const writeJsonFn = options.writeJsonFn || writeJson;
-
-	await ensureDirFn(dirname(metadataPath));
-	await writeJsonFn(metadataPath, metadata, { spaces: 2 });
+	await writeMetadataAt(metadataPath, metadata, options);
 }
 
 export async function clearDesktopInstallMetadata(

--- a/src/domains/desktop/desktop-install-metadata.ts
+++ b/src/domains/desktop/desktop-install-metadata.ts
@@ -1,0 +1,95 @@
+import { dirname } from "node:path";
+import { getDesktopInstallMetadataPath } from "@/domains/desktop/desktop-install-path-resolver.js";
+import { type DesktopInstallMetadata, DesktopInstallMetadataSchema } from "@/types/desktop.js";
+import { ensureDir, pathExists, readJson, remove, writeJson } from "fs-extra";
+
+export function getDesktopDownloadMetadataPath(downloadPath: string): string {
+	return `${downloadPath}.metadata.json`;
+}
+
+export async function readDesktopInstallMetadata(
+	options: {
+		platform?: NodeJS.Platform;
+		readJsonFn?: (path: string) => Promise<unknown>;
+		pathExistsFn?: (path: string) => Promise<boolean>;
+	} = {},
+): Promise<DesktopInstallMetadata | null> {
+	const metadataPath = getDesktopInstallMetadataPath({ platform: options.platform });
+	const pathExistsFn = options.pathExistsFn || pathExists;
+	const readJsonFn = options.readJsonFn || readJson;
+
+	if (!(await pathExistsFn(metadataPath))) {
+		return null;
+	}
+
+	try {
+		return DesktopInstallMetadataSchema.parse(await readJsonFn(metadataPath));
+	} catch {
+		return null;
+	}
+}
+
+export async function readDownloadedDesktopMetadata(
+	downloadPath: string,
+	options: {
+		readJsonFn?: (path: string) => Promise<unknown>;
+		pathExistsFn?: (path: string) => Promise<boolean>;
+	} = {},
+): Promise<DesktopInstallMetadata | null> {
+	const metadataPath = getDesktopDownloadMetadataPath(downloadPath);
+	const pathExistsFn = options.pathExistsFn || pathExists;
+	const readJsonFn = options.readJsonFn || readJson;
+
+	if (!(await pathExistsFn(metadataPath))) {
+		return null;
+	}
+
+	try {
+		return DesktopInstallMetadataSchema.parse(await readJsonFn(metadataPath));
+	} catch {
+		return null;
+	}
+}
+
+export async function writeDesktopInstallMetadata(
+	metadata: DesktopInstallMetadata,
+	options: {
+		platform?: NodeJS.Platform;
+		writeJsonFn?: (path: string, value: unknown, opts: { spaces: number }) => Promise<void>;
+		ensureDirFn?: (path: string) => Promise<void>;
+	} = {},
+): Promise<void> {
+	const metadataPath = getDesktopInstallMetadataPath({ platform: options.platform });
+	const ensureDirFn = options.ensureDirFn || ensureDir;
+	const writeJsonFn = options.writeJsonFn || writeJson;
+
+	await ensureDirFn(dirname(metadataPath));
+	await writeJsonFn(metadataPath, metadata, { spaces: 2 });
+}
+
+export async function writeDownloadedDesktopMetadata(
+	downloadPath: string,
+	metadata: DesktopInstallMetadata,
+	options: {
+		writeJsonFn?: (path: string, value: unknown, opts: { spaces: number }) => Promise<void>;
+		ensureDirFn?: (path: string) => Promise<void>;
+	} = {},
+): Promise<void> {
+	const metadataPath = getDesktopDownloadMetadataPath(downloadPath);
+	const ensureDirFn = options.ensureDirFn || ensureDir;
+	const writeJsonFn = options.writeJsonFn || writeJson;
+
+	await ensureDirFn(dirname(metadataPath));
+	await writeJsonFn(metadataPath, metadata, { spaces: 2 });
+}
+
+export async function clearDesktopInstallMetadata(
+	options: {
+		platform?: NodeJS.Platform;
+		removeFn?: (path: string) => Promise<void>;
+	} = {},
+): Promise<void> {
+	const metadataPath = getDesktopInstallMetadataPath({ platform: options.platform });
+	const removeFn = options.removeFn || remove;
+	await removeFn(metadataPath);
+}

--- a/src/domains/desktop/desktop-install-path-resolver.ts
+++ b/src/domains/desktop/desktop-install-path-resolver.ts
@@ -28,6 +28,12 @@ export function getDesktopInstallDirectory(options: { platform?: NodeJS.Platform
 	return dirname(getDesktopInstallPath(options));
 }
 
+export function getDesktopInstallMetadataPath(
+	options: { platform?: NodeJS.Platform } = {},
+): string {
+	return join(getDesktopInstallDirectory(options), "claudekit-control-center-install.json");
+}
+
 export function getDesktopDownloadDirectory(): string {
 	return join(PathResolver.getCacheDir(false), "desktop-downloads");
 }

--- a/src/domains/desktop/desktop-installed-artifact-validator.ts
+++ b/src/domains/desktop/desktop-installed-artifact-validator.ts
@@ -2,12 +2,16 @@ import { readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 import type { DesktopInstallMetadata } from "@/types/desktop.js";
 
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export async function validateInstalledDesktopArtifact(
 	binaryPath: string,
 	metadata: DesktopInstallMetadata,
 	options: {
 		platform?: NodeJS.Platform;
-		readFileFn?: typeof readFile;
+		readFileFn?: (path: string, encoding: "utf8") => Promise<string>;
 		statFn?: typeof stat;
 	} = {},
 ): Promise<boolean> {
@@ -23,7 +27,10 @@ export async function validateInstalledDesktopArtifact(
 
 		if (platform === "darwin") {
 			const infoPlist = await readFileFn(join(binaryPath, "Contents", "Info.plist"), "utf8");
-			return infoPlist.includes(metadata.version);
+			const versionPattern = new RegExp(
+				`<key>\\s*CFBundleShortVersionString\\s*</key>\\s*<string>${escapeRegExp(metadata.version)}</string>`,
+			);
+			return versionPattern.test(infoPlist);
 		}
 	} catch {
 		return false;

--- a/src/domains/desktop/desktop-installed-artifact-validator.ts
+++ b/src/domains/desktop/desktop-installed-artifact-validator.ts
@@ -1,0 +1,33 @@
+import { readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import type { DesktopInstallMetadata } from "@/types/desktop.js";
+
+export async function validateInstalledDesktopArtifact(
+	binaryPath: string,
+	metadata: DesktopInstallMetadata,
+	options: {
+		platform?: NodeJS.Platform;
+		readFileFn?: typeof readFile;
+		statFn?: typeof stat;
+	} = {},
+): Promise<boolean> {
+	const platform = options.platform || process.platform;
+	const readFileFn = options.readFileFn || readFile;
+	const statFn = options.statFn || stat;
+
+	try {
+		if (platform === "linux" || platform === "win32") {
+			const fileStat = await statFn(binaryPath);
+			return fileStat.isFile() && fileStat.size === metadata.assetSize;
+		}
+
+		if (platform === "darwin") {
+			const infoPlist = await readFileFn(join(binaryPath, "Contents", "Info.plist"), "utf8");
+			return infoPlist.includes(metadata.version);
+		}
+	} catch {
+		return false;
+	}
+
+	return false;
+}

--- a/src/domains/desktop/desktop-installer.ts
+++ b/src/domains/desktop/desktop-installer.ts
@@ -4,6 +4,10 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { promisify } from "node:util";
 import {
+	readDownloadedDesktopMetadata,
+	writeDesktopInstallMetadata,
+} from "@/domains/desktop/desktop-install-metadata.js";
+import {
 	getDesktopInstallDirectory,
 	getDesktopInstallPath,
 } from "@/domains/desktop/desktop-install-path-resolver.js";
@@ -35,10 +39,22 @@ export async function installDesktopBinary(
 		platform?: NodeJS.Platform;
 		extractZipFn?: (source: string, config: { dir: string }) => Promise<void>;
 		removeQuarantineFn?: (path: string) => Promise<void>;
+		readDownloadedMetadataFn?: (
+			downloadPath: string,
+		) => Promise<Awaited<ReturnType<typeof readDownloadedDesktopMetadata>>>;
+		persistInstallMetadataFn?: (
+			metadata: NonNullable<Awaited<ReturnType<typeof readDownloadedDesktopMetadata>>>,
+		) => Promise<void>;
 	} = {},
 ): Promise<string> {
 	const platform = options.platform || process.platform;
 	const targetPath = getDesktopInstallPath({ platform });
+	const readDownloadedMetadataFn =
+		options.readDownloadedMetadataFn || readDownloadedDesktopMetadata;
+	const persistInstallMetadataFn =
+		options.persistInstallMetadataFn ||
+		((metadata: NonNullable<Awaited<ReturnType<typeof readDownloadedDesktopMetadata>>>) =>
+			writeDesktopInstallMetadata(metadata, { platform }));
 	await ensureDir(getDesktopInstallDirectory({ platform }));
 
 	if (platform === "darwin") {
@@ -77,17 +93,29 @@ export async function installDesktopBinary(
 			await remove(stagingDir);
 			await remove(stagedInstallPath);
 		}
+		const metadata = await readDownloadedMetadataFn(downloadPath);
+		if (metadata) {
+			await persistInstallMetadataFn(metadata);
+		}
 		return targetPath;
 	}
 
 	if (platform === "linux") {
 		await copyFile(downloadPath, targetPath);
 		await chmod(targetPath, 0o755);
+		const metadata = await readDownloadedMetadataFn(downloadPath);
+		if (metadata) {
+			await persistInstallMetadataFn(metadata);
+		}
 		return targetPath;
 	}
 
 	if (platform === "win32") {
 		await copyFile(downloadPath, targetPath);
+		const metadata = await readDownloadedMetadataFn(downloadPath);
+		if (metadata) {
+			await persistInstallMetadataFn(metadata);
+		}
 		return targetPath;
 	}
 

--- a/src/domains/desktop/desktop-installer.ts
+++ b/src/domains/desktop/desktop-installer.ts
@@ -11,9 +11,31 @@ import {
 	getDesktopInstallDirectory,
 	getDesktopInstallPath,
 } from "@/domains/desktop/desktop-install-path-resolver.js";
+import { logger } from "@/shared/logger.js";
 import { copy, copyFile, ensureDir, pathExists, remove } from "fs-extra";
 
 const execFileAsync = promisify(execFile);
+
+async function persistInstallMetadataAfterSuccess(
+	downloadPath: string,
+	readDownloadedMetadataFn: (
+		downloadPath: string,
+	) => Promise<Awaited<ReturnType<typeof readDownloadedDesktopMetadata>>>,
+	persistInstallMetadataFn: (
+		metadata: NonNullable<Awaited<ReturnType<typeof readDownloadedDesktopMetadata>>>,
+	) => Promise<void>,
+): Promise<void> {
+	try {
+		const metadata = await readDownloadedMetadataFn(downloadPath);
+		if (metadata) {
+			await persistInstallMetadataFn(metadata);
+		}
+	} catch (error) {
+		logger.warning(
+			`Desktop install succeeded, but failed to persist install metadata: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
 
 async function findAppBundle(rootDir: string): Promise<string> {
 	const entries = await readdir(rootDir, { withFileTypes: true });
@@ -93,29 +115,32 @@ export async function installDesktopBinary(
 			await remove(stagingDir);
 			await remove(stagedInstallPath);
 		}
-		const metadata = await readDownloadedMetadataFn(downloadPath);
-		if (metadata) {
-			await persistInstallMetadataFn(metadata);
-		}
+		await persistInstallMetadataAfterSuccess(
+			downloadPath,
+			readDownloadedMetadataFn,
+			persistInstallMetadataFn,
+		);
 		return targetPath;
 	}
 
 	if (platform === "linux") {
 		await copyFile(downloadPath, targetPath);
 		await chmod(targetPath, 0o755);
-		const metadata = await readDownloadedMetadataFn(downloadPath);
-		if (metadata) {
-			await persistInstallMetadataFn(metadata);
-		}
+		await persistInstallMetadataAfterSuccess(
+			downloadPath,
+			readDownloadedMetadataFn,
+			persistInstallMetadataFn,
+		);
 		return targetPath;
 	}
 
 	if (platform === "win32") {
 		await copyFile(downloadPath, targetPath);
-		const metadata = await readDownloadedMetadataFn(downloadPath);
-		if (metadata) {
-			await persistInstallMetadataFn(metadata);
-		}
+		await persistInstallMetadataAfterSuccess(
+			downloadPath,
+			readDownloadedMetadataFn,
+			persistInstallMetadataFn,
+		);
 		return targetPath;
 	}
 

--- a/src/domains/desktop/desktop-release-manifest.ts
+++ b/src/domains/desktop/desktop-release-manifest.ts
@@ -21,6 +21,7 @@ export function buildDesktopReleaseManifest(input: {
 	version: string;
 	publishedAt: string;
 	assets: GitHubReleaseAsset[];
+	channel?: "stable" | "dev";
 }): DesktopReleaseManifest {
 	const macAsset = findAsset(input.assets, /macos-universal\.app\.zip$/i, "macOS");
 	const linuxAsset = findAsset(input.assets, /linux-x86_64\.AppImage$/i, "Linux");
@@ -29,6 +30,7 @@ export function buildDesktopReleaseManifest(input: {
 	return parseDesktopReleaseManifest({
 		version: input.version,
 		date: input.publishedAt,
+		channel: input.channel ?? "stable",
 		platforms: {
 			"darwin-aarch64": {
 				name: macAsset.name,

--- a/src/domains/desktop/desktop-release-service.ts
+++ b/src/domains/desktop/desktop-release-service.ts
@@ -1,4 +1,5 @@
 import { parseDesktopReleaseManifest } from "@/domains/desktop/desktop-release-manifest.js";
+import { isPrereleaseVersion } from "@/domains/versioning/checking/version-utils.js";
 import type { DesktopReleaseManifest } from "@/types/desktop.js";
 
 const DESKTOP_RELEASE_REPOSITORY = "https://github.com/mrgoonie/claudekit-cli/releases/download";
@@ -20,6 +21,37 @@ export function getDesktopManifestUrl(opts?: {
 	return `${DESKTOP_RELEASE_REPOSITORY}/${tag}/desktop-manifest.json`;
 }
 
+function resolveManifestChannel(
+	rawManifest: unknown,
+	opts?: { version?: string; channel?: DesktopChannel },
+): DesktopChannel {
+	if (rawManifest && typeof rawManifest === "object" && "channel" in rawManifest) {
+		const rawChannel = rawManifest.channel;
+		if (rawChannel === "stable" || rawChannel === "dev") {
+			return rawChannel;
+		}
+	}
+
+	if (
+		rawManifest &&
+		typeof rawManifest === "object" &&
+		"version" in rawManifest &&
+		typeof rawManifest.version === "string"
+	) {
+		return isPrereleaseVersion(rawManifest.version) ? "dev" : "stable";
+	}
+
+	if (opts?.version) {
+		return isPrereleaseVersion(opts.version) ? "dev" : "stable";
+	}
+
+	if (opts?.channel) {
+		return opts.channel;
+	}
+
+	return "stable";
+}
+
 export async function fetchDesktopReleaseManifest(
 	opts?: { version?: string; channel?: DesktopChannel },
 	fetchFn: typeof fetch = globalThis.fetch,
@@ -28,5 +60,13 @@ export async function fetchDesktopReleaseManifest(
 	if (!response.ok) {
 		throw new Error(`Failed to fetch desktop manifest: ${response.status} ${response.statusText}`);
 	}
-	return parseDesktopReleaseManifest(await response.json());
+	const rawManifest = await response.json();
+	const manifestRecord =
+		rawManifest && typeof rawManifest === "object"
+			? (rawManifest as Record<string, unknown>)
+			: { value: rawManifest };
+	return parseDesktopReleaseManifest({
+		...manifestRecord,
+		channel: resolveManifestChannel(rawManifest, opts),
+	});
 }

--- a/src/domains/desktop/desktop-uninstaller.ts
+++ b/src/domains/desktop/desktop-uninstaller.ts
@@ -1,3 +1,4 @@
+import { clearDesktopInstallMetadata } from "@/domains/desktop/desktop-install-metadata.js";
 import { getDesktopInstallPath } from "@/domains/desktop/desktop-install-path-resolver.js";
 import { pathExists, remove } from "fs-extra";
 
@@ -11,11 +12,13 @@ export async function uninstallDesktopBinary(
 		platform?: NodeJS.Platform;
 		pathExistsFn?: (path: string) => Promise<boolean>;
 		removeFn?: (path: string) => Promise<void>;
+		clearInstallMetadataFn?: (options?: { platform?: NodeJS.Platform }) => Promise<void>;
 	} = {},
 ): Promise<DesktopUninstallResult> {
 	const targetPath = getDesktopInstallPath({ platform: options.platform });
 	const pathExistsFn = options.pathExistsFn || pathExists;
 	const removeFn = options.removeFn || remove;
+	const clearInstallMetadataFn = options.clearInstallMetadataFn || clearDesktopInstallMetadata;
 
 	if (!(await pathExistsFn(targetPath))) {
 		return {
@@ -25,6 +28,7 @@ export async function uninstallDesktopBinary(
 	}
 
 	await removeFn(targetPath);
+	await clearInstallMetadataFn({ platform: options.platform });
 
 	return {
 		path: targetPath,

--- a/src/domains/desktop/desktop-uninstaller.ts
+++ b/src/domains/desktop/desktop-uninstaller.ts
@@ -1,5 +1,6 @@
 import { clearDesktopInstallMetadata } from "@/domains/desktop/desktop-install-metadata.js";
 import { getDesktopInstallPath } from "@/domains/desktop/desktop-install-path-resolver.js";
+import { logger } from "@/shared/logger.js";
 import { pathExists, remove } from "fs-extra";
 
 export interface DesktopUninstallResult {
@@ -28,7 +29,13 @@ export async function uninstallDesktopBinary(
 	}
 
 	await removeFn(targetPath);
-	await clearInstallMetadataFn({ platform: options.platform });
+	try {
+		await clearInstallMetadataFn({ platform: options.platform });
+	} catch (error) {
+		logger.warning(
+			`Desktop uninstall removed the app, but failed to clear install metadata: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
 
 	return {
 		path: targetPath,

--- a/src/domains/desktop/index.ts
+++ b/src/domains/desktop/index.ts
@@ -10,12 +10,18 @@ export {
 	getDesktopDownloadDirectory,
 	getDesktopInstallDirectory,
 	getDesktopInstallPath,
+	getDesktopInstallMetadataPath,
 } from "./desktop-install-path-resolver.js";
 export { buildDesktopLaunchCommand, launchDesktopApp } from "./desktop-app-launcher.js";
 export { fetchDesktopReleaseManifest, getDesktopManifestUrl } from "./desktop-release-service.js";
 export {
 	downloadDesktopBinary,
+	getDesktopUpdateStatus,
 	getDesktopBinaryPath,
 	installDesktopBinary,
 } from "./desktop-binary-manager.js";
+export {
+	clearDesktopInstallMetadata,
+	readDesktopInstallMetadata,
+} from "./desktop-install-metadata.js";
 export { uninstallDesktopBinary } from "./desktop-uninstaller.js";

--- a/src/domains/help/commands/app-command-help.ts
+++ b/src/domains/help/commands/app-command-help.ts
@@ -24,7 +24,7 @@ export const appCommandHelp: CommandHelp = {
 				},
 				{
 					flags: "--update",
-					description: "Re-download and install the latest desktop build before launch",
+					description: "Install a newer desktop build before launch when one is available",
 				},
 				{
 					flags: "--path",

--- a/src/types/desktop.ts
+++ b/src/types/desktop.ts
@@ -36,3 +36,14 @@ export const DesktopReleaseManifestSchema = z.object({
 	channel: z.enum(["stable", "dev"]).default("stable"),
 });
 export type DesktopReleaseManifest = z.infer<typeof DesktopReleaseManifestSchema>;
+
+export const DesktopInstallMetadataSchema = z.object({
+	version: z.string().min(1),
+	manifestDate: z.string().min(1),
+	channel: z.enum(["stable", "dev"]),
+	platformKey: DesktopPlatformKeySchema,
+	assetName: z.string().min(1),
+	assetSize: z.number().int().nonnegative(),
+	installedAt: z.string().min(1),
+});
+export type DesktopInstallMetadata = z.infer<typeof DesktopInstallMetadataSchema>;


### PR DESCRIPTION
## Summary
- fail fast on invalid Windows desktop bundle versions before expensive release builds or pushes
- pin an MSI-safe WiX version for the current desktop prerelease and validate it in hooks + desktop CI
- make `ck app --dev --update` skip redownloading when the installed desktop app already matches or exceeds the latest release on the requested channel
- persist desktop install metadata and stamp generated desktop manifests with the correct `stable`/`dev` channel

## Validation
- `bun run validate`
- `bun run desktop:validate-config`

## Notes
- This fixes the Windows MSI failure mode from Actions run `24616985708`, where WiX rejected the desktop prerelease version format during the bundle step.
- The WiX override addresses MSI compatibility and the new validator catches future mismatches early.
