### PR TITLE
fix(codex): merge codex_hooks into existing [features]; self-heal duplicates

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "3.41.4-dev.46",
-	"generatedAt": "2026-04-24T00:39:54.885Z",
+	"version": "3.41.4-dev.47",
+	"generatedAt": "2026-04-24T02:06:27.606Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-24T00:39:55.018Z -->
+<!-- generated: 2026-04-24T02:06:27.734Z -->

--- a/src/commands/portable/__tests__/codex-features-flag.test.ts
+++ b/src/commands/portable/__tests__/codex-features-flag.test.ts
@@ -29,7 +29,7 @@ describe("ensureCodexHooksFeatureFlag", () => {
 		expect(content).toContain("# --- ck-managed-features-end ---");
 	});
 
-	it("returns already-set when invoked a second time on an empty file (managed block present)", async () => {
+	it("returns updated when invoked a second time on a file containing only a managed block", async () => {
 		const configPath = join(testDir, "idempotent-config.toml");
 		// First write
 		const first = await ensureCodexHooksFeatureFlag(configPath);
@@ -159,6 +159,11 @@ hide_full_access_warning = true
 		expect(content).toContain("[notice]");
 		// No managed block should be written since we merged into the user's section
 		expect(content).not.toContain("ck-managed-features-start");
+		// Insertion position: codex_hooks goes at the END of the user's section,
+		// not the top — preserves the user's flag ordering.
+		const featuresBlock = content.match(/\[features\][\s\S]*?(?=\n\[|$)/)?.[0] ?? "";
+		const lines = featuresBlock.split("\n").filter((l) => l.trim().length > 0);
+		expect(lines[lines.length - 1]).toBe("codex_hooks = true");
 	});
 
 	/**
@@ -311,7 +316,7 @@ codex_hooks = true
 		expect(content).toContain("[shell]");
 	});
 
-	it("replaces managed block in-place when it already exists (idempotent update)", async () => {
+	it("strips and re-appends managed block when only managed block exists (idempotent update)", async () => {
 		const configPath = join(testDir, "replace-config.toml");
 		// Write an older managed block with slightly different content
 		writeFileSync(

--- a/src/commands/portable/__tests__/codex-features-flag.test.ts
+++ b/src/commands/portable/__tests__/codex-features-flag.test.ts
@@ -119,6 +119,198 @@ timeout = 120
 		expect(content).toContain("codex_hooks = true");
 	});
 
+	/**
+	 * Regression: bug where a user's existing `[features]` section caused a
+	 * second `[features]` header to be appended via the managed block, producing
+	 * TOML duplicate-key errors on next Codex load.
+	 */
+	it("merges codex_hooks into user's existing [features] section (no duplicate header)", async () => {
+		const configPath = join(testDir, "user-features-merge.toml");
+		writeFileSync(
+			configPath,
+			`[model_providers.cliproxy]
+name = "cliproxy"
+
+[features]
+unified_exec = true
+shell_snapshot = true
+multi_agent = true
+
+[notice]
+hide_full_access_warning = true
+`,
+		);
+
+		const result = await ensureCodexHooksFeatureFlag(configPath);
+		expect(result.status).toBe("updated");
+
+		const content = readFileSync(configPath, "utf8");
+		// Exactly ONE [features] header in the file
+		const featuresHeaderCount = (content.match(/^\[features\]\s*$/gm) || []).length;
+		expect(featuresHeaderCount).toBe(1);
+		// Flag merged into user's section
+		expect(content).toContain("codex_hooks = true");
+		// Pre-existing user flags preserved
+		expect(content).toContain("unified_exec = true");
+		expect(content).toContain("shell_snapshot = true");
+		expect(content).toContain("multi_agent = true");
+		// Surrounding sections preserved
+		expect(content).toContain("[model_providers.cliproxy]");
+		expect(content).toContain("[notice]");
+		// No managed block should be written since we merged into the user's section
+		expect(content).not.toContain("ck-managed-features-start");
+	});
+
+	/**
+	 * Self-heal test: user already suffers the bug (two `[features]` sections,
+	 * one user-owned and one managed). Next CLI run must strip the duplicate
+	 * managed block and fold the flag into the user's section.
+	 */
+	it("self-heals a broken config with duplicate [features] (user + managed)", async () => {
+		const configPath = join(testDir, "duplicate-features-heal.toml");
+		writeFileSync(
+			configPath,
+			`[model_providers.cliproxy]
+name = "cliproxy"
+
+[features]
+unified_exec = true
+multi_agent = true
+
+[notice]
+hide_full_access_warning = true
+
+# --- ck-managed-features-start ---
+[features]
+codex_hooks = true
+# --- ck-managed-features-end ---
+`,
+		);
+
+		const result = await ensureCodexHooksFeatureFlag(configPath);
+		expect(result.status).toBe("updated");
+
+		const content = readFileSync(configPath, "utf8");
+		// Exactly ONE [features] header — no duplicate TOML table
+		const featuresHeaderCount = (content.match(/^\[features\]\s*$/gm) || []).length;
+		expect(featuresHeaderCount).toBe(1);
+		// Managed block removed
+		expect(content).not.toContain("ck-managed-features-start");
+		expect(content).not.toContain("ck-managed-features-end");
+		// codex_hooks now lives in user section
+		expect(content).toContain("codex_hooks = true");
+		// User flags preserved
+		expect(content).toContain("unified_exec = true");
+		expect(content).toContain("multi_agent = true");
+		// Surrounding sections preserved
+		expect(content).toContain("[notice]");
+	});
+
+	it("updates codex_hooks = false to true inside user's [features] section", async () => {
+		const configPath = join(testDir, "user-features-false.toml");
+		writeFileSync(
+			configPath,
+			`[features]
+unified_exec = true
+codex_hooks = false
+multi_agent = true
+`,
+		);
+
+		const result = await ensureCodexHooksFeatureFlag(configPath);
+		expect(result.status).toBe("updated");
+
+		const content = readFileSync(configPath, "utf8");
+		expect(content).toContain("codex_hooks = true");
+		expect(content).not.toContain("codex_hooks = false");
+		// Only one [features] header, other flags preserved
+		const featuresHeaderCount = (content.match(/^\[features\]\s*$/gm) || []).length;
+		expect(featuresHeaderCount).toBe(1);
+		expect(content).toContain("unified_exec = true");
+		expect(content).toContain("multi_agent = true");
+	});
+
+	it("returns already-set when user's [features] already has codex_hooks = true among other flags", async () => {
+		const configPath = join(testDir, "user-features-already.toml");
+		const original = `[features]
+unified_exec = true
+codex_hooks = true
+multi_agent = true
+`;
+		writeFileSync(configPath, original);
+
+		const result = await ensureCodexHooksFeatureFlag(configPath);
+		expect(result.status).toBe("already-set");
+
+		const content = readFileSync(configPath, "utf8");
+		expect(content).toBe(original);
+	});
+
+	/**
+	 * Edge case: `[features.sub]` sub-table is present but no plain `[features]`.
+	 * The managed block should be appended (creates the supertable) — and only
+	 * one `[features]` header exists after write.
+	 */
+	it("treats [features.sub] as not being a plain [features] section", async () => {
+		const configPath = join(testDir, "features-subtable.toml");
+		writeFileSync(
+			configPath,
+			`[model]
+name = "o4-mini"
+
+[features.sub]
+nested_flag = true
+`,
+		);
+
+		const result = await ensureCodexHooksFeatureFlag(configPath);
+		expect(result.status).toBe("written");
+
+		const content = readFileSync(configPath, "utf8");
+		expect(content).toContain("codex_hooks = true");
+		// Sub-table preserved
+		expect(content).toContain("[features.sub]");
+		expect(content).toContain("nested_flag = true");
+		// Exactly ONE plain [features] header
+		const plainFeatures = (content.match(/^\[features\]\s*$/gm) || []).length;
+		expect(plainFeatures).toBe(1);
+	});
+
+	it("cleans up multiple accidental managed blocks from older buggy writes", async () => {
+		const configPath = join(testDir, "multi-managed-heal.toml");
+		writeFileSync(
+			configPath,
+			`[model]
+name = "o4-mini"
+
+# --- ck-managed-features-start ---
+[features]
+codex_hooks = true
+# --- ck-managed-features-end ---
+
+[shell]
+timeout = 120
+
+# --- ck-managed-features-start ---
+[features]
+codex_hooks = true
+# --- ck-managed-features-end ---
+`,
+		);
+
+		const result = await ensureCodexHooksFeatureFlag(configPath);
+		expect(result.status).toBe("updated");
+
+		const content = readFileSync(configPath, "utf8");
+		// Exactly one managed block and one [features] header after healing
+		const managedStarts = (content.match(/ck-managed-features-start/g) || []).length;
+		expect(managedStarts).toBe(1);
+		const featuresHeaders = (content.match(/^\[features\]\s*$/gm) || []).length;
+		expect(featuresHeaders).toBe(1);
+		expect(content).toContain("[model]");
+		expect(content).toContain("[shell]");
+	});
+
 	it("replaces managed block in-place when it already exists (idempotent update)", async () => {
 		const configPath = join(testDir, "replace-config.toml");
 		// Write an older managed block with slightly different content

--- a/src/commands/portable/codex-features-flag.ts
+++ b/src/commands/portable/codex-features-flag.ts
@@ -1,18 +1,25 @@
 /**
  * Codex config.toml feature-flag writer.
  *
- * Idempotently merges `[features] codex_hooks = true` into ~/.codex/config.toml
- * using sentinel comments — same pattern as codex-toml-installer.ts uses for
- * the managed agents block.
+ * Idempotently ensures `[features] codex_hooks = true` in ~/.codex/config.toml.
  *
- * The sentinel block looks like:
- *   # --- ck-managed-features-start ---
- *   [features]
- *   codex_hooks = true
- *   # --- ck-managed-features-end ---
+ * Two storage strategies depending on what the file already contains:
  *
- * Running this function multiple times is safe — the block is replaced in-place
- * on each run, never duplicated.
+ * 1. User already has a `[features]` section — merge `codex_hooks = true`
+ *    INTO that section (single-line insertion / in-place update). This avoids
+ *    TOML duplicate-key errors for users who already configured `[features]`
+ *    themselves (e.g. `unified_exec`, `multi_agent`, `shell_snapshot`).
+ *
+ * 2. No `[features]` section — append a self-contained managed block:
+ *      # --- ck-managed-features-start ---
+ *      [features]
+ *      codex_hooks = true
+ *      # --- ck-managed-features-end ---
+ *
+ * Every run FIRST strips any existing managed block, then decides whether to
+ * merge into the user's section or append a new managed block. This self-heals
+ * broken configs that already contain duplicate `[features]` headers produced
+ * by older versions of this function.
  */
 import { existsSync } from "node:fs";
 import { readFile, rename, unlink, writeFile } from "node:fs/promises";
@@ -32,9 +39,9 @@ codex_hooks = true
 ${SENTINEL_END}`;
 
 export type FeatureFlagWriteStatus =
-	| "written" // Flag was newly added
-	| "updated" // Existing managed block was refreshed
-	| "already-set" // [features] codex_hooks = true already present outside managed block
+	| "written" // Flag was newly added to a file that previously had no managed block or user [features]
+	| "updated" // Managed block was refreshed, merged into user [features], or duplicate cleaned up
+	| "already-set" // codex_hooks = true already present in user [features]; no write needed
 	| "failed"; // I/O error
 
 export interface FeatureFlagWriteResult {
@@ -49,23 +56,11 @@ export interface FeatureFlagWriteResult {
  * @param configTomlPath - Absolute path to the Codex config.toml file.
  * @param isGlobal - When true, boundary is set to ~/.codex/ (global install).
  *   When false (project-scoped), boundary is the config file's parent directory.
- *   Passing this explicitly avoids a false-positive when the project lives under
- *   the user's home directory (e.g. ~/projects/myapp/.codex/config.toml).
- *
- * Algorithm:
- * 1. Read existing file (or start with empty string if absent).
- * 2. If a managed block already exists, replace it with the canonical block.
- * 3. If `codex_hooks = true` already appears outside a managed block, return early.
- * 4. Otherwise append the managed block at end of file.
- * 5. Atomic write via temp + rename pattern.
  */
 export async function ensureCodexHooksFeatureFlag(
 	configTomlPath: string,
 	isGlobal = false,
 ): Promise<FeatureFlagWriteResult> {
-	// Boundary check: prevent writing outside ~/.codex/ or project .codex/ via symlink traversal.
-	// Use the explicit isGlobal flag (not string-contains homedir()) to avoid misclassifying
-	// project configs that live under the home directory (e.g. ~/projects/myapp/.codex/).
 	const boundary = isGlobal ? getCodexGlobalBoundary() : dirname(resolve(configTomlPath));
 	if (!(await isCanonicalPathWithinBoundary(dirname(resolve(configTomlPath)), boundary))) {
 		return {
@@ -75,7 +70,6 @@ export async function ensureCodexHooksFeatureFlag(
 		};
 	}
 
-	// Serialize all writes to the Codex directory via shared lock
 	return withCodexTargetLock(configTomlPath, () => _ensureFeatureFlagLocked(configTomlPath));
 }
 
@@ -94,26 +88,44 @@ async function _ensureFeatureFlagLocked(configTomlPath: string): Promise<Feature
 		}
 	}
 
-	// Case 1: managed block already present — replace it in-place (idempotent update)
-	const hasManagedBlock = existing.includes(SENTINEL_START) && existing.includes(SENTINEL_END);
+	// Step 1: strip ALL managed blocks (cleanup + prepare to re-decide).
+	// stripAllManagedBlocks handles the pathological case where a previous bug
+	// left multiple managed blocks in the file.
+	const { content: stripped, removed: hadManagedBlock } = stripAllManagedBlocks(existing);
+	let content = stripped;
+	let mutated = hadManagedBlock;
 
-	if (hasManagedBlock) {
-		const replaced = replaceManagedBlock(existing);
-		await atomicWrite(configTomlPath, replaced);
+	// Step 2: does a user-owned `[features]` section exist (NOT a sub-table like `[features.foo]`)?
+	const featuresHeaderIdx = findFeaturesSectionStart(content);
+
+	if (featuresHeaderIdx !== -1) {
+		const { updated, changed } = ensureFlagInFeaturesSection(content, featuresHeaderIdx);
+		content = updated;
+		mutated = mutated || changed;
+
+		if (!mutated) {
+			// User already had `codex_hooks = true` and no managed block existed — no-op.
+			return { status: "already-set", configPath: configTomlPath };
+		}
+
+		try {
+			await atomicWrite(configTomlPath, content);
+		} catch (err) {
+			return {
+				status: "failed",
+				configPath: configTomlPath,
+				error: `Failed to write ${configTomlPath}: ${err instanceof Error ? err.message : String(err)}`,
+			};
+		}
 		return { status: "updated", configPath: configTomlPath };
 	}
 
-	// Case 2: codex_hooks = true already set outside managed block — leave it alone
-	if (hasRawFeatureFlag(existing)) {
-		return { status: "already-set", configPath: configTomlPath };
-	}
-
-	// Case 3: not present — append managed block
-	const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n\n" : "\n";
-	const updated = `${existing}${separator}${MANAGED_BLOCK}\n`;
+	// Step 3: no user `[features]` section — append a managed block.
+	const separator = content.length === 0 ? "" : content.endsWith("\n") ? "\n" : "\n\n";
+	const withBlock = `${content}${separator}${MANAGED_BLOCK}\n`;
 
 	try {
-		await atomicWrite(configTomlPath, updated);
+		await atomicWrite(configTomlPath, withBlock);
 	} catch (err) {
 		return {
 			status: "failed",
@@ -122,57 +134,108 @@ async function _ensureFeatureFlagLocked(configTomlPath: string): Promise<Feature
 		};
 	}
 
-	return { status: "written", configPath: configTomlPath };
+	// If we stripped a managed block then re-appended one, it's semantically an update.
+	return { status: hadManagedBlock ? "updated" : "written", configPath: configTomlPath };
 }
 
 /**
- * Returns true if `codex_hooks = true` appears in the file content
- * outside of (or regardless of) the managed sentinel block.
- * Used to avoid double-writing when the user set it manually.
+ * Locate the byte offset of a plain `[features]` header line.
+ * Returns -1 if the section doesn't exist, or only sub-tables like `[features.foo]` exist.
  */
-function hasRawFeatureFlag(content: string): boolean {
-	// Strip any managed block first, then check remaining content.
-	// Regex tolerates trailing inline TOML comments (e.g. `codex_hooks = true  # my note`)
-	const withoutManaged = removeManagedBlock(content);
-	return /^\s*codex_hooks\s*=\s*true(\s*#[^\r\n]*)?\s*$/m.test(withoutManaged);
+function findFeaturesSectionStart(content: string): number {
+	const match = /^[ \t]*\[features\][ \t]*(?:#[^\r\n]*)?$/m.exec(content);
+	return match ? match.index : -1;
 }
 
 /**
- * Replace the content between sentinels with the canonical managed block.
- * Preserves content before and after the block.
+ * Within the `[features]` section starting at `headerStartIdx`, ensure a line
+ * `codex_hooks = true` exists. The section ends at the next `[table]` header
+ * (including sub-tables like `[features.foo]`) or EOF.
+ *
+ * - If line is missing: insert right after the header.
+ * - If line exists with `= false`: update to `= true`.
+ * - If line exists with `= true`: no change.
  */
-function replaceManagedBlock(content: string): string {
-	const startIdx = content.indexOf(SENTINEL_START);
-	// Use lastIndexOf for SENTINEL_END — more robust when content is malformed with multiple
-	// end sentinels (e.g. from a partial earlier write). The last occurrence is the true end.
-	const endIdx = content.lastIndexOf(SENTINEL_END);
+function ensureFlagInFeaturesSection(
+	content: string,
+	headerStartIdx: number,
+): { updated: string; changed: boolean } {
+	const headerLineEnd = content.indexOf("\n", headerStartIdx);
+	const bodyStart = headerLineEnd === -1 ? content.length : headerLineEnd + 1;
 
-	if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
-		// Malformed — just return unchanged
-		return content;
+	// Find next TOML table header (`\n[...]`) after the body starts
+	const rest = content.slice(bodyStart);
+	const nextHeaderMatch = /\n\[[^\]]+\]/.exec(rest);
+	const bodyEnd = nextHeaderMatch ? bodyStart + nextHeaderMatch.index + 1 : content.length;
+
+	const body = content.slice(bodyStart, bodyEnd);
+	const flagRegex = /^([ \t]*codex_hooks[ \t]*=[ \t]*)(true|false)([ \t]*#[^\r\n]*)?[ \t]*$/m;
+	const flagMatch = flagRegex.exec(body);
+
+	if (flagMatch) {
+		if (flagMatch[2] === "true") {
+			return { updated: content, changed: false };
+		}
+		const newBody = body.replace(
+			flagRegex,
+			(_m, prefix, _v, trailing) => `${prefix}true${trailing ?? ""}`,
+		);
+		return {
+			updated: content.slice(0, bodyStart) + newBody + content.slice(bodyEnd),
+			changed: true,
+		};
 	}
 
-	const endOfBlock = endIdx + SENTINEL_END.length;
-	// Consume trailing newline if present
-	const afterBlock =
-		content[endOfBlock] === "\n" ? content.slice(endOfBlock + 1) : content.slice(endOfBlock);
+	// Insert the line immediately after the header (with proper EOL handling).
+	if (headerLineEnd === -1) {
+		// Header is on the last line with no trailing newline
+		return { updated: `${content}\ncodex_hooks = true\n`, changed: true };
+	}
 
-	const before = content.slice(0, startIdx);
-	return `${before}${MANAGED_BLOCK}\n${afterBlock}`;
+	const insertion = "codex_hooks = true\n";
+	return {
+		updated: content.slice(0, bodyStart) + insertion + content.slice(bodyStart),
+		changed: true,
+	};
 }
 
-/** Strip the managed block from content entirely (used in hasRawFeatureFlag check). */
-function removeManagedBlock(content: string): string {
-	const startIdx = content.indexOf(SENTINEL_START);
-	const endIdx = content.indexOf(SENTINEL_END);
+/**
+ * Strip every `# --- ck-managed-features-start --- … # --- ck-managed-features-end ---`
+ * block from content. Returns the cleaned content plus whether any block was removed.
+ *
+ * Handles the pathological case where older buggy versions wrote multiple blocks.
+ */
+function stripAllManagedBlocks(content: string): { content: string; removed: boolean } {
+	let result = content;
+	let removed = false;
 
-	if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) return content;
+	while (true) {
+		const startIdx = result.indexOf(SENTINEL_START);
+		if (startIdx === -1) break;
+		const endIdx = result.indexOf(SENTINEL_END, startIdx);
+		if (endIdx === -1) break;
 
-	const endOfBlock = endIdx + SENTINEL_END.length;
-	const afterBlock =
-		content[endOfBlock] === "\n" ? content.slice(endOfBlock + 1) : content.slice(endOfBlock);
+		const endOfBlock = endIdx + SENTINEL_END.length;
+		// Consume one trailing newline
+		const afterBlockStart = result[endOfBlock] === "\n" ? endOfBlock + 1 : endOfBlock;
 
-	return content.slice(0, startIdx) + afterBlock;
+		// Also consume a preceding blank line separator if present, to avoid leaving
+		// stray double-blank runs behind.
+		let beforeBlockEnd = startIdx;
+		if (beforeBlockEnd >= 1 && result[beforeBlockEnd - 1] === "\n") {
+			beforeBlockEnd -= 1;
+			if (beforeBlockEnd >= 1 && result[beforeBlockEnd - 1] === "\n") {
+				beforeBlockEnd -= 1;
+			}
+			// Preserve one newline so the content above stays terminated
+			beforeBlockEnd += 1;
+		}
+
+		result = result.slice(0, beforeBlockEnd) + result.slice(afterBlockStart);
+		removed = true;
+	}
+
+	return { content: result, removed };
 }
 
 /** Write file atomically: write to temp file, then rename (POSIX-atomic). */
@@ -180,10 +243,8 @@ async function atomicWrite(filePath: string, content: string): Promise<void> {
 	const tempPath = `${filePath}.ck-tmp`;
 	try {
 		await writeFile(tempPath, content, "utf8");
-		// Node's fs.rename is atomic on POSIX
 		await rename(tempPath, filePath);
 	} catch (err) {
-		// Best-effort cleanup of temp file
 		try {
 			await unlink(tempPath);
 		} catch {

--- a/src/commands/portable/codex-features-flag.ts
+++ b/src/commands/portable/codex-features-flag.ts
@@ -163,7 +163,10 @@ function ensureFlagInFeaturesSection(
 	const headerLineEnd = content.indexOf("\n", headerStartIdx);
 	const bodyStart = headerLineEnd === -1 ? content.length : headerLineEnd + 1;
 
-	// Find next TOML table header (`\n[...]`) after the body starts
+	// Find next TOML table header (`\n[...]`) after the body starts.
+	// `+ 1` skips the leading `\n` that the pattern matches, so `bodyEnd` lands
+	// exactly on the `[` character of the next header (or EOF). This keeps the
+	// preceding newline inside the section body so insertion / slicing is clean.
 	const rest = content.slice(bodyStart);
 	const nextHeaderMatch = /\n\[[^\]]+\]/.exec(rest);
 	const bodyEnd = nextHeaderMatch ? bodyStart + nextHeaderMatch.index + 1 : content.length;
@@ -186,15 +189,26 @@ function ensureFlagInFeaturesSection(
 		};
 	}
 
-	// Insert the line immediately after the header (with proper EOL handling).
+	// Insert at the END of the section, preserving the user's existing flag order.
+	// This matches user expectations for other managed configs (e.g. `[agents]`)
+	// where CK-appended entries go at the bottom rather than jumping to the top.
 	if (headerLineEnd === -1) {
-		// Header is on the last line with no trailing newline
+		// Header has no trailing content at all — append on a fresh line.
 		return { updated: `${content}\ncodex_hooks = true\n`, changed: true };
 	}
 
-	const insertion = "codex_hooks = true\n";
+	// Trim a single trailing blank line inside the body (if any) so the new line
+	// sits directly under the last existing flag rather than after a gap.
+	let insertAt = bodyEnd;
+	while (insertAt > bodyStart && content[insertAt - 1] === "\n" && content[insertAt - 2] === "\n") {
+		insertAt -= 1;
+	}
+
+	const needsLeadingNewline = insertAt > bodyStart && content[insertAt - 1] !== "\n";
+	const insertion = `${needsLeadingNewline ? "\n" : ""}codex_hooks = true\n`;
+
 	return {
-		updated: content.slice(0, bodyStart) + insertion + content.slice(bodyStart),
+		updated: content.slice(0, insertAt) + insertion + content.slice(insertAt),
 		changed: true,
 	};
 }


### PR DESCRIPTION
## Problem

Users who had already configured `[features]` in `~/.codex/config.toml` (e.g. `unified_exec`, `multi_agent`, `shell_snapshot` — a common setup) got a second `[features]` header appended by the CK-managed block, producing a TOML duplicate-key error on next Codex load:

```
Error loading config.toml:
/Users/.../.codex/config.toml:163:2: duplicate key
    |
163 | [features]
    |  ^^^^^^^^
```

Closes #734

## Root Cause

`src/commands/portable/codex-features-flag.ts` had three branches:
1. Replace existing managed block.
2. Skip if `codex_hooks = true` appears anywhere (raw check).
3. Else append a managed `[features]` block.

Branch 3 never checked whether a user `[features]` table already existed. When the user had `[features]` without `codex_hooks`, the CLI blindly appended a second `[features]` header.

## What changed

| File | Change |
|---|---|
| `src/commands/portable/codex-features-flag.ts` | New algorithm: strip all managed blocks first (self-heal); if user `[features]` exists, merge `codex_hooks = true` into it; else append a managed block. Sub-tables like `[features.foo]` are correctly distinguished. |
| `src/commands/portable/__tests__/codex-features-flag.test.ts` | 6 new tests: user-features merge, duplicate-heal, `false -> true` update, `already-set` when user has it, `[features.sub]` edge case, multi-managed-block cleanup. |

## Self-Healing

Users already affected by the bug (two `[features]` sections in their config) will have the CK-managed duplicate stripped on next CLI run, with `codex_hooks = true` merged into their own `[features]` section. No manual intervention required.

Verified against real broken config (`~/.codex/config.toml` with 8 user flags + ck-managed duplicate): result parses cleanly as TOML with all 8 user flags preserved + `codex_hooks = true` added.

## Validation

- [x] `bun run validate` (typecheck + lint + test + build) passes
- [x] All 582 portable tests pass (13 in `codex-features-flag.test.ts` — 7 existing + 6 new)
- [x] Real-world verification: broken `~/.codex/config.toml` repro → single `[features]` header → Bun's TOML parser parses cleanly with all user flags intact