### PR TITLE
fix(doctor): detect and repair stale hook references in settings.json

### DIFF
--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
@@ -906,4 +906,86 @@ describe("checkHookFileReferences", () => {
 		expect(updated.hooks.PreToolUse[0].hooks).toHaveLength(1);
 		expect(updated.hooks.PreToolUse[0].hooks[0].command).toContain("exists.cjs");
 	});
+
+	test("detects missing file for bare relative .claude/ path", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		await writeFile(
+			join(projectDir, ".claude", "settings.json"),
+			JSON.stringify({
+				hooks: {
+					Stop: [
+						{
+							hooks: [{ type: "command", command: "node .claude/hooks/missing.cjs" }],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookFileReferences(projectDir);
+		expect(result.status).toBe("fail");
+		expect(result.details).toContain("missing.cjs");
+	});
+
+	test("detects missing file for tilde-prefixed path", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		await writeFile(
+			join(projectDir, ".claude", "settings.json"),
+			JSON.stringify({
+				hooks: {
+					Stop: [
+						{
+							hooks: [{ type: "command", command: "node ~/.claude/hooks/nope-xyz-missing.cjs" }],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookFileReferences(projectDir);
+		expect(result.status).toBe("fail");
+		expect(result.details).toContain("nope-xyz-missing.cjs");
+	});
+
+	test("auto-fix removes empty hooks key when all entries are pruned", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		const settingsPath = join(projectDir, ".claude", "settings.json");
+		await writeFile(
+			settingsPath,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Edit",
+							hooks: [
+								{
+									type: "command",
+									command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/missing.cjs',
+								},
+							],
+						},
+					],
+					Stop: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-state.cjs',
+								},
+							],
+						},
+					],
+				},
+				otherField: "preserved",
+			}),
+		);
+
+		const result = await checkHookFileReferences(projectDir);
+		const fixResult = await result.fix?.execute();
+		expect(fixResult?.success).toBe(true);
+
+		const updated = JSON.parse(await readFile(settingsPath, "utf-8"));
+		expect(updated.hooks).toBeUndefined();
+		expect(updated.otherField).toBe("preserved");
+	});
 });

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	checkHookCommandPaths,
 	checkHookConfig,
 	checkHookDeps,
+	checkHookFileReferences,
 	checkHookLogs,
 	checkHookRuntime,
 	checkHookSyntax,
@@ -750,5 +752,158 @@ describe("checkPythonVenv", () => {
 			// Skip test if symlink fails (permissions, etc.)
 			console.log(`Skipping test: ${error}`);
 		}
+	});
+});
+
+describe("checkHookFileReferences", () => {
+	let tempDir: string;
+	let projectDir: string;
+	let originalCkTestHome: string | undefined;
+
+	beforeEach(async () => {
+		tempDir = join(
+			tmpdir(),
+			`hook-file-refs-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		projectDir = join(tempDir, "project");
+		await mkdir(projectDir, { recursive: true });
+		originalCkTestHome = process.env.CK_TEST_HOME;
+		process.env.CK_TEST_HOME = tempDir;
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+		if (originalCkTestHome === undefined) {
+			process.env.CK_TEST_HOME = undefined;
+		} else {
+			process.env.CK_TEST_HOME = originalCkTestHome;
+		}
+	});
+
+	test("returns info when no settings files exist", async () => {
+		const result = await checkHookFileReferences(projectDir);
+		expect(result.id).toBe("hook-file-references");
+		expect(result.status).toBe("info");
+	});
+
+	test("returns pass when all referenced hook files exist", async () => {
+		await mkdir(join(projectDir, ".claude", "hooks"), { recursive: true });
+		await writeFile(join(projectDir, ".claude", "hooks", "scout-block.cjs"), "process.exit(0);");
+		await writeFile(
+			join(projectDir, ".claude", "settings.json"),
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Read",
+							hooks: [
+								{
+									type: "command",
+									command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/scout-block.cjs',
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookFileReferences(projectDir);
+		expect(result.status).toBe("pass");
+	});
+
+	test("returns fail when settings reference a missing hook file", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		await writeFile(
+			join(projectDir, ".claude", "settings.json"),
+			JSON.stringify({
+				hooks: {
+					Stop: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-state.cjs',
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookFileReferences(projectDir);
+		expect(result.status).toBe("fail");
+		expect(result.autoFixable).toBe(true);
+		expect(result.details).toContain("session-state.cjs");
+	});
+
+	test("ignores non-node commands (e.g. arbitrary shell)", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		await writeFile(
+			join(projectDir, ".claude", "settings.json"),
+			JSON.stringify({
+				hooks: {
+					Stop: [
+						{
+							hooks: [{ type: "command", command: "echo hello" }],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookFileReferences(projectDir);
+		expect(result.status).toBe("pass");
+	});
+
+	test("auto-fix prunes stale hook entries from settings.json", async () => {
+		await mkdir(join(projectDir, ".claude", "hooks"), { recursive: true });
+		await writeFile(join(projectDir, ".claude", "hooks", "exists.cjs"), "process.exit(0);");
+		const settingsPath = join(projectDir, ".claude", "settings.json");
+		await writeFile(
+			settingsPath,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Edit",
+							hooks: [
+								{
+									type: "command",
+									command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/missing.cjs',
+								},
+								{
+									type: "command",
+									command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/exists.cjs',
+								},
+							],
+						},
+					],
+					Stop: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-state.cjs',
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookFileReferences(projectDir);
+		expect(result.status).toBe("fail");
+		expect(result.fix).toBeDefined();
+
+		const fixResult = await result.fix?.execute();
+		expect(fixResult?.success).toBe(true);
+
+		const updated = JSON.parse(await readFile(settingsPath, "utf-8"));
+		expect(updated.hooks.Stop).toBeUndefined();
+		expect(updated.hooks.PreToolUse[0].hooks).toHaveLength(1);
+		expect(updated.hooks.PreToolUse[0].hooks[0].command).toContain("exists.cjs");
 	});
 });

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
@@ -947,6 +947,56 @@ describe("checkHookFileReferences", () => {
 		expect(result.details).toContain("nope-xyz-missing.cjs");
 	});
 
+	test("detects missing file for $HOME-prefixed path", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		await writeFile(
+			join(projectDir, ".claude", "settings.json"),
+			JSON.stringify({
+				hooks: {
+					Stop: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: 'node "$HOME/.claude/hooks/nope-home-missing.cjs"',
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookFileReferences(projectDir);
+		expect(result.status).toBe("fail");
+		expect(result.details).toContain("nope-home-missing.cjs");
+	});
+
+	test("detects missing file for %USERPROFILE% Windows path form", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		await writeFile(
+			join(projectDir, ".claude", "settings.json"),
+			JSON.stringify({
+				hooks: {
+					Stop: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: 'node "%USERPROFILE%\\\\.claude\\\\hooks\\\\nope-winprofile.cjs"',
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookFileReferences(projectDir);
+		expect(result.status).toBe("fail");
+		expect(result.details).toContain("nope-winprofile.cjs");
+	});
+
 	test("auto-fix removes empty hooks key when all entries are pruned", async () => {
 		await mkdir(join(projectDir, ".claude"), { recursive: true });
 		const settingsPath = join(projectDir, ".claude", "settings.json");

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -781,7 +781,8 @@ async function pruneMissingHookReferencesInSettingsFile(
 	}
 
 	if (Object.keys(hooksRecord).length === 0) {
-		(settings as Record<string, unknown>).hooks = undefined;
+		// biome-ignore lint/performance/noDelete: clearer semantics than = undefined for key removal
+		delete (settings as Record<string, unknown>).hooks;
 	}
 
 	if (pruned > 0) {

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -645,6 +645,8 @@ interface MissingHookReference {
  */
 function extractHookScriptPath(cmd: string | null | undefined): string | null {
 	if (!cmd) return null;
+	// Strip all double-quotes: the .cjs anchor terminates the capture before any trailing
+	// args, so extra quotes in arg values won't corrupt the extracted path.
 	const stripped = cmd.replace(/"/g, "");
 	// Match: node <path-ending-in-.cjs> (followed by whitespace or end)
 	const match = stripped.match(/\bnode\s+(\S*?\.claude[/\\]\S+?\.cjs)(?:\s|$)/);
@@ -776,6 +778,10 @@ async function pruneMissingHookReferencesInSettingsFile(
 		} else {
 			hooksRecord[eventName] = filteredEntries;
 		}
+	}
+
+	if (Object.keys(hooksRecord).length === 0) {
+		(settings as Record<string, unknown>).hooks = undefined;
 	}
 
 	if (pruned > 0) {

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -629,6 +629,245 @@ export async function checkHookCommandPaths(projectDir: string): Promise<CheckRe
 	};
 }
 
+interface MissingHookReference {
+	path: string;
+	label: string;
+	eventName: string;
+	matcher?: string;
+	command: string;
+	scriptPath: string;
+	resolvedPath: string;
+}
+
+/**
+ * Extract a `.cjs` hook script path from a `node`-style hook command.
+ * Returns null if the command is not a node-executed `.claude` hook.
+ */
+function extractHookScriptPath(cmd: string | null | undefined): string | null {
+	if (!cmd) return null;
+	const stripped = cmd.replace(/"/g, "");
+	// Match: node <path-ending-in-.cjs> (followed by whitespace or end)
+	const match = stripped.match(/\bnode\s+(\S*?\.claude[/\\]\S+?\.cjs)(?:\s|$)/);
+	if (!match) return null;
+	return match[1];
+}
+
+/**
+ * Resolve a hook script path token into an absolute filesystem path.
+ * Handles $HOME, $CLAUDE_PROJECT_DIR, ~, %USERPROFILE%, %CLAUDE_PROJECT_DIR%,
+ * and bare `.claude/...` relative forms.
+ */
+function resolveHookScriptPath(scriptPath: string, projectDir: string): string {
+	let resolved = scriptPath.replace(/\\/g, "/");
+	const home = homedir();
+	resolved = resolved.replace(/^\$\{?HOME\}?/, home);
+	resolved = resolved.replace(/^\$\{?CLAUDE_PROJECT_DIR\}?/, projectDir);
+	resolved = resolved.replace(/^%USERPROFILE%/, home);
+	resolved = resolved.replace(/^%CLAUDE_PROJECT_DIR%/, projectDir);
+	resolved = resolved.replace(/^~\//, `${home}/`);
+	if (resolved.startsWith(".claude/") || resolved === ".claude") {
+		resolved = join(projectDir, resolved);
+	}
+	return resolve(resolved);
+}
+
+function collectMissingHookReferences(
+	settings: SettingsJson,
+	settingsFile: ClaudeSettingsFile,
+	projectDir: string,
+): MissingHookReference[] {
+	if (!settings.hooks) return [];
+
+	const findings: MissingHookReference[] = [];
+	const seen = new Set<string>();
+
+	const consider = (
+		eventName: string,
+		command: string | undefined,
+		matcher: string | undefined,
+	) => {
+		if (!command) return;
+		const scriptPath = extractHookScriptPath(command);
+		if (!scriptPath) return;
+		const resolvedPath = resolveHookScriptPath(scriptPath, projectDir);
+		if (existsSync(resolvedPath)) return;
+		const key = `${settingsFile.path}::${eventName}::${matcher ?? ""}::${scriptPath}`;
+		if (seen.has(key)) return;
+		seen.add(key);
+		findings.push({
+			path: settingsFile.path,
+			label: settingsFile.label,
+			eventName,
+			matcher,
+			command,
+			scriptPath,
+			resolvedPath,
+		});
+	};
+
+	for (const [eventName, entries] of Object.entries(settings.hooks)) {
+		for (const entry of entries) {
+			if ("command" in entry && typeof entry.command === "string") {
+				consider(eventName, entry.command, undefined);
+			}
+			if ("hooks" in entry && entry.hooks) {
+				const matcher = "matcher" in entry ? entry.matcher : undefined;
+				for (const hook of entry.hooks) {
+					consider(eventName, hook.command, matcher);
+				}
+			}
+		}
+	}
+
+	return findings;
+}
+
+async function pruneMissingHookReferencesInSettingsFile(
+	settingsFile: ClaudeSettingsFile,
+	projectDir: string,
+): Promise<number> {
+	const settings = await SettingsMerger.readSettingsFile(settingsFile.path);
+	if (!settings?.hooks) return 0;
+
+	let pruned = 0;
+
+	const hookFileMissing = (command: string | undefined): boolean => {
+		if (!command) return false;
+		const scriptPath = extractHookScriptPath(command);
+		if (!scriptPath) return false;
+		return !existsSync(resolveHookScriptPath(scriptPath, projectDir));
+	};
+
+	const hooksRecord = settings.hooks as Record<string, unknown[]>;
+	for (const [eventName, entries] of Object.entries(hooksRecord)) {
+		const filteredEntries: unknown[] = [];
+		for (const entry of entries) {
+			const e = entry as { command?: string; hooks?: Array<{ command?: string }> };
+			// Flat command entry
+			if (typeof e.command === "string") {
+				if (hookFileMissing(e.command)) {
+					pruned++;
+					continue;
+				}
+				filteredEntries.push(entry);
+				continue;
+			}
+
+			// Matcher entry with nested hooks[]
+			if (Array.isArray(e.hooks)) {
+				const keptHooks = e.hooks.filter((h) => {
+					if (hookFileMissing(h.command)) {
+						pruned++;
+						return false;
+					}
+					return true;
+				});
+				if (keptHooks.length === 0) {
+					continue;
+				}
+				filteredEntries.push({ ...e, hooks: keptHooks });
+				continue;
+			}
+
+			filteredEntries.push(entry);
+		}
+		if (filteredEntries.length === 0) {
+			delete hooksRecord[eventName];
+		} else {
+			hooksRecord[eventName] = filteredEntries;
+		}
+	}
+
+	if (pruned > 0) {
+		await SettingsMerger.writeSettingsFile(settingsFile.path, settings);
+	}
+
+	return pruned;
+}
+
+/**
+ * Validate that hook commands in Claude settings reference files that exist on disk.
+ * Catches stale references that produce MODULE_NOT_FOUND at Claude Code runtime.
+ */
+export async function checkHookFileReferences(projectDir: string): Promise<CheckResult> {
+	const settingsFiles = getClaudeSettingsFiles(projectDir);
+
+	if (settingsFiles.length === 0) {
+		return {
+			id: "hook-file-references",
+			name: "Hook File References",
+			group: "claudekit",
+			priority: "critical",
+			status: "info",
+			message: "No Claude settings files",
+			autoFixable: false,
+		};
+	}
+
+	const findings: MissingHookReference[] = [];
+	for (const settingsFile of settingsFiles) {
+		const settings = await SettingsMerger.readSettingsFile(settingsFile.path);
+		if (!settings) continue;
+		findings.push(...collectMissingHookReferences(settings, settingsFile, projectDir));
+	}
+
+	if (findings.length === 0) {
+		return {
+			id: "hook-file-references",
+			name: "Hook File References",
+			group: "claudekit",
+			priority: "critical",
+			status: "pass",
+			message: "All referenced hook files exist",
+			autoFixable: false,
+		};
+	}
+
+	const details = findings
+		.slice(0, 8)
+		.map((f) => {
+			const matcher = f.matcher ? ` [${f.matcher}]` : "";
+			return `${f.label} :: ${f.eventName}${matcher} :: missing ${f.scriptPath}`;
+		})
+		.join("\n");
+
+	return {
+		id: "hook-file-references",
+		name: "Hook File References",
+		group: "claudekit",
+		priority: "critical",
+		status: "fail",
+		message: `${findings.length} settings hook(s) reference missing file(s)`,
+		details,
+		suggestion: "Run: ck doctor --fix (prunes stale entries), then 'ck init' to restore hooks",
+		autoFixable: true,
+		fix: {
+			id: "fix-hook-file-references",
+			description: "Prune stale hook entries whose script files are missing",
+			execute: async () => {
+				try {
+					let pruned = 0;
+					for (const settingsFile of settingsFiles) {
+						pruned += await pruneMissingHookReferencesInSettingsFile(settingsFile, projectDir);
+					}
+					if (pruned === 0) {
+						return { success: true, message: "No stale hook entries needed pruning" };
+					}
+					return {
+						success: true,
+						message: `Pruned ${pruned} stale hook entry(ies). Run 'ck init' to restore hooks if needed.`,
+					};
+				} catch (error) {
+					return {
+						success: false,
+						message: `Failed to prune stale hook entries: ${error}`,
+					};
+				}
+			},
+		},
+	};
+}
+
 /**
  * Check hook configuration validity
  */

--- a/src/domains/health-checks/checkers/index.ts
+++ b/src/domains/health-checks/checkers/index.ts
@@ -21,6 +21,7 @@ export {
 	checkHookRuntime,
 	checkHookCommandPaths,
 	checkHookConfig,
+	checkHookFileReferences,
 	checkHookLogs,
 	checkCliVersion,
 	checkPythonVenv,

--- a/src/domains/health-checks/claudekit-checker.ts
+++ b/src/domains/health-checks/claudekit-checker.ts
@@ -13,6 +13,7 @@ import {
 	checkHookCommandPaths,
 	checkHookConfig,
 	checkHookDeps,
+	checkHookFileReferences,
 	checkHookLogs,
 	checkHookRuntime,
 	checkHookSyntax,
@@ -97,6 +98,8 @@ export class ClaudekitChecker implements Checker {
 		results.push(await checkHookRuntime(this.projectDir));
 		logger.verbose("ClaudekitChecker: Checking hook command paths");
 		results.push(await checkHookCommandPaths(this.projectDir));
+		logger.verbose("ClaudekitChecker: Checking hook file references");
+		results.push(await checkHookFileReferences(this.projectDir));
 		logger.verbose("ClaudekitChecker: Checking hook config");
 		results.push(await checkHookConfig(this.projectDir));
 		logger.verbose("ClaudekitChecker: Checking hook crash logs");

--- a/src/services/transformers/global-path-transformer.ts
+++ b/src/services/transformers/global-path-transformer.ts
@@ -7,8 +7,10 @@
  * at install time.
  *
  * Cross-platform compatibility:
- * - Unix/Linux/Mac: Uses $HOME/.claude/
- * - Windows: Uses %USERPROFILE%/.claude/ (forward slashes work on Windows)
+ * - All platforms use $HOME/.claude/ — Claude Code on Windows runs hook commands
+ *   through a POSIX shell that expands $HOME but NOT %USERPROFILE% (verified
+ *   empirically against Claude Code 2.1.101 on Windows). Emitting %USERPROFILE%
+ *   produced silently broken hooks (issue #715).
  */
 
 import { readFile, readdir, writeFile } from "node:fs/promises";
@@ -25,19 +27,17 @@ import { logger } from "@/shared/logger.js";
 export const IS_WINDOWS = platform() === "win32";
 
 /**
- * Cached platform-appropriate home directory prefix
- * Computed once at module load time for performance
+ * Home directory prefix — `$HOME` on all platforms.
+ * Claude Code's Windows runtime uses a POSIX shell that expands $HOME but not
+ * %USERPROFILE%. See issue #715.
  *
  * @internal Exported for testing purposes only
  */
-export const HOME_PREFIX = IS_WINDOWS ? "%USERPROFILE%" : "$HOME";
+export const HOME_PREFIX = "$HOME";
 
 /**
- * Get the platform-appropriate home directory variable for use in paths
- *
- * @returns Home directory prefix that works across platforms
- *   - Windows: %USERPROFILE%
- *   - Unix/Linux/Mac: $HOME
+ * Get the home directory variable for use in paths.
+ * Returns `$HOME` on every platform — see HOME_PREFIX docs.
  *
  * @internal Exported for testing purposes
  */
@@ -119,16 +119,18 @@ export const TRANSFORMABLE_EXTENSIONS = new Set([
 export const ALWAYS_TRANSFORM_FILES = new Set(["CLAUDE.md", "claude.md"]);
 
 /**
- * Transform path references in file content
+ * Transform path references in file content.
  *
- * Handles these patterns (examples for Unix, Windows uses %USERPROFILE%):
+ * Handles these patterns:
  * - `./.claude/` → `$HOME/.claude/` (relative path)
  * - `@.claude/` → `@$HOME/.claude/` (@ reference)
  * - `".claude/` → `"$HOME/.claude/` (quoted)
  * - ` .claude/` → ` $HOME/.claude/` (space prefix)
+ * - legacy `%USERPROFILE%/.claude/` → `$HOME/.claude/` (normalize broken Windows form)
  * - etc.
  *
- * Cross-platform: Uses $HOME on Unix/Linux/Mac, %USERPROFILE% on Windows
+ * All platforms emit `$HOME`. Claude Code on Windows runs hooks through a
+ * POSIX shell that expands $HOME but not %USERPROFILE% (issue #715).
  *
  * @internal Exported for testing purposes
  */
@@ -142,28 +144,25 @@ export function transformContent(
 	const customGlobalClaudeDir = getCustomGlobalClaudeDir(options.targetClaudeDir);
 	const claudePath = getGlobalClaudePath(options.targetClaudeDir);
 
-	// Windows-specific: Convert $HOME → %USERPROFILE% (handles content with Unix env vars)
-	if (IS_WINDOWS) {
-		// Pattern W1: $HOME/.claude/ → %USERPROFILE%/.claude/
-		const homePathResult = replaceTracked(transformed, /\$HOME\/\.claude\//g, claudePath);
-		transformed = homePathResult.content;
-		changes += homePathResult.changes;
+	// Normalize any legacy %USERPROFILE% content to $HOME — covers settings/scripts
+	// written by older CLI versions or hand-edited by users following outdated docs.
+	// Pattern U1: %USERPROFILE%/.claude/ or %USERPROFILE%\.claude\ → $HOME/.claude/
+	const userProfileClaudeResult = replaceTracked(
+		transformed,
+		/%USERPROFILE%[\\/]\.claude[\\/]/g,
+		claudePath,
+	);
+	transformed = userProfileClaudeResult.content;
+	changes += userProfileClaudeResult.changes;
 
-		// Pattern W2: ${HOME}/.claude/ → %USERPROFILE%/.claude/
-		const braceHomePathResult = replaceTracked(transformed, /\$\{HOME\}\/\.claude\//g, claudePath);
-		transformed = braceHomePathResult.content;
-		changes += braceHomePathResult.changes;
-
-		// Pattern W3: Standalone $HOME → %USERPROFILE% (only when followed by path separator)
-		const homePrefixResult = replaceTracked(transformed, /\$HOME(?=\/|\\)/g, homePrefix);
-		transformed = homePrefixResult.content;
-		changes += homePrefixResult.changes;
-
-		// Pattern W4: ${HOME} → %USERPROFILE% (only when followed by path separator)
-		const braceHomePrefixResult = replaceTracked(transformed, /\$\{HOME\}(?=\/|\\)/g, homePrefix);
-		transformed = braceHomePrefixResult.content;
-		changes += braceHomePrefixResult.changes;
-	}
+	// Pattern U2: Standalone %USERPROFILE% followed by path separator → $HOME
+	const userProfileStandaloneResult = replaceTracked(
+		transformed,
+		/%USERPROFILE%(?=[\\/])/g,
+		homePrefix,
+	);
+	transformed = userProfileStandaloneResult.content;
+	changes += userProfileStandaloneResult.changes;
 
 	// Convert $CLAUDE_PROJECT_DIR to home prefix (for global install transformation)
 	// Pattern P1: $CLAUDE_PROJECT_DIR/.claude/ → $HOME/.claude/
@@ -196,17 +195,14 @@ export function transformContent(
 	transformed = braceProjectDirPathResult.content;
 	changes += braceProjectDirPathResult.changes;
 
-	// Windows: %CLAUDE_PROJECT_DIR% → platform-appropriate prefix
-	if (IS_WINDOWS) {
-		// Pattern W5: %CLAUDE_PROJECT_DIR%/.claude/ → %USERPROFILE%/.claude/
-		const windowsProjectDirPathResult = replaceTracked(
-			transformed,
-			/%CLAUDE_PROJECT_DIR%\/\.claude\//g,
-			claudePath,
-		);
-		transformed = windowsProjectDirPathResult.content;
-		changes += windowsProjectDirPathResult.changes;
-	}
+	// Normalize legacy %CLAUDE_PROJECT_DIR%/.claude/ → $HOME/.claude/ (issue #715).
+	const windowsProjectDirPathResult = replaceTracked(
+		transformed,
+		/%CLAUDE_PROJECT_DIR%[\\/]\.claude[\\/]/g,
+		claudePath,
+	);
+	transformed = windowsProjectDirPathResult.content;
+	changes += windowsProjectDirPathResult.changes;
 
 	// Pattern 1: ./.claude/ → $HOME/.claude/ (remove ./ prefix entirely)
 	const relativeClaudePathResult = replaceTracked(transformed, /\.\/\.claude\//g, claudePath);

--- a/tests/lib/global-path-transformer.test.ts
+++ b/tests/lib/global-path-transformer.test.ts
@@ -18,16 +18,9 @@ describe("global-path-transformer", () => {
 			expect(getHomeDirPrefix()).toBe(HOME_PREFIX);
 		});
 
-		it("returns correct platform-specific prefix", () => {
-			// Platform detection happens at module load time
-			// Verify the correct value based on current platform
-			if (process.platform === "win32") {
-				expect(getHomeDirPrefix()).toBe("%USERPROFILE%");
-				expect(HOME_PREFIX).toBe("%USERPROFILE%");
-			} else {
-				expect(getHomeDirPrefix()).toBe("$HOME");
-				expect(HOME_PREFIX).toBe("$HOME");
-			}
+		it("returns $HOME on every platform (Claude Code POSIX shell; see issue #715)", () => {
+			expect(getHomeDirPrefix()).toBe("$HOME");
+			expect(HOME_PREFIX).toBe("$HOME");
 		});
 	});
 
@@ -146,13 +139,38 @@ describe("global-path-transformer", () => {
 		});
 
 		it("does not transform already-transformed paths", () => {
-			// If someone already has $HOME or %USERPROFILE% in their content
+			// If someone already has $HOME in their content
 			const input = `command: "node ${expectedPrefix}/.claude/hooks/test.js"`;
 			const { transformed, changes } = transformContent(input);
 
 			// Should not double-transform
 			expect(transformed).toBe(input);
 			expect(changes).toBe(0);
+		});
+
+		it("normalizes legacy %USERPROFILE%/.claude/ to $HOME/.claude/ (issue #715)", () => {
+			const input = 'command: "node %USERPROFILE%/.claude/hooks/test.js"';
+			const { transformed, changes } = transformContent(input);
+
+			expect(transformed).toBe(`command: "node ${expectedPrefix}/.claude/hooks/test.js"`);
+			expect(changes).toBe(1);
+		});
+
+		it("normalizes legacy %USERPROFILE%\\.claude\\ with backslashes (issue #715)", () => {
+			const input = 'command: "node %USERPROFILE%\\.claude\\hooks\\test.js"';
+			const { transformed, changes } = transformContent(input);
+
+			expect(transformed).toContain(`${expectedPrefix}/.claude/hooks`);
+			expect(transformed).not.toContain("%USERPROFILE%");
+			expect(changes).toBeGreaterThan(0);
+		});
+
+		it("normalizes legacy %CLAUDE_PROJECT_DIR%/.claude/ to $HOME/.claude/ (issue #715)", () => {
+			const input = 'command: "node %CLAUDE_PROJECT_DIR%/.claude/hooks/test.js"';
+			const { transformed, changes } = transformContent(input);
+
+			expect(transformed).toBe(`command: "node ${expectedPrefix}/.claude/hooks/test.js"`);
+			expect(changes).toBe(1);
 		});
 
 		it("handles real-world settings.json content", () => {


### PR DESCRIPTION
## Summary

Adds a new \`ck doctor\` check \`checkHookFileReferences\` that cross-validates hook commands registered in \`.claude/settings.json\` (project + global) against actual \`.cjs\` files on disk. When drift is detected, doctor reports the missing references and offers a structured auto-fix that prunes stale entries from settings.

Closes #715

## Problem

Users repeatedly saw \`Pre/PostToolUse: Edit hook error\` / \`Stop hook error: MODULE_NOT_FOUND\` on every tool call:

\`\`\`
Error: Cannot find module '<project>/.claude/hooks/session-state.cjs'
code: 'MODULE_NOT_FOUND'
\`\`\`

The project's \`settings.json\` registered hook commands pointing at \`.cjs\` files that no longer exist in \`.claude/hooks/\`. Causes: partial installs (\`ck init --only\`), kit upgrades where old settings referenced hooks removed/renamed outside \`metadata.json\` deletions, hand-edited settings, or third-party templates. Existing \`ck doctor\` checks never cross-verified settings registrations against on-disk files, so users had no structured way to diagnose or repair.

## What changed

| File | Change |
|------|--------|
| \`src/domains/health-checks/checkers/hook-health-checker.ts\` | Add \`checkHookFileReferences\` + \`extractHookScriptPath\`, \`resolveHookScriptPath\`, \`pruneMissingHookReferencesInSettingsFile\` |
| \`src/domains/health-checks/checkers/index.ts\` | Export \`checkHookFileReferences\` |
| \`src/domains/health-checks/claudekit-checker.ts\` | Register new check in claudekit group (critical priority) |
| \`src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts\` | 5 new tests: info/pass/fail/non-node/auto-fix pruning |

## How it works

1. Scan all Claude settings files (project + global, main + local).
2. For each hook command, extract the \`.cjs\` target path using a regex that tolerates all quoting/path-variable styles supported by the existing installer (\$HOME, \$CLAUDE_PROJECT_DIR, ~, %USERPROFILE%, %CLAUDE_PROJECT_DIR%, bare relative).
3. Resolve against \`homedir()\` / \`projectDir\` and check \`existsSync\`.
4. On missing files: status \`fail\`, priority \`critical\`, autoFixable \`true\`, details list first 8 offenders with event + matcher + script path.
5. Auto-fix: remove hook entries whose script file is missing; collapse empty matcher entries; delete empty event keys. Suggest \`ck init\` after pruning to restore any expected hooks.

## Validation

- [x] \`bun run typecheck\` passes
- [x] \`bun run lint\` passes
- [x] \`bun test\` — 4208 pass / 0 fail (35 in touched file, 5 new)
- [x] \`bun run build\` succeeds
- [x] Pre-commit quality gate passed