### PR TITLE
fix(desktop): restore settings and config panels in Tauri mode

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -68,6 +68,15 @@ pub fn read_settings(project_path: String) -> Result<Value, String> {
     config_parser::read_json_file(&path)
 }
 
+/// Check whether settings.json exists for a project.
+#[tauri::command]
+pub fn settings_file_exists(project_path: String) -> Result<bool, String> {
+    let safe_path = validate_project_path(&project_path)?;
+    let base = paths::project_claude_dir(&safe_path);
+    let path = paths::settings_path(&base);
+    Ok(path.exists())
+}
+
 /// Write settings.json for a project. Creates .claude/ directory if needed.
 #[tauri::command]
 pub fn write_settings(project_path: String, settings: Value) -> Result<(), String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,6 +32,7 @@ pub fn run() {
             commands::config::read_config,
             commands::config::write_config,
             commands::config::read_settings,
+            commands::config::settings_file_exists,
             commands::config::write_settings,
             commands::config::read_statusline,
             commands::config::write_statusline,

--- a/src/types/ck-config.ts
+++ b/src/types/ck-config.ts
@@ -410,17 +410,24 @@ export type CkAssertion = z.infer<typeof CkAssertionSchema>;
 // update ALL of: CkHooksConfigSchema, DEFAULT_CK_CONFIG.hooks, CK_HOOK_NAMES,
 // src/schemas/ck-config.schema.json, GlobalConfigPage.tsx sections,
 // src/ui/src/services/configFieldDocs.ts, and src/ui/src/i18n/translations.ts (EN + VI)
-export const CkHooksConfigSchema = z.object({
-	"session-init": z.boolean().optional(),
-	"subagent-init": z.boolean().optional(),
-	"descriptive-name": z.boolean().optional(),
-	"dev-rules-reminder": z.boolean().optional(),
-	"usage-context-awareness": z.boolean().optional(),
-	"context-tracking": z.boolean().optional(),
-	"scout-block": z.boolean().optional(),
-	"privacy-block": z.boolean().optional(),
-	"simplify-gate": z.boolean().optional(),
-});
+//
+// NOTE: .passthrough() is intentional — user .ck.json files may contain
+// hook keys installed by older or newer kit versions (e.g. post-edit-simplify-reminder).
+// Without passthrough, Zod silently strips unknown keys causing the config panel
+// to appear to lose custom hook settings when round-tripped through the editor.
+export const CkHooksConfigSchema = z
+	.object({
+		"session-init": z.boolean().optional(),
+		"subagent-init": z.boolean().optional(),
+		"descriptive-name": z.boolean().optional(),
+		"dev-rules-reminder": z.boolean().optional(),
+		"usage-context-awareness": z.boolean().optional(),
+		"context-tracking": z.boolean().optional(),
+		"scout-block": z.boolean().optional(),
+		"privacy-block": z.boolean().optional(),
+		"simplify-gate": z.boolean().optional(),
+	})
+	.passthrough();
 export type CkHooksConfig = z.infer<typeof CkHooksConfigSchema>;
 
 // SYNC POINT: Simplify config block (mirrors claudekit-engineer simplify-gate hook).

--- a/src/ui/src/hooks/use-config-editor.ts
+++ b/src/ui/src/hooks/use-config-editor.ts
@@ -36,6 +36,7 @@ export interface UseConfigEditorReturn {
 	sources: Record<string, ConfigSource>;
 	schema: Record<string, unknown> | null;
 	isLoading: boolean;
+	loadError: string | null;
 	saveStatus: "idle" | "saving" | "saved" | "error";
 	syntaxError: string | null;
 	cursorLine: number;
@@ -70,6 +71,7 @@ export function useConfigEditor(options: UseConfigEditorOptions): UseConfigEdito
 
 	// Shared state
 	const [isLoading, setIsLoading] = useState(true);
+	const [loadError, setLoadError] = useState<string | null>(null);
 	const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
 	const [showResetConfirm, setShowResetConfirm] = useState(false);
 
@@ -88,6 +90,7 @@ export function useConfigEditor(options: UseConfigEditorOptions): UseConfigEdito
 	// Load all data on mount
 	useEffect(() => {
 		const loadData = async () => {
+			setLoadError(null);
 			try {
 				const [configData, schemaData] = await Promise.all([fetchConfig(), fetchSchema()]);
 
@@ -99,7 +102,9 @@ export function useConfigEditor(options: UseConfigEditorOptions): UseConfigEdito
 				setSchema(schemaData);
 				setJsonText(JSON.stringify(cfg, null, 2));
 			} catch (err) {
+				const detail = err instanceof Error ? err.message : String(err);
 				console.error("Failed to load config data:", err);
+				setLoadError(detail);
 			} finally {
 				setIsLoading(false);
 			}
@@ -204,6 +209,7 @@ export function useConfigEditor(options: UseConfigEditorOptions): UseConfigEdito
 		sources,
 		schema,
 		isLoading,
+		loadError,
 		saveStatus,
 		syntaxError,
 		cursorLine,

--- a/src/ui/src/i18n/translations.ts
+++ b/src/ui/src/i18n/translations.ts
@@ -274,6 +274,8 @@ export const translations = {
 		settingsJsonMissing: "No settings file found at ~/.claude/settings.json.",
 		settingsJsonLoadFailed: "Failed to load ~/.claude/settings.json.",
 		settingsLoadFailedDetail: "Error detail:",
+		configLoadFailed: "Failed to load configuration.",
+		configLoadFailedDetail: "Error detail:",
 		settingsBackupSaved: "Backup saved",
 		hookDiagnosticsTitle: "Hook Diagnostics",
 		hookDiagnosticsDesc:
@@ -1362,6 +1364,8 @@ export const translations = {
 		settingsJsonMissing: "Không tìm thấy tệp ~/.claude/settings.json.",
 		settingsJsonLoadFailed: "Không thể tải ~/.claude/settings.json.",
 		settingsLoadFailedDetail: "Chi tiết lỗi:",
+		configLoadFailed: "Không thể tải cấu hình.",
+		configLoadFailedDetail: "Chi tiết lỗi:",
 		settingsBackupSaved: "Đã lưu bản sao lưu",
 		hookDiagnosticsTitle: "Chẩn đoán Hook",
 		hookDiagnosticsDesc: "Xem hoạt động hook gần đây và lỗi mà không cần mở tệp JSONL thủ công.",

--- a/src/ui/src/lib/__tests__/tauri-commands.vitest.ts
+++ b/src/ui/src/lib/__tests__/tauri-commands.vitest.ts
@@ -7,6 +7,7 @@ import {
 	listProjectSessions,
 	readSettings,
 	scanForProjects,
+	settingsFileExists,
 	writeSettings,
 } from "../tauri-commands";
 
@@ -24,8 +25,13 @@ describe("tauri command wrappers", () => {
 		await readSettings("/tmp/project");
 		expect(invoke).toHaveBeenNthCalledWith(1, "read_settings", { projectPath: "/tmp/project" });
 
+		await settingsFileExists("/tmp/project");
+		expect(invoke).toHaveBeenNthCalledWith(2, "settings_file_exists", {
+			projectPath: "/tmp/project",
+		});
+
 		await writeSettings("/tmp/project", { model: "gpt-5" });
-		expect(invoke).toHaveBeenNthCalledWith(2, "write_settings", {
+		expect(invoke).toHaveBeenNthCalledWith(3, "write_settings", {
 			projectPath: "/tmp/project",
 			settings: { model: "gpt-5" },
 		});

--- a/src/ui/src/lib/tauri-commands.ts
+++ b/src/ui/src/lib/tauri-commands.ts
@@ -28,6 +28,10 @@ export const writeConfig = (projectPath: string, config: Record<string, unknown>
 export const readSettings = (projectPath: string): Promise<Record<string, unknown>> =>
 	invoke<Record<string, unknown>>("read_settings", { projectPath });
 
+/** Check whether .claude/settings.json exists for a project. */
+export const settingsFileExists = (projectPath: string): Promise<boolean> =>
+	invoke<boolean>("settings_file_exists", { projectPath });
+
 /** Write .claude/settings.json for a project. Creates .claude/ directory if needed. */
 export const writeSettings = (
 	projectPath: string,

--- a/src/ui/src/pages/GlobalConfigPage.tsx
+++ b/src/ui/src/pages/GlobalConfigPage.tsx
@@ -423,6 +423,16 @@ const GlobalConfigPage: React.FC = () => {
 				showFilePath={false}
 			/>
 
+			{/* Load error banner — surfaces fetchConfig failures (e.g. Tauri invoke errors) */}
+			{!editor.isLoading && editor.loadError && (
+				<div className="mx-4 mt-2 px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/30 text-xs text-red-500">
+					<p className="font-medium">{t("configLoadFailed")}</p>
+					<p className="mt-1 break-words">
+						{t("configLoadFailedDetail")} {editor.loadError}
+					</p>
+				</div>
+			)}
+
 			{/* Tab Bar */}
 			{/* Content area — config editor only (System moved to / home dashboard) */}
 			<div className="flex-1 flex min-h-0">

--- a/src/ui/src/services/__tests__/api.vitest.ts
+++ b/src/ui/src/services/__tests__/api.vitest.ts
@@ -12,6 +12,7 @@ vi.mock("../../lib/tauri-commands", () => ({
 	getGlobalConfigDir: vi.fn(),
 	getHomeDir: vi.fn(),
 	readSettings: vi.fn(),
+	settingsFileExists: vi.fn(),
 	getHealth: vi.fn(),
 	touchProject: vi.fn(),
 }));
@@ -172,10 +173,23 @@ describe("api service dual-mode routing", () => {
 
 	it("propagates tauri settings errors from fetchSettingsFile", async () => {
 		vi.mocked(isTauri).mockReturnValue(true);
-		vi.mocked(tauri.getGlobalConfigPath).mockResolvedValue("/Users/test/.claude/settings.json");
 		vi.mocked(tauri.getHomeDir).mockResolvedValue("/Users/test");
+		vi.mocked(tauri.settingsFileExists).mockResolvedValue(true);
 		vi.mocked(tauri.readSettings).mockRejectedValue(new Error("E_DENIED: capability check failed"));
 
 		await expect(api.fetchSettingsFile()).rejects.toThrow(/E_DENIED/);
+	});
+
+	it("keeps missing settings.json distinct from an empty object in Tauri mode", async () => {
+		vi.mocked(isTauri).mockReturnValue(true);
+		vi.mocked(tauri.getHomeDir).mockResolvedValue("/Users/test");
+		vi.mocked(tauri.settingsFileExists).mockResolvedValue(false);
+		vi.mocked(tauri.readSettings).mockResolvedValue({});
+
+		await expect(api.fetchSettingsFile()).resolves.toEqual({
+			path: "/Users/test/.claude/settings.json",
+			exists: false,
+			settings: {},
+		});
 	});
 });

--- a/src/ui/src/services/__tests__/ck-config-api.vitest.ts
+++ b/src/ui/src/services/__tests__/ck-config-api.vitest.ts
@@ -103,4 +103,25 @@ describe("ck-config-api desktop mode", () => {
 		).rejects.toThrow();
 		expect(tauri.writeConfig).not.toHaveBeenCalled();
 	});
+
+	it("updates a valid desktop field even when unrelated stored config is invalid", async () => {
+		vi.mocked(tauri.readConfig).mockResolvedValue({
+			statuslineLayout: {
+				theme: {
+					accent: "#ff00ff",
+				},
+			},
+		});
+
+		await updateCkConfigField("privacyBlock", false, "global");
+
+		expect(tauri.writeConfig).toHaveBeenCalledWith("/Users/test", {
+			statuslineLayout: {
+				theme: {
+					accent: "#ff00ff",
+				},
+			},
+			privacyBlock: false,
+		});
+	});
 });

--- a/src/ui/src/services/__tests__/ck-config-api.vitest.ts
+++ b/src/ui/src/services/__tests__/ck-config-api.vitest.ts
@@ -52,18 +52,19 @@ describe("ck-config-api desktop mode", () => {
 		);
 	});
 
-	it("falls back to an empty config when stored desktop config is invalid", async () => {
-		vi.mocked(tauri.readConfig).mockResolvedValue({
+	it("returns raw config as fallback when stored desktop config is invalid", async () => {
+		const rawConfig = {
 			statuslineLayout: {
 				theme: {
 					accent: "#ff00ff",
 				},
 			},
-		});
+		};
+		vi.mocked(tauri.readConfig).mockResolvedValue(rawConfig);
 
 		const response = await fetchCkConfigScope("global");
 
-		expect(response.config).toEqual({});
+		expect(response.config).toEqual(rawConfig);
 		expect(response.globalPath).toBe("/Users/test/.claude/.ck.json");
 	});
 

--- a/src/ui/src/services/api.ts
+++ b/src/ui/src/services/api.ts
@@ -11,6 +11,7 @@ import type {
 	Skill,
 } from "@/types";
 import type { ProjectActivePlan } from "@/types/plan-types";
+import { join } from "pathe";
 
 // TODO(Phase 3): When isTauri() is true, route project/config read/write calls
 // through @/lib/tauri-commands (invoke) instead of fetch("/api/..."). The web
@@ -496,23 +497,22 @@ export async function fetchSettings(): Promise<ApiSettings> {
 export async function fetchSettingsFile(): Promise<ApiSettingsFile> {
 	return routeCall({
 		tauri: async () => {
-			// Derive both the display path and read path from a single homeDir call
-			// to ensure they cannot diverge (getGlobalConfigPath and getHomeDir are
-			// separate Rust calls that could theoretically resolve differently).
+			// Derive the display path from a single homeDir call and ask Rust whether
+			// the file exists so desktop mode can distinguish "missing" from "{}".
 			const homeDir = await tauri.getHomeDir();
-			const settingsPath = `${homeDir}/.claude/settings.json`;
+			const settingsPath = join(homeDir, ".claude", "settings.json");
 
+			let exists: boolean;
 			let settings: Record<string, unknown>;
 			try {
-				settings = (await tauri.readSettings(homeDir)) as Record<string, unknown>;
+				[exists, settings] = await Promise.all([
+					tauri.settingsFileExists(homeDir),
+					tauri.readSettings(homeDir) as Promise<Record<string, unknown>>,
+				]);
 			} catch (err) {
 				const detail = err instanceof Error ? err.message : String(err);
 				throw new Error(`Failed to read settings from ${settingsPath}: ${detail}`);
 			}
-
-			// Treat any non-null object (even {}) as existing — the file may be present
-			// but intentionally empty. Use a distinct value (null/undefined) as "not found".
-			const exists = settings !== null && typeof settings === "object";
 
 			return {
 				path: settingsPath,

--- a/src/ui/src/services/api.ts
+++ b/src/ui/src/services/api.ts
@@ -496,13 +496,28 @@ export async function fetchSettings(): Promise<ApiSettings> {
 export async function fetchSettingsFile(): Promise<ApiSettingsFile> {
 	return routeCall({
 		tauri: async () => {
-			const globalPath = await tauri.getGlobalConfigPath();
+			// Derive both the display path and read path from a single homeDir call
+			// to ensure they cannot diverge (getGlobalConfigPath and getHomeDir are
+			// separate Rust calls that could theoretically resolve differently).
 			const homeDir = await tauri.getHomeDir();
-			const settings = await tauri.readSettings(homeDir);
+			const settingsPath = `${homeDir}/.claude/settings.json`;
+
+			let settings: Record<string, unknown>;
+			try {
+				settings = (await tauri.readSettings(homeDir)) as Record<string, unknown>;
+			} catch (err) {
+				const detail = err instanceof Error ? err.message : String(err);
+				throw new Error(`Failed to read settings from ${settingsPath}: ${detail}`);
+			}
+
+			// Treat any non-null object (even {}) as existing — the file may be present
+			// but intentionally empty. Use a distinct value (null/undefined) as "not found".
+			const exists = settings !== null && typeof settings === "object";
+
 			return {
-				path: globalPath,
-				exists: Object.keys(settings).length > 0,
-				settings: settings as Record<string, unknown>,
+				path: settingsPath,
+				exists,
+				settings,
 			};
 		},
 		web: async () => {

--- a/src/ui/src/services/ck-config-api.ts
+++ b/src/ui/src/services/ck-config-api.ts
@@ -138,8 +138,11 @@ async function readDesktopConfig(
 		return validateDesktopConfig(raw);
 	} catch (error) {
 		if (options?.fallbackToEmpty) {
-			console.warn("[ck-config-api] Failed to validate desktop config, using empty object", error);
-			return {};
+			// Use the raw (unvalidated) config instead of an empty object so the UI
+			// still shows the user's actual values even when schema validation fails
+			// due to schema drift (e.g. new hook keys not yet in CkHooksConfigSchema).
+			console.warn("[ck-config-api] Config validation failed, using raw config as-is", error);
+			return raw as Record<string, unknown>;
 		}
 		throw error;
 	}

--- a/src/ui/src/services/ck-config-api.ts
+++ b/src/ui/src/services/ck-config-api.ts
@@ -128,6 +128,11 @@ function validateDesktopConfig(config: Record<string, unknown>): Record<string, 
 	return parsed.data as Record<string, unknown>;
 }
 
+function buildValidatedDesktopPatch(fieldPath: string, value: unknown): Record<string, unknown> {
+	const patch = setNestedValue({}, fieldPath, value);
+	return validateDesktopConfig(patch);
+}
+
 async function readDesktopConfig(
 	projectRoot: string,
 	options?: { fallbackToEmpty?: boolean },
@@ -262,7 +267,8 @@ export async function updateCkConfigField(
 	if (isTauri()) {
 		const target = await getDesktopConfigTarget(scope, projectId);
 		const current = await readDesktopConfig(target.projectRoot, { fallbackToEmpty: true });
-		const updated = validateDesktopConfig(setNestedValue(current, fieldPath, value));
+		const patch = buildValidatedDesktopPatch(fieldPath, value);
+		const updated = deepMerge(current, patch);
 		await tauri.writeConfig(target.projectRoot, updated);
 		return;
 	}


### PR DESCRIPTION
## Summary

Fixes empty panels in the Tauri desktop app (Phase 1 of desktop/ck-config parity, issue #717):

- **System Settings JSON panel** — was silently failing to load `~/.claude/settings.json`. Now derives the path from `getHomeDir()` and surfaces explicit errors instead of rendering empty.
- **Global Config JSON panel** — editor load errors were swallowed. Added `loadError` surface in `useConfigEditor` and a visible banner in `GlobalConfigPage`.
- **Schema form / config validation** — `CkHooksConfigSchema` now uses `.passthrough()` so unknown hook keys aren't silently stripped. `readDesktopConfig` falls back to raw config when Zod validation fails (instead of dropping to `{}`), so users see their actual file contents.

## Test plan

- [x] `bun run ui:test` (117/117 pass, including updated `ck-config-api.vitest.ts` covering raw-fallback behavior)
- [x] `bun run validate` (typecheck + lint + build)
- [x] Pre-push hook green
- [ ] Manual smoke test in `bun run tauri:dev`: verify settings.json + .ck.json render; verify broken config still renders raw with warning

Closes #717