### PR TITLE
feat: redesign ck migrate terminal UX

### DIFF
--- a/__tests__/domains/help/help-commands.test.ts
+++ b/__tests__/domains/help/help-commands.test.ts
@@ -337,10 +337,10 @@ describe("help-commands", () => {
 			}
 		});
 
-		test("all example commands start with 'ck'", () => {
+		test("all example commands start with 'ck' (optionally prefixed with env vars)", () => {
 			for (const command of Object.values(HELP_REGISTRY)) {
 				for (const example of command.examples) {
-					expect(example.command).toMatch(/^ck\s+/);
+					expect(example.command).toMatch(/^(\w+=\S+\s+)*ck\s+/);
 				}
 			}
 		});

--- a/__tests__/domains/help/help-renderer.test.ts
+++ b/__tests__/domains/help/help-renderer.test.ts
@@ -121,7 +121,7 @@ describe("DEFAULT_HELP_OPTIONS", () => {
 	test("has correct default values", () => {
 		expect(DEFAULT_HELP_OPTIONS.showBanner).toBe(true);
 		expect(DEFAULT_HELP_OPTIONS.showExamples).toBe(true);
-		expect(DEFAULT_HELP_OPTIONS.maxExamples).toBe(2);
+		expect(DEFAULT_HELP_OPTIONS.maxExamples).toBe(3);
 		expect(DEFAULT_HELP_OPTIONS.interactive).toBe(false);
 	});
 
@@ -325,17 +325,15 @@ describe("renderHelp", () => {
 });
 
 describe("renderHelp - examples limit", () => {
-	test("limits examples to maxExamples (default 2)", () => {
+	test("limits examples to maxExamples (default 3)", () => {
 		const help = createMockCommandHelp(); // Has 3 examples
 		const output = renderHelp(help);
 		const stripped = stripColors(output);
 
-		// Should show first 2 examples
+		// Default maxExamples=3 shows all 3
 		expect(stripped).toContain("ck test --verbose");
 		expect(stripped).toContain("ck test --dry-run");
-
-		// Should NOT show 3rd example
-		expect(stripped).not.toContain("ck test --format json");
+		expect(stripped).toContain("ck test --format json");
 	});
 
 	test("respects custom maxExamples value", () => {

--- a/docs/ck-command-flow-guide.md
+++ b/docs/ck-command-flow-guide.md
@@ -17,7 +17,7 @@ ClaudeKit CLI (`ck`) is the primary user interface for bootstrapping and managin
 | `content` | Multi-channel content automation | See `docs/ck-content.md` |
 | `watch` | GitHub issue auto-responder | See `docs/ck-watch.md` |
 | `uninstall` | Remove installations | `--yes`, `--global` |
-| `watch` | Watch GitHub issues and auto-respond | `--interval`, `--dry-run` |
+| `migrate` | Reconcile and preview destination-aware migrations across providers | `-a, --agent`, `--all`, `-g, --global`, `--dry-run` |
 
 ### Global Flags
 

--- a/docs/reconciliation-architecture.md
+++ b/docs/reconciliation-architecture.md
@@ -69,6 +69,7 @@ flowchart TD
 - Emits summary counts:
   - `installed`, `skipped`, `failed`
 - Includes warnings and per-provider results for CLI + dashboard.
+- CLI summary output now includes destination-aware preflight rows plus a boxed WHERE / WHAT / NEXT footer so the target path stays visible before confirmation.
 
 ## Core Components
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -112,7 +112,7 @@ Detects installed kits, builds kit-specific commands, parallel version checks.
 
 1. **RECONCILE** — Pure function (`reconciler.ts`), zero I/O. Takes source items + registry + target states + manifest → produces `ReconcilePlan` with actions. 8-case decision matrix: install, update, skip, conflict, delete (+ rename/path-migration from manifest).
 2. **EXECUTE** — Applies plan actions. Interactive conflict resolution (`conflict-resolver.ts`) with diff preview. Updates Registry v3.0 with new checksums.
-3. **REPORT** — Terraform-style plan display (`plan-display.ts`). Dashboard summary via API.
+3. **REPORT** — Destination-aware plan display (`plan-display.ts`) with preflight rows and a boxed WHERE / WHAT / NEXT footer. Dashboard summary via API.
 
 **Key design invariants:**
 - Reconciler is pure — all I/O in caller (migrate-command.ts or migration-routes.ts)

--- a/src/commands/migrate/__tests__/migrate-ui-summary.test.ts
+++ b/src/commands/migrate/__tests__/migrate-ui-summary.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildPreflightRows,
+	buildProviderScopeSubtitle,
+	buildSourceSummaryLines,
+	buildTargetSummaryLines,
+} from "../migrate-ui-summary.js";
+
+describe("migrate UI summary helpers", () => {
+	it("marks codex commands as global-only when project scope was requested", () => {
+		const rows = buildPreflightRows(
+			{ agents: 0, commands: 4, config: 0, hooks: 0, rules: 0, skills: 0 },
+			["codex"],
+			{ actualGlobal: true, requestedGlobal: false },
+		);
+
+		expect(rows[0]?.destinations).toContain("~/.codex/prompts");
+		expect(rows[0]?.notes).toContain("Codex: global-only");
+	});
+
+	it("surfaces shared project skill roots across compatible providers", () => {
+		const rows = buildPreflightRows(
+			{ agents: 0, commands: 0, config: 0, hooks: 0, rules: 0, skills: 3 },
+			["codex", "gemini-cli"],
+			{ actualGlobal: false, requestedGlobal: false },
+		);
+
+		expect(rows[0]?.destinations).toEqual([".agents/skills"]);
+		expect(rows[0]?.notes.some((note) => note.includes("share .agents/skills"))).toBe(true);
+	});
+
+	it("summarizes destinations when more than three distinct targets exist", () => {
+		const lines = buildTargetSummaryLines([
+			{ count: 1, destinations: ["a", "b"], label: "Agents", notes: [] },
+			{ count: 1, destinations: ["c", "d"], label: "Skills", notes: [] },
+		]);
+
+		expect(lines).toEqual(["a", "b", "c", "+1 more destination(s)"]);
+	});
+
+	it("builds readable provider and source summary lines", () => {
+		expect(buildProviderScopeSubtitle(["codex", "gemini-cli"], true)).toBe(
+			"Codex, Gemini CLI -> global",
+		);
+		expect(
+			buildSourceSummaryLines(
+				{ agents: 2, commands: 1, config: 1, hooks: 0, rules: 0, skills: 3 },
+				["/Users/test/.claude/agents", "/Users/test/.claude/skills"],
+			)[0],
+		).toContain("2 agents");
+	});
+});

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -12,6 +12,11 @@ import { handleDeletions } from "../../domains/installation/deletion-handler.js"
 import { logger } from "../../shared/logger.js";
 import type { KitType } from "../../types/kit.js";
 import type { ClaudeKitMetadata } from "../../types/metadata.js";
+import {
+	formatDisplayPath,
+	renderPreflightRow,
+	renderSourceTargetHeader,
+} from "../../ui/ck-cli-design/index.js";
 import { discoverAgents, getAgentSourcePath } from "../agents/agents-discovery.js";
 import { discoverCommands, getCommandSourcePath } from "../commands/commands-discovery.js";
 import { cleanupStaleCodexConfigEntries } from "../portable/codex-toml-installer.js";
@@ -21,7 +26,6 @@ import {
 	discoverRules,
 	getHooksSourcePath,
 	getRulesSourcePath,
-	resolveSourceOrigin,
 } from "../portable/config-discovery.js";
 import { resolveConflict } from "../portable/conflict-resolver.js";
 import { convertItem } from "../portable/converters/index.js";
@@ -39,6 +43,7 @@ import {
 } from "../portable/portable-registry.js";
 import {
 	detectInstalledProviders,
+	getPortableBasePath,
 	getProvidersSupporting,
 	providers,
 } from "../portable/provider-registry.js";
@@ -57,7 +62,16 @@ import type {
 import { reconcile } from "../portable/reconciler.js";
 import type { PortableInstallResult, PortableItem, ProviderType } from "../portable/types.js";
 import { discoverSkills, getSkillSourcePath } from "../skills/skills-discovery.js";
+import type { SkillInfo } from "../skills/types.js";
+import { createMigrateProgressSink } from "./migrate-progress.js";
 import { resolveMigrationScope } from "./migrate-scope-resolver.js";
+import {
+	type PortableSourceCounts,
+	buildPreflightRows,
+	buildProviderScopeSubtitle,
+	buildSourceSummaryLines,
+	buildTargetSummaryLines,
+} from "./migrate-ui-summary.js";
 import { installSkillDirectories } from "./skill-directory-installer.js";
 
 /** Options for ck migrate */
@@ -130,6 +144,9 @@ async function executeDeleteAction(
 			action.global,
 		);
 		return {
+			operation: "delete",
+			portableType: action.type,
+			itemName: action.item,
 			provider: action.provider as ProviderType,
 			providerDisplayName:
 				providers[action.provider as ProviderType]?.displayName || action.provider,
@@ -142,6 +159,9 @@ async function executeDeleteAction(
 		};
 	} catch (error) {
 		return {
+			operation: "delete",
+			portableType: action.type,
+			itemName: action.item,
 			provider: action.provider as ProviderType,
 			providerDisplayName:
 				providers[action.provider as ProviderType]?.displayName || action.provider,
@@ -215,7 +235,6 @@ function inferKitTypeFromSourceMetadata(sourceMetadata: ClaudeKitMetadata): KitT
  */
 export async function migrateCommand(options: MigrateOptions): Promise<void> {
 	console.log();
-	p.intro(pc.bgMagenta(pc.black(" ck migrate ")));
 
 	try {
 		const scope = resolveMigrationScope(process.argv.slice(2), options);
@@ -266,35 +285,6 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			p.outro(pc.red("Nothing to migrate"));
 			return;
 		}
-
-		// Show discovery summary with CWD and source attribution
-		p.log.info(pc.dim(`  CWD: ${process.cwd()}`));
-		const parts: string[] = [];
-		if (agents.length > 0) {
-			const origin = resolveSourceOrigin(agentSource);
-			parts.push(`${agents.length} agent(s) ${pc.dim(`<- ${origin}`)}`);
-		}
-		if (commands.length > 0) {
-			const origin = resolveSourceOrigin(commandSource);
-			parts.push(`${commands.length} command(s) ${pc.dim(`<- ${origin}`)}`);
-		}
-		if (skills.length > 0) {
-			const origin = resolveSourceOrigin(skillSource);
-			parts.push(`${skills.length} skill(s) ${pc.dim(`<- ${origin}`)}`);
-		}
-		if (configItem) {
-			const origin = resolveSourceOrigin(configItem.sourcePath);
-			parts.push(`config ${pc.dim(`<- ${origin}`)}`);
-		}
-		if (ruleItems.length > 0) {
-			const origin = resolveSourceOrigin(rulesSourcePath);
-			parts.push(`${ruleItems.length} rule(s) ${pc.dim(`<- ${origin}`)}`);
-		}
-		if (hookItems.length > 0) {
-			const origin = resolveSourceOrigin(hooksSource);
-			parts.push(`${hookItems.length} hook(s) ${pc.dim(`<- ${origin}`)}`);
-		}
-		p.log.info(`Found: ${parts.join(", ")}`);
 
 		// Phase 2: Select providers
 		const detectedProviders = await detectInstalledProviders();
@@ -382,7 +372,8 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		selectedProviders = Array.from(new Set(selectedProviders));
 
 		// Phase 3: Select scope
-		let installGlobally = options.global ?? false;
+		let requestedGlobal = options.global ?? false;
+		let installGlobally = requestedGlobal;
 		if (options.global === undefined && !options.yes) {
 			const projectTarget = join(process.cwd(), ".claude");
 			const globalTarget = join(homedir(), ".claude");
@@ -390,14 +381,14 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 				message: "Installation scope",
 				options: [
 					{
-						value: false,
-						label: "Project",
-						hint: `-> ${projectTarget}`,
-					},
-					{
 						value: true,
 						label: "Global",
 						hint: `-> ${globalTarget}`,
+					},
+					{
+						value: false,
+						label: "Project",
+						hint: `-> ${projectTarget}`,
 					},
 				],
 			});
@@ -405,7 +396,8 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 				p.cancel("Migrate cancelled");
 				return;
 			}
-			installGlobally = scopeChoice as boolean;
+			requestedGlobal = scopeChoice as boolean;
+			installGlobally = requestedGlobal;
 		}
 
 		const codexCommandsRequireGlobal =
@@ -418,58 +410,77 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			p.log.info(pc.dim("Codex commands are global-only; scope adjusted to global."));
 		}
 
-		// Phase 4: Summary
-		console.log();
-		p.log.step(pc.bold("Migrate Summary"));
+		const sourceCounts: PortableSourceCounts = {
+			agents: agents.length,
+			commands: commands.length,
+			config: configItem ? 1 : 0,
+			hooks: hookItems.length,
+			rules: ruleItems.length,
+			skills: skills.length,
+		};
+		const sourceOrigins = [
+			agentSource,
+			commandSource,
+			skillSource,
+			configItem?.sourcePath ?? null,
+			rulesSourcePath,
+			hooksSource,
+		].filter((origin): origin is string => origin !== null);
+		const preflightRows = buildPreflightRows(sourceCounts, selectedProviders, {
+			actualGlobal: installGlobally,
+			requestedGlobal,
+		});
+		const discoveryParts: string[] = [];
+		const agentSourceDisplay = agentSource ? formatDisplayPath(agentSource) : "source unavailable";
+		const commandSourceDisplay = commandSource
+			? formatDisplayPath(commandSource)
+			: "source unavailable";
+		const skillSourceDisplay = skillSource ? formatDisplayPath(skillSource) : "source unavailable";
+		const rulesSourceDisplay = rulesSourcePath
+			? formatDisplayPath(rulesSourcePath)
+			: "source unavailable";
+		const hooksSourceDisplay = hooksSource ? formatDisplayPath(hooksSource) : "source unavailable";
 		if (agents.length > 0) {
-			p.log.message(`  Agents: ${agents.map((a) => pc.cyan(a.name)).join(", ")}`);
+			discoveryParts.push(`${agents.length} agent(s) ${pc.dim(`<- ${agentSourceDisplay}`)}`);
 		}
 		if (commands.length > 0) {
-			const cmdNames = commands.map((c) => pc.cyan(`/${c.displayName || c.name}`)).join(", ");
-			p.log.message(`  Commands: ${cmdNames}`);
+			discoveryParts.push(`${commands.length} command(s) ${pc.dim(`<- ${commandSourceDisplay}`)}`);
 		}
 		if (skills.length > 0) {
-			p.log.message(`  Skills: ${skills.map((s) => pc.cyan(s.name)).join(", ")}`);
+			discoveryParts.push(`${skills.length} skill(s) ${pc.dim(`<- ${skillSourceDisplay}`)}`);
 		}
 		if (configItem) {
-			const lines = configItem.body.split("\n").length;
-			p.log.message(`  Config: ${pc.cyan("CLAUDE.md")} (${lines} lines)`);
+			discoveryParts.push(`config ${pc.dim(`<- ${formatDisplayPath(configItem.sourcePath)}`)}`);
 		}
 		if (ruleItems.length > 0) {
-			p.log.message(`  Rules: ${pc.cyan(`${ruleItems.length} file(s)`)}`);
+			discoveryParts.push(`${ruleItems.length} rule(s) ${pc.dim(`<- ${rulesSourceDisplay}`)}`);
 		}
 		if (hookItems.length > 0) {
-			p.log.message(`  Hooks: ${pc.cyan(`${hookItems.length} file(s)`)}`);
+			discoveryParts.push(`${hookItems.length} hook(s) ${pc.dim(`<- ${hooksSourceDisplay}`)}`);
 		}
+
+		console.log();
+		console.log(
+			renderSourceTargetHeader({
+				sourceLines: buildSourceSummaryLines(sourceCounts, sourceOrigins),
+				subtitle: buildProviderScopeSubtitle(selectedProviders, installGlobally),
+				targetLines: buildTargetSummaryLines(preflightRows),
+				title: "ck migrate",
+			}).join("\n"),
+		);
+		p.log.info(pc.dim(`  CWD: ${process.cwd()}`));
+		p.log.info(`Found: ${discoveryParts.join(", ")}`);
+
+		console.log();
+		p.log.step(pc.bold("Migrate Summary"));
 		const providerNames = selectedProviders
 			.map((prov) => pc.cyan(providers[prov].displayName))
 			.join(", ");
 		p.log.message(`  Providers: ${providerNames}`);
-		const targetDir = installGlobally ? join(homedir(), ".claude") : join(process.cwd(), ".claude");
-		p.log.message(
-			`  Scope: ${installGlobally ? "Global" : "Project"} ${pc.dim(`-> ${targetDir}`)}`,
-		);
-
-		// Show unsupported combos
-		const cmdProviders = getProvidersSupporting("commands");
-		const unsupportedCmd = selectedProviders.filter((pv) => !cmdProviders.includes(pv));
-		if (commands.length > 0 && unsupportedCmd.length > 0) {
-			p.log.info(
-				pc.dim(
-					`  [i] Commands skipped for: ${unsupportedCmd.map((pv) => providers[pv].displayName).join(", ")} (unsupported)`,
-				),
-			);
-		}
-		const hookProviders = getProvidersSupporting("hooks");
-		const unsupportedHooks = selectedProviders.filter((pv) => !hookProviders.includes(pv));
-		if (hookItems.length > 0 && unsupportedHooks.length > 0) {
-			p.log.info(
-				pc.dim(
-					`  [i] Hooks skipped for: ${unsupportedHooks
-						.map((pv) => providers[pv].displayName)
-						.join(", ")} (unsupported)`,
-				),
-			);
+		for (const row of preflightRows) {
+			for (const line of renderPreflightRow(row)) {
+				console.log(line);
+			}
 		}
 
 		// Load CkConfig for taxonomy overrides and apply before conversion
@@ -520,8 +531,11 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 
 		// Dry-run: show plan and exit
 		if (options.dryRun) {
-			console.log();
-			p.outro(pc.green("Dry run complete — no files written"));
+			displayMigrationSummary(
+				plan,
+				buildDryRunFallbackResults(skills, selectedProviders, installGlobally, plan.actions),
+				{ color: useColor, dryRun: true },
+			);
 			return;
 		}
 
@@ -592,10 +606,7 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			}
 		}
 
-		const installSpinner = p.spinner();
-		installSpinner.start("Migrating...");
-
-		const allResults: PortableInstallResult[] = [];
+		let allResults: PortableInstallResult[] = [];
 		const installOpts = { global: installGlobally };
 		const agentByName = new Map(agents.map((item) => [item.name, item]));
 		const commandByName = new Map(commands.map((item) => [item.name, item]));
@@ -604,6 +615,19 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		const ruleByName = new Map(ruleItems.map((item) => [item.name, item]));
 		const hookByName = new Map(hookItems.map((item) => [item.name, item]));
 		const successfulHookFiles = new Map<ProviderType, string[]>();
+		const postProgressWarnings: string[] = [];
+		const writeTasks: Array<
+			| {
+					item: PortableItem;
+					provider: ProviderType;
+					type: "agent" | "command" | "config" | "rules" | "hooks";
+			  }
+			| {
+					item: SkillInfo;
+					provider: ProviderType;
+					type: "skill";
+			  }
+		> = [];
 
 		for (const action of plannedExecActions) {
 			const provider = action.provider as ProviderType;
@@ -612,74 +636,42 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			if (action.type === "agent") {
 				const item = agentByName.get(action.item);
 				if (!item || !getProvidersSupporting("agents").includes(provider)) continue;
-				allResults.push(...(await installPortableItems([item], [provider], "agent", installOpts)));
+				writeTasks.push({ item, provider, type: "agent" });
 				continue;
 			}
 
 			if (action.type === "command") {
 				const item = commandByName.get(action.item);
 				if (!item || !getProvidersSupporting("commands").includes(provider)) continue;
-				allResults.push(
-					...(await installPortableItems([item], [provider], "command", installOpts)),
-				);
+				writeTasks.push({ item, provider, type: "command" });
 				continue;
 			}
 
 			if (action.type === "skill") {
 				const item = skillByName.get(action.item);
 				if (!item || !getProvidersSupporting("skills").includes(provider)) continue;
-				allResults.push(...(await installSkillDirectories([item], [provider], installOpts)));
+				writeTasks.push({ item, provider, type: "skill" });
 				continue;
 			}
 
 			if (action.type === "config") {
 				const item = configByName.get(action.item);
 				if (!item || !getProvidersSupporting("config").includes(provider)) continue;
-				allResults.push(...(await installPortableItems([item], [provider], "config", installOpts)));
+				writeTasks.push({ item, provider, type: "config" });
 				continue;
 			}
 
 			if (action.type === "rules") {
 				const item = ruleByName.get(action.item);
 				if (!item || !getProvidersSupporting("rules").includes(provider)) continue;
-				allResults.push(...(await installPortableItems([item], [provider], "rules", installOpts)));
+				writeTasks.push({ item, provider, type: "rules" });
 				continue;
 			}
 
 			if (action.type === "hooks") {
 				const item = hookByName.get(action.item);
 				if (!item || !getProvidersSupporting("hooks").includes(provider)) continue;
-				const hookResults = await installPortableItems([item], [provider], "hooks", installOpts);
-				allResults.push(...hookResults);
-				// Track successfully installed hook filenames for settings.json merge
-				for (const r of hookResults.filter((r) => r.success && !r.skipped)) {
-					const existing = successfulHookFiles.get(provider) ?? [];
-					existing.push(basename(r.path));
-					successfulHookFiles.set(provider, existing);
-				}
-			}
-		}
-
-		// After all actions executed, merge hooks into target settings.json per provider
-		for (const [hooksProvider, files] of successfulHookFiles) {
-			if (files.length === 0) continue;
-			const mergeResult = await migrateHooksSettings({
-				// Source is claude-code — the merger dynamically checks settingsJsonPath,
-				// so any provider with hooks configuration can serve as source in the future.
-				sourceProvider: "claude-code",
-				targetProvider: hooksProvider,
-				installedHookFiles: files,
-				global: installGlobally,
-			});
-			if (mergeResult.success && mergeResult.hooksRegistered > 0) {
-				logger.verbose(
-					`Registered ${mergeResult.hooksRegistered} hook(s) in ${hooksProvider} settings.json`,
-				);
-			} else {
-				const feedbackMessage = mergeResult.error ?? mergeResult.message;
-				if (feedbackMessage) {
-					p.log.warn(feedbackMessage);
-				}
+				writeTasks.push({ item, provider, type: "hooks" });
 			}
 		}
 
@@ -692,8 +684,60 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			const skillProviders = selectedProviders.filter((pv) =>
 				getProvidersSupporting("skills").includes(pv),
 			);
-			if (skillProviders.length > 0) {
-				allResults.push(...(await installSkillDirectories(skills, skillProviders, installOpts)));
+			for (const provider of skillProviders) {
+				for (const skill of skills) {
+					writeTasks.push({ item: skill, provider, type: "skill" });
+				}
+			}
+		}
+
+		const progressSink = createMigrateProgressSink(writeTasks.length + plannedDeleteActions.length);
+		const writtenPaths = new Set<string>();
+		for (const task of writeTasks) {
+			const taskResults =
+				task.type === "skill"
+					? annotateInstallResults(
+							await installSkillDirectories([task.item], [task.provider], installOpts),
+							"skill",
+							task.item.name,
+						)
+					: annotateInstallResults(
+							await installPortableItems([task.item], [task.provider], task.type, installOpts),
+							task.type,
+							task.item.name,
+						);
+			allResults.push(...taskResults);
+			for (const result of taskResults.filter((entry) => entry.success && !entry.skipped)) {
+				if (result.path.length > 0) {
+					writtenPaths.add(resolve(result.path));
+				}
+				if (task.type === "hooks") {
+					const existing = successfulHookFiles.get(task.provider) ?? [];
+					existing.push(basename(result.path));
+					successfulHookFiles.set(task.provider, existing);
+				}
+			}
+			progressSink.tick(progressLabelForType(task.type));
+		}
+
+		// After all actions executed, merge hooks into target settings.json per provider
+		for (const [hooksProvider, files] of successfulHookFiles) {
+			if (files.length === 0) continue;
+			const mergeResult = await migrateHooksSettings({
+				sourceProvider: "claude-code",
+				targetProvider: hooksProvider,
+				installedHookFiles: files,
+				global: installGlobally,
+			});
+			if (mergeResult.success && mergeResult.hooksRegistered > 0) {
+				logger.verbose(
+					`Registered ${mergeResult.hooksRegistered} hook(s) in ${hooksProvider} settings.json`,
+				);
+			} else {
+				const feedbackMessage = mergeResult.error ?? mergeResult.message;
+				if (feedbackMessage) {
+					postProgressWarnings.push(feedbackMessage);
+				}
 			}
 		}
 
@@ -701,18 +745,17 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		// This runs AFTER skill installation so new dirs exist before old ones are removed.
 		await processMetadataDeletions(skillSource, installGlobally);
 
-		const writtenPaths = new Set(
-			allResults
-				.filter((result) => result.success && !result.skipped && result.path.length > 0)
-				.map((result) => resolve(result.path)),
-		);
-
 		for (const deleteAction of plannedDeleteActions) {
 			allResults.push(
 				await executeDeleteAction(deleteAction, {
 					preservePaths: writtenPaths,
 				}),
 			);
+			progressSink.tick("Cleanup");
+		}
+		progressSink.done();
+		for (const warning of postProgressWarnings) {
+			p.log.warn(warning);
 		}
 
 		// Best-effort registry healing for checksum-only skips. This covers both
@@ -775,11 +818,6 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			logger.debug("[migrate] Failed to update appliedManifestVersion — will retry on next run");
 		}
 
-		installSpinner.stop("Migrate complete");
-
-		// Display migration summary with plan context
-		displayMigrationSummary(plan, allResults, { color: useColor });
-
 		// Check for partial failure and offer rollback (#407)
 		const failed = allResults.filter((r) => !r.success);
 		const successful = allResults.filter((r) => r.success && !r.skipped);
@@ -801,18 +839,24 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 				});
 
 				if (!p.isCancel(shouldRollback) && shouldRollback) {
-					await rollbackResults(successful);
+					const rolledBackPaths = await rollbackResults(successful);
+					allResults = allResults.map((result) =>
+						result.path.length > 0 && rolledBackPaths.has(result.path)
+							? { ...result, skipped: true, skipReason: "Rolled back after failure" }
+							: result,
+					);
 					p.log.info(`Rolled back ${newWrites.length} file(s)`);
 				}
 			}
 		}
 
+		// Display migration summary with plan context
+		displayMigrationSummary(plan, allResults, { color: useColor });
+
 		// Show detailed results if there are failures
 		if (failed.length > 0) {
 			console.log();
 			displayResults(allResults);
-		} else {
-			p.outro(pc.green("Migration complete!"));
 		}
 		if (failed.length > 0 || hasEmbeddedPartialFailures) {
 			process.exitCode = 1;
@@ -828,7 +872,8 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
  * Rollback successfully written files from a partial migration failure (#407).
  * Only removes files/dirs that were created in this run — not pre-existing content.
  */
-async function rollbackResults(results: PortableInstallResult[]): Promise<void> {
+async function rollbackResults(results: PortableInstallResult[]): Promise<Set<string>> {
+	const rolledBackPaths = new Set<string>();
 	for (const result of results) {
 		if (!result.path || !existsSync(result.path)) continue;
 
@@ -842,10 +887,12 @@ async function rollbackResults(results: PortableInstallResult[]): Promise<void> 
 			} else {
 				await unlink(result.path);
 			}
+			rolledBackPaths.add(result.path);
 		} catch {
 			// Best-effort cleanup — don't fail on rollback errors
 		}
 	}
+	return rolledBackPaths;
 }
 
 function warnConversionFallback(warning: ConversionFallbackWarning): void {
@@ -873,7 +920,7 @@ async function computeSourceStates(
 	const states: SourceItemState[] = [];
 
 	// Helper to process items of a given type
-	const processItems = async (
+	const processItems = (
 		itemList: PortableItem[],
 		type: "agent" | "command" | "config" | "rules" | "hooks",
 	) => {
@@ -886,13 +933,13 @@ async function computeSourceStates(
 		}
 	};
 
-	await processItems(items.agents, "agent");
-	await processItems(items.commands, "command");
+	processItems(items.agents, "agent");
+	processItems(items.commands, "command");
 	if (items.config) {
-		await processItems([items.config], "config");
+		processItems([items.config], "config");
 	}
-	await processItems(items.rules, "rules");
-	await processItems(items.hooks, "hooks");
+	processItems(items.rules, "rules");
+	processItems(items.hooks, "hooks");
 
 	return states;
 }
@@ -962,11 +1009,72 @@ function displayResults(results: PortableInstallResult[]): void {
 	if (failed.length > 0) summaryParts.push(`${failed.length} failed`);
 
 	if (summaryParts.length === 0) {
-		p.outro(pc.yellow("No installations performed"));
 	} else if (failed.length > 0 && successful.length === 0) {
-		p.outro(pc.red("Migrate failed"));
 		process.exit(1);
-	} else {
-		p.outro(pc.green(`Done! ${summaryParts.join(", ")}`));
 	}
+}
+
+function annotateInstallResults(
+	results: PortableInstallResult[],
+	portableType: PortableInstallResult["portableType"],
+	itemName: string,
+): PortableInstallResult[] {
+	return results.map((result) => ({
+		...result,
+		itemName,
+		operation: "apply",
+		portableType,
+	}));
+}
+
+function progressLabelForType(type: string): string {
+	switch (type) {
+		case "agent":
+			return "Agents";
+		case "command":
+			return "Commands";
+		case "config":
+			return "Config";
+		case "rules":
+			return "Rules";
+		case "hooks":
+			return "Hooks";
+		case "skill":
+			return "Skills";
+		default:
+			return "Migrating";
+	}
+}
+
+function buildDryRunFallbackResults(
+	skills: SkillInfo[],
+	selectedProviders: ProviderType[],
+	installGlobally: boolean,
+	plannedActions: ReconcileAction[],
+): PortableInstallResult[] {
+	const plannedSkillActions = plannedActions.filter((action) => action.type === "skill").length;
+	if (skills.length === 0 || plannedSkillActions > 0) {
+		return [];
+	}
+
+	const results: PortableInstallResult[] = [];
+	for (const provider of selectedProviders.filter((entry) =>
+		getProvidersSupporting("skills").includes(entry),
+	)) {
+		const basePath = getPortableBasePath(provider, "skills", { global: installGlobally });
+		if (!basePath) continue;
+		for (const skill of skills) {
+			results.push({
+				itemName: skill.name,
+				operation: "apply",
+				path: join(basePath, skill.name),
+				portableType: "skill",
+				provider,
+				providerDisplayName: providers[provider].displayName,
+				success: true,
+			});
+		}
+	}
+
+	return results;
 }

--- a/src/commands/migrate/migrate-progress.ts
+++ b/src/commands/migrate/migrate-progress.ts
@@ -1,0 +1,62 @@
+import pc from "picocolors";
+import { type CliDesignContext, createCliDesignContext } from "../../ui/ck-cli-design/index.js";
+
+export interface ProgressSink {
+	done(message?: string): void;
+	tick(label: string): void;
+}
+
+export function createMigrateProgressSink(
+	total: number,
+	context = createCliDesignContext(),
+): ProgressSink {
+	if (!process.stdout.isTTY || process.env.CI || process.env.TERM === "dumb") {
+		return createDotProgressSink();
+	}
+	return createTtyProgressSink(total, context);
+}
+
+function createDotProgressSink(): ProgressSink {
+	let current = 0;
+	return {
+		done(message) {
+			if (current > 0) process.stdout.write("\n");
+			if (message) console.log(message);
+		},
+		tick() {
+			current += 1;
+			process.stdout.write(".");
+		},
+	};
+}
+
+function createTtyProgressSink(total: number, context: CliDesignContext): ProgressSink {
+	let current = 0;
+	let rendered = false;
+
+	return {
+		done(message) {
+			if (rendered) {
+				process.stdout.write("\r\x1b[K");
+			}
+			if (message) {
+				console.log(context.useColor ? pc.green(message) : message);
+			}
+		},
+		tick(label) {
+			current += 1;
+			const width = Math.max(10, Math.min(20, context.width - 34));
+			const percent = total === 0 ? 100 : Math.round((current / total) * 100);
+			const filled = Math.round((percent / 100) * width);
+			const empty = width - filled;
+			const isUnicode = context.box.bullet !== "+";
+			const bar = `${isUnicode ? "█".repeat(filled) : "=".repeat(filled)}${
+				isUnicode ? "░".repeat(empty) : "-".repeat(empty)
+			}`;
+			const heading = context.useColor ? pc.bold(label) : label;
+			const line = `  ${heading} ${bar} ${String(percent).padStart(3, " ")}%`;
+			process.stdout.write(`\r${line}`);
+			rendered = true;
+		},
+	};
+}

--- a/src/commands/migrate/migrate-ui-summary.ts
+++ b/src/commands/migrate/migrate-ui-summary.ts
@@ -1,0 +1,138 @@
+import { formatDisplayPath } from "../../ui/ck-cli-design/index.js";
+import { getPortableBasePath, providers } from "../portable/provider-registry.js";
+import type { ProviderType } from "../portable/types.js";
+
+type PortableGroup = "agents" | "commands" | "skills" | "config" | "rules" | "hooks";
+
+export interface PortableSourceCounts {
+	agents: number;
+	commands: number;
+	config: number;
+	hooks: number;
+	rules: number;
+	skills: number;
+}
+
+export interface PreflightRowData {
+	count: number;
+	destinations: string[];
+	label: string;
+	notes: string[];
+}
+
+const PORTABLE_TYPES: Array<{ key: PortableGroup; label: string }> = [
+	{ key: "agents", label: "Agents" },
+	{ key: "commands", label: "Commands" },
+	{ key: "skills", label: "Skills" },
+	{ key: "config", label: "Config" },
+	{ key: "rules", label: "Rules" },
+	{ key: "hooks", label: "Hooks" },
+];
+
+const MERGE_STRATEGIES = new Set(["merge-single", "yaml-merge", "json-merge"]);
+
+export function buildPreflightRows(
+	counts: PortableSourceCounts,
+	selectedProviders: ProviderType[],
+	options: { actualGlobal: boolean; requestedGlobal: boolean },
+): PreflightRowData[] {
+	return PORTABLE_TYPES.flatMap(({ key, label }) => {
+		const count = counts[key];
+		if (count <= 0) return [];
+
+		const destinations = new Map<string, ProviderType[]>();
+		const notes = new Set<string>();
+
+		for (const provider of selectedProviders) {
+			const config = providers[provider][key];
+			if (!config) {
+				notes.add(`${providers[provider].displayName}: unsupported`);
+				continue;
+			}
+
+			const destination = getPortableBasePath(provider, key, { global: options.actualGlobal });
+			if (!destination) {
+				const note = options.actualGlobal ? "project-only" : "global-only";
+				notes.add(`${providers[provider].displayName}: ${note}`);
+				continue;
+			}
+
+			const normalizedDestination = formatDisplayPath(destination);
+			destinations.set(normalizedDestination, [
+				...(destinations.get(normalizedDestination) ?? []),
+				provider,
+			]);
+
+			if (!options.requestedGlobal && config.projectPath === null && config.globalPath !== null) {
+				notes.add(`${providers[provider].displayName}: global-only`);
+			}
+			if (options.requestedGlobal && config.globalPath === null && config.projectPath !== null) {
+				notes.add(`${providers[provider].displayName}: project-only`);
+			}
+			if (MERGE_STRATEGIES.has(config.writeStrategy)) {
+				notes.add(`${providers[provider].displayName}: merge`);
+			}
+		}
+
+		for (const [destination, providersAtPath] of destinations) {
+			if (providersAtPath.length > 1) {
+				notes.add(
+					`${providersAtPath.map((provider) => providers[provider].displayName).join(", ")} share ${destination}`,
+				);
+			}
+		}
+
+		return [
+			{
+				count,
+				destinations: Array.from(destinations.keys()),
+				label,
+				notes: Array.from(notes),
+			},
+		];
+	});
+}
+
+export function buildTargetSummaryLines(rows: PreflightRowData[]): string[] {
+	const allDestinations = Array.from(
+		new Set(
+			rows.flatMap((row) => row.destinations).filter((destination) => destination.length > 0),
+		),
+	);
+	if (allDestinations.length === 0) {
+		return ["No compatible destination found for the selected providers"];
+	}
+	if (allDestinations.length <= 3) {
+		return allDestinations;
+	}
+	return [...allDestinations.slice(0, 3), `+${allDestinations.length - 3} more destination(s)`];
+}
+
+export function buildProviderScopeSubtitle(
+	selectedProviders: ProviderType[],
+	global: boolean,
+): string {
+	const scope = global ? "global" : "project";
+	if (selectedProviders.length === 1) {
+		return `${providers[selectedProviders[0]].displayName} -> ${scope}`;
+	}
+	if (selectedProviders.length <= 3) {
+		return `${selectedProviders.map((provider) => providers[provider].displayName).join(", ")} -> ${scope}`;
+	}
+	return `${selectedProviders.length} providers -> ${scope}`;
+}
+
+export function buildSourceSummaryLines(counts: PortableSourceCounts, origins: string[]): string[] {
+	const parts: string[] = [];
+	if (counts.agents > 0) parts.push(`${counts.agents} agents`);
+	if (counts.skills > 0) parts.push(`${counts.skills} skills`);
+	if (counts.commands > 0) parts.push(`${counts.commands} commands`);
+	if (counts.rules > 0) parts.push(`${counts.rules} rules`);
+	if (counts.hooks > 0) parts.push(`${counts.hooks} hooks`);
+	if (counts.config > 0) parts.push("config");
+
+	const uniqueOrigins = Array.from(new Set(origins.map((origin) => formatDisplayPath(origin))));
+	const summary = parts.length > 0 ? parts.join(" · ") : "portable items detected";
+	if (uniqueOrigins.length === 0) return [summary];
+	return [summary, `from ${uniqueOrigins.join(" · ")}`];
+}

--- a/src/commands/portable/__tests__/plan-display.test.ts
+++ b/src/commands/portable/__tests__/plan-display.test.ts
@@ -2,7 +2,7 @@
  * Tests for plan-display module
  */
 import { describe, expect, test } from "bun:test";
-import { displayReconcilePlan } from "../plan-display.js";
+import { buildCompletionFooter, displayReconcilePlan } from "../plan-display.js";
 import type { ReconcilePlan } from "../reconcile-types.js";
 
 describe("displayReconcilePlan", () => {
@@ -85,5 +85,66 @@ describe("displayReconcilePlan", () => {
 		// Should show first 5 and "and N more..."
 		displayReconcilePlan(plan, { color: false });
 		expect(true).toBe(true);
+	});
+});
+
+describe("buildCompletionFooter", () => {
+	test("includes skill-only fallback data in dry-run summaries", () => {
+		const footer = buildCompletionFooter(
+			{
+				actions: [],
+				hasConflicts: false,
+				summary: { install: 0, update: 0, skip: 0, conflict: 0, delete: 0 },
+			},
+			[
+				{
+					itemName: "scout",
+					operation: "apply",
+					path: "/tmp/project/.agents/skills/scout",
+					portableType: "skill",
+					provider: "codex",
+					providerDisplayName: "Codex",
+					success: true,
+				},
+			],
+			true,
+		);
+
+		expect(footer.subtitle).toContain("1 item(s) would change");
+		expect(footer.zones.find((zone) => zone.label === "WHAT")?.lines.join(" ")).toContain(
+			"1 skills",
+		);
+		expect(footer.zones.find((zone) => zone.label === "WHERE")?.lines.join(" ")).toContain(
+			".agents/skills",
+		);
+	});
+
+	test("omits deleted paths from WHERE and reports deleted counts", () => {
+		const footer = buildCompletionFooter(
+			{
+				actions: [],
+				hasConflicts: false,
+				summary: { install: 0, update: 0, skip: 0, conflict: 0, delete: 1 },
+			},
+			[
+				{
+					itemName: "old-hook",
+					operation: "delete",
+					path: "/tmp/project/.codex/hooks/old-hook.cjs",
+					portableType: "hooks",
+					provider: "codex",
+					providerDisplayName: "Codex",
+					success: true,
+				},
+			],
+			false,
+		);
+
+		expect(footer.zones.find((zone) => zone.label === "WHERE")?.lines).toEqual([
+			"No destination paths written",
+		]);
+		expect(footer.zones.find((zone) => zone.label === "WHAT")?.lines.join(" ")).toContain(
+			"1 deleted",
+		);
 	});
 });

--- a/src/commands/portable/__tests__/provider-registry.test.ts
+++ b/src/commands/portable/__tests__/provider-registry.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import {
 	binaryCache,
 	detectProviderPathCollisions,
+	getPortableBasePath,
 	getProvidersSupporting,
 	hasBinaryInPath,
 	providers,
@@ -280,6 +281,16 @@ describe("provider-registry", () => {
 
 		it("codex skills projectPath remains .agents/skills after detection cleanup", () => {
 			expect(providers.codex.skills?.projectPath).toBe(".agents/skills");
+		});
+
+		it("getPortableBasePath returns the directory base for per-file targets", () => {
+			expect(getPortableBasePath("codex", "skills", { global: false })).toBe(".agents/skills");
+		});
+
+		it("getPortableBasePath returns the file target for merge-single targets", () => {
+			expect(
+				getPortableBasePath("codex", "config", { global: true })?.replace(/\\/g, "/"),
+			).toContain(".codex/AGENTS.md");
 		});
 	});
 

--- a/src/commands/portable/plan-display.ts
+++ b/src/commands/portable/plan-display.ts
@@ -3,16 +3,34 @@
  * ASCII-only indicators, TTY-aware colors
  * Groups by action type, then sub-groups by portable type (agent, command, skill, etc.)
  */
+import { basename, dirname, extname } from "node:path";
 import pc from "picocolors";
+import {
+	formatCdHint,
+	formatDisplayPath,
+	renderNextStepsFooter,
+	renderPanel,
+} from "../../ui/ck-cli-design/index.js";
 import { sanitizeSingleLineTerminalText } from "./output-sanitizer.js";
 import type { ReconcileAction, ReconcilePlan } from "./reconcile-types.js";
-import type { PortableInstallResult } from "./types.js";
+import type {
+	PortableInstallResult,
+	PortableType as PortableItemType,
+	ProviderType,
+} from "./types.js";
 
 const DEFAULT_MAX_PLAN_GROUP_ITEMS = 20;
 
-type PortableType = ReconcileAction["type"];
-const TYPE_ORDER: PortableType[] = ["agent", "command", "skill", "config", "rules", "hooks"];
-const TYPE_LABELS: Record<PortableType, string> = {
+type ReconcilePortableType = ReconcileAction["type"];
+const TYPE_ORDER: ReconcilePortableType[] = [
+	"agent",
+	"command",
+	"skill",
+	"config",
+	"rules",
+	"hooks",
+];
+const TYPE_LABELS: Record<ReconcilePortableType, string> = {
 	agent: "Subagents",
 	command: "Commands",
 	skill: "Skills",
@@ -38,8 +56,8 @@ function resolveMaxItemsPerGroup(options: DisplayOptions): number {
 	return DEFAULT_MAX_PLAN_GROUP_ITEMS;
 }
 
-function subGroupByType(actions: ReconcileAction[]): Map<PortableType, ReconcileAction[]> {
-	const map = new Map<PortableType, ReconcileAction[]>();
+function subGroupByType(actions: ReconcileAction[]): Map<ReconcilePortableType, ReconcileAction[]> {
+	const map = new Map<ReconcilePortableType, ReconcileAction[]>();
 	for (const action of actions) {
 		const type = action.type;
 		const list = map.get(type) || [];
@@ -210,49 +228,270 @@ function summarizeExecutionResults(results: PortableInstallResult[]): {
 export function displayMigrationSummary(
 	plan: ReconcilePlan,
 	results: PortableInstallResult[],
-	options: { color: boolean },
+	options: { color: boolean; dryRun?: boolean },
 ): void {
+	const footer = buildCompletionFooter(plan, results, options.dryRun === true);
 	console.log();
-	console.log("  Migration Complete");
-	console.log();
+	console.log(
+		renderPanel({
+			subtitle: footer.subtitle,
+			title: footer.title,
+			zones: footer.zones,
+		}).join("\n"),
+	);
 
-	const { summary } = plan;
-	const resultSummary = summarizeExecutionResults(results);
-
-	// Plan-based counts are the source of truth for what happened
-	const installed = summary.install;
-	const updated = summary.update;
-	const skipped = summary.skip;
-	const deleted = summary.delete;
-	const failed = resultSummary.failed;
-
-	if (installed > 0) {
-		console.log(`  ${options.color ? pc.green("[OK]") : "[OK]"} ${installed} installed`);
-	}
-	if (updated > 0) {
-		console.log(`  ${options.color ? pc.green("[OK]") : "[OK]"} ${updated} updated`);
-	}
-	if (skipped > 0) {
-		console.log(`  ${options.color ? pc.dim("[i]") : "[i]"}  ${skipped} skipped`);
-	}
-	if (deleted > 0) {
-		console.log(`  ${options.color ? pc.dim("[-]") : "[-]"}  ${deleted} deleted`);
-	}
-	if (failed > 0) {
-		console.log(`  ${options.color ? pc.red("[X]") : "[X]"} ${failed} failed`);
-	}
-
-	// Conflict resolutions
-	const conflicts = plan.actions.filter((a) => a.action === "conflict");
-	if (conflicts.length > 0) {
+	if (footer.conflicts.length > 0) {
 		console.log();
 		console.log("  Conflicts resolved:");
-		for (const c of conflicts) {
-			const conflictKey = sanitizeSingleLineTerminalText(`${c.provider}/${c.type}/${c.item}`);
-			const resolution = sanitizeSingleLineTerminalText(c.resolution?.type ?? "skipped");
-			console.log(`    ${conflictKey}: ${resolution}`);
+		for (const conflict of footer.conflicts) {
+			console.log(`    ${conflict}`);
 		}
 	}
 
 	console.log();
+}
+
+export function buildCompletionFooter(
+	plan: ReconcilePlan,
+	results: PortableInstallResult[],
+	dryRun: boolean,
+): {
+	conflicts: string[];
+	subtitle: string;
+	title: string;
+	zones: Array<{ label: string; lines: string[] }>;
+} {
+	const providersInRun = collectProviders(plan, results);
+	const conflicts = plan.actions
+		.filter((action) => action.action === "conflict" && action.resolution?.type)
+		.map((action) =>
+			sanitizeSingleLineTerminalText(
+				`${action.provider}/${action.type}/${action.item}: ${action.resolution?.type ?? "skipped"}`,
+			),
+		);
+	const resultSummary = summarizeExecutionResults(results);
+	const typeCounts = dryRun
+		? mergeTypeCounts(collectPlannedTypeCounts(plan), collectResultTypeCounts(results))
+		: collectResultTypeCounts(results);
+	const whereLines = dryRun
+		? mergeWhereLines(collectPlannedWhereLines(plan), collectResultWhereLines(results))
+		: collectResultWhereLines(results);
+	const issuesCount = results.filter((result) => !result.success).length;
+	const deleteCount = results.filter(
+		(result) => result.success && !result.skipped && result.operation === "delete",
+	).length;
+	const zones: Array<{ label: string; lines: string[] }> = [
+		{
+			label: "WHERE",
+			lines: whereLines.length > 0 ? whereLines : ["No destination paths written"],
+		},
+		{
+			label: "WHAT",
+			lines: dryRun
+				? buildWhatLines(typeCounts, "would change")
+				: buildWhatLines(typeCounts, buildApplySummary(resultSummary, deleteCount)),
+		},
+		{
+			label: "NEXT",
+			lines: renderNextStepsFooter({ commands: buildNextCommands(providersInRun, typeCounts) }),
+		},
+	];
+
+	if (!dryRun && issuesCount > 0) {
+		zones.push({
+			label: "ISSUES",
+			lines: [
+				`${issuesCount} item(s) failed`,
+				"Re-run ck migrate after fixing the reported errors.",
+			],
+		});
+	}
+
+	return {
+		conflicts,
+		subtitle: dryRun
+			? `${sumTypeCounts(typeCounts)} item(s) would change`
+			: `${resultSummary.applied} applied, ${issuesCount} failed`,
+		title: dryRun ? "Dry run complete" : "Migration complete",
+		zones,
+	};
+}
+
+function collectProviders(plan: ReconcilePlan, results: PortableInstallResult[]): ProviderType[] {
+	const providersFromResults = results.map((result) => result.provider as ProviderType);
+	const providersFromPlan = plan.actions.map((action) => action.provider as ProviderType);
+	return Array.from(new Set([...providersFromResults, ...providersFromPlan]));
+}
+
+function collectResultTypeCounts(results: PortableInstallResult[]): Map<PortableItemType, number> {
+	const counts = new Map<PortableItemType, number>();
+	for (const result of results) {
+		if (!result.success || result.skipped || !result.portableType) continue;
+		counts.set(result.portableType, (counts.get(result.portableType) ?? 0) + 1);
+	}
+	return counts;
+}
+
+function collectPlannedTypeCounts(plan: ReconcilePlan): Map<PortableItemType, number> {
+	const counts = new Map<PortableItemType, number>();
+	for (const action of plan.actions) {
+		if (!shouldCountInFooter(action)) continue;
+		counts.set(action.type, (counts.get(action.type) ?? 0) + 1);
+	}
+	return counts;
+}
+
+function collectResultWhereLines(results: PortableInstallResult[]): string[] {
+	const destinations = Array.from(
+		new Set(
+			results
+				.filter(
+					(result) =>
+						result.success &&
+						!result.skipped &&
+						result.path.length > 0 &&
+						result.operation !== "delete",
+				)
+				.map((result) => normalizeWhereDestination(result.path, result.portableType ?? "config")),
+		),
+	).slice(0, 5);
+	return destinations.map(
+		(destination) =>
+			`${formatDisplayPath(destination)} -> ${formatCdHint(resolveCdTarget(destination))}`,
+	);
+}
+
+function collectPlannedWhereLines(plan: ReconcilePlan): string[] {
+	const destinations = Array.from(
+		new Set(
+			plan.actions
+				.filter((action) => shouldCountInFooter(action) && action.targetPath.length > 0)
+				.map((action) => normalizeWhereDestination(action.targetPath, action.type)),
+		),
+	).slice(0, 5);
+	return destinations.map(
+		(destination) =>
+			`${formatDisplayPath(destination)} -> ${formatCdHint(resolveCdTarget(destination))}`,
+	);
+}
+
+function resolveCdTarget(destination: string): string {
+	return extname(destination).length > 0 ? dirname(destination) : destination;
+}
+
+function normalizeWhereDestination(path: string, portableType: PortableItemType): string {
+	if (portableType === "agent" || portableType === "command" || portableType === "skill") {
+		return dirname(path);
+	}
+	if (portableType === "hooks") {
+		return dirname(path);
+	}
+	if (portableType === "rules") {
+		const fileName = basename(path).toLowerCase();
+		if (
+			fileName === "agents.md" ||
+			fileName === "gemini.md" ||
+			fileName === ".goosehints" ||
+			fileName === "custom_modes.yaml" ||
+			fileName === "custom_modes.yml"
+		) {
+			return path;
+		}
+		return dirname(path);
+	}
+	return path;
+}
+
+function shouldCountInFooter(action: ReconcileAction): boolean {
+	if (action.action === "install" || action.action === "update" || action.action === "delete") {
+		return true;
+	}
+	if (action.action !== "conflict") return false;
+	const resolution = action.resolution?.type;
+	return resolution === "overwrite" || resolution === "smart-merge" || resolution === "resolved";
+}
+
+function buildWhatLines(counts: Map<PortableItemType, number>, trailingSummary: string): string[] {
+	const orderedCounts: PortableItemType[] = [
+		"agent",
+		"skill",
+		"command",
+		"config",
+		"rules",
+		"hooks",
+	];
+	const labels: Record<PortableItemType, string> = {
+		agent: "agents",
+		command: "commands",
+		config: "config",
+		hooks: "hooks",
+		rules: "rules",
+		skill: "skills",
+	};
+	const parts = orderedCounts
+		.map((type) => (counts.get(type) ? `${counts.get(type)} ${labels[type]}` : null))
+		.filter((part): part is string => part !== null);
+	if (parts.length === 0) {
+		return [trailingSummary];
+	}
+	return [parts.join(" · "), trailingSummary];
+}
+
+function buildNextCommands(
+	providersInRun: ProviderType[],
+	typeCounts: Map<PortableItemType, number>,
+): string[] {
+	const firstProvider = providersInRun[0];
+	const commands = ["ck doctor"];
+	if (!firstProvider) return commands;
+
+	const preferredChecks: Array<{ flag: PortableItemType; command: string }> = [
+		{ flag: "skill", command: `ck skills --installed --agent ${firstProvider}` },
+		{ flag: "agent", command: `ck agents --installed --agent ${firstProvider}` },
+		{ flag: "command", command: `ck commands --installed --agent ${firstProvider}` },
+	];
+
+	for (const check of preferredChecks) {
+		if ((typeCounts.get(check.flag) ?? 0) > 0 && commands.length < 3) {
+			commands.push(check.command);
+		}
+	}
+
+	return commands.slice(0, 3);
+}
+
+function mergeTypeCounts(
+	primary: Map<PortableItemType, number>,
+	fallback: Map<PortableItemType, number>,
+): Map<PortableItemType, number> {
+	const merged = new Map(primary);
+	for (const [portableType, count] of fallback) {
+		merged.set(portableType, (merged.get(portableType) ?? 0) + count);
+	}
+	return merged;
+}
+
+function mergeWhereLines(primary: string[], fallback: string[]): string[] {
+	return Array.from(new Set([...primary, ...fallback]));
+}
+
+function buildApplySummary(
+	resultSummary: { applied: number; skipped: number; failed: number },
+	deleteCount: number,
+): string {
+	const appliedCount = Math.max(0, resultSummary.applied - deleteCount);
+	const parts = [`${appliedCount} applied`];
+	if (deleteCount > 0) {
+		parts.push(`${deleteCount} deleted`);
+	}
+	parts.push(`${resultSummary.skipped} skipped`);
+	return parts.join(", ");
+}
+
+function sumTypeCounts(counts: Map<PortableItemType, number>): number {
+	let total = 0;
+	for (const count of counts.values()) {
+		total += count;
+	}
+	return total;
 }

--- a/src/commands/portable/provider-registry.ts
+++ b/src/commands/portable/provider-registry.ts
@@ -930,6 +930,22 @@ export function getProvidersSupporting(
 }
 
 /**
+ * Get the base destination path for a portable type on a specific provider.
+ * For per-file strategies this returns the parent directory. For merge/single
+ * targets it returns the actual target file path.
+ */
+export function getPortableBasePath(
+	provider: ProviderType,
+	portableType: "agents" | "commands" | "skills" | "config" | "rules" | "hooks",
+	options: { global: boolean },
+): string | null {
+	const config = providers[provider];
+	const pathConfig = config[portableType];
+	if (!pathConfig) return null;
+	return options.global ? pathConfig.globalPath : pathConfig.projectPath;
+}
+
+/**
  * Get install path for a portable item on a specific provider
  */
 export function getPortableInstallPath(
@@ -942,7 +958,7 @@ export function getPortableInstallPath(
 	const pathConfig = config[portableType];
 	if (!pathConfig) return null;
 
-	const basePath = options.global ? pathConfig.globalPath : pathConfig.projectPath;
+	const basePath = getPortableBasePath(provider, portableType, options);
 	if (!basePath) return null;
 
 	// For merge-single / yaml-merge / json-merge / single-file, the path IS the target file

--- a/src/commands/portable/types.ts
+++ b/src/commands/portable/types.ts
@@ -127,6 +127,7 @@ export interface PortableInstallResult {
 	providerDisplayName: string;
 	success: boolean;
 	path: string;
+	operation?: "apply" | "delete";
 	error?: string;
 	overwritten?: boolean;
 	skipped?: boolean;

--- a/src/domains/help/commands/migrate-command-help.ts
+++ b/src/domains/help/commands/migrate-command-help.ts
@@ -8,20 +8,21 @@ import type { CommandHelp } from "../help-types.js";
 
 export const migrateCommandHelp: CommandHelp = {
 	name: "migrate",
-	description: "Migrate agents, commands, skills, config, rules, and hooks to other providers",
+	description:
+		"Migrate Claude Code agents, commands, skills, config, rules, and hooks to other providers",
 	usage: "ck migrate [options]",
 	examples: [
 		{
-			command: "ck migrate --agent opencode",
-			description: "Migrate OpenCode-native items while reusing Claude-compatible skill roots",
+			command: "ck migrate --agent codex --dry-run",
+			description: "Preview the destination-aware migration plan before writing files",
 		},
 		{
-			command: "ck migrate --agent droid --agent codex",
-			description: "Migrate to specific providers",
+			command: "ck migrate --agent codex -g",
+			description: "Write to Codex global paths such as ~/.codex/ and ~/.agents/skills",
 		},
 		{
-			command: "ck migrate --dry-run",
-			description: "Preview migration plan without writing files",
+			command: "CK_FORCE_ASCII=1 ck migrate --agent codex",
+			description: "Force ASCII borders on legacy Windows terminals (cmd.exe, older PowerShell)",
 		},
 	],
 	optionGroups: [
@@ -38,19 +39,19 @@ export const migrateCommandHelp: CommandHelp = {
 				},
 				{
 					flags: "-g, --global",
-					description: "Install globally instead of project-level",
+					description: "Install globally instead of the default project-level scope",
 				},
 				{
 					flags: "-y, --yes",
-					description: "Skip confirmation prompts",
+					description: "Skip confirmation prompts after the pre-flight summary",
 				},
 				{
 					flags: "-f, --force",
-					description: "Force reinstall deleted/edited items",
+					description: "Force reinstall deleted or edited managed items",
 				},
 				{
 					flags: "--dry-run",
-					description: "Preview plan without writing files",
+					description: "Preview plan, destinations, and next steps without writing files",
 				},
 			],
 		},

--- a/src/domains/help/help-interceptor.ts
+++ b/src/domains/help/help-interceptor.ts
@@ -22,7 +22,7 @@ function getHelpOptions(): HelpOptions {
 		...DEFAULT_HELP_OPTIONS,
 		showBanner: isTTY, // Hide banner in pipes/CI
 		showExamples: true,
-		maxExamples: 2,
+		maxExamples: 3,
 		interactive: isTTY, // Enable interactive mode for TTY
 		width,
 		noColor,

--- a/src/domains/help/help-renderer.ts
+++ b/src/domains/help/help-renderer.ts
@@ -22,7 +22,7 @@ import type {
 export const DEFAULT_HELP_OPTIONS: HelpOptions = {
 	showBanner: true,
 	showExamples: true,
-	maxExamples: 2,
+	maxExamples: 3,
 	interactive: false,
 	width: process.stdout.columns || 80,
 	theme: defaultTheme,

--- a/src/ui/ck-cli-design/__tests__/next-steps-footer.test.ts
+++ b/src/ui/ck-cli-design/__tests__/next-steps-footer.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { renderNextStepsFooter } from "../next-steps-footer.js";
+import { createCliDesignContext } from "../tokens.js";
+
+describe("renderNextStepsFooter", () => {
+	it("uses a unicode bullet when unicode rendering is available", () => {
+		const lines = renderNextStepsFooter({
+			commands: ["ck doctor"],
+			context: createCliDesignContext({
+				columns: 72,
+				env: { LANG: "en_US.UTF-8" } as NodeJS.ProcessEnv,
+				isTTY: true,
+				platform: "darwin",
+			}),
+		});
+
+		expect(lines[0]).toBe("• ck doctor");
+	});
+
+	it("uses an ASCII bullet when the ASCII fallback is forced", () => {
+		const lines = renderNextStepsFooter({
+			commands: ["ck doctor"],
+			context: createCliDesignContext({
+				columns: 72,
+				env: { ...process.env, CK_FORCE_ASCII: "1" },
+				isTTY: true,
+				platform: "win32",
+			}),
+		});
+
+		expect(lines[0]).toBe("- ck doctor");
+	});
+});

--- a/src/ui/ck-cli-design/__tests__/panel-rendering.test.ts
+++ b/src/ui/ck-cli-design/__tests__/panel-rendering.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { renderPanel } from "../panel.js";
+import { createCliDesignContext, stripAnsi } from "../tokens.js";
+
+describe("renderPanel", () => {
+	it("renders boxed zones on wide terminals", () => {
+		const output = renderPanel({
+			context: createCliDesignContext({
+				columns: 72,
+				env: { ...process.env, LANG: "en_US.UTF-8" },
+				isTTY: true,
+				platform: "darwin",
+			}),
+			subtitle: "Codex -> global",
+			title: "ck migrate",
+			zones: [
+				{ label: "WHERE", lines: ["~/.agents/skills -> cd ~/.agents/skills"] },
+				{ label: "WHAT", lines: ["2 skills · 1 command"] },
+			],
+		}).join("\n");
+		const plainOutput = stripAnsi(output);
+
+		expect(plainOutput.startsWith("╔═ ck migrate") || plainOutput.startsWith("+- ck migrate")).toBe(
+			true,
+		);
+		expect(plainOutput).toContain("WHERE");
+		expect(plainOutput).toContain("WHAT");
+	});
+
+	it("falls back to plain text on narrow terminals", () => {
+		const output = renderPanel({
+			context: createCliDesignContext({ columns: 48, env: process.env, isTTY: true }),
+			title: "ck migrate",
+			zones: [{ label: "NEXT", lines: ["ck doctor"] }],
+		}).join("\n");
+
+		expect(output).not.toContain("╔");
+		expect(output).toContain("ck migrate");
+		expect(output).toContain("NEXT");
+	});
+});

--- a/src/ui/ck-cli-design/__tests__/preflight-row.test.ts
+++ b/src/ui/ck-cli-design/__tests__/preflight-row.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { renderPreflightRow } from "../preflight-row.js";
+import { createCliDesignContext } from "../tokens.js";
+
+describe("renderPreflightRow", () => {
+	it("renders multiple destinations and inline notes", () => {
+		const lines = renderPreflightRow({
+			context: createCliDesignContext({ columns: 72, env: process.env, isTTY: true }),
+			count: 4,
+			destinations: ["~/.codex/prompts", "~/.agents/skills"],
+			label: "Commands",
+			notes: ["Codex: global-only"],
+		});
+
+		expect(lines[0]).toContain("Commands");
+		expect(lines[0]).toContain("~/.codex/prompts");
+		expect(lines[1]).toContain("~/.agents/skills");
+		expect(lines[2]).toContain("Codex: global-only");
+	});
+
+	it("falls back gracefully when no destination is available", () => {
+		const lines = renderPreflightRow({
+			context: createCliDesignContext({ columns: 72, env: process.env, isTTY: true }),
+			count: 2,
+			destinations: [],
+			label: "Commands",
+			notes: ["Cline: unsupported"],
+		});
+
+		expect(lines[0]).toContain("unsupported for selected provider(s)");
+		expect(lines[1]).toContain("Cline: unsupported");
+	});
+});

--- a/src/ui/ck-cli-design/__tests__/source-target-header.test.ts
+++ b/src/ui/ck-cli-design/__tests__/source-target-header.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import { renderSourceTargetHeader } from "../source-target-header.js";
+import { createCliDesignContext } from "../tokens.js";
+
+describe("renderSourceTargetHeader", () => {
+	it("renders source and destination zones in the same panel", () => {
+		const output = renderSourceTargetHeader({
+			context: createCliDesignContext({ columns: 72, env: process.env, isTTY: true }),
+			sourceLines: ["14 agents · 82 skills", "from ~/.claude/agents · ~/.claude/skills"],
+			subtitle: "Codex -> project",
+			targetLines: [".codex/agents", ".agents/skills"],
+			title: "ck migrate",
+		}).join("\n");
+
+		expect(output).toContain("SOURCE");
+		expect(output).toContain("DESTINATION");
+		expect(output).toContain(".agents/skills");
+	});
+});

--- a/src/ui/ck-cli-design/__tests__/tokens.test.ts
+++ b/src/ui/ck-cli-design/__tests__/tokens.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { homedir } from "node:os";
+import {
+	createCliDesignContext,
+	formatCdHint,
+	formatDisplayPath,
+	truncateMiddle,
+} from "../tokens.js";
+
+describe("ck-cli-design tokens", () => {
+	it("forces ASCII when CK_FORCE_ASCII is enabled", () => {
+		const context = createCliDesignContext({
+			columns: 72,
+			env: { ...process.env, CK_FORCE_ASCII: "1" },
+			isTTY: true,
+			platform: "win32",
+		});
+
+		expect(context.box.h).toBe("-");
+		expect(context.box.v).toBe("|");
+	});
+
+	it("drops boxed panels on narrow terminals", () => {
+		const context = createCliDesignContext({
+			columns: 48,
+			env: process.env,
+			isTTY: true,
+			platform: "darwin",
+		});
+
+		expect(context.supportsPanels).toBe(false);
+		expect(context.width).toBe(48);
+	});
+
+	it("formats home-relative paths with a tilde prefix", () => {
+		expect(formatDisplayPath(`${homedir()}/.agents/skills`)).toBe("~/.agents/skills");
+	});
+
+	it("truncates long paths through the middle", () => {
+		expect(truncateMiddle("~/.very/long/path/to/skills/example", 20)).toBe("~/.very/l.../example");
+	});
+
+	it("keeps Windows cd hints readable without doubled separators", () => {
+		expect(formatCdHint("C:\\Users\\kai\\.agents\\skills", "win32")).toBe(
+			'cd /d "C:\\Users\\kai\\.agents\\skills"',
+		);
+	});
+
+	it("returns unicode context for WT_SESSION regardless of TTY", () => {
+		const context = createCliDesignContext({
+			columns: 72,
+			env: { WT_SESSION: "1" },
+			isTTY: false,
+			platform: "win32",
+		});
+		expect(context.box.bullet).toBe("●");
+	});
+
+	it("returns ASCII context when TERM=dumb even if WT_SESSION is set", () => {
+		const context = createCliDesignContext({
+			columns: 72,
+			env: { WT_SESSION: "1", TERM: "dumb" },
+			isTTY: false,
+			platform: "win32",
+		});
+		expect(context.box.bullet).toBe("+");
+	});
+});

--- a/src/ui/ck-cli-design/index.ts
+++ b/src/ui/ck-cli-design/index.ts
@@ -1,0 +1,21 @@
+export { renderNextStepsFooter, type NextStepsFooterOptions } from "./next-steps-footer.js";
+export { renderPanel, type PanelOptions, type PanelZone } from "./panel.js";
+export { renderPreflightRow, type PreflightRowOptions } from "./preflight-row.js";
+export {
+	renderSourceTargetHeader,
+	type SourceTargetHeaderOptions,
+} from "./source-target-header.js";
+export {
+	createCliDesignContext,
+	formatCdHint,
+	formatDisplayPath,
+	padVisible,
+	paint,
+	stripAnsi,
+	truncateMiddle,
+	type BoxChars,
+	type CliDesignContext,
+	type CliDesignContextOptions,
+	visibleWidth,
+	wrapText,
+} from "./tokens.js";

--- a/src/ui/ck-cli-design/next-steps-footer.ts
+++ b/src/ui/ck-cli-design/next-steps-footer.ts
@@ -1,0 +1,17 @@
+import {
+	type CliDesignContext,
+	type CliDesignContextOptions,
+	createCliDesignContext,
+} from "./tokens.js";
+
+export interface NextStepsFooterOptions {
+	commands: string[];
+	context?: CliDesignContext;
+	contextOptions?: CliDesignContextOptions;
+}
+
+export function renderNextStepsFooter(options: NextStepsFooterOptions): string[] {
+	const context = options.context ?? createCliDesignContext(options.contextOptions);
+	const bullet = context.box.bullet === "+" ? "-" : "•";
+	return options.commands.map((command) => `${bullet} ${command}`);
+}

--- a/src/ui/ck-cli-design/panel.ts
+++ b/src/ui/ck-cli-design/panel.ts
@@ -1,0 +1,130 @@
+import {
+	type BoxChars,
+	type CliDesignContext,
+	type CliDesignContextOptions,
+	createCliDesignContext,
+	visibleWidth as measureWidth,
+	padVisible,
+	paint,
+	truncateMiddle,
+	wrapText,
+} from "./tokens.js";
+
+export interface PanelZone {
+	label: string;
+	lines: string[];
+}
+
+export interface PanelOptions {
+	context?: CliDesignContext;
+	contextOptions?: CliDesignContextOptions;
+	subtitle?: string;
+	title: string;
+	zones: PanelZone[];
+}
+
+export function renderPanel(options: PanelOptions): string[] {
+	const context = options.context ?? createCliDesignContext(options.contextOptions);
+	const title = paint(options.title, "heading", context);
+	const subtitle = options.subtitle ? paint(options.subtitle, "muted", context) : null;
+	if (!context.supportsPanels) {
+		return renderPlainPanel(options.zones, title, subtitle, context);
+	}
+	return renderBoxedPanel(options.zones, title, subtitle, context);
+}
+
+function renderPlainPanel(
+	zones: PanelZone[],
+	title: string,
+	subtitle: string | null,
+	context: CliDesignContext,
+): string[] {
+	const lines = [title];
+	if (subtitle) lines.push(subtitle);
+	lines.push("");
+	for (const zone of zones) {
+		lines.push(paint(zone.label, "accent", context));
+		for (const line of zone.lines) {
+			lines.push(...wrapText(line, context.width - 2).map((entry) => `  ${entry}`));
+		}
+		lines.push("");
+	}
+	return trimTrailingBlank(lines);
+}
+
+function renderBoxedPanel(
+	zones: PanelZone[],
+	title: string,
+	subtitle: string | null,
+	context: CliDesignContext,
+): string[] {
+	const labelWidth = Math.min(12, Math.max(...zones.map((zone) => zone.label.length), 4));
+	const innerWidth = context.width - 4;
+	const lines: string[] = [renderTopBorder(title, context.box, context.width)];
+
+	if (subtitle) {
+		lines.push(renderContentLine(subtitle, innerWidth, context.box));
+		lines.push(renderContentLine("", innerWidth, context.box));
+	}
+
+	for (const [index, zone] of zones.entries()) {
+		for (const line of formatZone(zone, labelWidth, innerWidth, context)) {
+			lines.push(renderContentLine(line, innerWidth, context.box));
+		}
+		if (index < zones.length - 1) {
+			lines.push(renderContentLine("", innerWidth, context.box));
+		}
+	}
+
+	lines.push(renderBottomBorder(context.box, context.width));
+	return lines;
+}
+
+function formatZone(
+	zone: PanelZone,
+	labelWidth: number,
+	innerWidth: number,
+	context: CliDesignContext,
+): string[] {
+	const availableWidth = Math.max(8, innerWidth - labelWidth - 3);
+	const label = paint(zone.label, "accent", context);
+	const rendered: string[] = [];
+
+	for (const [index, rawLine] of zone.lines.entries()) {
+		const wrappedLines = wrapText(rawLine, availableWidth);
+		for (const [wrappedIndex, wrappedLine] of wrappedLines.entries()) {
+			const prefix =
+				index === 0 && wrappedIndex === 0 ? padVisible(label, labelWidth) : " ".repeat(labelWidth);
+			rendered.push(` ${prefix} ${wrappedLine}`);
+		}
+	}
+
+	return rendered;
+}
+
+function renderTopBorder(title: string, box: BoxChars, width: number): string {
+	const availableWidth = width - 2;
+	const decorationWidth = 3;
+	const maxTitleWidth = Math.max(1, availableWidth - decorationWidth - 1);
+	const safeTitle =
+		measureWidth(title) > maxTitleWidth ? truncateMiddle(title, maxTitleWidth) : title;
+	const heading = `${box.h} ${safeTitle} `;
+	const fill = Math.max(1, availableWidth - measureWidth(heading));
+	return `${box.tl}${heading}${box.h.repeat(fill)}${box.tr}`;
+}
+
+function renderBottomBorder(box: BoxChars, width: number): string {
+	return `${box.bl}${box.h.repeat(width - 2)}${box.br}`;
+}
+
+function renderContentLine(content: string, width: number, box: BoxChars): string {
+	return `${box.v} ${padVisible(content, width)} ${box.v}`;
+}
+
+function trimTrailingBlank(lines: string[]): string[] {
+	const trimmed = [...lines];
+	while (trimmed[trimmed.length - 1] === "") {
+		trimmed.pop();
+	}
+	return trimmed;
+}

--- a/src/ui/ck-cli-design/preflight-row.ts
+++ b/src/ui/ck-cli-design/preflight-row.ts
@@ -1,0 +1,40 @@
+import {
+	type CliDesignContext,
+	type CliDesignContextOptions,
+	createCliDesignContext,
+	padVisible,
+	paint,
+	truncateMiddle,
+} from "./tokens.js";
+
+export interface PreflightRowOptions {
+	context?: CliDesignContext;
+	contextOptions?: CliDesignContextOptions;
+	count: number;
+	destinations: string[];
+	icon?: string;
+	label: string;
+	notes?: string[];
+}
+
+export function renderPreflightRow(options: PreflightRowOptions): string[] {
+	const context = options.context ?? createCliDesignContext(options.contextOptions);
+	const icon = options.icon ?? context.box.bullet;
+	const label = padVisible(options.label, 10);
+	const count = String(options.count).padStart(3, " ");
+	const prefix = `  [${icon}] ${label} ${count} -> `;
+	const availableWidth = Math.max(10, context.width - prefix.length);
+	const [firstDestination, ...extraDestinations] =
+		options.destinations.length > 0
+			? options.destinations
+			: ["unsupported for selected provider(s)"];
+
+	const lines = [`${prefix}${truncateMiddle(firstDestination, availableWidth)}`];
+	for (const destination of extraDestinations) {
+		lines.push(`${" ".repeat(prefix.length)}${truncateMiddle(destination, availableWidth)}`);
+	}
+	for (const note of options.notes ?? []) {
+		lines.push(`${" ".repeat(prefix.length)}${paint(`(${note})`, "muted", context)}`);
+	}
+	return lines;
+}

--- a/src/ui/ck-cli-design/source-target-header.ts
+++ b/src/ui/ck-cli-design/source-target-header.ts
@@ -1,0 +1,28 @@
+import { renderPanel } from "./panel.js";
+import {
+	type CliDesignContext,
+	type CliDesignContextOptions,
+	createCliDesignContext,
+} from "./tokens.js";
+
+export interface SourceTargetHeaderOptions {
+	context?: CliDesignContext;
+	contextOptions?: CliDesignContextOptions;
+	sourceLines: string[];
+	subtitle?: string;
+	targetLines: string[];
+	title: string;
+}
+
+export function renderSourceTargetHeader(options: SourceTargetHeaderOptions): string[] {
+	const context = options.context ?? createCliDesignContext(options.contextOptions);
+	return renderPanel({
+		context,
+		subtitle: options.subtitle,
+		title: options.title,
+		zones: [
+			{ label: "SOURCE", lines: options.sourceLines },
+			{ label: "DESTINATION", lines: options.targetLines },
+		],
+	});
+}

--- a/src/ui/ck-cli-design/tokens.ts
+++ b/src/ui/ck-cli-design/tokens.ts
@@ -1,0 +1,234 @@
+import { homedir, platform } from "node:os";
+import { resolve, win32 } from "node:path";
+import pc from "picocolors";
+
+export const PANEL_MIN_WIDTH = 60;
+export const PANEL_MAX_WIDTH = 72;
+const DEFAULT_WIDTH = PANEL_MAX_WIDTH;
+
+export interface BoxChars {
+	tl: string;
+	tr: string;
+	bl: string;
+	br: string;
+	h: string;
+	v: string;
+	bullet: string;
+}
+
+export interface CliDesignContext {
+	box: BoxChars;
+	platform: NodeJS.Platform;
+	rawWidth: number;
+	supportsPanels: boolean;
+	useColor: boolean;
+	width: number;
+}
+
+export interface CliDesignContextOptions {
+	columns?: number;
+	env?: NodeJS.ProcessEnv;
+	isTTY?: boolean;
+	platform?: NodeJS.Platform;
+}
+
+const UNICODE_BOX: BoxChars = {
+	tl: "╔",
+	tr: "╗",
+	bl: "╚",
+	br: "╝",
+	h: "═",
+	v: "║",
+	bullet: "●",
+};
+
+const ASCII_BOX: BoxChars = {
+	tl: "+",
+	tr: "+",
+	bl: "+",
+	br: "+",
+	h: "-",
+	v: "|",
+	bullet: "+",
+};
+
+export function createCliDesignContext(options: CliDesignContextOptions = {}): CliDesignContext {
+	const env = options.env ?? process.env;
+	const isTTY = options.isTTY ?? process.stdout.isTTY === true;
+	const rawWidth = options.columns ?? process.stdout.columns ?? DEFAULT_WIDTH;
+	const width = Math.max(40, Math.min(rawWidth, PANEL_MAX_WIDTH));
+	const currentPlatform = options.platform ?? platform();
+
+	return {
+		box: supportsCliUnicode({ env, isTTY, platform: currentPlatform }) ? UNICODE_BOX : ASCII_BOX,
+		platform: currentPlatform,
+		rawWidth,
+		supportsPanels: width >= PANEL_MIN_WIDTH,
+		useColor: isTTY && !env.NO_COLOR,
+		width,
+	};
+}
+
+function supportsCliUnicode(options: {
+	env: NodeJS.ProcessEnv;
+	isTTY: boolean;
+	platform: NodeJS.Platform;
+}): boolean {
+	const { env, isTTY, platform } = options;
+	if (env.CK_FORCE_ASCII === "1" || env.NO_UNICODE === "1") return false;
+	if (env.TERM === "dumb") return false;
+	if (env.WT_SESSION) return true;
+	const ci = (env.CI ?? "").trim().toLowerCase();
+	if (ci === "true" || ci === "1") return true;
+	if (!isTTY) return false;
+	if (env.TERM_PROGRAM === "iTerm.app") return true;
+	if (env.TERM_PROGRAM === "Apple_Terminal") return true;
+	if (env.TERM_PROGRAM === "vscode") return true;
+	if (env.KONSOLE_VERSION) return true;
+
+	const locale = `${env.LANG ?? ""}${env.LC_ALL ?? ""}`.toLowerCase();
+	if (locale.includes("utf")) return true;
+	if (platform === "win32") return false;
+	return true;
+}
+
+export function stripAnsi(value: string): string {
+	let result = "";
+	for (let index = 0; index < value.length; index += 1) {
+		const code = value.charCodeAt(index);
+		if (code !== 27) {
+			result += value[index];
+			continue;
+		}
+
+		const next = value[index + 1];
+		if (next === "[") {
+			index += 2;
+			while (index < value.length) {
+				const char = value.charCodeAt(index);
+				if (char >= 0x40 && char <= 0x7e) break;
+				index += 1;
+			}
+			continue;
+		}
+
+		if (next === "]") {
+			index += 2;
+			while (index < value.length) {
+				if (value.charCodeAt(index) === 7) break;
+				if (value.charCodeAt(index) === 27 && value[index + 1] === "\\") {
+					index += 1;
+					break;
+				}
+				index += 1;
+			}
+			continue;
+		}
+
+		if (next !== undefined) index += 1;
+	}
+	return result;
+}
+
+export function visibleWidth(value: string): number {
+	return stripAnsi(value).length;
+}
+
+export function padVisible(value: string, width: number): string {
+	const padding = Math.max(0, width - visibleWidth(value));
+	return `${value}${" ".repeat(padding)}`;
+}
+
+// value must be plain text; ANSI sequences in input corrupt slice offsets
+export function truncateMiddle(value: string, width: number): string {
+	if (width <= 0) return "";
+	if (visibleWidth(value) <= width) return value;
+	if (width <= 3) return ".".repeat(width);
+	const keep = width - 3;
+	const front = Math.ceil(keep / 2);
+	const back = Math.floor(keep / 2);
+	return `${value.slice(0, front)}...${value.slice(value.length - back)}`;
+}
+
+export function wrapText(value: string, width: number): string[] {
+	if (width <= 0) return [""];
+	const words = value.split(/\s+/).filter(Boolean);
+	if (words.length === 0) return [""];
+
+	const lines: string[] = [];
+	let current = "";
+	for (const word of words) {
+		const candidate = current.length === 0 ? word : `${current} ${word}`;
+		if (visibleWidth(candidate) <= width) {
+			current = candidate;
+			continue;
+		}
+		if (current.length > 0) {
+			lines.push(current);
+			current = "";
+		}
+		if (visibleWidth(word) <= width) {
+			current = word;
+			continue;
+		}
+		let remaining = word;
+		while (visibleWidth(remaining) > width) {
+			lines.push(`${remaining.slice(0, Math.max(1, width - 3))}...`);
+			remaining = remaining.slice(Math.max(1, width - 3));
+		}
+		current = remaining;
+	}
+
+	if (current.length > 0) {
+		lines.push(current);
+	}
+
+	return lines;
+}
+
+export function formatDisplayPath(value: string): string {
+	const normalized = value.replace(/\\/g, "/");
+	const home = homedir().replace(/\\/g, "/");
+	if (normalized === home) return "~";
+	if (normalized.startsWith(`${home}/`)) {
+		return normalized.replace(home, "~");
+	}
+	return normalized;
+}
+
+// Paths containing embedded double quotes (legal on POSIX, rare on Windows) are
+// rendered as-is — shell-correct escaping would require quote-escape logic per
+// platform. If a real user hits this we will add proper escaping.
+export function formatCdHint(value: string, currentPlatform: NodeJS.Platform = platform()): string {
+	if (currentPlatform === "win32") {
+		const absolutePath = win32.resolve(value);
+		return `cd /d "${absolutePath}"`;
+	}
+
+	const absolutePath = resolve(value);
+	const displayPath = formatDisplayPath(absolutePath);
+	if (displayPath.includes(" ")) {
+		return `cd "${displayPath}"`;
+	}
+	return `cd ${displayPath}`;
+}
+
+export function paint(
+	value: string,
+	tone: "accent" | "muted" | "success" | "warning" | "heading",
+	context: CliDesignContext,
+): string {
+	if (!context.useColor) return value;
+	switch (tone) {
+		case "accent":
+			return pc.cyan(value);
+		case "muted":
+			return pc.dim(value);
+		case "success":
+			return pc.green(value);
+		case "warning":
+			return pc.yellow(value);
+		case "heading":
+			return pc.bold(value);
+	}
+}

--- a/tests/domains/help/migrate-command-help.test.ts
+++ b/tests/domains/help/migrate-command-help.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { migrateCommandHelp } from "@/domains/help/commands/migrate-command-help.js";
+
+describe("migrate command help", () => {
+	test("documents the new dry-run and ASCII fallback workflows", () => {
+		expect(migrateCommandHelp.description).toContain("Claude Code");
+		expect(migrateCommandHelp.examples.map((example) => example.command)).toContain(
+			"ck migrate --agent codex --dry-run",
+		);
+		expect(migrateCommandHelp.examples.map((example) => example.command).join(" ")).toContain(
+			"CK_FORCE_ASCII=1",
+		);
+		expect(
+			migrateCommandHelp.optionGroups
+				.flatMap((group) => group.options)
+				.find((option) => option.flags === "--dry-run")?.description,
+		).toContain("destinations");
+	});
+});


### PR DESCRIPTION
## Summary
- redesign `ck migrate` terminal output around visible destinations and next steps
- add reusable `ck-cli-design` primitives for intro panels, preflight rows, and completion footers
- cover edge cases for unsupported provider rows, skill-only dry runs, delete summaries, and ASCII fallback

## Validation
- `bun run validate`
- `bun run dev migrate --agent codex --dry-run --yes`
- `CK_FORCE_ASCII=1 bun run dev migrate --agent codex --dry-run --yes`

## Docs
- local CLI docs updated in this repo
- companion docs PR: https://github.com/claudekit/claudekit-docs/pull/150

Docs impact: major
Action: created companion `claudekit-docs` PR #150 to `dev`