### PR TITLE
fix(ui): JSON editor text invisible in packaged builds (CSS cascade bug)

### DIFF
--- a/src/ui/src/components/JsonEditor.tsx
+++ b/src/ui/src/components/JsonEditor.tsx
@@ -42,9 +42,16 @@ const createDashboardTheme = () => {
 			height: "100% !important",
 		},
 		".cm-content": {
+			// Set color explicitly (don't rely on cascade from "&") — production Vite
+			// bundles reorder CSS so @uiw/react-codemirror's internal defaults can
+			// override the root color, leaving text invisible against the surface.
+			color: "var(--dash-text)",
 			caretColor: "var(--dash-accent)",
 			fontFamily: "'JetBrains Mono', Menlo, monospace",
 			padding: "1rem",
+		},
+		".cm-line": {
+			color: "var(--dash-text)",
 		},
 		".cm-cursor, .cm-dropCursor": {
 			borderLeftColor: "var(--dash-accent)",


### PR DESCRIPTION
## Problem

In `ck app --dev` (packaged Tauri binary), the Claude Settings JSON panel renders with visible line numbers and \"SYNTAX VALID\" status, but the content area is blank. Same bug would affect any end user running \`ck config ui\` from an npm install (falls back to static-served prod bundle).

Works in \`bun run tauri:dev\` and \`ck config ui\` from a source checkout, because those paths serve CSS through Vite's dev middleware in source order.

## Root cause

\`JsonEditor.tsx\` theme relied on CSS cascade: \`\"&\" { color: var(--dash-text) }\` → inherited by \`.cm-content\`. Vite's production CSS bundling reorders sheets such that \`@uiw/react-codemirror\`'s internal default stylesheet lands **after** our theme, overriding \`.cm-content\`'s \`color\` with a value that matches \`--dash-surface\` (invisible).

## Fix

Set \`color: var(--dash-text)\` directly on \`.cm-content\` and \`.cm-line\` so no later-loaded rule can override.

## Test plan

- [x] \`bun run validate\` passes (typecheck + lint + all tests + build)
- [ ] After merge + tag: verify JSON content renders on macOS via \`ck app --dev\`
- [ ] (Bonus) verify \`bun run ui:build && cd src/ui && bun run preview\` reproduces the bug pre-fix and confirms the fix

## Follow-up

Tag \`desktop-v0.1.0-dev.7\` after merge to ship the fixed binary.