### PR TITLE
fix(desktop): fetch release manifest via GitHub API (bypass CDN cache)

### DIFF
--- a/src/__tests__/domains/desktop/desktop-release-service.test.ts
+++ b/src/__tests__/domains/desktop/desktop-release-service.test.ts
@@ -4,6 +4,51 @@ import {
 	getDesktopManifestUrl,
 } from "@/domains/desktop/desktop-release-service.js";
 
+const MANIFEST_PLATFORMS = {
+	"darwin-aarch64": {
+		name: "mac.zip",
+		url: "https://example.com/mac.zip",
+		size: 100,
+		assetType: "app-zip",
+	},
+	"darwin-x86_64": {
+		name: "mac.zip",
+		url: "https://example.com/mac.zip",
+		size: 100,
+		assetType: "app-zip",
+	},
+	"linux-x86_64": {
+		name: "linux.AppImage",
+		url: "https://example.com/linux.AppImage",
+		size: 200,
+		assetType: "appimage",
+	},
+	"windows-x86_64": {
+		name: "windows.exe",
+		url: "https://example.com/windows.exe",
+		size: 300,
+		assetType: "portable-exe",
+	},
+};
+
+function mockApiFetch(manifest: Record<string, unknown>, assetId = 999) {
+	return mock(async (url: string | URL | Request) => {
+		const u = String(url);
+		if (u.includes("/releases/tags/")) {
+			return {
+				ok: true,
+				json: async () => ({
+					assets: [{ id: assetId, name: "desktop-manifest.json" }],
+				}),
+			};
+		}
+		if (u.includes(`/releases/assets/${assetId}`)) {
+			return { ok: true, json: async () => manifest };
+		}
+		throw new Error(`unexpected fetch: ${u}`);
+	});
+}
+
 describe("desktop-release-service", () => {
 	test("builds stable latest URL (no args)", () => {
 		expect(getDesktopManifestUrl()).toBe(
@@ -21,46 +66,17 @@ describe("desktop-release-service", () => {
 		expect(getDesktopManifestUrl({ version: "0.1.0" })).toBe(
 			"https://github.com/mrgoonie/claudekit-cli/releases/download/desktop-v0.1.0/desktop-manifest.json",
 		);
-		// version + channel: version wins, channel is ignored (specific tag, not pointer)
 		expect(getDesktopManifestUrl({ version: "0.1.0", channel: "dev" })).toBe(
 			"https://github.com/mrgoonie/claudekit-cli/releases/download/desktop-v0.1.0/desktop-manifest.json",
 		);
 	});
 
-	test("fetches and parses the desktop manifest (stable channel)", async () => {
-		const fetchFn = mock(async () => ({
-			ok: true,
-			json: async () => ({
-				version: "0.1.0",
-				date: "2026-04-15T21:00:00Z",
-				platforms: {
-					"darwin-aarch64": {
-						name: "mac.zip",
-						url: "https://example.com/mac.zip",
-						size: 100,
-						assetType: "app-zip",
-					},
-					"darwin-x86_64": {
-						name: "mac.zip",
-						url: "https://example.com/mac.zip",
-						size: 100,
-						assetType: "app-zip",
-					},
-					"linux-x86_64": {
-						name: "linux.AppImage",
-						url: "https://example.com/linux.AppImage",
-						size: 200,
-						assetType: "appimage",
-					},
-					"windows-x86_64": {
-						name: "windows.exe",
-						url: "https://example.com/windows.exe",
-						size: 300,
-						assetType: "portable-exe",
-					},
-				},
-			}),
-		}));
+	test("fetches and parses manifest via GH API (stable channel)", async () => {
+		const fetchFn = mockApiFetch({
+			version: "0.1.0",
+			date: "2026-04-15T21:00:00Z",
+			platforms: MANIFEST_PLATFORMS,
+		});
 
 		const manifest = await fetchDesktopReleaseManifest(
 			undefined,
@@ -68,89 +84,58 @@ describe("desktop-release-service", () => {
 		);
 
 		expect(fetchFn).toHaveBeenCalledWith(
-			"https://github.com/mrgoonie/claudekit-cli/releases/download/desktop-latest/desktop-manifest.json",
+			"https://api.github.com/repos/mrgoonie/claudekit-cli/releases/tags/desktop-latest",
+			{ headers: { Accept: "application/vnd.github+json" } },
+		);
+		expect(fetchFn).toHaveBeenCalledWith(
+			"https://api.github.com/repos/mrgoonie/claudekit-cli/releases/assets/999",
+			{ headers: { Accept: "application/octet-stream" } },
 		);
 		expect(manifest.channel).toBe("stable");
 		expect(manifest.platforms["windows-x86_64"]?.assetType).toBe("portable-exe");
 	});
 
-	test("fetchDesktopReleaseManifest calls dev URL when channel=dev", async () => {
-		const fetchFn = mock(async () => ({
-			ok: true,
-			json: async () => ({
-				version: "0.1.0",
-				date: "2026-04-15T21:00:00Z",
-				channel: "dev",
-				platforms: {
-					"darwin-aarch64": {
-						name: "mac.zip",
-						url: "https://example.com/mac.zip",
-						size: 100,
-						assetType: "app-zip",
-					},
-					"darwin-x86_64": {
-						name: "mac.zip",
-						url: "https://example.com/mac.zip",
-						size: 100,
-						assetType: "app-zip",
-					},
-					"linux-x86_64": {
-						name: "linux.AppImage",
-						url: "https://example.com/linux.AppImage",
-						size: 200,
-						assetType: "appimage",
-					},
-					"windows-x86_64": {
-						name: "windows.exe",
-						url: "https://example.com/windows.exe",
-						size: 300,
-						assetType: "portable-exe",
-					},
-				},
-			}),
-		}));
+	test("resolves dev channel tag via API when channel=dev", async () => {
+		const fetchFn = mockApiFetch({
+			version: "0.1.0",
+			date: "2026-04-15T21:00:00Z",
+			channel: "dev",
+			platforms: MANIFEST_PLATFORMS,
+		});
 
 		await fetchDesktopReleaseManifest({ channel: "dev" }, fetchFn as unknown as typeof fetch);
 
 		expect(fetchFn).toHaveBeenCalledWith(
-			"https://github.com/mrgoonie/claudekit-cli/releases/download/desktop-latest-dev/desktop-manifest.json",
+			"https://api.github.com/repos/mrgoonie/claudekit-cli/releases/tags/desktop-latest-dev",
+			{ headers: { Accept: "application/vnd.github+json" } },
 		);
 	});
 
+	test("resolves version-specific tag via API", async () => {
+		const fetchFn = mockApiFetch({
+			version: "0.1.0-dev.2",
+			date: "2026-04-15T21:00:00Z",
+			platforms: MANIFEST_PLATFORMS,
+		});
+
+		const manifest = await fetchDesktopReleaseManifest(
+			{ version: "0.1.0-dev.2" },
+			fetchFn as unknown as typeof fetch,
+		);
+
+		expect(fetchFn).toHaveBeenCalledWith(
+			"https://api.github.com/repos/mrgoonie/claudekit-cli/releases/tags/desktop-v0.1.0-dev.2",
+			{ headers: { Accept: "application/vnd.github+json" } },
+		);
+		expect(manifest.channel).toBe("dev");
+	});
+
 	test("backfills channel=dev for legacy dev manifests that predate the channel field", async () => {
-		const fetchFn = mock(async () => ({
-			ok: true,
-			json: async () => ({
-				version: "0.1.0-dev.2",
-				date: "2026-04-15T21:00:00Z",
-				platforms: {
-					"darwin-aarch64": {
-						name: "mac.zip",
-						url: "https://example.com/mac.zip",
-						size: 100,
-						assetType: "app-zip",
-					},
-					"darwin-x86_64": {
-						name: "mac.zip",
-						url: "https://example.com/mac.zip",
-						size: 100,
-						assetType: "app-zip",
-					},
-					"linux-x86_64": {
-						name: "linux.AppImage",
-						url: "https://example.com/linux.AppImage",
-						size: 200,
-						assetType: "appimage",
-					},
-					"windows-x86_64": {
-						name: "windows.exe",
-						url: "https://example.com/windows.exe",
-						size: 300,
-						assetType: "portable-exe",
-					},
-				},
-			}),
-		}));
+		const fetchFn = mockApiFetch({
+			version: "0.1.0-dev.2",
+			date: "2026-04-15T21:00:00Z",
+			platforms: MANIFEST_PLATFORMS,
+		});
 
 		const manifest = await fetchDesktopReleaseManifest(
 			{ channel: "dev" },
@@ -160,50 +145,7 @@ describe("desktop-release-service", () => {
 		expect(manifest.channel).toBe("dev");
 	});
 
-	test("infers channel=dev for version-specific prerelease manifests that lack the channel field", async () => {
-		const fetchFn = mock(async () => ({
-			ok: true,
-			json: async () => ({
-				version: "0.1.0-dev.2",
-				date: "2026-04-15T21:00:00Z",
-				platforms: {
-					"darwin-aarch64": {
-						name: "mac.zip",
-						url: "https://example.com/mac.zip",
-						size: 100,
-						assetType: "app-zip",
-					},
-					"darwin-x86_64": {
-						name: "mac.zip",
-						url: "https://example.com/mac.zip",
-						size: 100,
-						assetType: "app-zip",
-					},
-					"linux-x86_64": {
-						name: "linux.AppImage",
-						url: "https://example.com/linux.AppImage",
-						size: 200,
-						assetType: "appimage",
-					},
-					"windows-x86_64": {
-						name: "windows.exe",
-						url: "https://example.com/windows.exe",
-						size: 300,
-						assetType: "portable-exe",
-					},
-				},
-			}),
-		}));
-
-		const manifest = await fetchDesktopReleaseManifest(
-			{ version: "0.1.0-dev.2" },
-			fetchFn as unknown as typeof fetch,
-		);
-
-		expect(manifest.channel).toBe("dev");
-	});
-
-	test("throws when the manifest request fails", async () => {
+	test("throws when the tag lookup fails", async () => {
 		const fetchFn = mock(async () => ({
 			ok: false,
 			status: 404,
@@ -213,5 +155,16 @@ describe("desktop-release-service", () => {
 		await expect(
 			fetchDesktopReleaseManifest({}, fetchFn as unknown as typeof fetch),
 		).rejects.toThrow(/404/i);
+	});
+
+	test("throws when the release has no manifest asset", async () => {
+		const fetchFn = mock(async () => ({
+			ok: true,
+			json: async () => ({ assets: [] }),
+		}));
+
+		await expect(
+			fetchDesktopReleaseManifest({}, fetchFn as unknown as typeof fetch),
+		).rejects.toThrow(/no desktop-manifest\.json asset/i);
 	});
 });

--- a/src/domains/desktop/desktop-release-service.ts
+++ b/src/domains/desktop/desktop-release-service.ts
@@ -3,22 +3,21 @@ import { isPrereleaseVersion } from "@/domains/versioning/checking/version-utils
 import type { DesktopReleaseManifest } from "@/types/desktop.js";
 
 const DESKTOP_RELEASE_REPOSITORY = "https://github.com/mrgoonie/claudekit-cli/releases/download";
+const GITHUB_API_REPO = "https://api.github.com/repos/mrgoonie/claudekit-cli";
+const MANIFEST_ASSET_NAME = "desktop-manifest.json";
 
 export type DesktopChannel = "stable" | "dev";
+
+function resolveTag(opts?: { version?: string; channel?: DesktopChannel }): string {
+	if (opts?.version) return `desktop-v${opts.version}`;
+	return (opts?.channel ?? "stable") === "dev" ? "desktop-latest-dev" : "desktop-latest";
+}
 
 export function getDesktopManifestUrl(opts?: {
 	version?: string;
 	channel?: DesktopChannel;
 }): string {
-	const version = opts?.version;
-	const channel = opts?.channel ?? "stable";
-	let tag: string;
-	if (version) {
-		tag = `desktop-v${version}`;
-	} else {
-		tag = channel === "dev" ? "desktop-latest-dev" : "desktop-latest";
-	}
-	return `${DESKTOP_RELEASE_REPOSITORY}/${tag}/desktop-manifest.json`;
+	return `${DESKTOP_RELEASE_REPOSITORY}/${resolveTag(opts)}/${MANIFEST_ASSET_NAME}`;
 }
 
 function resolveManifestChannel(
@@ -52,15 +51,40 @@ function resolveManifestChannel(
 	return "stable";
 }
 
+// GitHub's CDN (releases/download/...) caches the manifest asset blob by name across
+// all tags, serving stale/garbage content even after `gh release upload --clobber`
+// replaces it. The GH API asset endpoint is not cached — use it instead.
+async function fetchManifestViaApi(tag: string, fetchFn: typeof fetch): Promise<unknown> {
+	const tagRes = await fetchFn(`${GITHUB_API_REPO}/releases/tags/${tag}`, {
+		headers: { Accept: "application/vnd.github+json" },
+	});
+	if (!tagRes.ok) {
+		throw new Error(
+			`Failed to resolve desktop release tag ${tag}: ${tagRes.status} ${tagRes.statusText}`,
+		);
+	}
+	const tagBody = (await tagRes.json()) as { assets?: Array<{ id?: number; name?: string }> };
+	const asset = tagBody.assets?.find((a) => a.name === MANIFEST_ASSET_NAME);
+	if (!asset?.id) {
+		throw new Error(`Release tag ${tag} has no ${MANIFEST_ASSET_NAME} asset`);
+	}
+	const assetRes = await fetchFn(`${GITHUB_API_REPO}/releases/assets/${asset.id}`, {
+		headers: { Accept: "application/octet-stream" },
+	});
+	if (!assetRes.ok) {
+		throw new Error(
+			`Failed to fetch desktop manifest asset ${asset.id}: ${assetRes.status} ${assetRes.statusText}`,
+		);
+	}
+	return assetRes.json();
+}
+
 export async function fetchDesktopReleaseManifest(
 	opts?: { version?: string; channel?: DesktopChannel },
 	fetchFn: typeof fetch = globalThis.fetch,
 ): Promise<DesktopReleaseManifest> {
-	const response = await fetchFn(getDesktopManifestUrl(opts));
-	if (!response.ok) {
-		throw new Error(`Failed to fetch desktop manifest: ${response.status} ${response.statusText}`);
-	}
-	const rawManifest = await response.json();
+	const tag = resolveTag(opts);
+	const rawManifest = await fetchManifestViaApi(tag, fetchFn);
 	const manifestRecord =
 		rawManifest && typeof rawManifest === "object"
 			? (rawManifest as Record<string, unknown>)


### PR DESCRIPTION
## Problem

`ck app --dev --update` has been delivering a poisoned/garbage desktop manifest to every user, regardless of how many times CI rebuilt and re-uploaded. Users see wrong app icons and settings-load failures on freshly-installed dev binaries (dev.4, dev.5).

## Root cause

GitHub's releases CDN (`releases/download/{tag}/{asset}`) caches manifest asset blobs **by asset name** and serves stale content across tags. `gh release upload --clobber` rotates the blob ID at the API layer, but the public download URL continues serving the old cached content. This persists even after deleting and recreating the release.

Verified: `GET releases/download/desktop-v0.1.0-dev.5/desktop-manifest.json` returns 559 bytes of schema text; `GET api.github.com/.../releases/assets/{id}` with `Accept: application/octet-stream` returns the correct 1393-byte manifest JSON.

## Fix

Switch `fetchDesktopReleaseManifest` to a two-step GitHub API flow:
1. `GET /releases/tags/{tag}` → discover asset id
2. `GET /releases/assets/{id}` with `Accept: application/octet-stream` → raw JSON

The API asset endpoint is not CDN-cached.

`getDesktopManifestUrl` is preserved — it's still the canonical download URL builder used inside the manifest payload for the binary download URLs themselves (those are versioned tag paths, which do eventually refresh).

## Test plan

- [x] Unit tests updated to reflect two-call flow
- [x] `bun run validate` passes locally (typecheck + lint + all tests + build)
- [ ] After merge: tag `desktop-v0.1.0-dev.6`, verify `ck app --dev --update` pulls correct manifest
- [ ] Smoke test on macOS: correct icon, settings panel loads

## Notes

Post-merge the user must tag `desktop-v0.1.0-dev.6` to ship a fresh binary that embeds the fixed manifest fetcher.