### PR TITLE
fix(migrate): copy hook companion dirs (lib/, scout-block/) and .ckignore

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "3.41.4-dev.48",
-	"generatedAt": "2026-04-24T04:59:00.352Z",
+	"version": "3.41.4-dev.49",
+	"generatedAt": "2026-04-24T15:14:46.683Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1079,4 +1079,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-24T04:59:00.466Z -->
+<!-- generated: 2026-04-24T15:14:46.801Z -->

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -1068,6 +1068,18 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 				logger.verbose(
 					`[migrate] Copied hook companions to ${hooksProvider}: dirs=[${companionResult.copiedDirs.join(",")}] dotfiles=[${companionResult.copiedDotfiles.join(",")}]`,
 				);
+				const companionParts: string[] = [];
+				if (companionResult.copiedDirs.length > 0) {
+					companionParts.push(`${companionResult.copiedDirs.join(", ")}`);
+				}
+				if (companionResult.copiedDotfiles.length > 0) {
+					companionParts.push(companionResult.copiedDotfiles.join(", "));
+				}
+				if (companionParts.length > 0) {
+					p.log.info(
+						pc.dim(`Copied hook companions to ${hooksProvider}: ${companionParts.join(" + ")}`),
+					);
+				}
 			}
 		}
 

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -21,6 +21,7 @@ import { discoverAgents, getAgentSourcePath } from "../agents/agents-discovery.j
 import { discoverCommands, getCommandSourcePath } from "../commands/commands-discovery.js";
 import { cleanupStaleCodexConfigEntries } from "../portable/codex-toml-installer.js";
 import {
+	copyHooksCompanionDirs,
 	discoverConfig,
 	discoverHooks,
 	discoverRules,
@@ -1044,6 +1045,28 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			} catch (err) {
 				postProgressWarnings.push(
 					`Could not update opencode.json model (${err instanceof Error ? err.message : String(err)}). Agents may fail with ProviderModelNotFoundError until a model is set.`,
+				);
+			}
+		}
+
+		// Copy hook companion directories (lib/, scout-block/, etc.) and .ckignore to each
+		// provider's hooks directory so that `require('./lib/*.cjs')` calls inside hooks
+		// resolve correctly. This runs after per-file hook installs and before settings merger.
+		if (hooksSource && successfulHookFiles.size > 0) {
+			for (const hooksProvider of successfulHookFiles.keys()) {
+				const providerCfg = providers[hooksProvider];
+				const targetHooksDir = installGlobally
+					? providerCfg.hooks?.globalPath
+					: providerCfg.hooks?.projectPath;
+				if (!targetHooksDir) continue;
+				const companionResult = await copyHooksCompanionDirs(hooksSource, targetHooksDir);
+				if (companionResult.errors.length > 0) {
+					for (const e of companionResult.errors) {
+						postProgressWarnings.push(`Hook companion copy warning (${e.name}): ${e.error}`);
+					}
+				}
+				logger.verbose(
+					`[migrate] Copied hook companions to ${hooksProvider}: dirs=[${companionResult.copiedDirs.join(",")}] dotfiles=[${companionResult.copiedDotfiles.join(",")}]`,
 				);
 			}
 		}

--- a/src/commands/portable/__tests__/config-discovery.test.ts
+++ b/src/commands/portable/__tests__/config-discovery.test.ts
@@ -503,5 +503,37 @@ describe("config-discovery", () => {
 			expect(result.copiedDirs).toEqual(["lib"]);
 			expect(existsSync(join(dst, ".logs"))).toBe(false);
 		});
+
+		it("is idempotent — calling twice produces the same result with no errors", async () => {
+			// Second invocation on same src/dst should be a no-op overwrite.
+			// Users may re-run `ck migrate` repeatedly; companion copy must be safe.
+			const providerSrcRoot = join(testDir, "companion-idempotent-src");
+			const providerDstRoot = join(testDir, "companion-idempotent-dst");
+			const src = join(providerSrcRoot, "hooks");
+			const dst = join(providerDstRoot, "hooks");
+
+			mkdirSync(join(src, "lib"), { recursive: true });
+			mkdirSync(join(src, "scout-block"), { recursive: true });
+			writeFileSync(join(src, "lib", "utils.cjs"), "module.exports = {};");
+			writeFileSync(join(src, "scout-block", "fmt.cjs"), "module.exports = {};");
+			writeFileSync(join(providerSrcRoot, ".ckignore"), "!dist\n");
+
+			const first = await copyHooksCompanionDirs(src, dst);
+			const second = await copyHooksCompanionDirs(src, dst);
+
+			expect(first.copiedDirs.sort()).toEqual(["lib", "scout-block"]);
+			expect(first.copiedDotfiles).toContain(".ckignore");
+			expect(first.errors).toHaveLength(0);
+
+			// Second invocation reports same results (no duplicates, no errors)
+			expect(second.copiedDirs.sort()).toEqual(["lib", "scout-block"]);
+			expect(second.copiedDotfiles).toContain(".ckignore");
+			expect(second.errors).toHaveLength(0);
+
+			// Target content unchanged after second call
+			expect(existsSync(join(dst, "lib", "utils.cjs"))).toBe(true);
+			expect(existsSync(join(dst, "scout-block", "fmt.cjs"))).toBe(true);
+			expect(existsSync(join(providerDstRoot, ".ckignore"))).toBe(true);
+		});
 	});
 });

--- a/src/commands/portable/__tests__/config-discovery.test.ts
+++ b/src/commands/portable/__tests__/config-discovery.test.ts
@@ -1,8 +1,17 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { chmodSync, mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	realpathSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	copyHooksCompanionDirs,
 	discoverConfig,
 	discoverHooks,
 	discoverRules,
@@ -383,6 +392,116 @@ describe("config-discovery", () => {
 					chmodSync(maybeUnreadableHook, 0o644);
 				}
 			}
+		});
+	});
+
+	// Regression test for GH-741: companion dirs (lib/, scout-block/) and .ckignore
+	// must be copied alongside hook scripts so require('./lib/*.cjs') resolves correctly.
+	describe("copyHooksCompanionDirs", () => {
+		it("copies lib/ and scout-block/ subdirectories to the target dir", async () => {
+			const src = join(testDir, "companion-src-dirs");
+			const dst = join(testDir, "companion-dst-dirs");
+
+			mkdirSync(join(src, "lib"), { recursive: true });
+			mkdirSync(join(src, "scout-block"), { recursive: true });
+			writeFileSync(join(src, "lib", "colors.cjs"), "module.exports = {};");
+			writeFileSync(join(src, "lib", "hook-logger.cjs"), "module.exports = {};");
+			writeFileSync(join(src, "scout-block", "pattern-matcher.cjs"), "module.exports = {};");
+			// Top-level hook file — should NOT be copied by companion copy (handled by installPerFile)
+			writeFileSync(join(src, "session-init.cjs"), "module.exports = {};");
+
+			const result = await copyHooksCompanionDirs(src, dst);
+
+			expect(result.copiedDirs).toContain("lib");
+			expect(result.copiedDirs).toContain("scout-block");
+			expect(result.errors).toHaveLength(0);
+
+			// Verify files exist at target
+			expect(existsSync(join(dst, "lib", "colors.cjs"))).toBe(true);
+			expect(existsSync(join(dst, "lib", "hook-logger.cjs"))).toBe(true);
+			expect(existsSync(join(dst, "scout-block", "pattern-matcher.cjs"))).toBe(true);
+			// Top-level hook should NOT have been copied by companion copy
+			expect(existsSync(join(dst, "session-init.cjs"))).toBe(false);
+		});
+
+		it("copies .ckignore from source parent to target parent (scout-block layout)", async () => {
+			// scout-block resolves .ckignore via path.dirname(__dirname), i.e. one
+			// level up from hooks/. Mirror that layout: .ckignore lives at the
+			// provider root (~/.claude/.ckignore → ~/.codex/.ckignore), NOT inside hooks/.
+			const providerSrcRoot = join(testDir, "parent-ckignore-src-root");
+			const providerDstRoot = join(testDir, "parent-ckignore-dst-root");
+			const src = join(providerSrcRoot, "hooks");
+			const dst = join(providerDstRoot, "hooks");
+
+			mkdirSync(src, { recursive: true });
+			mkdirSync(providerDstRoot, { recursive: true });
+			// .ckignore lives at the PARENT of hooks/, not inside hooks/
+			writeFileSync(join(providerSrcRoot, ".ckignore"), "!node_modules\n!dist\n");
+
+			const result = await copyHooksCompanionDirs(src, dst);
+
+			expect(result.copiedDotfiles).toContain(".ckignore");
+			expect(result.errors).toHaveLength(0);
+			expect(existsSync(join(providerDstRoot, ".ckignore"))).toBe(true);
+			// Should NOT be written inside hooks/
+			expect(existsSync(join(dst, ".ckignore"))).toBe(false);
+		});
+
+		it("excludes __tests__ and tests directories", async () => {
+			const src = join(testDir, "companion-src-skip-tests");
+			const dst = join(testDir, "companion-dst-skip-tests");
+
+			mkdirSync(join(src, "__tests__"), { recursive: true });
+			mkdirSync(join(src, "tests"), { recursive: true });
+			mkdirSync(join(src, "lib"), { recursive: true });
+			writeFileSync(join(src, "__tests__", "hook.test.cjs"), "test('noop', () => {});");
+			writeFileSync(join(src, "tests", "hook.test.cjs"), "test('noop', () => {});");
+			writeFileSync(join(src, "lib", "utils.cjs"), "module.exports = {};");
+
+			const result = await copyHooksCompanionDirs(src, dst);
+
+			expect(result.copiedDirs).toEqual(["lib"]);
+			expect(existsSync(join(dst, "__tests__"))).toBe(false);
+			expect(existsSync(join(dst, "tests"))).toBe(false);
+			expect(existsSync(join(dst, "lib", "utils.cjs"))).toBe(true);
+		});
+
+		it("is a no-op when source equals target (same-path guard)", async () => {
+			const src = join(testDir, "companion-same-path");
+			mkdirSync(join(src, "lib"), { recursive: true });
+			writeFileSync(join(src, "lib", "utils.cjs"), "module.exports = {};");
+
+			const result = await copyHooksCompanionDirs(src, src);
+
+			expect(result.copiedDirs).toHaveLength(0);
+			expect(result.copiedDotfiles).toHaveLength(0);
+			expect(result.errors).toHaveLength(0);
+		});
+
+		it("returns empty result for nonexistent source directory", async () => {
+			const src = join(testDir, "companion-src-missing-xyz");
+			const dst = join(testDir, "companion-dst-missing-xyz");
+
+			const result = await copyHooksCompanionDirs(src, dst);
+
+			expect(result.copiedDirs).toHaveLength(0);
+			expect(result.copiedDotfiles).toHaveLength(0);
+			expect(result.errors).toHaveLength(0);
+		});
+
+		it("does not copy hidden directories (e.g. .logs)", async () => {
+			const src = join(testDir, "companion-src-hidden");
+			const dst = join(testDir, "companion-dst-hidden");
+
+			mkdirSync(join(src, ".logs"), { recursive: true });
+			mkdirSync(join(src, "lib"), { recursive: true });
+			writeFileSync(join(src, ".logs", "debug.log"), "some log");
+			writeFileSync(join(src, "lib", "utils.cjs"), "module.exports = {};");
+
+			const result = await copyHooksCompanionDirs(src, dst);
+
+			expect(result.copiedDirs).toEqual(["lib"]);
+			expect(existsSync(join(dst, ".logs"))).toBe(false);
 		});
 	});
 });

--- a/src/commands/portable/config-discovery.ts
+++ b/src/commands/portable/config-discovery.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
-import { readFile, readdir } from "node:fs/promises";
+import { cp, mkdir, readFile, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { extname, join, relative, sep } from "node:path";
+import { basename, extname, join, relative, resolve, sep } from "node:path";
 import {
 	findExistingProjectConfigPath,
 	findExistingProjectLayoutPath,
@@ -13,6 +13,137 @@ const HOOK_EXTENSIONS = new Set([".js", ".cjs", ".mjs", ".ts"]);
 
 /** Shell/batch hook extensions that are skipped (not node-runnable) */
 const SHELL_HOOK_EXTENSIONS = new Set([".sh", ".ps1", ".bat", ".cmd"]);
+
+/**
+ * Subdirectory names that must never be copied to a target hooks directory.
+ * Covers test directories and hidden dotfile directories.
+ */
+const HOOKS_SKIP_DIR_NAMES = new Set(["__tests__", "tests", ".logs", "docs"]);
+
+/**
+ * Dotfiles (in the hooks source root, NOT subdirs) that should accompany
+ * hook scripts to the target because hooks require them at runtime.
+ */
+const HOOKS_COMPANION_DOTFILES = new Set([".ckignore"]);
+
+/**
+ * Result of copying companion directories for a hooks install.
+ */
+export interface HooksCompanionCopyResult {
+	/** Subdirectory names successfully copied */
+	copiedDirs: string[];
+	/** Companion dotfiles (e.g. .ckignore) successfully copied */
+	copiedDotfiles: string[];
+	/** Non-fatal errors encountered during copy (per dir/file) */
+	errors: Array<{ name: string; error: string }>;
+}
+
+/**
+ * Copy hook companion directories (e.g. lib/, scout-block/) and companion dotfiles
+ * (e.g. .ckignore) from a source hooks directory to a target directory.
+ *
+ * Called after hook .cjs files are installed so that `require('./lib/*.cjs')` calls
+ * inside hooks resolve without MODULE_NOT_FOUND errors.
+ *
+ * Rules:
+ * - Only subdirectories are copied (not top-level files — those are handled by installPerFile).
+ * - Directories listed in HOOKS_SKIP_DIR_NAMES (__tests__, tests, .logs, docs) are excluded.
+ * - Directories whose names start with "." are excluded.
+ * - Dotfiles in HOOKS_COMPANION_DOTFILES (.ckignore) are copied from the source hooks
+ *   directory's PARENT to the target's PARENT (e.g. ~/.claude/.ckignore →
+ *   ~/.codex/.ckignore). This matches scout-block's `path.dirname(__dirname)` lookup.
+ * - Source and target identical paths are silently skipped (no-op for claude-code → claude-code).
+ * - Individual copy failures are non-fatal; they are collected in errors[].
+ */
+export async function copyHooksCompanionDirs(
+	sourceDir: string,
+	targetDir: string,
+): Promise<HooksCompanionCopyResult> {
+	const result: HooksCompanionCopyResult = {
+		copiedDirs: [],
+		copiedDotfiles: [],
+		errors: [],
+	};
+
+	// Same-path guard: when source IS the target (claude-code project scope), skip entirely.
+	if (resolve(sourceDir) === resolve(targetDir)) {
+		return result;
+	}
+
+	if (!existsSync(sourceDir)) {
+		return result;
+	}
+
+	let entries: Array<import("node:fs").Dirent<string>>;
+	try {
+		entries = await readdir(sourceDir, { withFileTypes: true, encoding: "utf8" });
+	} catch {
+		return result;
+	}
+
+	await mkdir(targetDir, { recursive: true });
+
+	// Copy companion dotfiles from source's PARENT dir to target's PARENT dir.
+	// scout-block resolves `.ckignore` via `path.dirname(__dirname)` — i.e. at
+	// ~/.codex/.ckignore (not ~/.codex/hooks/.ckignore). So we mirror the layout.
+	const sourceParent = resolve(sourceDir, "..");
+	const targetParent = resolve(targetDir, "..");
+	if (sourceParent !== targetParent) {
+		for (const dotfile of HOOKS_COMPANION_DOTFILES) {
+			const srcPath = join(sourceParent, dotfile);
+			if (!existsSync(srcPath)) continue;
+			const dstPath = join(targetParent, dotfile);
+			try {
+				await mkdir(targetParent, { recursive: true });
+				await cp(srcPath, dstPath, { force: true });
+				result.copiedDotfiles.push(dotfile);
+			} catch (err) {
+				result.errors.push({
+					name: dotfile,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		}
+	}
+
+	for (const entry of entries) {
+		// Only process directories
+		if (!entry.isDirectory()) continue;
+
+		// Skip hidden dirs and excluded test dirs
+		if (entry.name.startsWith(".") || HOOKS_SKIP_DIR_NAMES.has(entry.name)) continue;
+
+		// Validate: no path traversal in dir name
+		const safeName = basename(entry.name);
+		if (!safeName || safeName === "." || safeName === ".." || safeName !== entry.name) continue;
+
+		const srcDir = join(sourceDir, entry.name);
+		const dstDir = join(targetDir, entry.name);
+
+		// Skip if the resolved source subdir IS the target subdir
+		if (resolve(srcDir) === resolve(dstDir)) continue;
+
+		// Verify srcDir is a real directory (not a symlink to dir)
+		try {
+			const s = await stat(srcDir);
+			if (!s.isDirectory()) continue;
+		} catch {
+			continue;
+		}
+
+		try {
+			await cp(srcDir, dstDir, { recursive: true, force: true });
+			result.copiedDirs.push(entry.name);
+		} catch (err) {
+			result.errors.push({
+				name: entry.name,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+
+	return result;
+}
 
 /** Determine if a source path is project-local or global */
 export function resolveSourceOrigin(sourcePath: string | null): "project" | "global" {

--- a/src/commands/portable/config-discovery.ts
+++ b/src/commands/portable/config-discovery.ts
@@ -16,7 +16,10 @@ const SHELL_HOOK_EXTENSIONS = new Set([".sh", ".ps1", ".bat", ".cmd"]);
 
 /**
  * Subdirectory names that must never be copied to a target hooks directory.
- * Covers test directories and hidden dotfile directories.
+ * - `__tests__`, `tests`: unit tests, not required at runtime
+ * - `.logs`: per-hook runtime log output (written, not read)
+ * - `docs`: JSDoc or markdown authors occasionally drop here; hooks never
+ *   `require()` from docs/, so copying it just bloats the target
  */
 const HOOKS_SKIP_DIR_NAMES = new Set(["__tests__", "tests", ".logs", "docs"]);
 
@@ -81,7 +84,18 @@ export async function copyHooksCompanionDirs(
 		return result;
 	}
 
-	await mkdir(targetDir, { recursive: true });
+	// Non-fatal mkdir per function contract. In practice the hooks dir already
+	// exists from per-file install, but an ACL-restricted target would
+	// otherwise throw past the caller and abort downstream steps.
+	try {
+		await mkdir(targetDir, { recursive: true });
+	} catch (err) {
+		result.errors.push({
+			name: targetDir,
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return result;
+	}
 
 	// Copy companion dotfiles from source's PARENT dir to target's PARENT dir.
 	// scout-block resolves `.ckignore` via `path.dirname(__dirname)` — i.e. at
@@ -123,7 +137,11 @@ export async function copyHooksCompanionDirs(
 		// Skip if the resolved source subdir IS the target subdir
 		if (resolve(srcDir) === resolve(dstDir)) continue;
 
-		// Verify srcDir is a real directory (not a symlink to dir)
+		// TOCTOU guard: re-stat the entry — even though readdir already reported
+		// it as a directory, another process could have raced to replace it
+		// between readdir and the cp call. stat() follows symlinks, so a
+		// symlink-to-dir still resolves as a directory here; the `isDirectory`
+		// check on the Dirent above already filtered bare symlinks.
 		try {
 			const s = await stat(srcDir);
 			if (!s.isDirectory()) continue;


### PR DESCRIPTION
## Problem

`ck migrate` copied top-level hook files into the target provider (e.g. `~/.codex/hooks/scout-block.cjs`) but silently missed the sibling directories and dotfile those hooks require at runtime:

- `lib/` — 18 shared helper modules imported via `require('./lib/*.cjs')`
- `scout-block/` — 6 formatter modules imported by the scout-block hook
- `.ckignore` — gitignore-style baseline resolved by `scout-checker` via `path.dirname(__dirname)` — i.e. at the provider root, NOT inside `hooks/`

Without these, every migrated hook crashes on `MODULE_NOT_FOUND` and falls through the outer `try/catch` fail-open path. scout-block silently allows operations it should block. privacy-block silently allows sensitive file reads. Users see no indication their safety hooks are inert.

Closes #741

## Root Cause

`discoverHooks()` returns only top-level `*.cjs`/`.js`/`.mjs`/`.ts` files as `PortableItem`s. The portable installer copies those but has no mechanism to bring along companion subdirs or provider-level dotfiles.

## Fix

New `copyHooksCompanionDirs(sourceDir, targetDir)` in `config-discovery.ts`:
- Recursively copies non-test, non-hidden subdirs from source hooks dir → target hooks dir
- Copies dotfiles in `HOOKS_COMPANION_DOTFILES` (`{.ckignore}`) from source PARENT → target PARENT to match the scout-block layout
- Same-path guard (claude-code → claude-code = no-op)
- Per-item errors non-fatal, collected in `errors[]`

Called from `migrate-command.ts` once per provider after hook files install, before `migrateHooksSettings`.

## What changed

| File | Change |
|---|---|
| `src/commands/portable/config-discovery.ts` | +126 — `copyHooksCompanionDirs`, `HooksCompanionCopyResult`, constants |
| `src/commands/migrate/migrate-command.ts` | +23 — import + invoke after hook install per provider |
| `src/commands/portable/__tests__/config-discovery.test.ts` | +115 — 6 regression tests |

## Validation

- [x] `bun run validate` — typecheck + lint + build + test, all pass
- [x] 36/36 tests in `config-discovery.test.ts` (6 new + 30 existing)
- [x] 628/628 tests in `src/commands/portable/` suite
- [x] Smoke test against real `~/.claude/hooks/` → temp target confirmed `lib/`, `scout-block/`, `.ckignore` all land correctly

## Real-world verification

Manually applied equivalent of this fix on developer Mac (`~/.codex/hooks/lib/` + `~/.codex/hooks/scout-block/` + `~/.codex/.ckignore`) → all 8 registered Codex hooks now respond correctly. Fresh `ck migrate` run on Windows dev.49 produced the broken state documented in #741 (top-level hooks only, no companion dirs). This PR will produce the complete state on next `ck migrate`.

## Follow-ups (out of scope, separate issues)

- Codex hook wrappers disabled on Windows (`skipped-windows`) — blocks full hook UX on Win
- `~/.claude/.ck.json` config lookup hardcoded in `lib/ck-config-utils.cjs` regardless of installed provider — cross-provider leak
- Companion dirs not tracked in portable registry → reconciler won't detect user edits to `lib/` files