### PR TITLE
fix(migrate): install scope bleed + hooks.json self-heal

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "3.41.4-dev.49",
-	"generatedAt": "2026-04-24T15:14:46.683Z",
+	"version": "3.41.4-dev.50",
+	"generatedAt": "2026-04-24T19:05:19.887Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
 	"version": "3.41.4-dev.50",
-	"generatedAt": "2026-04-24T19:05:19.887Z",
+	"generatedAt": "2026-04-24T19:35:28.461Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1079,4 +1079,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-24T15:14:46.801Z -->
+<!-- generated: 2026-04-24T19:05:20.007Z -->

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1079,4 +1079,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-24T19:05:20.007Z -->
+<!-- generated: 2026-04-24T19:35:28.581Z -->

--- a/src/__tests__/domains/web-server/routes/migration-routes.test.ts
+++ b/src/__tests__/domains/web-server/routes/migration-routes.test.ts
@@ -537,6 +537,52 @@ describe("migration reconcile route", () => {
 		expect(body.discovery.skills).toBe(2);
 	});
 
+	test("install mode with skills=false does not fall back to installing discovered skills (#740)", async () => {
+		getSkillSourcePathMock.mockReturnValueOnce("/tmp/skills");
+		discoverSkillsMock.mockResolvedValueOnce([
+			{
+				name: "skill-a",
+				displayName: "Skill A",
+				description: "",
+				version: "1.0.0",
+				license: "MIT",
+				path: "/tmp/skill-a",
+			},
+		]);
+
+		// Synthetic install plan built by the UI's buildSyntheticPlan — user
+		// selected only hooks, not skills. Skills must stay untouched even
+		// though discovery would surface them.
+		const plan = {
+			actions: [],
+			summary: { install: 0, update: 0, skip: 0, conflict: 0, delete: 0 },
+			hasConflicts: false,
+			meta: {
+				include: {
+					agents: false,
+					commands: false,
+					skills: false,
+					config: false,
+					rules: false,
+					hooks: true,
+				},
+				providers: ["codex"],
+				items: { skills: [] },
+				mode: "install",
+			},
+		};
+
+		const res = await fetch(`${ctx.baseUrl}/api/migrate/execute`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ plan, resolutions: {}, mode: "install" }),
+		});
+
+		expect(res.status).toBe(200);
+		// Scope holds: no skill installs triggered by the fallback.
+		expect(installSkillDirectoriesMock).not.toHaveBeenCalled();
+	});
+
 	test('accepts global query values "1", "0", and empty string', async () => {
 		const trueLike = await fetch(`${ctx.baseUrl}/api/migrate/reconcile?providers=codex&global=1`);
 		expect(trueLike.status).toBe(200);

--- a/src/__tests__/domains/web-server/routes/migration-routes.test.ts
+++ b/src/__tests__/domains/web-server/routes/migration-routes.test.ts
@@ -583,6 +583,51 @@ describe("migration reconcile route", () => {
 		expect(installSkillDirectoriesMock).not.toHaveBeenCalled();
 	});
 
+	test("install mode with skills=true but items.skills=[] does not install discovered skills (#740 guard)", async () => {
+		getSkillSourcePathMock.mockReturnValueOnce("/tmp/skills");
+		discoverSkillsMock.mockResolvedValueOnce([
+			{
+				name: "skill-a",
+				displayName: "Skill A",
+				description: "",
+				version: "1.0.0",
+				license: "MIT",
+				path: "/tmp/skill-a",
+			},
+		]);
+
+		// Exercises the inner ternary: include.skills: true passes the outer
+		// guard, but allowedSkillNames is empty — install mode must mean
+		// "install nothing", not fall back to "install everything".
+		const plan = {
+			actions: [],
+			summary: { install: 0, update: 0, skip: 0, conflict: 0, delete: 0 },
+			hasConflicts: false,
+			meta: {
+				include: {
+					agents: false,
+					commands: false,
+					skills: true,
+					config: false,
+					rules: false,
+					hooks: false,
+				},
+				providers: ["codex"],
+				items: { skills: [] },
+				mode: "install",
+			},
+		};
+
+		const res = await fetch(`${ctx.baseUrl}/api/migrate/execute`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ plan, resolutions: {}, mode: "install" }),
+		});
+
+		expect(res.status).toBe(200);
+		expect(installSkillDirectoriesMock).not.toHaveBeenCalled();
+	});
+
 	test('accepts global query values "1", "0", and empty string', async () => {
 		const trueLike = await fetch(`${ctx.baseUrl}/api/migrate/reconcile?providers=codex&global=1`);
 		expect(trueLike.status).toBe(200);

--- a/src/commands/portable/__tests__/hooks-settings-merger.test.ts
+++ b/src/commands/portable/__tests__/hooks-settings-merger.test.ts
@@ -193,6 +193,79 @@ describe("mergeHooksIntoSettings", () => {
 		expect(result.backupPath).not.toBeNull();
 		expect(existsSync(result.backupPath as string)).toBe(true);
 	});
+
+	it("prunes stale absolute-path hooks whose target file is missing (self-heal)", async () => {
+		const path = join(testDir, "merge-selfheal.json");
+		const liveHook = join(testDir, "live-hook.cjs");
+		const staleHook = join(testDir, "does-not-exist.cjs");
+		writeFileSync(liveHook, "// live");
+
+		writeFileSync(
+			path,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "*",
+							hooks: [
+								{ type: "command", command: staleHook }, // stale — file missing
+								{ type: "command", command: liveHook }, // live — file present
+								{ type: "command", command: "npm run lint" }, // non-path — keep
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		const newHooks = {
+			PreToolUse: [
+				{
+					matcher: "*",
+					hooks: [{ type: "command", command: liveHook }], // duplicate of live
+				},
+			],
+		};
+		await mergeHooksIntoSettings(path, newHooks);
+
+		const content = JSON.parse(await Bun.file(path).text());
+		const commands = content.hooks.PreToolUse[0].hooks.map((h: { command: string }) => h.command);
+		// Stale removed
+		expect(commands).not.toContain(staleHook);
+		// Live preserved (deduped)
+		expect(commands.filter((c: string) => c === liveHook)).toHaveLength(1);
+		// Non-path shell command preserved
+		expect(commands).toContain("npm run lint");
+	});
+
+	it("drops a group when all its hooks are stale", async () => {
+		const path = join(testDir, "merge-drop-group.json");
+		const staleHook = join(testDir, "stale-only.cjs");
+		writeFileSync(
+			path,
+			JSON.stringify({
+				hooks: {
+					Stop: [
+						{
+							matcher: "*",
+							hooks: [{ type: "command", command: staleHook }],
+						},
+					],
+				},
+			}),
+		);
+
+		const newHooks = {
+			SessionStart: [{ hooks: [{ type: "command", command: "echo ok" }] }],
+		};
+		await mergeHooksIntoSettings(path, newHooks);
+
+		const content = JSON.parse(await Bun.file(path).text());
+		// Stop event entirely removed (group had only stale hook)
+		expect(content.hooks.Stop).toBeUndefined();
+		// New event registered
+		expect(content.hooks.SessionStart).toHaveLength(1);
+	});
 });
 
 describe("migrateHooksSettings", () => {

--- a/src/commands/portable/__tests__/hooks-settings-merger.test.ts
+++ b/src/commands/portable/__tests__/hooks-settings-merger.test.ts
@@ -195,9 +195,12 @@ describe("mergeHooksIntoSettings", () => {
 	});
 
 	it("prunes stale absolute-path hooks whose target file is missing (self-heal)", async () => {
+		// Paths under a fake .codex/hooks/ directory to exercise the CK-managed scope.
+		const ckHooksDir = join(testDir, ".codex", "hooks");
+		await Bun.write(join(ckHooksDir, ".keep"), "");
 		const path = join(testDir, "merge-selfheal.json");
-		const liveHook = join(testDir, "live-hook.cjs");
-		const staleHook = join(testDir, "does-not-exist.cjs");
+		const liveHook = join(ckHooksDir, "live-hook.cjs");
+		const staleHook = join(ckHooksDir, "does-not-exist.cjs");
 		writeFileSync(liveHook, "// live");
 
 		writeFileSync(
@@ -239,8 +242,10 @@ describe("mergeHooksIntoSettings", () => {
 	});
 
 	it("drops a group when all its hooks are stale", async () => {
+		const ckHooksDir = join(testDir, ".claude", "hooks");
+		await Bun.write(join(ckHooksDir, ".keep"), "");
 		const path = join(testDir, "merge-drop-group.json");
-		const staleHook = join(testDir, "stale-only.cjs");
+		const staleHook = join(ckHooksDir, "stale-only.cjs");
 		writeFileSync(
 			path,
 			JSON.stringify({
@@ -265,6 +270,40 @@ describe("mergeHooksIntoSettings", () => {
 		expect(content.hooks.Stop).toBeUndefined();
 		// New event registered
 		expect(content.hooks.SessionStart).toHaveLength(1);
+	});
+
+	it("preserves user-owned absolute-path hooks outside CK install locations", async () => {
+		// User's own absolute-path hook — not under ~/.claude/, ~/.codex/, ~/.gemini/.
+		// Even if the file is missing (e.g. network mount unavailable), it must survive.
+		const path = join(testDir, "merge-user-owned.json");
+		const userHook = join(testDir, "custom", "user-script.sh");
+		const ckStaleHook = join(testDir, ".codex", "hooks", "stale.cjs");
+
+		writeFileSync(
+			path,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "*",
+							hooks: [
+								{ type: "command", command: userHook }, // user-owned, missing → keep
+								{ type: "command", command: ckStaleHook }, // ck-owned, missing → prune
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		await mergeHooksIntoSettings(path, {
+			SessionStart: [{ hooks: [{ type: "command", command: "echo ok" }] }],
+		});
+
+		const content = JSON.parse(await Bun.file(path).text());
+		const commands = content.hooks.PreToolUse[0].hooks.map((h: { command: string }) => h.command);
+		expect(commands).toContain(userHook); // user-owned preserved
+		expect(commands).not.toContain(ckStaleHook); // ck-owned pruned
 	});
 });
 

--- a/src/commands/portable/hooks-settings-merger.ts
+++ b/src/commands/portable/hooks-settings-merger.ts
@@ -7,7 +7,7 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import type { CodexCapabilities } from "./codex-capabilities.js";
 import { detectCodexCapabilities } from "./codex-capabilities.js";
 import { ensureCodexHooksFeatureFlag } from "./codex-features-flag.js";
@@ -302,7 +302,11 @@ export async function mergeHooksIntoSettings(
 	}
 
 	const existingHooks = (existingSettings.hooks ?? {}) as HooksSection;
-	const merged = deduplicateMerge(existingHooks, newHooks);
+	// Self-heal stale ck-managed entries: drop hooks whose command is an
+	// absolute file path pointing at a missing file. Fixes the "duplicates"
+	// symptom after users purge ~/.codex/hooks/ without clearing hooks.json (#739).
+	const pruned = pruneStaleFileHooks(existingHooks);
+	const merged = deduplicateMerge(pruned, newHooks);
 	existingSettings.hooks = merged;
 
 	// Atomic write: temp file + rename
@@ -318,6 +322,51 @@ export async function mergeHooksIntoSettings(
 	}
 
 	return { backupPath };
+}
+
+/**
+ * Extract the leading file-path token from a command string, if any.
+ * Returns null for commands that don't start with an absolute path.
+ * Examples:
+ *   "/Users/x/.codex/hooks/abc.cjs"          → "/Users/x/.codex/hooks/abc.cjs"
+ *   "/Users/x/hook.cjs --flag"                → "/Users/x/hook.cjs"
+ *   "node /Users/x/hook.cjs"                  → null (first token is "node")
+ *   "npm run lint"                            → null
+ */
+function extractLeadingAbsolutePath(command: string): string | null {
+	const trimmed = command.trim();
+	if (trimmed.length === 0) return null;
+	// Take first whitespace-delimited token
+	const firstToken = trimmed.split(/\s+/)[0];
+	if (!firstToken) return null;
+	if (!isAbsolute(firstToken)) return null;
+	return firstToken;
+}
+
+/**
+ * Drop hook entries whose command references a missing file on disk.
+ * Only considers commands whose first token is an absolute path — shell
+ * expressions and PATH-resolved binaries are preserved verbatim.
+ */
+function pruneStaleFileHooks(existing: HooksSection): HooksSection {
+	const result: HooksSection = {};
+	for (const [event, groups] of Object.entries(existing)) {
+		const prunedGroups: HookGroup[] = [];
+		for (const group of groups) {
+			const survivingHooks = group.hooks.filter((h) => {
+				const path = extractLeadingAbsolutePath(h.command);
+				if (path === null) return true; // Not a file-path command — keep
+				return existsSync(path);
+			});
+			if (survivingHooks.length > 0) {
+				prunedGroups.push({ ...group, hooks: survivingHooks });
+			}
+		}
+		if (prunedGroups.length > 0) {
+			result[event] = prunedGroups;
+		}
+	}
+	return result;
 }
 
 /**

--- a/src/commands/portable/hooks-settings-merger.ts
+++ b/src/commands/portable/hooks-settings-merger.ts
@@ -344,9 +344,26 @@ function extractLeadingAbsolutePath(command: string): string | null {
 }
 
 /**
- * Drop hook entries whose command references a missing file on disk.
- * Only considers commands whose first token is an absolute path — shell
- * expressions and PATH-resolved binaries are preserved verbatim.
+ * True if the absolute path looks like a CK-managed hook install location.
+ * We only self-heal ck-owned entries to avoid silently dropping a user's
+ * own absolute-path hook whose file is temporarily unavailable (network
+ * mount, recently deleted, cross-platform path).
+ */
+function isCkManagedHookPath(absPath: string): boolean {
+	// Normalize separators so the check works on POSIX and Windows.
+	const normalized = absPath.replace(/\\/g, "/");
+	return (
+		normalized.includes("/.claude/hooks/") ||
+		normalized.includes("/.codex/hooks/") ||
+		normalized.includes("/.gemini/hooks/")
+	);
+}
+
+/**
+ * Drop CK-managed hook entries whose command references a missing file on
+ * disk. Only paths that look like CK install locations are evaluated —
+ * shell expressions, PATH-resolved binaries, and user-owned absolute-path
+ * hooks are preserved verbatim.
  */
 function pruneStaleFileHooks(existing: HooksSection): HooksSection {
 	const result: HooksSection = {};
@@ -356,6 +373,7 @@ function pruneStaleFileHooks(existing: HooksSection): HooksSection {
 			const survivingHooks = group.hooks.filter((h) => {
 				const path = extractLeadingAbsolutePath(h.command);
 				if (path === null) return true; // Not a file-path command — keep
+				if (!isCkManagedHookPath(path)) return true; // Not CK-owned — keep
 				return existsSync(path);
 			});
 			if (survivingHooks.length > 0) {

--- a/src/domains/web-server/routes/migration-routes.ts
+++ b/src/domains/web-server/routes/migration-routes.ts
@@ -154,7 +154,9 @@ const PLAN_EXECUTE_PAYLOAD_SCHEMA = z
 	.object({
 		plan: RECONCILE_PLAN_SCHEMA,
 		resolutions: z.record(CONFLICT_RESOLUTION_SCHEMA).optional().default({}),
-		// P2 addition — telemetry/audit only, no behavior change
+		// Behavioral: in "install" mode the plan is authoritative — the skills
+		// fallback treats an empty allowedSkillNames as "none" instead of
+		// "install everything". See #740.
 		mode: z.enum(["reconcile", "install"]).optional(),
 	})
 	.passthrough();

--- a/src/domains/web-server/routes/migration-routes.ts
+++ b/src/domains/web-server/routes/migration-routes.ts
@@ -1491,6 +1491,10 @@ export function registerMigrationRoutes(app: Express): void {
 				}
 				const plan = parity.value;
 				const resolutionsObj: Record<string, ConflictResolution> = payloadParsed.data.resolutions;
+				// Install mode treats the plan as authoritative — no type-level fallbacks.
+				// See #740: previously the skills fallback installed all discovered skills
+				// whenever plan had zero skill actions, leaking scope into unselected types.
+				const executionMode = payloadParsed.data.mode ?? "reconcile";
 
 				// Apply resolutions to conflicted actions
 				const resolutionsMap = new Map(Object.entries(resolutionsObj));
@@ -1668,14 +1672,19 @@ export function registerMigrationRoutes(app: Express): void {
 
 				const allPlanProviders = getProvidersFromPlan(plan);
 
-				// Handle skills fallback (directory-based, may not be in reconcile actions)
+				// Handle skills fallback (directory-based, may not be in reconcile actions).
+				// In install mode, the plan is authoritative — skip the fallback entirely
+				// when include.skills is false. When include.skills is true, an empty
+				// allowedSkillNames means "no skills selected" (not "install everything").
 				const plannedSkillActions = execActions.filter((a) => a.type === "skill").length;
 				if (includeFromPlan.skills && discovered.skills.length > 0 && plannedSkillActions === 0) {
 					const allowedSkillNames = getPlanItemsByType(plan, "skills");
 					const plannedSkills =
 						allowedSkillNames.length > 0
 							? discovered.skills.filter((skill) => allowedSkillNames.includes(skill.name))
-							: discovered.skills;
+							: executionMode === "install"
+								? []
+								: discovered.skills;
 					const skillProviders = allPlanProviders.filter((provider) =>
 						providerSupportsType(provider, "skill"),
 					);

--- a/src/ui/src/components/migrate/install-picker.tsx
+++ b/src/ui/src/components/migrate/install-picker.tsx
@@ -300,6 +300,10 @@ export function buildDefaultSelectedSet(candidates: InstallCandidate[]): Set<str
 /**
  * Build a synthetic ReconcilePlan from selected InstallCandidates.
  * Used to POST to /api/migrate/execute in Install mode.
+ *
+ * Meta is populated from the ACTUAL selection so server-side helpers
+ * (`getIncludeFromPlan`, `getPlanItemsByType`) don't over-expand scope
+ * and trigger fallbacks for types the user didn't select. See #740.
  */
 export function buildSyntheticPlan(
 	candidates: InstallCandidate[],
@@ -319,6 +323,12 @@ export function buildSyntheticPlan(
 	summary: { install: number; update: number; skip: number; conflict: number; delete: number };
 	hasConflicts: boolean;
 	banners: never[];
+	meta: {
+		include: Record<"agents" | "commands" | "skills" | "config" | "rules" | "hooks", boolean>;
+		providers: string[];
+		items: Record<"agents" | "commands" | "skills" | "config" | "rules" | "hooks", string[]>;
+		mode: "install";
+	};
 } {
 	const selected = candidates.filter((c) => selectedKeys.has(candidateKey(c)));
 	const actions = selected.map((c) => ({
@@ -332,10 +342,52 @@ export function buildSyntheticPlan(
 		reasonCode: "new-item" as const,
 		isDirectoryItem: c.isDirectoryItem,
 	}));
+
+	// Map portable type to include key
+	const toKey = (t: InstallCandidate["type"]) =>
+		({
+			agent: "agents" as const,
+			command: "commands" as const,
+			skill: "skills" as const,
+			config: "config" as const,
+			rules: "rules" as const,
+			hooks: "hooks" as const,
+		})[t];
+
+	const include = {
+		agents: false,
+		commands: false,
+		skills: false,
+		config: false,
+		rules: false,
+		hooks: false,
+	};
+	const items: Record<"agents" | "commands" | "skills" | "config" | "rules" | "hooks", string[]> = {
+		agents: [],
+		commands: [],
+		skills: [],
+		config: [],
+		rules: [],
+		hooks: [],
+	};
+	const providerSet = new Set<string>();
+	for (const c of selected) {
+		const key = toKey(c.type);
+		include[key] = true;
+		items[key].push(c.item);
+		providerSet.add(c.provider);
+	}
+
 	return {
 		actions,
 		summary: { install: actions.length, update: 0, skip: 0, conflict: 0, delete: 0 },
 		hasConflicts: false,
 		banners: [],
+		meta: {
+			include,
+			providers: Array.from(providerSet),
+			items,
+			mode: "install",
+		},
 	};
 }


### PR DESCRIPTION
## Summary

Fixes two post-PR-737 migrate issues bundled into one PR since both live in the same surface area.

### #740 — Install mode scope bleed
Selecting only hooks in Install mode installed every discovered skill. Synthetic plans built by `buildSyntheticPlan` lacked `meta.include`, so `getIncludeFromPlan` fell back to inference + forced `skills: true`. With zero skill actions in the plan, the skills fallback in `/api/migrate/execute` installed all discovered skills.

- `buildSyntheticPlan` now emits truthful `meta` from actual selection: `include`, `items`, `providers`, and `mode: "install"`.
- `/api/migrate/execute` now reads `payload.mode` and treats the plan as authoritative in install mode — an empty `allowedSkillNames` means "nothing", not "everything".
- Existing skills-fallback tests preserved (reconcile mode unchanged).

### #739 — hooks.json self-heal
After users purged `~/.codex/hooks/` without clearing `hooks.json`, stale absolute-path entries persisted. New migrate registrations piled on top → visible "duplicates" + Codex invoking missing files.

- `mergeHooksIntoSettings` now prunes existing hook entries whose command's leading token is an absolute path pointing at a missing file, before merging new registrations.
- Shell expressions (`npm run lint`, `node …`), PATH-resolved binaries, and live paths are untouched.
- Groups with zero surviving hooks are dropped entirely.

## Test plan
- [x] Unit: 2 new `pruneStaleFileHooks` tests (stale-removed, whole-group-dropped) in `hooks-settings-merger.test.ts`
- [x] Unit: new install-mode scope-bleed guard test in `migration-routes.test.ts`
- [x] `bun test` — 4521 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run ui:build` — clean
- [x] `bun run lint:fix` — clean
- [ ] Manual smoke: install-mode picker → select only hooks → verify skills untouched (post-merge on Mac)

Closes #739
Closes #740