### PR TITLE
fix(desktop): repair invalid installs and sync desktop tag versions

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -104,6 +104,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Preflight desktop bundle sync script
+        shell: bash
         run: |
           CURRENT_VERSION="$(jq -r '.version' src-tauri/tauri.conf.json)"
           bun run desktop:sync-version "$CURRENT_VERSION"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -49,6 +49,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Preflight desktop bundle sync script
+        shell: bash
         run: |
           CURRENT_VERSION="$(jq -r '.version' src-tauri/tauri.conf.json)"
           bun run desktop:sync-version "$CURRENT_VERSION"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -49,11 +49,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Preflight desktop bundle sync script
-        shell: bash
-        run: |
-          CURRENT_VERSION="$(jq -r '.version' src-tauri/tauri.conf.json)"
-          bun run desktop:sync-version "$CURRENT_VERSION"
-          git diff --exit-code src-tauri/tauri.conf.json
+        run: bun run desktop:check-sync
 
       - name: Validate desktop bundle config
         run: bun run desktop:validate-config
@@ -104,11 +100,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Preflight desktop bundle sync script
-        shell: bash
-        run: |
-          CURRENT_VERSION="$(jq -r '.version' src-tauri/tauri.conf.json)"
-          bun run desktop:sync-version "$CURRENT_VERSION"
-          git diff --exit-code src-tauri/tauri.conf.json
+        run: bun run desktop:check-sync
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -19,6 +19,7 @@ on:
       - 'src/domains/help/commands/app-command-help.ts'
       - 'src/types/desktop.ts'
       - 'scripts/generate-desktop-release-manifest.ts'
+      - 'scripts/sync-desktop-bundle-config.ts'
       - '.github/workflows/desktop-build.yml'
   workflow_dispatch:
 
@@ -46,6 +47,12 @@ jobs:
 
       - name: Install frontend dependencies
         run: bun install --frozen-lockfile
+
+      - name: Preflight desktop bundle sync script
+        run: |
+          CURRENT_VERSION="$(jq -r '.version' src-tauri/tauri.conf.json)"
+          bun run desktop:sync-version "$CURRENT_VERSION"
+          git diff --exit-code src-tauri/tauri.conf.json
 
       - name: Validate desktop bundle config
         run: bun run desktop:validate-config
@@ -94,6 +101,12 @@ jobs:
 
       - name: Install frontend dependencies
         run: bun install --frozen-lockfile
+
+      - name: Preflight desktop bundle sync script
+        run: |
+          CURRENT_VERSION="$(jq -r '.version' src-tauri/tauri.conf.json)"
+          bun run desktop:sync-version "$CURRENT_VERSION"
+          git diff --exit-code src-tauri/tauri.conf.json
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -156,6 +169,10 @@ jobs:
       - name: Install frontend dependencies
         run: bun install --frozen-lockfile
 
+      - name: Sync desktop bundle version from release tag
+        if: startsWith(github.ref, 'refs/tags/desktop-v')
+        run: bun run desktop:sync-version "${{ github.ref_name }}"
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
@@ -184,6 +201,28 @@ jobs:
         with:
           args: ${{ matrix.args }}
           # tagName/releaseName only set on desktop-v* tags — see release job below
+
+      - name: Verify macOS bundle version matches release tag
+        if: matrix.platform == 'macos-latest' && startsWith(github.ref, 'refs/tags/desktop-v')
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#desktop-v}"
+          APP_MATCHES="$(find src-tauri/target/universal-apple-darwin/release/bundle -path '*macos/*.app' -type d | sort)"
+          APP_COUNT="$(printf '%s\n' "$APP_MATCHES" | sed '/^$/d' | wc -l | tr -d ' ')"
+          if [ "$APP_COUNT" -ne 1 ]; then
+            echo "Expected exactly one macOS app bundle for version verification, found $APP_COUNT"
+            printf '%s\n' "$APP_MATCHES"
+            exit 1
+          fi
+          APP_PATH="$APP_MATCHES"
+
+          ACTUAL_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP_PATH/Contents/Info.plist")"
+          if [ "$ACTUAL_VERSION" != "$VERSION" ]; then
+            echo "Desktop bundle version mismatch: expected $VERSION, got $ACTUAL_VERSION"
+            exit 1
+          fi
 
       - name: Prepare portable desktop assets
         shell: bash

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"tauri:build": "tauri build",
 		"desktop:validate-config": "bun scripts/validate-desktop-bundle-config.ts",
 		"desktop:sync-version": "bun scripts/sync-desktop-bundle-config.ts",
+		"desktop:check-sync": "bun scripts/sync-desktop-bundle-config.ts --check",
 		"desktop:validate-icons": "bun scripts/validate-desktop-icon-source.ts",
 		"icons:regen": "./scripts/regen-desktop-icons.sh",
 		"dev": "bun run src/index.ts",
@@ -49,7 +50,7 @@
 		"dev:quick": "./scripts/dev-quick-start.sh",
 		"dev:all": "./scripts/dev-quick-start.sh all",
 		"metrics": "bun run scripts/workflow-metrics.ts",
-		"validate": "bun run typecheck && bun run lint && bun run desktop:validate-config && bun run desktop:validate-icons && bun test && bun run ui:test && bun run build",
+		"validate": "bun run typecheck && bun run lint && bun run desktop:check-sync && bun run desktop:validate-config && bun run desktop:validate-icons && bun test && bun run ui:test && bun run build",
 		"install:hooks": "./.githooks/install.sh",
 		"prepare": "node -e \"try{require('child_process').execSync('git rev-parse --git-dir',{stdio:'ignore'});require('child_process').execSync('bash .githooks/install.sh',{stdio:'inherit'})}catch(e){console.warn('[i] Hook install skipped:',e.message)}\""
 	},

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"tauri:dev": "tauri dev",
 		"tauri:build": "tauri build",
 		"desktop:validate-config": "bun scripts/validate-desktop-bundle-config.ts",
+		"desktop:sync-version": "bun scripts/sync-desktop-bundle-config.ts",
 		"desktop:validate-icons": "bun scripts/validate-desktop-icon-source.ts",
 		"icons:regen": "./scripts/regen-desktop-icons.sh",
 		"dev": "bun run src/index.ts",

--- a/scripts/sync-desktop-bundle-config.ts
+++ b/scripts/sync-desktop-bundle-config.ts
@@ -16,9 +16,9 @@ async function main(): Promise<void> {
 	const inputArg = args.find((arg) => arg !== "--check");
 	const rawInput =
 		inputArg ||
-		process.env.DESKTOP_RELEASE_VERSION ||
-		process.env.GITHUB_REF_NAME ||
-		(checkOnly ? current.version : undefined);
+		(checkOnly
+			? current.version
+			: process.env.DESKTOP_RELEASE_VERSION || process.env.GITHUB_REF_NAME);
 	if (!rawInput) {
 		throw new Error(
 			"Usage: bun scripts/sync-desktop-bundle-config.ts [--check] <desktop-vX.Y.Z | X.Y.Z>",

--- a/scripts/sync-desktop-bundle-config.ts
+++ b/scripts/sync-desktop-bundle-config.ts
@@ -1,0 +1,56 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import {
+	loadDesktopBundleConfig,
+	parseDesktopReleaseVersion,
+	synchronizeDesktopBundleConfig,
+	validateDesktopBundleConfig,
+} from "../src/domains/desktop/desktop-bundle-version.js";
+
+const CONFIG_PATH = fileURLToPath(new URL("../src-tauri/tauri.conf.json", import.meta.url));
+
+async function main(): Promise<void> {
+	const rawInput =
+		process.argv[2] || process.env.DESKTOP_RELEASE_VERSION || process.env.GITHUB_REF_NAME;
+	if (!rawInput) {
+		throw new Error("Usage: bun scripts/sync-desktop-bundle-config.ts <desktop-vX.Y.Z | X.Y.Z>");
+	}
+
+	const appVersion = parseDesktopReleaseVersion(rawInput);
+	const current = await loadDesktopBundleConfig(CONFIG_PATH);
+	const updated = synchronizeDesktopBundleConfig(current, appVersion);
+	const changed =
+		current.version !== updated.version ||
+		current.bundle.windows.wix.version !== updated.bundle.windows.wix.version;
+
+	if (changed) {
+		const rawConfig = JSON.parse(await readFile(CONFIG_PATH, "utf8")) as {
+			version?: string;
+			bundle?: {
+				windows?: {
+					wix?: {
+						version?: string;
+					};
+				};
+			};
+		};
+		rawConfig.version = updated.version;
+		rawConfig.bundle ??= {};
+		rawConfig.bundle.windows ??= {};
+		rawConfig.bundle.windows.wix ??= {};
+		rawConfig.bundle.windows.wix.version = updated.bundle.windows.wix.version;
+		await writeFile(CONFIG_PATH, `${JSON.stringify(rawConfig, null, "\t")}\n`);
+	}
+
+	const validated = validateDesktopBundleConfig(updated);
+	const prefix = changed ? "synced" : "already";
+	console.log(
+		`[desktop-config] ${prefix} at app version ${validated.appVersion} -> wix.version ${validated.expectedWixVersion}`,
+	);
+}
+
+main().catch((error) => {
+	const message = error instanceof Error ? error.message : String(error);
+	console.error(`[desktop-config] ${message}`);
+	process.exitCode = 1;
+});

--- a/scripts/sync-desktop-bundle-config.ts
+++ b/scripts/sync-desktop-bundle-config.ts
@@ -10,20 +10,34 @@ import {
 const CONFIG_PATH = fileURLToPath(new URL("../src-tauri/tauri.conf.json", import.meta.url));
 
 async function main(): Promise<void> {
+	const current = await loadDesktopBundleConfig(CONFIG_PATH);
+	const args = process.argv.slice(2);
+	const checkOnly = args.includes("--check");
+	const inputArg = args.find((arg) => arg !== "--check");
 	const rawInput =
-		process.argv[2] || process.env.DESKTOP_RELEASE_VERSION || process.env.GITHUB_REF_NAME;
+		inputArg ||
+		process.env.DESKTOP_RELEASE_VERSION ||
+		process.env.GITHUB_REF_NAME ||
+		(checkOnly ? current.version : undefined);
 	if (!rawInput) {
-		throw new Error("Usage: bun scripts/sync-desktop-bundle-config.ts <desktop-vX.Y.Z | X.Y.Z>");
+		throw new Error(
+			"Usage: bun scripts/sync-desktop-bundle-config.ts [--check] <desktop-vX.Y.Z | X.Y.Z>",
+		);
 	}
 
 	const appVersion = parseDesktopReleaseVersion(rawInput);
-	const current = await loadDesktopBundleConfig(CONFIG_PATH);
 	const updated = synchronizeDesktopBundleConfig(current, appVersion);
 	const changed =
 		current.version !== updated.version ||
 		current.bundle.windows.wix.version !== updated.bundle.windows.wix.version;
 
 	if (changed) {
+		if (checkOnly) {
+			throw new Error(
+				`Desktop bundle config is out of sync for app version ${appVersion}; run bun run desktop:sync-version "${appVersion}"`,
+			);
+		}
+
 		const rawConfig = JSON.parse(await readFile(CONFIG_PATH, "utf8")) as {
 			version?: string;
 			bundle?: {
@@ -43,7 +57,7 @@ async function main(): Promise<void> {
 	}
 
 	const validated = validateDesktopBundleConfig(updated);
-	const prefix = changed ? "synced" : "already";
+	const prefix = checkOnly ? "verified" : changed ? "synced" : "already";
 	console.log(
 		`[desktop-config] ${prefix} at app version ${validated.appVersion} -> wix.version ${validated.expectedWixVersion}`,
 	);

--- a/src/__tests__/commands/app/app-command.test.ts
+++ b/src/__tests__/commands/app/app-command.test.ts
@@ -106,6 +106,7 @@ describe("appCommand", () => {
 		expect(info).toHaveBeenCalledWith(
 			"Installed ClaudeKit Control Center build (0.1.0-dev.5) needs repair. Downloading the latest build...",
 		);
+		expect(info).not.toHaveBeenCalledWith("ClaudeKit Control Center not found. Downloading...");
 		expect(downloadBinary).toHaveBeenCalled();
 		expect(installBinary).toHaveBeenCalledWith("/tmp/download.zip");
 		expect(launchBinary).toHaveBeenCalledWith("/Applications/ClaudeKit Control Center.app");

--- a/src/__tests__/commands/app/app-command.test.ts
+++ b/src/__tests__/commands/app/app-command.test.ts
@@ -112,6 +112,36 @@ describe("appCommand", () => {
 		expect(launchBinary).toHaveBeenCalledWith("/Applications/ClaudeKit Control Center.app");
 	});
 
+	test("launches the installed desktop binary when metadata is missing", async () => {
+		const downloadBinary = mock(async () => "/tmp/download.zip");
+		const launchBinary = mock(() => {});
+		const success = mock(() => {});
+
+		await appCommand(
+			{},
+			{
+				getBinaryPath: () => "/Applications/ClaudeKit Control Center.app",
+				getInstallPath: () => "/Applications/ClaudeKit Control Center.app",
+				getInstallHealth: async () => ({
+					currentVersion: null,
+					healthy: false,
+					reason: "missing-metadata",
+				}),
+				downloadBinary,
+				installBinary: async (path) => path,
+				launchBinary,
+				uninstallBinary: async () => ({ path: "/unused", removed: false }),
+				info: () => {},
+				success,
+				printLine: () => {},
+			},
+		);
+
+		expect(downloadBinary).not.toHaveBeenCalled();
+		expect(launchBinary).toHaveBeenCalledWith("/Applications/ClaudeKit Control Center.app");
+		expect(success).toHaveBeenCalledWith("Launching ClaudeKit Control Center...");
+	});
+
 	test("downloads, installs, and launches when the desktop binary is missing", async () => {
 		const downloadBinary = mock(async () => "/tmp/download.zip");
 		const installBinary = mock(async () => "/Applications/ClaudeKit Control Center.app");

--- a/src/__tests__/commands/app/app-command.test.ts
+++ b/src/__tests__/commands/app/app-command.test.ts
@@ -56,6 +56,11 @@ describe("appCommand", () => {
 			{
 				getBinaryPath: () => "/Applications/ClaudeKit Control Center.app",
 				getInstallPath: () => "/Applications/ClaudeKit Control Center.app",
+				getInstallHealth: async () => ({
+					currentVersion: "0.1.0-dev.7",
+					healthy: true,
+					reason: "healthy",
+				}),
 				downloadBinary,
 				installBinary: async (path) => path,
 				launchBinary,
@@ -69,6 +74,41 @@ describe("appCommand", () => {
 		expect(downloadBinary).not.toHaveBeenCalled();
 		expect(launchBinary).toHaveBeenCalledWith("/Applications/ClaudeKit Control Center.app");
 		expect(success).toHaveBeenCalledWith("Launching ClaudeKit Control Center...");
+	});
+
+	test("auto-repairs an unhealthy installed desktop binary on normal launch", async () => {
+		const downloadBinary = mock(async () => "/tmp/download.zip");
+		const installBinary = mock(async () => "/Applications/ClaudeKit Control Center.app");
+		const launchBinary = mock(() => {});
+		const info = mock(() => {});
+		const success = mock(() => {});
+
+		await appCommand(
+			{},
+			{
+				getBinaryPath: () => "/Applications/ClaudeKit Control Center.app",
+				getInstallPath: () => "/Applications/ClaudeKit Control Center.app",
+				getInstallHealth: async () => ({
+					currentVersion: "0.1.0-dev.5",
+					healthy: false,
+					reason: "artifact-invalid",
+				}),
+				downloadBinary,
+				installBinary,
+				launchBinary,
+				uninstallBinary: async () => ({ path: "/unused", removed: false }),
+				info,
+				success,
+				printLine: () => {},
+			},
+		);
+
+		expect(info).toHaveBeenCalledWith(
+			"Installed ClaudeKit Control Center build (0.1.0-dev.5) needs repair. Downloading the latest build...",
+		);
+		expect(downloadBinary).toHaveBeenCalled();
+		expect(installBinary).toHaveBeenCalledWith("/tmp/download.zip");
+		expect(launchBinary).toHaveBeenCalledWith("/Applications/ClaudeKit Control Center.app");
 	});
 
 	test("downloads, installs, and launches when the desktop binary is missing", async () => {

--- a/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
+++ b/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
@@ -170,6 +170,37 @@ describe("desktop-binary-manager", () => {
 		});
 	});
 
+	test("reports missing-binary when update metadata exists but the binary path is gone", async () => {
+		await writeDesktopInstallMetadata(
+			{
+				version: "0.1.0",
+				manifestDate: "2026-04-15T21:00:00Z",
+				channel: "stable",
+				platformKey: "linux-x86_64",
+				assetName: "claudekit-control-center_0.1.0_linux-x86_64.AppImage",
+				assetSize: 202,
+				installedAt: "2026-04-15T21:05:00Z",
+			},
+			{ platform: "linux" },
+		);
+
+		const status = await getDesktopUpdateStatus({
+			channel: "stable",
+			platform: "linux",
+			arch: "x64",
+			fetchManifest: async () => manifest,
+			binaryPath: null,
+			validateInstalledArtifact: async () => true,
+		});
+
+		expect(status).toEqual({
+			currentVersion: "0.1.0",
+			latestVersion: "0.1.0",
+			updateAvailable: true,
+			reason: "missing-binary",
+		});
+	});
+
 	test("reports installed-newer when the installed build is newer on the same channel", async () => {
 		await writeDesktopInstallMetadata(
 			{

--- a/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
+++ b/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
@@ -311,6 +311,34 @@ describe("desktop-binary-manager", () => {
 		});
 	});
 
+	test("does not downgrade when the actual installed bundle is newer than the latest manifest", async () => {
+		const status = await getDesktopUpdateStatus({
+			channel: "stable",
+			platform: "darwin",
+			arch: "arm64",
+			fetchManifest: async () => manifest,
+			readInstallMetadata: async () => ({
+				version: "0.1.0",
+				manifestDate: "2026-04-15T21:00:00Z",
+				channel: "stable",
+				platformKey: "darwin-aarch64",
+				assetName: "claudekit-control-center_0.1.0_macos-universal.app.zip",
+				assetSize: 101,
+				installedAt: "2026-04-15T21:05:00Z",
+			}),
+			binaryPath: "/tmp/ck-phase-3-home/Applications/ClaudeKit Control Center.app",
+			validateInstalledArtifact: async () => false,
+			readInstalledArtifactVersion: async () => "0.1.1",
+		});
+
+		expect(status).toEqual({
+			currentVersion: "0.1.1",
+			latestVersion: "0.1.0",
+			updateAvailable: false,
+			reason: "installed-newer",
+		});
+	});
+
 	test("forces an update when the installed desktop metadata is for a different channel", async () => {
 		const status = await getDesktopUpdateStatus({
 			channel: "stable",

--- a/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
+++ b/src/__tests__/domains/desktop/desktop-binary-manager.test.ts
@@ -3,6 +3,7 @@ import { rm } from "node:fs/promises";
 import {
 	downloadDesktopBinary,
 	getDesktopBinaryPath,
+	getDesktopInstallHealth,
 	getDesktopUpdateStatus,
 } from "@/domains/desktop/desktop-binary-manager.js";
 import { writeDesktopInstallMetadata } from "@/domains/desktop/desktop-install-metadata.js";
@@ -142,6 +143,33 @@ describe("desktop-binary-manager", () => {
 		});
 	});
 
+	test("reports unhealthy install when metadata exists but the binary is missing", async () => {
+		await writeDesktopInstallMetadata(
+			{
+				version: "0.1.0",
+				manifestDate: "2026-04-15T21:00:00Z",
+				channel: "stable",
+				platformKey: "linux-x86_64",
+				assetName: "claudekit-control-center_0.1.0_linux-x86_64.AppImage",
+				assetSize: 202,
+				installedAt: "2026-04-15T21:05:00Z",
+			},
+			{ platform: "linux" },
+		);
+
+		const health = await getDesktopInstallHealth({
+			platform: "linux",
+			binaryPath: null,
+			validateInstalledArtifact: async () => true,
+		});
+
+		expect(health).toEqual({
+			currentVersion: "0.1.0",
+			healthy: false,
+			reason: "missing-binary",
+		});
+	});
+
 	test("reports installed-newer when the installed build is newer on the same channel", async () => {
 		await writeDesktopInstallMetadata(
 			{
@@ -194,6 +222,58 @@ describe("desktop-binary-manager", () => {
 
 		expect(status).toEqual({
 			currentVersion: "0.1.0",
+			latestVersion: "0.1.0",
+			updateAvailable: true,
+			reason: "update-available",
+		});
+	});
+
+	test("reports the actual installed version when install health detects artifact drift", async () => {
+		const health = await getDesktopInstallHealth({
+			platform: "darwin",
+			binaryPath: "/tmp/ck-phase-3-home/Applications/ClaudeKit Control Center.app",
+			readInstallMetadata: async () => ({
+				version: "0.1.0-dev.6",
+				manifestDate: "2026-04-20T03:29:54Z",
+				channel: "dev",
+				platformKey: "darwin-aarch64",
+				assetName: "claudekit-control-center_0.1.0-dev.6_macos-universal.app.zip",
+				assetSize: 12598654,
+				installedAt: "2026-04-20T03:31:34.201Z",
+			}),
+			validateInstalledArtifact: async () => false,
+			readInstalledArtifactVersion: async () => "0.1.0-dev.5",
+		});
+
+		expect(health).toEqual({
+			currentVersion: "0.1.0-dev.5",
+			healthy: false,
+			reason: "artifact-invalid",
+		});
+	});
+
+	test("reports the actual installed bundle version when metadata is ahead of the artifact", async () => {
+		const status = await getDesktopUpdateStatus({
+			channel: "stable",
+			platform: "darwin",
+			arch: "arm64",
+			fetchManifest: async () => manifest,
+			readInstallMetadata: async () => ({
+				version: "0.1.0-dev.6",
+				manifestDate: "2026-04-15T21:00:00Z",
+				channel: "stable",
+				platformKey: "darwin-aarch64",
+				assetName: "claudekit-control-center_0.1.0_macos-universal.app.zip",
+				assetSize: 101,
+				installedAt: "2026-04-15T21:05:00Z",
+			}),
+			binaryPath: "/tmp/ck-phase-3-home/Applications/ClaudeKit Control Center.app",
+			validateInstalledArtifact: async () => false,
+			readInstalledArtifactVersion: async () => "0.1.0-dev.5",
+		});
+
+		expect(status).toEqual({
+			currentVersion: "0.1.0-dev.5",
 			latestVersion: "0.1.0",
 			updateAvailable: true,
 			reason: "update-available",

--- a/src/__tests__/domains/desktop/desktop-bundle-version.test.ts
+++ b/src/__tests__/domains/desktop/desktop-bundle-version.test.ts
@@ -124,4 +124,23 @@ describe("desktop-bundle-version", () => {
 		expect(synced.bundle.windows.wix.version).toBe("0.1.7");
 		expect(() => validateDesktopBundleConfig(synced)).not.toThrow();
 	});
+
+	test("preserves an equivalent four-part wix.version during sync no-op checks", () => {
+		const synced = synchronizeDesktopBundleConfig(
+			{
+				version: "0.1.0",
+				bundle: {
+					windows: {
+						wix: {
+							version: "0.1.511.0",
+						},
+					},
+				},
+			},
+			"0.1.0",
+		);
+
+		expect(synced.bundle.windows.wix.version).toBe("0.1.511.0");
+		expect(() => validateDesktopBundleConfig(synced)).not.toThrow();
+	});
 });

--- a/src/__tests__/domains/desktop/desktop-bundle-version.test.ts
+++ b/src/__tests__/domains/desktop/desktop-bundle-version.test.ts
@@ -10,6 +10,7 @@ import { compareVersions } from "compare-versions";
 describe("desktop-bundle-version", () => {
 	test("derives a monotonic MSI-safe version from a prerelease app version", () => {
 		expect(deriveWindowsWixVersion("0.1.0-dev.2")).toBe("0.1.2");
+		expect(deriveWindowsWixVersion("1.0.0-dev.0")).toBe("1.0.0");
 		expect(deriveWindowsWixVersion("1.2.3-rc.12")).toBe("1.2.1932");
 	});
 
@@ -56,6 +57,21 @@ describe("desktop-bundle-version", () => {
 					windows: {
 						wix: {
 							version: "0.1.511.0",
+						},
+					},
+				},
+			}),
+		).not.toThrow();
+	});
+
+	test("accepts a three-part wix.version ending in .0 for dev.0 releases", () => {
+		expect(() =>
+			validateDesktopBundleConfig({
+				version: "1.0.0-dev.0",
+				bundle: {
+					windows: {
+						wix: {
+							version: "1.0.0",
 						},
 					},
 				},

--- a/src/__tests__/domains/desktop/desktop-bundle-version.test.ts
+++ b/src/__tests__/domains/desktop/desktop-bundle-version.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
 	deriveWindowsWixVersion,
+	parseDesktopReleaseVersion,
+	synchronizeDesktopBundleConfig,
 	validateDesktopBundleConfig,
 } from "@/domains/desktop/desktop-bundle-version.js";
 import { compareVersions } from "compare-versions";
@@ -74,5 +76,36 @@ describe("desktop-bundle-version", () => {
 				},
 			}),
 		).toThrow(/requires bundle\.windows\.wix\.version 0\.1\.2/i);
+	});
+
+	test("parses the app version from a desktop release tag", () => {
+		expect(parseDesktopReleaseVersion("desktop-v0.1.0-dev.7")).toBe("0.1.0-dev.7");
+		expect(parseDesktopReleaseVersion("0.1.0-dev.7")).toBe("0.1.0-dev.7");
+	});
+
+	test("synchronizes desktop bundle config version and wix.version from release input", () => {
+		const synced = synchronizeDesktopBundleConfig(
+			{
+				version: "0.1.0-dev.5",
+				productName: "ClaudeKit Control Center",
+				bundle: {
+					active: true,
+					windows: {
+						wix: {
+							version: "0.1.5",
+							language: "en-US",
+						},
+					},
+				},
+			},
+			"desktop-v0.1.0-dev.7",
+		);
+
+		expect(synced.version).toBe("0.1.0-dev.7");
+		expect(synced.productName).toBe("ClaudeKit Control Center");
+		expect(synced.bundle.active).toBe(true);
+		expect(synced.bundle.windows.wix.language).toBe("en-US");
+		expect(synced.bundle.windows.wix.version).toBe("0.1.7");
+		expect(() => validateDesktopBundleConfig(synced)).not.toThrow();
 	});
 });

--- a/src/__tests__/domains/desktop/desktop-installed-artifact-validator.test.ts
+++ b/src/__tests__/domains/desktop/desktop-installed-artifact-validator.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { validateInstalledDesktopArtifact } from "@/domains/desktop/desktop-installed-artifact-validator.js";
+import {
+	readInstalledDesktopArtifactVersion,
+	validateInstalledDesktopArtifact,
+} from "@/domains/desktop/desktop-installed-artifact-validator.js";
 
 describe("desktop-installed-artifact-validator", () => {
 	test("matches the exact CFBundleShortVersionString value on macOS", async () => {
@@ -54,5 +57,23 @@ describe("desktop-installed-artifact-validator", () => {
 		);
 
 		expect(isValid).toBe(false);
+	});
+
+	test("reads the exact macOS bundle version from Info.plist", async () => {
+		const version = await readInstalledDesktopArtifactVersion(
+			"/Applications/ClaudeKit Control Center.app",
+			{
+				platform: "darwin",
+				readFileFn: async () => `<?xml version="1.0"?>
+<plist>
+  <dict>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0-dev.7</string>
+  </dict>
+</plist>`,
+			},
+		);
+
+		expect(version).toBe("0.1.0-dev.7");
 	});
 });

--- a/src/__tests__/domains/desktop/desktop-installer.test.ts
+++ b/src/__tests__/domains/desktop/desktop-installer.test.ts
@@ -108,6 +108,43 @@ describe("desktop-installer", () => {
 		expect(await Bun.file(installedPath).text()).toBe("linux-binary");
 	});
 
+	test("keeps a successful linux install when backup cleanup fails after swap", async () => {
+		const installDir = "/tmp/ck-phase-3-installer-home/.local/bin";
+		await mkdir(installDir, { recursive: true });
+		const installedPath = join(installDir, "claudekit-control-center");
+		const backupPath = join(installDir, "claudekit-control-center.backup");
+		await writeFile(installedPath, "old-linux-binary");
+
+		const fixturesDir = "/tmp/ck-phase-3-installer-fixtures";
+		await mkdir(fixturesDir, { recursive: true });
+		const sourcePath = join(fixturesDir, "claudekit-control-center.AppImage");
+		await writeFile(sourcePath, "new-linux-binary");
+
+		try {
+			const result = await installDesktopBinary(sourcePath, {
+				platform: "linux",
+				readDownloadedMetadataFn: async () => ({
+					version: "0.1.0-dev.2",
+					manifestDate: "2026-04-19T00:00:00Z",
+					channel: "dev",
+					platformKey: "linux-x86_64",
+					assetName: "claudekit-control-center_0.1.0-dev.2_linux-x86_64.AppImage",
+					assetSize: "new-linux-binary".length,
+					installedAt: "2026-04-19T00:00:00Z",
+				}),
+				persistInstallMetadataFn: async () => {
+					await chmod(installDir, 0o555);
+				},
+			});
+
+			expect(result).toBe(installedPath);
+			expect(await Bun.file(installedPath).text()).toBe("new-linux-binary");
+			expect(await Bun.file(backupPath).text()).toBe("old-linux-binary");
+		} finally {
+			await chmod(installDir, 0o755);
+		}
+	});
+
 	test("rejects a linux install when the copied artifact does not match downloaded metadata", async () => {
 		const fixturesDir = "/tmp/ck-phase-3-installer-fixtures";
 		await mkdir(fixturesDir, { recursive: true });

--- a/src/__tests__/domains/desktop/desktop-installer.test.ts
+++ b/src/__tests__/domains/desktop/desktop-installer.test.ts
@@ -31,7 +31,7 @@ describe("desktop-installer", () => {
 				channel: "dev",
 				platformKey: "linux-x86_64",
 				assetName: "claudekit-control-center_0.1.0-dev.2_linux-x86_64.AppImage",
-				assetSize: 111,
+				assetSize: "linux-binary".length,
 				installedAt: "2026-04-19T00:00:00Z",
 			}),
 		);
@@ -51,7 +51,7 @@ describe("desktop-installer", () => {
 			channel: "dev",
 			platformKey: "linux-x86_64",
 			assetName: "claudekit-control-center_0.1.0-dev.2_linux-x86_64.AppImage",
-			assetSize: 111,
+			assetSize: "linux-binary".length,
 			installedAt: "2026-04-19T00:00:00Z",
 		});
 	});
@@ -94,7 +94,7 @@ describe("desktop-installer", () => {
 				channel: "dev",
 				platformKey: "linux-x86_64",
 				assetName: "claudekit-control-center_0.1.0-dev.2_linux-x86_64.AppImage",
-				assetSize: 111,
+				assetSize: "linux-binary".length,
 				installedAt: "2026-04-19T00:00:00Z",
 			}),
 			persistInstallMetadataFn: async () => {
@@ -106,6 +106,68 @@ describe("desktop-installer", () => {
 			"/tmp/ck-phase-3-installer-home/.local/bin/claudekit-control-center",
 		);
 		expect(await Bun.file(installedPath).text()).toBe("linux-binary");
+	});
+
+	test("rejects a linux install when the copied artifact does not match downloaded metadata", async () => {
+		const fixturesDir = "/tmp/ck-phase-3-installer-fixtures";
+		await mkdir(fixturesDir, { recursive: true });
+		const sourcePath = join(fixturesDir, "claudekit-control-center.AppImage");
+		await writeFile(sourcePath, "linux-binary");
+		await writeFile(
+			`${sourcePath}.metadata.json`,
+			JSON.stringify({
+				version: "0.1.0-dev.7",
+				manifestDate: "2026-04-20T00:00:00Z",
+				channel: "dev",
+				platformKey: "linux-x86_64",
+				assetName: "claudekit-control-center_0.1.0-dev.7_linux-x86_64.AppImage",
+				assetSize: 999,
+				installedAt: "2026-04-20T00:00:00Z",
+			}),
+		);
+
+		await expect(
+			installDesktopBinary(sourcePath, {
+				platform: "linux",
+			}),
+		).rejects.toThrow(/failed validation/i);
+
+		await expect(
+			stat("/tmp/ck-phase-3-installer-home/.local/bin/claudekit-control-center"),
+		).rejects.toThrow();
+		expect(await readDesktopInstallMetadata({ platform: "linux" })).toBeNull();
+	});
+
+	test("restores the previous linux binary when validation fails after overwrite", async () => {
+		const installDir = "/tmp/ck-phase-3-installer-home/.local/bin";
+		await mkdir(installDir, { recursive: true });
+		const installedPath = join(installDir, "claudekit-control-center");
+		await writeFile(installedPath, "old-linux-binary");
+
+		const fixturesDir = "/tmp/ck-phase-3-installer-fixtures";
+		await mkdir(fixturesDir, { recursive: true });
+		const sourcePath = join(fixturesDir, "claudekit-control-center.AppImage");
+		await writeFile(sourcePath, "new-linux-binary");
+		await writeFile(
+			`${sourcePath}.metadata.json`,
+			JSON.stringify({
+				version: "0.1.0-dev.7",
+				manifestDate: "2026-04-20T00:00:00Z",
+				channel: "dev",
+				platformKey: "linux-x86_64",
+				assetName: "claudekit-control-center_0.1.0-dev.7_linux-x86_64.AppImage",
+				assetSize: 999,
+				installedAt: "2026-04-20T00:00:00Z",
+			}),
+		);
+
+		await expect(
+			installDesktopBinary(sourcePath, {
+				platform: "linux",
+			}),
+		).rejects.toThrow(/failed validation/i);
+
+		expect(await Bun.file(installedPath).text()).toBe("old-linux-binary");
 	});
 
 	test("preserves the existing macOS install when quarantine removal fails before swap", async () => {
@@ -132,6 +194,54 @@ describe("desktop-installer", () => {
 				},
 			}),
 		).rejects.toThrow(/quarantine failed/);
+
+		expect(
+			await Bun.file(
+				"/tmp/ck-phase-3-installer-home/Applications/ClaudeKit Control Center.app/Contents/Info.plist",
+			).text(),
+		).toBe("old-version");
+	});
+
+	test("restores the previous macOS app when the swapped bundle fails release validation", async () => {
+		const currentInstallPath =
+			"/tmp/ck-phase-3-installer-home/Applications/ClaudeKit Control Center.app/Contents";
+		await mkdir(currentInstallPath, { recursive: true });
+		await writeFile(join(currentInstallPath, "Info.plist"), "old-version");
+
+		const fixturesDir = "/tmp/ck-phase-3-installer-fixtures";
+		await mkdir(fixturesDir, { recursive: true });
+		const downloadPath = join(fixturesDir, "claudekit-control-center.app.zip");
+		await writeFile(downloadPath, "placeholder");
+
+		await expect(
+			installDesktopBinary(downloadPath, {
+				platform: "darwin",
+				readDownloadedMetadataFn: async () => ({
+					version: "0.1.0-dev.7",
+					manifestDate: "2026-04-20T00:00:00Z",
+					channel: "dev",
+					platformKey: "darwin-aarch64",
+					assetName: "claudekit-control-center_0.1.0-dev.7_macos-universal.app.zip",
+					assetSize: 0,
+					installedAt: "2026-04-20T00:00:00Z",
+				}),
+				extractZipFn: async (_source, config) => {
+					const appDir = join(config.dir, "ClaudeKit Control Center.app", "Contents");
+					await mkdir(appDir, { recursive: true });
+					await writeFile(
+						join(appDir, "Info.plist"),
+						`<?xml version="1.0"?>
+<plist>
+  <dict>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0-dev.5</string>
+  </dict>
+</plist>`,
+					);
+				},
+				removeQuarantineFn: async () => {},
+			}),
+		).rejects.toThrow(/failed validation/i);
 
 		expect(
 			await Bun.file(

--- a/src/commands/app/app-command.ts
+++ b/src/commands/app/app-command.ts
@@ -62,6 +62,7 @@ export async function appCommand(
 	const info = deps.info || output.info.bind(output);
 	const success = deps.success || output.success.bind(output);
 	const printLine = deps.printLine || console.log;
+	let repairingInstall = false;
 
 	if (options.web) {
 		info("Opening ClaudeKit web dashboard...");
@@ -104,6 +105,7 @@ export async function appCommand(
 					? `Installed ClaudeKit Control Center build (${installHealth.currentVersion}) needs repair. Downloading the latest build...`
 					: "Installed ClaudeKit Control Center needs repair. Downloading the latest build...",
 			);
+			repairingInstall = true;
 		} catch {
 			success("Launching ClaudeKit Control Center...");
 			launchBinary(existingBinary);
@@ -125,11 +127,11 @@ export async function appCommand(
 		}
 	}
 
-	info(
-		options.update
-			? "Downloading and installing the latest ClaudeKit Control Center build..."
-			: "ClaudeKit Control Center not found. Downloading...",
-	);
+	if (options.update) {
+		info("Downloading and installing the latest ClaudeKit Control Center build...");
+	} else if (!repairingInstall) {
+		info("ClaudeKit Control Center not found. Downloading...");
+	}
 	const downloadedBinary = await downloadBinary({ channel });
 	const installedBinary = await installBinary(downloadedBinary);
 	success(`Installed ClaudeKit Control Center to ${installedBinary}`);

--- a/src/commands/app/app-command.ts
+++ b/src/commands/app/app-command.ts
@@ -3,6 +3,7 @@ import type { DesktopChannel } from "@/domains/desktop/desktop-release-service.j
 import {
 	downloadDesktopBinary,
 	getDesktopBinaryPath,
+	getDesktopInstallHealth,
 	getDesktopInstallPath,
 	getDesktopUpdateStatus,
 	installDesktopBinary,
@@ -49,6 +50,7 @@ export async function appCommand(
 	const launchWeb = deps.launchWeb || configUICommand;
 	const getBinaryPath = deps.getBinaryPath || getDesktopBinaryPath;
 	const getInstallPath = deps.getInstallPath || getDesktopInstallPath;
+	const getInstallHealth = deps.getInstallHealth || getDesktopInstallHealth;
 	const getUpdateStatus = deps.getUpdateStatus || getDesktopUpdateStatus;
 	const downloadBinary =
 		deps.downloadBinary ||
@@ -89,9 +91,24 @@ export async function appCommand(
 
 	const existingBinary = getBinaryPath();
 	if (existingBinary && !options.update) {
-		success("Launching ClaudeKit Control Center...");
-		launchBinary(existingBinary);
-		return;
+		try {
+			const installHealth = await getInstallHealth({ binaryPath: existingBinary });
+			if (installHealth.healthy) {
+				success("Launching ClaudeKit Control Center...");
+				launchBinary(existingBinary);
+				return;
+			}
+
+			info(
+				installHealth.currentVersion
+					? `Installed ClaudeKit Control Center build (${installHealth.currentVersion}) needs repair. Downloading the latest build...`
+					: "Installed ClaudeKit Control Center needs repair. Downloading the latest build...",
+			);
+		} catch {
+			success("Launching ClaudeKit Control Center...");
+			launchBinary(existingBinary);
+			return;
+		}
 	}
 
 	if (options.update && existingBinary) {

--- a/src/commands/app/app-command.ts
+++ b/src/commands/app/app-command.ts
@@ -94,7 +94,7 @@ export async function appCommand(
 	if (existingBinary && !options.update) {
 		try {
 			const installHealth = await getInstallHealth({ binaryPath: existingBinary });
-			if (installHealth.healthy) {
+			if (installHealth.healthy || installHealth.reason === "missing-metadata") {
 				success("Launching ClaudeKit Control Center...");
 				launchBinary(existingBinary);
 				return;

--- a/src/commands/app/types.ts
+++ b/src/commands/app/types.ts
@@ -1,5 +1,8 @@
 import type { ConfigUIOptions } from "@/commands/config/types.js";
-import type { DesktopUpdateStatus } from "@/domains/desktop/desktop-binary-manager.js";
+import type {
+	DesktopInstallHealth,
+	DesktopUpdateStatus,
+} from "@/domains/desktop/desktop-binary-manager.js";
 import type { DesktopChannel } from "@/domains/desktop/desktop-release-service.js";
 import type { DesktopUninstallResult } from "@/domains/desktop/desktop-uninstaller.js";
 
@@ -20,6 +23,7 @@ export interface AppCommandDependencies {
 		channel?: DesktopChannel;
 		binaryPath?: string | null;
 	}) => Promise<DesktopUpdateStatus>;
+	getInstallHealth?: (opts?: { binaryPath?: string | null }) => Promise<DesktopInstallHealth>;
 	downloadBinary?: (opts?: { channel?: DesktopChannel }) => Promise<string>;
 	installBinary?: (downloadPath: string) => Promise<string>;
 	launchBinary?: (binaryPath: string) => void;

--- a/src/domains/desktop/desktop-binary-manager.ts
+++ b/src/domains/desktop/desktop-binary-manager.ts
@@ -85,7 +85,12 @@ export interface DesktopUpdateStatus {
 	currentVersion: string | null;
 	latestVersion: string;
 	updateAvailable: boolean;
-	reason: "up-to-date" | "update-available" | "installed-newer" | "unknown-installed-version";
+	reason:
+		| "up-to-date"
+		| "update-available"
+		| "installed-newer"
+		| "unknown-installed-version"
+		| "missing-binary";
 }
 
 export interface DesktopInstallHealth {
@@ -182,7 +187,7 @@ export async function getDesktopUpdateStatus(
 			currentVersion: installed.version,
 			latestVersion,
 			updateAvailable: true,
-			reason: "unknown-installed-version",
+			reason: "missing-binary",
 		};
 	}
 

--- a/src/domains/desktop/desktop-binary-manager.ts
+++ b/src/domains/desktop/desktop-binary-manager.ts
@@ -191,20 +191,32 @@ export async function getDesktopUpdateStatus(
 		};
 	}
 
+	const sameChannel = installed.channel === requestedChannel;
+	const samePlatform = installed.platformKey === platformKey;
+
 	if (!(await validateInstalledArtifact(binaryPath, installed, { platform: options.platform }))) {
 		const installedArtifactVersion = await readInstalledArtifactVersion(binaryPath, {
 			platform: options.platform,
 		});
+		const currentVersion = installedArtifactVersion || installed.version;
+		const installedArtifactIsNewer =
+			sameChannel && samePlatform && isNewerVersion(latestVersion, currentVersion);
+		if (installedArtifactIsNewer) {
+			return {
+				currentVersion,
+				latestVersion,
+				updateAvailable: false,
+				reason: "installed-newer",
+			};
+		}
 		return {
-			currentVersion: installedArtifactVersion || installed.version,
+			currentVersion,
 			latestVersion,
 			updateAvailable: true,
 			reason: "update-available",
 		};
 	}
 
-	const sameChannel = installed.channel === requestedChannel;
-	const samePlatform = installed.platformKey === platformKey;
 	const metadataMatchesRelease =
 		sameChannel &&
 		installed.platformKey === platformKey &&

--- a/src/domains/desktop/desktop-binary-manager.ts
+++ b/src/domains/desktop/desktop-binary-manager.ts
@@ -12,7 +12,10 @@ import {
 	getDesktopDownloadDirectory,
 	getDesktopInstallPath,
 } from "@/domains/desktop/desktop-install-path-resolver.js";
-import { validateInstalledDesktopArtifact } from "@/domains/desktop/desktop-installed-artifact-validator.js";
+import {
+	readInstalledDesktopArtifactVersion,
+	validateInstalledDesktopArtifact,
+} from "@/domains/desktop/desktop-installed-artifact-validator.js";
 import { installDesktopBinary } from "@/domains/desktop/desktop-installer.js";
 import {
 	type DesktopChannel,
@@ -85,6 +88,63 @@ export interface DesktopUpdateStatus {
 	reason: "up-to-date" | "update-available" | "installed-newer" | "unknown-installed-version";
 }
 
+export interface DesktopInstallHealth {
+	currentVersion: string | null;
+	healthy: boolean;
+	reason: "healthy" | "missing-metadata" | "missing-binary" | "artifact-invalid";
+}
+
+export async function getDesktopInstallHealth(
+	options: {
+		platform?: NodeJS.Platform;
+		readInstallMetadata?: typeof readDesktopInstallMetadata;
+		binaryPath?: string | null;
+		validateInstalledArtifact?: typeof validateInstalledDesktopArtifact;
+		readInstalledArtifactVersion?: typeof readInstalledDesktopArtifactVersion;
+	} = {},
+): Promise<DesktopInstallHealth> {
+	const readInstallMetadata = options.readInstallMetadata || readDesktopInstallMetadata;
+	const validateInstalledArtifact =
+		options.validateInstalledArtifact || validateInstalledDesktopArtifact;
+	const readInstalledArtifactVersion =
+		options.readInstalledArtifactVersion || readInstalledDesktopArtifactVersion;
+	const installed = await readInstallMetadata({ platform: options.platform });
+
+	if (!installed) {
+		return {
+			currentVersion: null,
+			healthy: false,
+			reason: "missing-metadata",
+		};
+	}
+
+	const binaryPath = options.binaryPath || getDesktopBinaryPath({ platform: options.platform });
+	if (!binaryPath) {
+		return {
+			currentVersion: installed.version,
+			healthy: false,
+			reason: "missing-binary",
+		};
+	}
+
+	if (!(await validateInstalledArtifact(binaryPath, installed, { platform: options.platform }))) {
+		const installedArtifactVersion = await readInstalledArtifactVersion(binaryPath, {
+			platform: options.platform,
+		});
+		return {
+			currentVersion: installedArtifactVersion || installed.version,
+			healthy: false,
+			reason: "artifact-invalid",
+		};
+	}
+
+	return {
+		currentVersion: installed.version,
+		healthy: true,
+		reason: "healthy",
+	};
+}
+
 export async function getDesktopUpdateStatus(
 	options: {
 		channel?: DesktopChannel;
@@ -94,6 +154,7 @@ export async function getDesktopUpdateStatus(
 		readInstallMetadata?: typeof readDesktopInstallMetadata;
 		binaryPath?: string | null;
 		validateInstalledArtifact?: typeof validateInstalledDesktopArtifact;
+		readInstalledArtifactVersion?: typeof readInstalledDesktopArtifactVersion;
 	} = {},
 ): Promise<DesktopUpdateStatus> {
 	const { manifest, entry, platformKey } = await resolveDesktopReleaseAsset(undefined, options);
@@ -101,6 +162,8 @@ export async function getDesktopUpdateStatus(
 	const readInstallMetadata = options.readInstallMetadata || readDesktopInstallMetadata;
 	const validateInstalledArtifact =
 		options.validateInstalledArtifact || validateInstalledDesktopArtifact;
+	const readInstalledArtifactVersion =
+		options.readInstalledArtifactVersion || readInstalledDesktopArtifactVersion;
 	const installed = await readInstallMetadata({ platform: options.platform });
 	const requestedChannel = options.channel ?? "stable";
 
@@ -124,8 +187,11 @@ export async function getDesktopUpdateStatus(
 	}
 
 	if (!(await validateInstalledArtifact(binaryPath, installed, { platform: options.platform }))) {
+		const installedArtifactVersion = await readInstalledArtifactVersion(binaryPath, {
+			platform: options.platform,
+		});
 		return {
-			currentVersion: installed.version,
+			currentVersion: installedArtifactVersion || installed.version,
 			latestVersion,
 			updateAvailable: true,
 			reason: "update-available",

--- a/src/domains/desktop/desktop-bundle-version.ts
+++ b/src/domains/desktop/desktop-bundle-version.ts
@@ -38,6 +38,10 @@ function normalizeWindowsWixVersion(version: string): string {
 	return /^\d+\.\d+\.\d+\.0$/.test(version) ? version.slice(0, -2) : version;
 }
 
+function windowsWixVersionsMatch(actualVersion: string, expectedVersion: string): boolean {
+	return normalizeWindowsWixVersion(actualVersion) === expectedVersion;
+}
+
 export function parseDesktopReleaseVersion(input: string): string {
 	const trimmed = input.trim();
 	if (trimmed.startsWith("desktop-v")) {
@@ -96,7 +100,7 @@ export function validateDesktopBundleConfig(config: DesktopBundleConfig): {
 	const expectedWixVersion = deriveWindowsWixVersion(appVersion);
 	const actualWixVersion = config.bundle.windows.wix.version;
 
-	if (normalizeWindowsWixVersion(actualWixVersion) !== expectedWixVersion) {
+	if (!windowsWixVersionsMatch(actualWixVersion, expectedWixVersion)) {
 		throw new Error(
 			`Desktop Windows MSI version mismatch: tauri.conf version ${appVersion} requires bundle.windows.wix.version ${expectedWixVersion} (or ${expectedWixVersion}.0), found ${actualWixVersion}`,
 		);
@@ -115,7 +119,10 @@ export function synchronizeDesktopBundleConfig(
 ): DesktopBundleConfig {
 	const appVersion = parseDesktopReleaseVersion(inputVersion);
 	const wixVersion = deriveWindowsWixVersion(appVersion);
-	if (config.version === appVersion && config.bundle.windows.wix.version === wixVersion) {
+	const currentWixVersion = config.bundle.windows.wix.version;
+	const wixVersionMatches = windowsWixVersionsMatch(currentWixVersion, wixVersion);
+
+	if (config.version === appVersion && wixVersionMatches) {
 		return config;
 	}
 	return {
@@ -127,7 +134,7 @@ export function synchronizeDesktopBundleConfig(
 				...config.bundle.windows,
 				wix: {
 					...config.bundle.windows.wix,
-					version: wixVersion,
+					version: wixVersionMatches ? currentWixVersion : wixVersion,
 				},
 			},
 		},

--- a/src/domains/desktop/desktop-bundle-version.ts
+++ b/src/domains/desktop/desktop-bundle-version.ts
@@ -35,7 +35,7 @@ const DesktopBundleConfigSchema = z
 export type DesktopBundleConfig = z.infer<typeof DesktopBundleConfigSchema>;
 
 function normalizeWindowsWixVersion(version: string): string {
-	return version.endsWith(".0") ? version.slice(0, -2) : version;
+	return /^\d+\.\d+\.\d+\.0$/.test(version) ? version.slice(0, -2) : version;
 }
 
 export function parseDesktopReleaseVersion(input: string): string {

--- a/src/domains/desktop/desktop-bundle-version.ts
+++ b/src/domains/desktop/desktop-bundle-version.ts
@@ -13,21 +13,37 @@ const WINDOWS_MSI_PRERELEASE_BASES = {
 	rc: 384,
 } as const;
 
-const DesktopBundleConfigSchema = z.object({
-	version: z.string().min(1),
-	bundle: z.object({
-		windows: z.object({
-			wix: z.object({
-				version: z.string().min(1),
-			}),
-		}),
-	}),
-});
+const DesktopBundleConfigSchema = z
+	.object({
+		version: z.string().min(1),
+		bundle: z
+			.object({
+				windows: z
+					.object({
+						wix: z
+							.object({
+								version: z.string().min(1),
+							})
+							.passthrough(),
+					})
+					.passthrough(),
+			})
+			.passthrough(),
+	})
+	.passthrough();
 
-type DesktopBundleConfig = z.infer<typeof DesktopBundleConfigSchema>;
+export type DesktopBundleConfig = z.infer<typeof DesktopBundleConfigSchema>;
 
 function normalizeWindowsWixVersion(version: string): string {
 	return version.endsWith(".0") ? version.slice(0, -2) : version;
+}
+
+export function parseDesktopReleaseVersion(input: string): string {
+	const trimmed = input.trim();
+	if (trimmed.startsWith("desktop-v")) {
+		return trimmed.slice("desktop-v".length);
+	}
+	return trimmed;
 }
 
 export function deriveWindowsWixVersion(appVersion: string): string {
@@ -90,6 +106,31 @@ export function validateDesktopBundleConfig(config: DesktopBundleConfig): {
 		appVersion,
 		expectedWixVersion,
 		actualWixVersion,
+	};
+}
+
+export function synchronizeDesktopBundleConfig(
+	config: DesktopBundleConfig,
+	inputVersion: string,
+): DesktopBundleConfig {
+	const appVersion = parseDesktopReleaseVersion(inputVersion);
+	const wixVersion = deriveWindowsWixVersion(appVersion);
+	if (config.version === appVersion && config.bundle.windows.wix.version === wixVersion) {
+		return config;
+	}
+	return {
+		...config,
+		version: appVersion,
+		bundle: {
+			...config.bundle,
+			windows: {
+				...config.bundle.windows,
+				wix: {
+					...config.bundle.windows.wix,
+					version: wixVersion,
+				},
+			},
+		},
 	};
 }
 

--- a/src/domains/desktop/desktop-installed-artifact-validator.ts
+++ b/src/domains/desktop/desktop-installed-artifact-validator.ts
@@ -6,6 +6,30 @@ function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+const MAC_BUNDLE_VERSION_PATTERN =
+	/<key>\s*CFBundleShortVersionString\s*<\/key>\s*<string>([^<]+)<\/string>/;
+
+export async function readInstalledDesktopArtifactVersion(
+	binaryPath: string,
+	options: {
+		platform?: NodeJS.Platform;
+		readFileFn?: (path: string, encoding: "utf8") => Promise<string>;
+	} = {},
+): Promise<string | null> {
+	const platform = options.platform || process.platform;
+	if (platform !== "darwin") {
+		return null;
+	}
+
+	const readFileFn = options.readFileFn || readFile;
+	try {
+		const infoPlist = await readFileFn(join(binaryPath, "Contents", "Info.plist"), "utf8");
+		return infoPlist.match(MAC_BUNDLE_VERSION_PATTERN)?.[1] ?? null;
+	} catch {
+		return null;
+	}
+}
+
 export async function validateInstalledDesktopArtifact(
 	binaryPath: string,
 	metadata: DesktopInstallMetadata,
@@ -26,11 +50,15 @@ export async function validateInstalledDesktopArtifact(
 		}
 
 		if (platform === "darwin") {
-			const infoPlist = await readFileFn(join(binaryPath, "Contents", "Info.plist"), "utf8");
-			const versionPattern = new RegExp(
-				`<key>\\s*CFBundleShortVersionString\\s*</key>\\s*<string>${escapeRegExp(metadata.version)}</string>`,
-			);
-			return versionPattern.test(infoPlist);
+			const installedVersion = await readInstalledDesktopArtifactVersion(binaryPath, {
+				platform,
+				readFileFn,
+			});
+			if (!installedVersion) {
+				return false;
+			}
+			const versionPattern = new RegExp(`^${escapeRegExp(metadata.version)}$`);
+			return versionPattern.test(installedVersion);
 		}
 	} catch {
 		return false;

--- a/src/domains/desktop/desktop-installer.ts
+++ b/src/domains/desktop/desktop-installer.ts
@@ -50,6 +50,16 @@ async function persistInstallMetadataAfterSuccess(
 	}
 }
 
+async function removeBackupInstallPathAfterSuccess(backupInstallPath: string): Promise<void> {
+	try {
+		await remove(backupInstallPath);
+	} catch (error) {
+		logger.warning(
+			`Desktop install succeeded, but failed to remove backup install at ${backupInstallPath}: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
 async function findAppBundle(rootDir: string): Promise<string> {
 	const entries = await readdir(rootDir, { withFileTypes: true });
 	for (const entry of entries) {
@@ -131,7 +141,7 @@ export async function installDesktopBinary(
 				validateInstalledArtifactFn,
 				persistInstallMetadataFn,
 			);
-			await remove(backupInstallPath);
+			await removeBackupInstallPathAfterSuccess(backupInstallPath);
 		} catch (error) {
 			if (await pathExists(backupInstallPath)) {
 				if (await pathExists(targetPath)) {
@@ -166,7 +176,7 @@ export async function installDesktopBinary(
 				validateInstalledArtifactFn,
 				persistInstallMetadataFn,
 			);
-			await remove(backupInstallPath);
+			await removeBackupInstallPathAfterSuccess(backupInstallPath);
 		} catch (error) {
 			if (await pathExists(backupInstallPath)) {
 				if (await pathExists(targetPath)) {
@@ -197,7 +207,7 @@ export async function installDesktopBinary(
 				validateInstalledArtifactFn,
 				persistInstallMetadataFn,
 			);
-			await remove(backupInstallPath);
+			await removeBackupInstallPathAfterSuccess(backupInstallPath);
 		} catch (error) {
 			if (await pathExists(backupInstallPath)) {
 				if (await pathExists(targetPath)) {

--- a/src/domains/desktop/desktop-installer.ts
+++ b/src/domains/desktop/desktop-installer.ts
@@ -11,6 +11,7 @@ import {
 	getDesktopInstallDirectory,
 	getDesktopInstallPath,
 } from "@/domains/desktop/desktop-install-path-resolver.js";
+import { validateInstalledDesktopArtifact } from "@/domains/desktop/desktop-installed-artifact-validator.js";
 import { logger } from "@/shared/logger.js";
 import { copy, copyFile, ensureDir, pathExists, remove } from "fs-extra";
 
@@ -18,18 +19,30 @@ const execFileAsync = promisify(execFile);
 
 async function persistInstallMetadataAfterSuccess(
 	downloadPath: string,
+	targetPath: string,
+	platform: NodeJS.Platform,
 	readDownloadedMetadataFn: (
 		downloadPath: string,
 	) => Promise<Awaited<ReturnType<typeof readDownloadedDesktopMetadata>>>,
+	validateInstalledArtifactFn: typeof validateInstalledDesktopArtifact,
 	persistInstallMetadataFn: (
 		metadata: NonNullable<Awaited<ReturnType<typeof readDownloadedDesktopMetadata>>>,
 	) => Promise<void>,
 ): Promise<void> {
+	const metadata = await readDownloadedMetadataFn(downloadPath);
+	if (!metadata) {
+		return;
+	}
+
+	const isValid = await validateInstalledArtifactFn(targetPath, metadata, { platform });
+	if (!isValid) {
+		throw new Error(
+			`Installed desktop artifact at ${targetPath} failed validation for release ${metadata.version}`,
+		);
+	}
+
 	try {
-		const metadata = await readDownloadedMetadataFn(downloadPath);
-		if (metadata) {
-			await persistInstallMetadataFn(metadata);
-		}
+		await persistInstallMetadataFn(metadata);
 	} catch (error) {
 		logger.warning(
 			`Desktop install succeeded, but failed to persist install metadata: ${error instanceof Error ? error.message : String(error)}`,
@@ -64,6 +77,7 @@ export async function installDesktopBinary(
 		readDownloadedMetadataFn?: (
 			downloadPath: string,
 		) => Promise<Awaited<ReturnType<typeof readDownloadedDesktopMetadata>>>;
+		validateInstalledArtifactFn?: typeof validateInstalledDesktopArtifact;
 		persistInstallMetadataFn?: (
 			metadata: NonNullable<Awaited<ReturnType<typeof readDownloadedDesktopMetadata>>>,
 		) => Promise<void>;
@@ -73,6 +87,8 @@ export async function installDesktopBinary(
 	const targetPath = getDesktopInstallPath({ platform });
 	const readDownloadedMetadataFn =
 		options.readDownloadedMetadataFn || readDownloadedDesktopMetadata;
+	const validateInstalledArtifactFn =
+		options.validateInstalledArtifactFn || validateInstalledDesktopArtifact;
 	const persistInstallMetadataFn =
 		options.persistInstallMetadataFn ||
 		((metadata: NonNullable<Awaited<ReturnType<typeof readDownloadedDesktopMetadata>>>) =>
@@ -94,6 +110,7 @@ export async function installDesktopBinary(
 		const stagingDir = await mkdtemp(join(tmpdir(), "ck-desktop-app-"));
 		const stagedInstallPath = join(dirname(targetPath), `${basename(targetPath)}.new`);
 		const backupInstallPath = join(dirname(targetPath), `${basename(targetPath)}.backup`);
+		let swappedInstall = false;
 		try {
 			await extractZipFn(downloadPath, { dir: stagingDir });
 			const appBundlePath = await findAppBundle(stagingDir);
@@ -105,42 +122,93 @@ export async function installDesktopBinary(
 				await rename(targetPath, backupInstallPath);
 			}
 			await rename(stagedInstallPath, targetPath);
+			swappedInstall = true;
+			await persistInstallMetadataAfterSuccess(
+				downloadPath,
+				targetPath,
+				platform,
+				readDownloadedMetadataFn,
+				validateInstalledArtifactFn,
+				persistInstallMetadataFn,
+			);
 			await remove(backupInstallPath);
 		} catch (error) {
-			if ((await pathExists(backupInstallPath)) && !(await pathExists(targetPath))) {
+			if (await pathExists(backupInstallPath)) {
+				if (await pathExists(targetPath)) {
+					await remove(targetPath);
+				}
 				await rename(backupInstallPath, targetPath);
+			} else if (swappedInstall && (await pathExists(targetPath))) {
+				await remove(targetPath);
 			}
 			throw error;
 		} finally {
 			await remove(stagingDir);
 			await remove(stagedInstallPath);
 		}
-		await persistInstallMetadataAfterSuccess(
-			downloadPath,
-			readDownloadedMetadataFn,
-			persistInstallMetadataFn,
-		);
 		return targetPath;
 	}
 
 	if (platform === "linux") {
-		await copyFile(downloadPath, targetPath);
-		await chmod(targetPath, 0o755);
-		await persistInstallMetadataAfterSuccess(
-			downloadPath,
-			readDownloadedMetadataFn,
-			persistInstallMetadataFn,
-		);
+		const backupInstallPath = join(dirname(targetPath), `${basename(targetPath)}.backup`);
+		try {
+			await remove(backupInstallPath);
+			if (await pathExists(targetPath)) {
+				await rename(targetPath, backupInstallPath);
+			}
+			await copyFile(downloadPath, targetPath);
+			await chmod(targetPath, 0o755);
+			await persistInstallMetadataAfterSuccess(
+				downloadPath,
+				targetPath,
+				platform,
+				readDownloadedMetadataFn,
+				validateInstalledArtifactFn,
+				persistInstallMetadataFn,
+			);
+			await remove(backupInstallPath);
+		} catch (error) {
+			if (await pathExists(backupInstallPath)) {
+				if (await pathExists(targetPath)) {
+					await remove(targetPath);
+				}
+				await rename(backupInstallPath, targetPath);
+			} else if (await pathExists(targetPath)) {
+				await remove(targetPath);
+			}
+			throw error;
+		}
 		return targetPath;
 	}
 
 	if (platform === "win32") {
-		await copyFile(downloadPath, targetPath);
-		await persistInstallMetadataAfterSuccess(
-			downloadPath,
-			readDownloadedMetadataFn,
-			persistInstallMetadataFn,
-		);
+		const backupInstallPath = join(dirname(targetPath), `${basename(targetPath)}.backup`);
+		try {
+			await remove(backupInstallPath);
+			if (await pathExists(targetPath)) {
+				await rename(targetPath, backupInstallPath);
+			}
+			await copyFile(downloadPath, targetPath);
+			await persistInstallMetadataAfterSuccess(
+				downloadPath,
+				targetPath,
+				platform,
+				readDownloadedMetadataFn,
+				validateInstalledArtifactFn,
+				persistInstallMetadataFn,
+			);
+			await remove(backupInstallPath);
+		} catch (error) {
+			if (await pathExists(backupInstallPath)) {
+				if (await pathExists(targetPath)) {
+					await remove(targetPath);
+				}
+				await rename(backupInstallPath, targetPath);
+			} else if (await pathExists(targetPath)) {
+				await remove(targetPath);
+			}
+			throw error;
+		}
 		return targetPath;
 	}
 

--- a/src/domains/desktop/index.ts
+++ b/src/domains/desktop/index.ts
@@ -16,6 +16,7 @@ export { buildDesktopLaunchCommand, launchDesktopApp } from "./desktop-app-launc
 export { fetchDesktopReleaseManifest, getDesktopManifestUrl } from "./desktop-release-service.js";
 export {
 	downloadDesktopBinary,
+	getDesktopInstallHealth,
 	getDesktopUpdateStatus,
 	getDesktopBinaryPath,
 	installDesktopBinary,

--- a/src/ui/src/layouts/__tests__/app-layout.vitest.tsx
+++ b/src/ui/src/layouts/__tests__/app-layout.vitest.tsx
@@ -93,6 +93,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 describe("AppLayout tray integration", () => {
 	beforeEach(() => {
+		vi.resetModules();
 		navigateMock.mockReset();
 		touchProjectMock.mockReset();
 		listenMock.mockReset();


### PR DESCRIPTION
## Summary

- repair invalid installed desktop bundles on normal `ck app` launch instead of blindly relaunching a bad app
- validate desktop installs before persisting release metadata and roll back safely on install failure
- sync Tauri desktop bundle versions from `desktop-v*` tags and preflight that path in desktop CI
- verify the macOS release bundle version matches the desktop release tag

## Root Cause

The packaged desktop regression had two coupled problems:

1. Existing bad desktop installs could keep launching on the default `ck app` path because only `--update` checked release/install health.
2. Desktop release artifacts could drift from their tag/manifests because the Tauri bundle version in `src-tauri/tauri.conf.json` was not being synchronized from the desktop release tag during build.

## Changes

| File | Change |
|------|--------|
| `src/commands/app/app-command.ts` | auto-repair invalid installed desktop bundles on normal launch |
| `src/domains/desktop/desktop-binary-manager.ts` | expose install health and surface actual installed macOS bundle version on drift |
| `src/domains/desktop/desktop-installer.ts` | validate installs before persisting metadata and restore previous binaries on failure |
| `src/domains/desktop/desktop-bundle-version.ts` | add desktop tag/version sync helpers |
| `scripts/sync-desktop-bundle-config.ts` | sync `src-tauri/tauri.conf.json` version + WiX version from release input |
| `.github/workflows/desktop-build.yml` | preflight sync path in PR jobs and verify tagged macOS bundle version in release builds |

## Validation

- [x] `bun run validate`
- [x] `bun run ui:build`
- [x] desktop targeted regression tests for app launch, install health, installer rollback, and bundle sync
