### PR TITLE
feat(health): expose dashboard feature flags via /api/health

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "3.41.4-dev.44",
-	"generatedAt": "2026-04-22T12:54:47.862Z",
+	"version": "3.41.4-dev.45",
+	"generatedAt": "2026-04-24T00:24:33.113Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-22T12:54:47.980Z -->
+<!-- generated: 2026-04-24T00:24:33.252Z -->

--- a/src/__tests__/domains/web-server/routes/health-routes.test.ts
+++ b/src/__tests__/domains/web-server/routes/health-routes.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	DASHBOARD_FEATURES,
+	registerHealthRoutes,
+} from "@/domains/web-server/routes/health-routes.js";
+import express, { type Express } from "express";
+
+interface TestServer {
+	server: ReturnType<Express["listen"]>;
+	baseUrl: string;
+}
+
+async function setupServer(): Promise<TestServer> {
+	const app = express();
+	registerHealthRoutes(app);
+
+	const server = app.listen(0);
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("Failed to start test server");
+	}
+
+	return {
+		server,
+		baseUrl: `http://127.0.0.1:${address.port}`,
+	};
+}
+
+async function teardownServer(ctx: TestServer): Promise<void> {
+	await new Promise<void>((resolve) => ctx.server.close(() => resolve()));
+}
+
+describe("GET /api/health", () => {
+	let ctx: TestServer;
+
+	beforeEach(async () => {
+		ctx = await setupServer();
+	});
+
+	afterEach(async () => {
+		await teardownServer(ctx);
+	});
+
+	it("returns status ok with correct shape", async () => {
+		const res = await fetch(`${ctx.baseUrl}/api/health`);
+
+		expect(res.status).toBe(200);
+
+		const body = (await res.json()) as {
+			status: string;
+			timestamp: string;
+			uptime: number;
+			features: string[];
+		};
+
+		expect(body.status).toBe("ok");
+		expect(typeof body.timestamp).toBe("string");
+		expect(typeof body.uptime).toBe("number");
+		expect(Array.isArray(body.features)).toBe(true);
+	});
+
+	it("features array is non-empty and includes plans-dashboard", async () => {
+		const res = await fetch(`${ctx.baseUrl}/api/health`);
+		const body = (await res.json()) as { features: string[] };
+
+		expect(body.features.length).toBeGreaterThan(0);
+		expect(body.features).toContain("plans-dashboard");
+	});
+
+	it("features array matches DASHBOARD_FEATURES constant", async () => {
+		const res = await fetch(`${ctx.baseUrl}/api/health`);
+		const body = (await res.json()) as { features: string[] };
+
+		expect(body.features).toEqual([...DASHBOARD_FEATURES]);
+	});
+});

--- a/src/domains/web-server/routes/health-routes.ts
+++ b/src/domains/web-server/routes/health-routes.ts
@@ -4,12 +4,33 @@
 
 import type { Express, Request, Response } from "express";
 
+/**
+ * Stable identifiers for dashboard capability surfaces.
+ * Add a new entry here when a new top-level route group is registered.
+ * External launchers (e.g. engineer plans-kanban) use these to feature-detect
+ * without coupling to a specific CLI version number.
+ */
+export const DASHBOARD_FEATURES = [
+	"plans-dashboard",
+	"workflows",
+	"migrate",
+	"statusline",
+	"projects",
+	"skills",
+	"agents",
+	"commands",
+	"mcp",
+] as const;
+
+export type DashboardFeature = (typeof DASHBOARD_FEATURES)[number];
+
 export function registerHealthRoutes(app: Express): void {
 	app.get("/api/health", (_req: Request, res: Response) => {
 		res.json({
 			status: "ok",
 			timestamp: new Date().toISOString(),
 			uptime: process.uptime(),
+			features: DASHBOARD_FEATURES,
 		});
 	});
 }

--- a/src/domains/web-server/routes/health-routes.ts
+++ b/src/domains/web-server/routes/health-routes.ts
@@ -5,17 +5,21 @@
 import type { Express, Request, Response } from "express";
 
 /**
- * Stable identifiers for dashboard capability surfaces.
- * Add a new entry here when a new top-level route group is registered.
- * External launchers (e.g. engineer plans-kanban) use these to feature-detect
- * without coupling to a specific CLI version number.
+ * Stable identifiers for frontend dashboard surfaces (React Router routes in
+ * `src/ui/src/router.tsx`). Only surfaces that external launchers or tooling may
+ * feature-detect belong here — not every registered route or API group needs
+ * an entry. External consumers treat these as opaque strings; renaming a flag
+ * is a breaking change.
+ *
+ * Source of truth for the routes referenced here: `src/ui/src/router.tsx`.
  */
 export const DASHBOARD_FEATURES = [
+	// `/plans` SPA route. Suffixed `-dashboard` to disambiguate from the plan
+	// file concept elsewhere in the CLI; intentionally does not mirror the path.
 	"plans-dashboard",
 	"workflows",
 	"migrate",
 	"statusline",
-	"projects",
 	"skills",
 	"agents",
 	"commands",


### PR DESCRIPTION
## Summary

Extend `GET /api/health` response with a `features: string[]` field listing stable dashboard capability identifiers (e.g. `plans-dashboard`, `workflows`, `migrate`).

External launchers (engineer `plans-kanban` skill, future tooling) can now feature-detect dashboard surfaces on the running CLI instead of coupling to version numbers or probing individual routes.

Closes #732

## Why

Engineer beta shipped a launcher that opens `http://localhost:3456/plans`. Users on stable CLI (no `/plans` route yet) saw every click redirect to `/config/global`. The launcher had no way to check capability before opening the browser. A small, stable feature flag surface solves this cleanly.

Coordinated with engineer PR: https://github.com/claudekit/claudekit-engineer/issues/697

## Changes

| File | Change |
|------|--------|
| `src/domains/web-server/routes/health-routes.ts` | Add `DASHBOARD_FEATURES` const + `features` field on response |
| `src/__tests__/domains/web-server/routes/health-routes.test.ts` | New: 3 tests (shape, plans-dashboard present, exact match) |

## Test plan

- [x] Unit: web-server suite 125 pass / 0 fail
- [x] Lint: biome clean
- [x] Build: pass
- [ ] Manual: hit `http://localhost:3456/api/health` after `ck config ui`, confirm `features` array present