### PR TITLE
fix(migrate): write default model to opencode.json to avoid ProviderModelNotFoundError

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
 	"version": "3.41.4-dev.44",
-	"generatedAt": "2026-04-22T12:07:51.428Z",
+	"generatedAt": "2026-04-22T12:54:47.862Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "3.41.4-dev.43",
-	"generatedAt": "2026-04-21T02:36:02.158Z",
+	"version": "3.41.4-dev.44",
+	"generatedAt": "2026-04-22T11:52:07.487Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
 	"version": "3.41.4-dev.44",
-	"generatedAt": "2026-04-22T11:52:07.487Z",
+	"generatedAt": "2026-04-22T12:07:51.428Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-22T12:07:51.545Z -->
+<!-- generated: 2026-04-22T12:54:47.980Z -->

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-22T11:52:07.607Z -->
+<!-- generated: 2026-04-22T12:07:51.545Z -->

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-21T02:36:02.283Z -->
+<!-- generated: 2026-04-22T11:52:07.607Z -->

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -725,9 +725,17 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		// config; without it, OpenCode throws ProviderModelNotFoundError (#728).
 		if (selectedProviders.includes("opencode")) {
 			try {
-				const result = await ensureOpenCodeModel({ global: installGlobally });
+				const result = await ensureOpenCodeModel({
+					global: installGlobally,
+					interactive: process.stdout.isTTY === true && !options.yes,
+				});
 				if (result.action === "created" || result.action === "added") {
-					p.log.info(`Set default model "${result.model}" in ${result.path}`);
+					const reason = result.reason ? ` (${result.reason})` : "";
+					p.log.info(`Set default model "${result.model}" in ${result.path}${reason}`);
+				} else if (result.action === "skipped") {
+					p.log.warn(
+						"Skipped writing default model to opencode.json. Migrated agents may fail with ProviderModelNotFoundError until you set one.",
+					);
 				}
 			} catch (err) {
 				postProgressWarnings.push(

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -32,6 +32,7 @@ import { convertItem } from "../portable/converters/index.js";
 import { generateDiff } from "../portable/diff-display.js";
 import { migrateHooksSettings } from "../portable/hooks-settings-merger.js";
 import { setTaxonomyOverrides } from "../portable/model-taxonomy.js";
+import { ensureOpenCodeModel } from "../portable/opencode-config-installer.js";
 import { displayMigrationSummary, displayReconcilePlan } from "../portable/plan-display.js";
 import { installPortableItems } from "../portable/portable-installer.js";
 import { loadPortableManifest } from "../portable/portable-manifest.js";
@@ -718,6 +719,21 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 				}
 			}
 			progressSink.tick(progressLabelForType(task.type));
+		}
+
+		// Ensure opencode.json has a `model` — migrated agents inherit from global
+		// config; without it, OpenCode throws ProviderModelNotFoundError (#728).
+		if (selectedProviders.includes("opencode")) {
+			try {
+				const result = await ensureOpenCodeModel({ global: installGlobally });
+				if (result.action === "created" || result.action === "added") {
+					p.log.info(`Set default model "${result.model}" in ${result.path}`);
+				}
+			} catch (err) {
+				postProgressWarnings.push(
+					`Could not update opencode.json model (${err instanceof Error ? err.message : String(err)}). Agents may fail with ProviderModelNotFoundError until a model is set.`,
+				);
+			}
 		}
 
 		// After all actions executed, merge hooks into target settings.json per provider

--- a/src/commands/portable/__tests__/opencode-config-installer.test.ts
+++ b/src/commands/portable/__tests__/opencode-config-installer.test.ts
@@ -144,32 +144,7 @@ describe("ensureOpenCodeModel (global scope)", () => {
 		expect(contents.model).toBe(OPENCODE_DEFAULT_MODEL);
 	});
 
-	it("uses detected provider's hint when auth.json has known provider", async () => {
-		const authDir = join(tempHome, ".local", "share", "opencode");
-		await mkdir(authDir, { recursive: true });
-		await writeFile(
-			join(authDir, "auth.json"),
-			JSON.stringify({ openai: { type: "api", key: "sk-x" } }),
-			"utf-8",
-		);
-
-		const suggestion = await suggestOpenCodeDefaultModel(tempHome);
-		expect(suggestion.model).toMatch(/^openai\//);
-		expect(suggestion.reason).toContain("openai");
-
-		const result = await ensureOpenCodeModel({ global: true, homeDir: tempHome });
-		expect(result.model).toMatch(/^openai\//);
-		expect(result.reason).toContain("openai");
-	});
-
-	it(".ck.json override takes precedence over auth detection", async () => {
-		const authDir = join(tempHome, ".local", "share", "opencode");
-		await mkdir(authDir, { recursive: true });
-		await writeFile(
-			join(authDir, "auth.json"),
-			JSON.stringify({ openai: { type: "api", key: "sk-x" } }),
-			"utf-8",
-		);
+	it(".ck.json override takes precedence over fallback default", async () => {
 		setTaxonomyOverrides({
 			opencode: { default: { model: "custom/local-model" } },
 		});
@@ -179,10 +154,89 @@ describe("ensureOpenCodeModel (global scope)", () => {
 		expect(result.reason).toContain("override");
 	});
 
-	it("falls back to OPENCODE_DEFAULT_MODEL when no auth and no override", async () => {
+	it("suggests OPENCODE_DEFAULT_MODEL when no override", async () => {
 		const suggestion = await suggestOpenCodeDefaultModel(tempHome);
 		expect(suggestion.model).toBe(OPENCODE_DEFAULT_MODEL);
 		expect(suggestion.reason).toContain("fallback");
+	});
+
+	it("prompter receives detected providers from auth.json", async () => {
+		const authDir = join(tempHome, ".local", "share", "opencode");
+		await mkdir(authDir, { recursive: true });
+		await writeFile(
+			join(authDir, "auth.json"),
+			JSON.stringify({ anthropic: {}, openai: {} }),
+			"utf-8",
+		);
+
+		let capturedProviders: string[] = [];
+		const result = await ensureOpenCodeModel({
+			global: true,
+			homeDir: tempHome,
+			interactive: true,
+			prompter: async (ctx) => {
+				capturedProviders = ctx.detectedProviders;
+				return { action: "accept" };
+			},
+		});
+
+		expect(capturedProviders).toEqual(["anthropic", "openai"]);
+		expect(result.action).toBe("created");
+		expect(result.model).toBe(OPENCODE_DEFAULT_MODEL);
+	});
+
+	it("interactive accept writes the suggested model", async () => {
+		const result = await ensureOpenCodeModel({
+			global: true,
+			homeDir: tempHome,
+			interactive: true,
+			prompter: async () => ({ action: "accept" }),
+		});
+
+		expect(result.action).toBe("created");
+		expect(result.model).toBe(OPENCODE_DEFAULT_MODEL);
+		const contents = JSON.parse(await readFile(result.path, "utf-8"));
+		expect(contents.model).toBe(OPENCODE_DEFAULT_MODEL);
+	});
+
+	it("interactive custom writes user-provided model", async () => {
+		const result = await ensureOpenCodeModel({
+			global: true,
+			homeDir: tempHome,
+			interactive: true,
+			prompter: async () => ({ action: "custom", value: "openrouter/x-ai/grok-4" }),
+		});
+
+		expect(result.action).toBe("created");
+		expect(result.model).toBe("openrouter/x-ai/grok-4");
+		const contents = JSON.parse(await readFile(result.path, "utf-8"));
+		expect(contents.model).toBe("openrouter/x-ai/grok-4");
+	});
+
+	it("interactive skip leaves file untouched and returns action:skipped", async () => {
+		const result = await ensureOpenCodeModel({
+			global: true,
+			homeDir: tempHome,
+			interactive: true,
+			prompter: async () => ({ action: "skip" }),
+		});
+
+		expect(result.action).toBe("skipped");
+		expect(result.model).toBe("");
+		// File must not have been created
+		await expect(readFile(result.path, "utf-8")).rejects.toThrow();
+	});
+
+	it("non-object JSON (array) is overwritten with warning", async () => {
+		const globalDir = join(tempHome, ".config", "opencode");
+		await mkdir(globalDir, { recursive: true });
+		await writeFile(join(globalDir, "opencode.json"), "[]", "utf-8");
+
+		const result = await ensureOpenCodeModel({ global: true, homeDir: tempHome });
+
+		expect(result.action).toBe("created");
+		const contents = JSON.parse(await readFile(result.path, "utf-8"));
+		expect(contents.model).toBe(OPENCODE_DEFAULT_MODEL);
 	});
 
 	it("preserves existing fields in global config", async () => {

--- a/src/commands/portable/__tests__/opencode-config-installer.test.ts
+++ b/src/commands/portable/__tests__/opencode-config-installer.test.ts
@@ -6,7 +6,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { OPENCODE_DEFAULT_MODEL, setTaxonomyOverrides } from "../model-taxonomy.js";
-import { ensureOpenCodeModel } from "../opencode-config-installer.js";
+import { ensureOpenCodeModel, suggestOpenCodeDefaultModel } from "../opencode-config-installer.js";
 
 describe("ensureOpenCodeModel (project scope)", () => {
 	let tempDir: string;
@@ -142,6 +142,47 @@ describe("ensureOpenCodeModel (global scope)", () => {
 		expect(result.model).toBe(OPENCODE_DEFAULT_MODEL);
 		const contents = JSON.parse(await readFile(result.path, "utf-8"));
 		expect(contents.model).toBe(OPENCODE_DEFAULT_MODEL);
+	});
+
+	it("uses detected provider's hint when auth.json has known provider", async () => {
+		const authDir = join(tempHome, ".local", "share", "opencode");
+		await mkdir(authDir, { recursive: true });
+		await writeFile(
+			join(authDir, "auth.json"),
+			JSON.stringify({ openai: { type: "api", key: "sk-x" } }),
+			"utf-8",
+		);
+
+		const suggestion = await suggestOpenCodeDefaultModel(tempHome);
+		expect(suggestion.model).toMatch(/^openai\//);
+		expect(suggestion.reason).toContain("openai");
+
+		const result = await ensureOpenCodeModel({ global: true, homeDir: tempHome });
+		expect(result.model).toMatch(/^openai\//);
+		expect(result.reason).toContain("openai");
+	});
+
+	it(".ck.json override takes precedence over auth detection", async () => {
+		const authDir = join(tempHome, ".local", "share", "opencode");
+		await mkdir(authDir, { recursive: true });
+		await writeFile(
+			join(authDir, "auth.json"),
+			JSON.stringify({ openai: { type: "api", key: "sk-x" } }),
+			"utf-8",
+		);
+		setTaxonomyOverrides({
+			opencode: { default: { model: "custom/local-model" } },
+		});
+
+		const result = await ensureOpenCodeModel({ global: true, homeDir: tempHome });
+		expect(result.model).toBe("custom/local-model");
+		expect(result.reason).toContain("override");
+	});
+
+	it("falls back to OPENCODE_DEFAULT_MODEL when no auth and no override", async () => {
+		const suggestion = await suggestOpenCodeDefaultModel(tempHome);
+		expect(suggestion.model).toBe(OPENCODE_DEFAULT_MODEL);
+		expect(suggestion.reason).toContain("fallback");
 	});
 
 	it("preserves existing fields in global config", async () => {

--- a/src/commands/portable/__tests__/opencode-config-installer.test.ts
+++ b/src/commands/portable/__tests__/opencode-config-installer.test.ts
@@ -91,4 +91,73 @@ describe("ensureOpenCodeModel (project scope)", () => {
 		const result = await ensureOpenCodeModel({ global: false });
 		expect(result.action).toBe("created");
 	});
+
+	it("treats empty/whitespace model as missing and adds default", async () => {
+		await writeFile(
+			join(tempDir, "opencode.json"),
+			JSON.stringify({ model: "   ", mcp: { foo: {} } }, null, 2),
+			"utf-8",
+		);
+
+		const result = await ensureOpenCodeModel({ global: false });
+
+		expect(result.action).toBe("added");
+		expect(result.model).toBe(OPENCODE_DEFAULT_MODEL);
+		const contents = JSON.parse(await readFile(join(tempDir, "opencode.json"), "utf-8"));
+		expect(contents.model).toBe(OPENCODE_DEFAULT_MODEL);
+		expect(contents.mcp).toEqual({ foo: {} });
+	});
+
+	it("treats non-string model as missing and adds default", async () => {
+		await writeFile(
+			join(tempDir, "opencode.json"),
+			JSON.stringify({ model: 123 }, null, 2),
+			"utf-8",
+		);
+
+		const result = await ensureOpenCodeModel({ global: false });
+
+		expect(result.action).toBe("added");
+		expect(result.model).toBe(OPENCODE_DEFAULT_MODEL);
+	});
+});
+
+describe("ensureOpenCodeModel (global scope)", () => {
+	let tempHome: string;
+
+	beforeEach(async () => {
+		tempHome = await mkdtemp(join(tmpdir(), "ck-opencode-home-"));
+	});
+
+	afterEach(async () => {
+		setTaxonomyOverrides(undefined);
+		await rm(tempHome, { recursive: true, force: true });
+	});
+
+	it("writes to ~/.config/opencode/opencode.json when global:true", async () => {
+		const result = await ensureOpenCodeModel({ global: true, homeDir: tempHome });
+
+		expect(result.action).toBe("created");
+		expect(result.path).toBe(join(tempHome, ".config", "opencode", "opencode.json"));
+		expect(result.model).toBe(OPENCODE_DEFAULT_MODEL);
+		const contents = JSON.parse(await readFile(result.path, "utf-8"));
+		expect(contents.model).toBe(OPENCODE_DEFAULT_MODEL);
+	});
+
+	it("preserves existing fields in global config", async () => {
+		const globalDir = join(tempHome, ".config", "opencode");
+		await mkdir(globalDir, { recursive: true });
+		await writeFile(
+			join(globalDir, "opencode.json"),
+			JSON.stringify({ mcp: { x: { command: ["y"] } } }, null, 2),
+			"utf-8",
+		);
+
+		const result = await ensureOpenCodeModel({ global: true, homeDir: tempHome });
+
+		expect(result.action).toBe("added");
+		const contents = JSON.parse(await readFile(result.path, "utf-8"));
+		expect(contents.model).toBe(OPENCODE_DEFAULT_MODEL);
+		expect(contents.mcp).toEqual({ x: { command: ["y"] } });
+	});
 });

--- a/src/commands/portable/__tests__/opencode-config-installer.test.ts
+++ b/src/commands/portable/__tests__/opencode-config-installer.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+/**
+ * Tests for opencode-config-installer — regression coverage for #728.
+ */
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { OPENCODE_DEFAULT_MODEL, setTaxonomyOverrides } from "../model-taxonomy.js";
+import { ensureOpenCodeModel } from "../opencode-config-installer.js";
+
+describe("ensureOpenCodeModel (project scope)", () => {
+	let tempDir: string;
+	let originalCwd: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "ck-opencode-"));
+		originalCwd = process.cwd();
+		process.chdir(tempDir);
+	});
+
+	afterEach(async () => {
+		process.chdir(originalCwd);
+		setTaxonomyOverrides(undefined);
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("creates opencode.json with default model when file missing", async () => {
+		const result = await ensureOpenCodeModel({ global: false });
+
+		expect(result.action).toBe("created");
+		expect(result.model).toBe(OPENCODE_DEFAULT_MODEL);
+
+		const contents = JSON.parse(await readFile(join(tempDir, "opencode.json"), "utf-8"));
+		expect(contents.model).toBe(OPENCODE_DEFAULT_MODEL);
+	});
+
+	it("adds model to existing opencode.json while preserving other fields", async () => {
+		await writeFile(
+			join(tempDir, "opencode.json"),
+			JSON.stringify({ mcp: { pencil: { command: ["foo"] } } }, null, 2),
+			"utf-8",
+		);
+
+		const result = await ensureOpenCodeModel({ global: false });
+
+		expect(result.action).toBe("added");
+		const contents = JSON.parse(await readFile(join(tempDir, "opencode.json"), "utf-8"));
+		expect(contents.model).toBe(OPENCODE_DEFAULT_MODEL);
+		expect(contents.mcp).toEqual({ pencil: { command: ["foo"] } });
+	});
+
+	it("leaves existing model field untouched", async () => {
+		await writeFile(
+			join(tempDir, "opencode.json"),
+			JSON.stringify({ model: "anthropic/claude-opus-4-5" }, null, 2),
+			"utf-8",
+		);
+
+		const result = await ensureOpenCodeModel({ global: false });
+
+		expect(result.action).toBe("existing");
+		expect(result.model).toBe("anthropic/claude-opus-4-5");
+	});
+
+	it("recreates config when existing file is malformed JSON", async () => {
+		await writeFile(join(tempDir, "opencode.json"), "{ not json", "utf-8");
+
+		const result = await ensureOpenCodeModel({ global: false });
+
+		expect(result.action).toBe("created");
+		const contents = JSON.parse(await readFile(join(tempDir, "opencode.json"), "utf-8"));
+		expect(contents.model).toBe(OPENCODE_DEFAULT_MODEL);
+	});
+
+	it("honors .ck.json taxonomy override for opencode default model", async () => {
+		setTaxonomyOverrides({
+			opencode: { default: { model: "anthropic/claude-opus-4-5" } },
+		});
+
+		const result = await ensureOpenCodeModel({ global: false });
+
+		expect(result.model).toBe("anthropic/claude-opus-4-5");
+	});
+
+	it("creates parent directory when missing (global scope analogue)", async () => {
+		// Simulate a global-style nested config dir under the temp project
+		const nested = join(tempDir, "nested", "config");
+		await mkdir(nested, { recursive: true });
+		process.chdir(nested);
+
+		const result = await ensureOpenCodeModel({ global: false });
+		expect(result.action).toBe("created");
+	});
+});

--- a/src/commands/portable/model-taxonomy.ts
+++ b/src/commands/portable/model-taxonomy.ts
@@ -18,6 +18,15 @@ export interface ModelResolveResult {
 	warning?: string;
 }
 
+/**
+ * Default OpenCode model written to opencode.json when migration detects no global
+ * model set. Single source of truth — update here when model versions are deprecated.
+ * Users can override via .ck.json taxonomy (`opencode.default` key) without forking.
+ * Ref: #728 — without a resolvable global model, OpenCode throws ProviderModelNotFoundError
+ * on any agent invocation.
+ */
+export const OPENCODE_DEFAULT_MODEL = "anthropic/claude-sonnet-4-5";
+
 /** Source model name → capability tier */
 const SOURCE_TIER_MAP: Record<string, ModelTier> = {
 	opus: "heavy",
@@ -47,6 +56,15 @@ export function setTaxonomyOverrides(
 	overrides: Record<string, Record<string, ResolvedModel>> | undefined,
 ): void {
 	userOverrides = overrides;
+}
+
+/**
+ * Resolve the OpenCode default model, respecting .ck.json user overrides.
+ * Looks for `opencode.default.model` in user overrides; otherwise returns
+ * `OPENCODE_DEFAULT_MODEL`.
+ */
+export function resolveOpenCodeDefaultModel(): string {
+	return userOverrides?.opencode?.default?.model ?? OPENCODE_DEFAULT_MODEL;
 }
 
 /**

--- a/src/commands/portable/model-taxonomy.ts
+++ b/src/commands/portable/model-taxonomy.ts
@@ -67,6 +67,11 @@ export function resolveOpenCodeDefaultModel(): string {
 	return userOverrides?.opencode?.default?.model ?? OPENCODE_DEFAULT_MODEL;
 }
 
+/** User-set opencode default model override from .ck.json, if any. */
+export function getOpenCodeDefaultModelOverride(): string | undefined {
+	return userOverrides?.opencode?.default?.model;
+}
+
 /**
  * Resolve a source model name to a target provider's equivalent.
  * Returns null for inherit/undefined/unmapped providers (let target use defaults).

--- a/src/commands/portable/model-taxonomy.ts
+++ b/src/commands/portable/model-taxonomy.ts
@@ -25,7 +25,7 @@ export interface ModelResolveResult {
  * Ref: #728 — without a resolvable global model, OpenCode throws ProviderModelNotFoundError
  * on any agent invocation.
  */
-export const OPENCODE_DEFAULT_MODEL = "anthropic/claude-sonnet-4-5";
+export const OPENCODE_DEFAULT_MODEL = "anthropic/claude-sonnet-4-6";
 
 /** Source model name → capability tier */
 const SOURCE_TIER_MAP: Record<string, ModelTier> = {

--- a/src/commands/portable/opencode-config-installer.ts
+++ b/src/commands/portable/opencode-config-installer.ts
@@ -10,10 +10,10 @@
  * UX scope:
  * - Never overwrites an existing non-empty `model` field — power users with custom
  *   provider setups are left untouched.
- * - Detects providers with auth in `~/.local/share/opencode/auth.json` and
- *   suggests a matching model from the first authenticated provider.
- * - In interactive mode, prompts before writing; in `--yes` mode, writes the
- *   suggested default.
+ * - Detects authenticated providers from `~/.local/share/opencode/auth.json` and
+ *   shows them to the user so they can type a provider-specific model.
+ * - In interactive mode, prompts before writing; in non-interactive/--yes mode,
+ *   writes the fallback default (verified anthropic model).
  */
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
@@ -30,29 +30,28 @@ export interface EnsureOpenCodeModelResult {
 	reason?: string;
 }
 
+/**
+ * Prompter abstraction — default uses `@clack/prompts`. Tests inject a stub.
+ * Return `{ action: "accept" }` to use the suggested model, `{ action: "custom", value }`
+ * to override, or `{ action: "skip" }` to skip writing.
+ */
+export type OpenCodeModelPrompter = (ctx: {
+	suggestion: string;
+	reason: string;
+	detectedProviders: string[];
+}) => Promise<{ action: "accept" } | { action: "custom"; value: string } | { action: "skip" }>;
+
 export interface EnsureOpenCodeModelOptions {
 	global: boolean;
-	/** If true, prompt user before writing. Otherwise write suggested default silently. */
+	/** If true, call prompter before writing. Otherwise write suggested default silently. */
 	interactive?: boolean;
 	/** Override home directory (for tests). Defaults to `os.homedir()`. */
 	homeDir?: string;
 	/** Override project directory (for tests). Defaults to `process.cwd()`. */
 	cwd?: string;
+	/** Inject a prompter (for tests). Defaults to the clack-based prompter. */
+	prompter?: OpenCodeModelPrompter;
 }
-
-/**
- * Known OpenCode provider → suggested default model. Kept minimal — covers the
- * providers users most often authenticate against. Used only when the user
- * has NO model configured and no `.ck.json` override.
- */
-const PROVIDER_MODEL_HINTS: Record<string, string> = {
-	anthropic: "anthropic/claude-sonnet-4-6",
-	openai: "openai/gpt-5",
-	google: "google/gemini-2.5-pro",
-	openrouter: "openrouter/anthropic/claude-sonnet-4-6",
-	"github-copilot": "github-copilot/claude-sonnet-4-6",
-	groq: "groq/llama-3.3-70b-versatile",
-};
 
 function getOpenCodeConfigPath(options: EnsureOpenCodeModelOptions): string {
 	if (options.global) {
@@ -73,7 +72,7 @@ async function detectAuthenticatedProviders(homeDir?: string): Promise<string[]>
 			return Object.keys(parsed as Record<string, unknown>);
 		}
 	} catch {
-		// Missing or malformed auth.json — silently fall back to hardcoded default.
+		// Missing or malformed auth.json — silently return empty.
 	}
 	return [];
 }
@@ -81,9 +80,11 @@ async function detectAuthenticatedProviders(homeDir?: string): Promise<string[]>
 /**
  * Suggest a default model to write based on (in priority order):
  * 1. `.ck.json` taxonomy override (`opencode.default.model`)
- * 2. First authenticated provider in `~/.local/share/opencode/auth.json` that has
- *    a known model hint
- * 3. Hardcoded `OPENCODE_DEFAULT_MODEL` constant
+ * 2. Hardcoded `OPENCODE_DEFAULT_MODEL` — only Anthropic is verified against the
+ *    OpenCode provider registry. For other providers, we don't auto-guess a model
+ *    ID (would risk reproducing the exact ProviderModelNotFoundError #728 fixes);
+ *    the interactive prompt surfaces detected providers so the user can type
+ *    their own `provider/model-id`.
  */
 export async function suggestOpenCodeDefaultModel(
 	homeDir?: string,
@@ -92,17 +93,45 @@ export async function suggestOpenCodeDefaultModel(
 	if (override) {
 		return { model: override, reason: ".ck.json override" };
 	}
-
-	const providers = await detectAuthenticatedProviders(homeDir);
-	for (const provider of providers) {
-		const hint = PROVIDER_MODEL_HINTS[provider];
-		if (hint) {
-			return { model: hint, reason: `detected ${provider} auth` };
-		}
-	}
-
+	// Silence unused param lint — homeDir kept for API stability and future auth-aware logic.
+	void homeDir;
 	return { model: OPENCODE_DEFAULT_MODEL, reason: "fallback default" };
 }
+
+/** Default clack-based prompter. */
+const clackPrompter: OpenCodeModelPrompter = async ({ suggestion, reason, detectedProviders }) => {
+	const providersHint =
+		detectedProviders.length > 0
+			? `Authenticated providers in opencode: ${detectedProviders.join(", ")}`
+			: "No authenticated providers detected in opencode.";
+	const response = await p.select({
+		message: `No default model in opencode.json. ${providersHint}`,
+		options: [
+			{
+				value: "accept",
+				label: `Write "${suggestion}"`,
+				hint: reason,
+			},
+			{ value: "custom", label: "Enter a different model..." },
+			{ value: "skip", label: "Skip — I'll configure opencode.json myself" },
+		],
+		initialValue: "accept",
+	});
+
+	if (p.isCancel(response) || response === "skip") return { action: "skip" };
+	if (response === "accept") return { action: "accept" };
+
+	const custom = await p.text({
+		message: "Model (format: provider/model-id, e.g. openai/gpt-5)",
+		placeholder: suggestion,
+		validate: (value) => {
+			if (!value || !value.includes("/")) return "Must be in 'provider/model-id' format";
+			return undefined;
+		},
+	});
+	if (p.isCancel(custom)) return { action: "skip" };
+	return { action: "custom", value: custom };
+};
 
 /**
  * Ensure opencode.json has a `model` field. Returns the action taken.
@@ -122,6 +151,12 @@ export async function ensureOpenCodeModel(
 		const parsed = JSON.parse(raw) as unknown;
 		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
 			existing = parsed as Record<string, unknown>;
+		} else {
+			// Valid JSON but non-object (array/string/number) — overwriting will drop
+			// whatever was there. Warn so user isn't surprised.
+			logger.warning(
+				`ensureOpenCodeModel: ${configPath} is valid JSON but not an object; overwriting with default model`,
+			);
 		}
 	} catch (err) {
 		const errno = (err as NodeJS.ErrnoException | null)?.code;
@@ -144,27 +179,20 @@ export async function ensureOpenCodeModel(
 		return { path: configPath, action: "existing", model: existing.model };
 	}
 
-	// No model configured — compute a suggestion.
+	// No model configured — compute a suggestion and (maybe) prompt.
 	const suggestion = await suggestOpenCodeDefaultModel(options.homeDir);
 	let chosenModel = suggestion.model;
 
-	// Interactive confirmation when TTY + not --yes.
 	if (options.interactive) {
-		const response = await p.select({
-			message: "No default model in opencode.json. Migrated agents will inherit from it.",
-			options: [
-				{
-					value: "accept",
-					label: `Write "${suggestion.model}"`,
-					hint: suggestion.reason,
-				},
-				{ value: "custom", label: "Enter a different model..." },
-				{ value: "skip", label: "Skip — I'll configure opencode.json myself" },
-			],
-			initialValue: "accept",
+		const detectedProviders = await detectAuthenticatedProviders(options.homeDir);
+		const prompter = options.prompter ?? clackPrompter;
+		const response = await prompter({
+			suggestion: suggestion.model,
+			reason: suggestion.reason,
+			detectedProviders,
 		});
 
-		if (p.isCancel(response) || response === "skip") {
+		if (response.action === "skip") {
 			return {
 				path: configPath,
 				action: "skipped",
@@ -173,24 +201,8 @@ export async function ensureOpenCodeModel(
 			};
 		}
 
-		if (response === "custom") {
-			const custom = await p.text({
-				message: "Model (format: provider/model-id, e.g. openai/gpt-5)",
-				placeholder: suggestion.model,
-				validate: (value) => {
-					if (!value || !value.includes("/")) return "Must be in 'provider/model-id' format";
-					return undefined;
-				},
-			});
-			if (p.isCancel(custom)) {
-				return {
-					path: configPath,
-					action: "skipped",
-					model: "",
-					reason: "user cancelled",
-				};
-			}
-			chosenModel = custom;
+		if (response.action === "custom") {
+			chosenModel = response.value;
 		}
 	}
 

--- a/src/commands/portable/opencode-config-installer.ts
+++ b/src/commands/portable/opencode-config-installer.ts
@@ -19,11 +19,21 @@ export interface EnsureOpenCodeModelResult {
 	model: string;
 }
 
-function getOpenCodeConfigPath(global: boolean): string {
-	if (global) {
-		return join(homedir(), ".config", "opencode", "opencode.json");
+export interface EnsureOpenCodeModelOptions {
+	global: boolean;
+	/** Override home directory (for tests). Defaults to `os.homedir()`. */
+	homeDir?: string;
+	/** Override project directory (for tests). Defaults to `process.cwd()`. */
+	cwd?: string;
+}
+
+function getOpenCodeConfigPath(options: EnsureOpenCodeModelOptions): string {
+	if (options.global) {
+		// OpenCode's global config path — `~/.config/opencode/opencode.json` on all
+		// platforms (OpenCode uses XDG layout even on Windows).
+		return join(options.homeDir ?? homedir(), ".config", "opencode", "opencode.json");
 	}
-	return join(process.cwd(), "opencode.json");
+	return join(options.cwd ?? process.cwd(), "opencode.json");
 }
 
 /**
@@ -32,10 +42,10 @@ function getOpenCodeConfigPath(global: boolean): string {
  * - "added": file existed but lacked model, field inserted
  * - "created": file did not exist, minimal config written
  */
-export async function ensureOpenCodeModel(options: {
-	global: boolean;
-}): Promise<EnsureOpenCodeModelResult> {
-	const configPath = getOpenCodeConfigPath(options.global);
+export async function ensureOpenCodeModel(
+	options: EnsureOpenCodeModelOptions,
+): Promise<EnsureOpenCodeModelResult> {
+	const configPath = getOpenCodeConfigPath(options);
 	const defaultModel = resolveOpenCodeDefaultModel();
 
 	let existing: Record<string, unknown> | null = null;
@@ -47,8 +57,18 @@ export async function ensureOpenCodeModel(options: {
 		}
 	} catch (err) {
 		const errno = (err as NodeJS.ErrnoException | null)?.code;
-		if (errno && errno !== "ENOENT") {
-			logger.verbose(`ensureOpenCodeModel: failed to read ${configPath} (${errno}); recreating`);
+		if (errno === "ENOENT") {
+			// expected when file doesn't exist yet
+		} else if (err instanceof SyntaxError) {
+			// Malformed JSON — existing non-model fields will be lost on overwrite.
+			// Warn user-visibly rather than silently dropping their config.
+			logger.warning(
+				`ensureOpenCodeModel: ${configPath} is not valid JSON; overwriting with default model (existing contents will be lost)`,
+			);
+		} else {
+			logger.verbose(
+				`ensureOpenCodeModel: failed to read ${configPath} (${errno ?? String(err)}); recreating`,
+			);
 		}
 	}
 

--- a/src/commands/portable/opencode-config-installer.ts
+++ b/src/commands/portable/opencode-config-installer.ts
@@ -6,26 +6,53 @@
  * Writes to the minimal location: global at `~/.config/opencode/opencode.json`,
  * project at `<cwd>/opencode.json`. Preserves any existing fields; only fills in
  * `model` when missing.
+ *
+ * UX scope:
+ * - Never overwrites an existing non-empty `model` field — power users with custom
+ *   provider setups are left untouched.
+ * - Detects providers with auth in `~/.local/share/opencode/auth.json` and
+ *   suggests a matching model from the first authenticated provider.
+ * - In interactive mode, prompts before writing; in `--yes` mode, writes the
+ *   suggested default.
  */
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { logger } from "@/shared/logger.js";
-import { resolveOpenCodeDefaultModel } from "./model-taxonomy.js";
+import * as p from "@clack/prompts";
+import { OPENCODE_DEFAULT_MODEL, getOpenCodeDefaultModelOverride } from "./model-taxonomy.js";
 
 export interface EnsureOpenCodeModelResult {
 	path: string;
-	action: "added" | "existing" | "created";
+	action: "added" | "existing" | "created" | "skipped";
 	model: string;
+	/** Human-readable reason for the chosen default. */
+	reason?: string;
 }
 
 export interface EnsureOpenCodeModelOptions {
 	global: boolean;
+	/** If true, prompt user before writing. Otherwise write suggested default silently. */
+	interactive?: boolean;
 	/** Override home directory (for tests). Defaults to `os.homedir()`. */
 	homeDir?: string;
 	/** Override project directory (for tests). Defaults to `process.cwd()`. */
 	cwd?: string;
 }
+
+/**
+ * Known OpenCode provider → suggested default model. Kept minimal — covers the
+ * providers users most often authenticate against. Used only when the user
+ * has NO model configured and no `.ck.json` override.
+ */
+const PROVIDER_MODEL_HINTS: Record<string, string> = {
+	anthropic: "anthropic/claude-sonnet-4-6",
+	openai: "openai/gpt-5",
+	google: "google/gemini-2.5-pro",
+	openrouter: "openrouter/anthropic/claude-sonnet-4-6",
+	"github-copilot": "github-copilot/claude-sonnet-4-6",
+	groq: "groq/llama-3.3-70b-versatile",
+};
 
 function getOpenCodeConfigPath(options: EnsureOpenCodeModelOptions): string {
 	if (options.global) {
@@ -36,17 +63,58 @@ function getOpenCodeConfigPath(options: EnsureOpenCodeModelOptions): string {
 	return join(options.cwd ?? process.cwd(), "opencode.json");
 }
 
+/** Read authenticated provider IDs from OpenCode's auth.json. Returns [] on any failure. */
+async function detectAuthenticatedProviders(homeDir?: string): Promise<string[]> {
+	const authPath = join(homeDir ?? homedir(), ".local", "share", "opencode", "auth.json");
+	try {
+		const raw = await readFile(authPath, "utf-8");
+		const parsed = JSON.parse(raw) as unknown;
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			return Object.keys(parsed as Record<string, unknown>);
+		}
+	} catch {
+		// Missing or malformed auth.json — silently fall back to hardcoded default.
+	}
+	return [];
+}
+
+/**
+ * Suggest a default model to write based on (in priority order):
+ * 1. `.ck.json` taxonomy override (`opencode.default.model`)
+ * 2. First authenticated provider in `~/.local/share/opencode/auth.json` that has
+ *    a known model hint
+ * 3. Hardcoded `OPENCODE_DEFAULT_MODEL` constant
+ */
+export async function suggestOpenCodeDefaultModel(
+	homeDir?: string,
+): Promise<{ model: string; reason: string }> {
+	const override = getOpenCodeDefaultModelOverride();
+	if (override) {
+		return { model: override, reason: ".ck.json override" };
+	}
+
+	const providers = await detectAuthenticatedProviders(homeDir);
+	for (const provider of providers) {
+		const hint = PROVIDER_MODEL_HINTS[provider];
+		if (hint) {
+			return { model: hint, reason: `detected ${provider} auth` };
+		}
+	}
+
+	return { model: OPENCODE_DEFAULT_MODEL, reason: "fallback default" };
+}
+
 /**
  * Ensure opencode.json has a `model` field. Returns the action taken.
  * - "existing": file already had a model, nothing changed
  * - "added": file existed but lacked model, field inserted
  * - "created": file did not exist, minimal config written
+ * - "skipped": user declined the prompt in interactive mode
  */
 export async function ensureOpenCodeModel(
 	options: EnsureOpenCodeModelOptions,
 ): Promise<EnsureOpenCodeModelResult> {
 	const configPath = getOpenCodeConfigPath(options);
-	const defaultModel = resolveOpenCodeDefaultModel();
 
 	let existing: Record<string, unknown> | null = null;
 	try {
@@ -76,13 +144,64 @@ export async function ensureOpenCodeModel(
 		return { path: configPath, action: "existing", model: existing.model };
 	}
 
-	const next = { ...(existing ?? {}), model: defaultModel };
+	// No model configured — compute a suggestion.
+	const suggestion = await suggestOpenCodeDefaultModel(options.homeDir);
+	let chosenModel = suggestion.model;
+
+	// Interactive confirmation when TTY + not --yes.
+	if (options.interactive) {
+		const response = await p.select({
+			message: "No default model in opencode.json. Migrated agents will inherit from it.",
+			options: [
+				{
+					value: "accept",
+					label: `Write "${suggestion.model}"`,
+					hint: suggestion.reason,
+				},
+				{ value: "custom", label: "Enter a different model..." },
+				{ value: "skip", label: "Skip — I'll configure opencode.json myself" },
+			],
+			initialValue: "accept",
+		});
+
+		if (p.isCancel(response) || response === "skip") {
+			return {
+				path: configPath,
+				action: "skipped",
+				model: "",
+				reason: "user declined",
+			};
+		}
+
+		if (response === "custom") {
+			const custom = await p.text({
+				message: "Model (format: provider/model-id, e.g. openai/gpt-5)",
+				placeholder: suggestion.model,
+				validate: (value) => {
+					if (!value || !value.includes("/")) return "Must be in 'provider/model-id' format";
+					return undefined;
+				},
+			});
+			if (p.isCancel(custom)) {
+				return {
+					path: configPath,
+					action: "skipped",
+					model: "",
+					reason: "user cancelled",
+				};
+			}
+			chosenModel = custom;
+		}
+	}
+
+	const next = { ...(existing ?? {}), model: chosenModel };
 	await mkdir(dirname(configPath), { recursive: true });
 	await writeFile(configPath, `${JSON.stringify(next, null, 2)}\n`, "utf-8");
 
 	return {
 		path: configPath,
 		action: existing ? "added" : "created",
-		model: defaultModel,
+		model: chosenModel,
+		reason: suggestion.reason,
 	};
 }

--- a/src/commands/portable/opencode-config-installer.ts
+++ b/src/commands/portable/opencode-config-installer.ts
@@ -1,0 +1,68 @@
+/**
+ * OpenCode config installer — ensures opencode.json has a `model` set so migrated
+ * agents can resolve a provider. Without a global model, OpenCode throws
+ * `ProviderModelNotFoundError` on every agent invocation (#728).
+ *
+ * Writes to the minimal location: global at `~/.config/opencode/opencode.json`,
+ * project at `<cwd>/opencode.json`. Preserves any existing fields; only fills in
+ * `model` when missing.
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { logger } from "@/shared/logger.js";
+import { resolveOpenCodeDefaultModel } from "./model-taxonomy.js";
+
+export interface EnsureOpenCodeModelResult {
+	path: string;
+	action: "added" | "existing" | "created";
+	model: string;
+}
+
+function getOpenCodeConfigPath(global: boolean): string {
+	if (global) {
+		return join(homedir(), ".config", "opencode", "opencode.json");
+	}
+	return join(process.cwd(), "opencode.json");
+}
+
+/**
+ * Ensure opencode.json has a `model` field. Returns the action taken.
+ * - "existing": file already had a model, nothing changed
+ * - "added": file existed but lacked model, field inserted
+ * - "created": file did not exist, minimal config written
+ */
+export async function ensureOpenCodeModel(options: {
+	global: boolean;
+}): Promise<EnsureOpenCodeModelResult> {
+	const configPath = getOpenCodeConfigPath(options.global);
+	const defaultModel = resolveOpenCodeDefaultModel();
+
+	let existing: Record<string, unknown> | null = null;
+	try {
+		const raw = await readFile(configPath, "utf-8");
+		const parsed = JSON.parse(raw) as unknown;
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			existing = parsed as Record<string, unknown>;
+		}
+	} catch (err) {
+		const errno = (err as NodeJS.ErrnoException | null)?.code;
+		if (errno && errno !== "ENOENT") {
+			logger.verbose(`ensureOpenCodeModel: failed to read ${configPath} (${errno}); recreating`);
+		}
+	}
+
+	if (existing && typeof existing.model === "string" && existing.model.trim().length > 0) {
+		return { path: configPath, action: "existing", model: existing.model };
+	}
+
+	const next = { ...(existing ?? {}), model: defaultModel };
+	await mkdir(dirname(configPath), { recursive: true });
+	await writeFile(configPath, `${JSON.stringify(next, null, 2)}\n`, "utf-8");
+
+	return {
+		path: configPath,
+		action: existing ? "added" : "created",
+		model: defaultModel,
+	};
+}


### PR DESCRIPTION
## Problem

After \`ck migrate --agent opencode\`, invoking any migrated agent (\`/brainstormer\`, \`/ui-ux-designer\`, etc.) throws \`ProviderModelNotFoundError\` if the user's \`opencode.json\` has no global \`model\` set.

Closes #728

## Root Cause

OpenCode's model resolution cascade:
- subagent without \`model\` → inherits from invoking primary
- primary without \`model\` → inherits from global \`opencode.json\`
- neither set → \`ProviderModelNotFoundError\` (src: \`sst/opencode src/provider/provider.ts:553\`)

Our FM-to-FM converter (\`convertOpenCodeAgent\`) correctly omits \`model\` per-agent for portability — but we never ensure the global config has one either.

## Fix

Write a single default model to \`opencode.json\` during \`ck migrate --agent opencode\` if the file lacks one. Agents keep inheriting (no per-agent hardcoding, no stale version strings scattered across N files), users edit one place when upgrading.

- **One source of truth:** \`OPENCODE_DEFAULT_MODEL\` constant in \`model-taxonomy.ts\`
- **User override:** \`.ck.json\` taxonomy (\`opencode.default.model\`) — no fork needed
- **Idempotent:** preserves existing \`model\` and any other fields (\`mcp\`, etc.)

## Changes

| File | Change |
|------|--------|
| \`src/commands/portable/model-taxonomy.ts\` | Add \`OPENCODE_DEFAULT_MODEL\` + \`resolveOpenCodeDefaultModel()\` |
| \`src/commands/portable/opencode-config-installer.ts\` | New \`ensureOpenCodeModel()\` helper |
| \`src/commands/migrate/migrate-command.ts\` | Call helper after install when opencode is a target |
| \`src/commands/portable/__tests__/opencode-config-installer.test.ts\` | 6 regression tests |

## Test plan

- [x] \`bun run validate\` passes (typecheck + lint + test + build)
- [x] New tests cover: create-if-missing, add-if-no-model, preserve-existing, malformed-json recovery, .ck.json override
- [ ] Manual: run \`ck migrate --agent opencode\` on a fresh opencode.json, verify \`/brainstormer\` invokable