### PR TITLE
fix(codex): translate Claude-Code exit-code block to Codex deny JSON

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "3.41.4-dev.50",
-	"generatedAt": "2026-04-24T19:35:28.461Z",
+	"version": "3.41.4-dev.51",
+	"generatedAt": "2026-04-24T21:06:34.128Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1079,4 +1079,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-24T19:35:28.581Z -->
+<!-- generated: 2026-04-24T21:06:34.277Z -->

--- a/src/commands/portable/__tests__/codex-hook-wrapper.test.ts
+++ b/src/commands/portable/__tests__/codex-hook-wrapper.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CodexCapabilities } from "../codex-capabilities.js";
@@ -75,8 +76,8 @@ describe("buildWrapperScript", () => {
 
 	it("passes through non-JSON output unchanged", () => {
 		const script = buildWrapperScript("/hook.cjs", caps);
-		// Script should handle the non-JSON case gracefully
-		expect(script).toContain("Not valid JSON");
+		// Non-JSON handling lives in the catch block after JSON.parse.
+		expect(script).toContain("Non-JSON stdout");
 	});
 });
 
@@ -154,5 +155,130 @@ describe("generateCodexHookWrappers", () => {
 
 		const content = readFileSync(results[0].wrapperPath, "utf8");
 		expect(content).toContain(originalPath);
+	});
+});
+
+/**
+ * Behavioral tests for the Claude-Code-exit-code → Codex-JSON translation (#738).
+ * Each test generates a real wrapper script around a synthetic original hook,
+ * invokes the wrapper via `node`, and asserts stdout/exit-code.
+ */
+describe("buildWrapperScript — exit-code → JSON protocol translation (#738)", () => {
+	function writeFakeOriginalHook(
+		path: string,
+		body: { exit: number; stdout?: string; stderr?: string },
+	): void {
+		const stdoutLit = body.stdout ? JSON.stringify(body.stdout) : '""';
+		const stderrLit = body.stderr ? JSON.stringify(body.stderr) : '""';
+		writeFileSync(
+			path,
+			`#!/usr/bin/env node
+if (${stdoutLit}) process.stdout.write(${stdoutLit});
+if (${stderrLit}) process.stderr.write(${stderrLit});
+process.exit(${body.exit});
+`,
+			{ mode: 0o755 },
+		);
+	}
+
+	function runWrapper(
+		wrapperPath: string,
+		event: string,
+	): { stdout: string; stderr: string; status: number | null } {
+		const result = spawnSync(process.execPath, [wrapperPath], {
+			input: JSON.stringify({ hook_event_name: event }),
+			encoding: "utf8",
+		});
+		return { stdout: result.stdout, stderr: result.stderr, status: result.status };
+	}
+
+	it("exit 2 + stderr + no stdout on PreToolUse → emits permissionDecision:deny + exit 0", () => {
+		const wrapperDir = join(testDir, "trans-exit2-nostdout");
+		const originalHook = join(testDir, "block-hook.cjs");
+		writeFakeOriginalHook(originalHook, { exit: 2, stderr: "Path is blocked" });
+
+		const results = generateCodexHookWrappers([originalHook], wrapperDir, caps);
+		expect(results[0].success).toBe(true);
+
+		const out = runWrapper(results[0].wrapperPath, "PreToolUse");
+		expect(out.status).toBe(0);
+		const parsed = JSON.parse(out.stdout);
+		expect(parsed.permissionDecision).toBe("deny");
+		expect(parsed.reason).toBe("Path is blocked");
+	});
+
+	it("exit 2 + non-JSON stdout on PreToolUse → uses stdout as deny reason", () => {
+		const wrapperDir = join(testDir, "trans-exit2-rawstdout");
+		const originalHook = join(testDir, "raw-block.cjs");
+		writeFakeOriginalHook(originalHook, { exit: 2, stdout: "Denied: env access" });
+
+		const results = generateCodexHookWrappers([originalHook], wrapperDir, caps);
+		const out = runWrapper(results[0].wrapperPath, "PreToolUse");
+		expect(out.status).toBe(0);
+		const parsed = JSON.parse(out.stdout);
+		expect(parsed.permissionDecision).toBe("deny");
+		expect(parsed.reason).toBe("Denied: env access");
+	});
+
+	it("exit 2 on Stop (no deny support) → exit code passes through without translation", () => {
+		const wrapperDir = join(testDir, "trans-stop-event");
+		const originalHook = join(testDir, "stop-block.cjs");
+		writeFakeOriginalHook(originalHook, { exit: 2, stderr: "Stop blocked" });
+
+		const results = generateCodexHookWrappers([originalHook], wrapperDir, caps);
+		const out = runWrapper(results[0].wrapperPath, "Stop");
+		expect(out.status).toBe(2);
+		expect(out.stdout).toBe("");
+		expect(out.stderr).toContain("Stop blocked");
+	});
+
+	it("exit 0 + no stdout → silent allow, no translation", () => {
+		const wrapperDir = join(testDir, "trans-silent-allow");
+		const originalHook = join(testDir, "allow-hook.cjs");
+		writeFakeOriginalHook(originalHook, { exit: 0 });
+
+		const results = generateCodexHookWrappers([originalHook], wrapperDir, caps);
+		const out = runWrapper(results[0].wrapperPath, "PreToolUse");
+		expect(out.status).toBe(0);
+		expect(out.stdout).toBe("");
+	});
+
+	it("hook emits valid JSON with deny → scrubbed and passed through, exit 0", () => {
+		const wrapperDir = join(testDir, "trans-json-deny");
+		const originalHook = join(testDir, "json-deny.cjs");
+		writeFakeOriginalHook(originalHook, {
+			exit: 0,
+			stdout: JSON.stringify({
+				permissionDecision: "deny",
+				reason: "Blocked by rule",
+				additionalContext: "should-be-scrubbed",
+			}),
+		});
+
+		const results = generateCodexHookWrappers([originalHook], wrapperDir, caps);
+		const out = runWrapper(results[0].wrapperPath, "PreToolUse");
+		expect(out.status).toBe(0);
+		const parsed = JSON.parse(out.stdout);
+		expect(parsed.permissionDecision).toBe("deny");
+		expect(parsed.reason).toBe("Blocked by rule");
+		// additionalContext scrubbed for PreToolUse
+		expect(parsed.additionalContext).toBeUndefined();
+	});
+
+	it("exit 2 + JSON without permissionDecision → translates to deny", () => {
+		const wrapperDir = join(testDir, "trans-exit2-json-noDeny");
+		const originalHook = join(testDir, "json-bare.cjs");
+		writeFakeOriginalHook(originalHook, {
+			exit: 2,
+			stdout: JSON.stringify({ something: "else" }),
+			stderr: "Nope",
+		});
+
+		const results = generateCodexHookWrappers([originalHook], wrapperDir, caps);
+		const out = runWrapper(results[0].wrapperPath, "PreToolUse");
+		expect(out.status).toBe(0);
+		const parsed = JSON.parse(out.stdout);
+		expect(parsed.permissionDecision).toBe("deny");
+		expect(parsed.reason).toBe("Nope");
 	});
 });

--- a/src/commands/portable/__tests__/codex-hook-wrapper.test.ts
+++ b/src/commands/portable/__tests__/codex-hook-wrapper.test.ts
@@ -45,12 +45,13 @@ describe("buildWrapperScript", () => {
 		const script = buildWrapperScript("/hook.cjs", caps);
 		// PostToolUse supports additionalContext so should NOT be in STRIP_RULES
 		// The STRIP_RULES object only contains events where fields need stripping
-		const stripRulesMatch = script.match(/const STRIP_RULES = (\{.*?\});/s);
-		if (stripRulesMatch) {
-			const stripRules = JSON.parse(stripRulesMatch[1]);
-			// PostToolUse should not be in strip rules (it supports additionalContext)
-			expect(stripRules.PostToolUse).toBeUndefined();
+		const scrubRulesMatch = script.match(/const SCRUB_RULES = (\{.*?\});/s);
+		if (scrubRulesMatch === null) {
+			throw new Error("SCRUB_RULES declaration not found in generated script");
 		}
+		const scrubRules = JSON.parse(scrubRulesMatch[1]);
+		// PostToolUse should not be in scrub rules (it supports additionalContext)
+		expect(scrubRules.PostToolUse).toBeUndefined();
 	});
 
 	it("uses spawnSync to invoke the original hook", () => {
@@ -263,6 +264,27 @@ process.exit(${body.exit});
 		expect(parsed.reason).toBe("Blocked by rule");
 		// additionalContext scrubbed for PreToolUse
 		expect(parsed.additionalContext).toBeUndefined();
+	});
+
+	it("exit 2 + JSON with permissionDecision:deny → keeps hook's reason, exits 0 (consistency)", () => {
+		const wrapperDir = join(testDir, "trans-exit2-json-hasDeny");
+		const originalHook = join(testDir, "json-deny-exit2.cjs");
+		writeFakeOriginalHook(originalHook, {
+			exit: 2,
+			stdout: JSON.stringify({
+				permissionDecision: "deny",
+				reason: "Hook-supplied reason",
+			}),
+		});
+
+		const results = generateCodexHookWrappers([originalHook], wrapperDir, caps);
+		const out = runWrapper(results[0].wrapperPath, "PreToolUse");
+		// Translating: exit 0 keeps the deny authoritative (same contract as emitDeny)
+		expect(out.status).toBe(0);
+		const parsed = JSON.parse(out.stdout);
+		expect(parsed.permissionDecision).toBe("deny");
+		// Hook's own reason preserved — not overwritten by the translator
+		expect(parsed.reason).toBe("Hook-supplied reason");
 	});
 
 	it("exit 2 + JSON without permissionDecision → translates to deny", () => {

--- a/src/commands/portable/codex-hook-wrapper.ts
+++ b/src/commands/portable/codex-hook-wrapper.ts
@@ -285,7 +285,10 @@ function main() {
     }
 
     process.stdout.write(JSON.stringify(sanitized));
-    process.exit(exitCode);
+    // When the hook already emitted a valid deny JSON but also exited 2,
+    // exit 0 so Codex treats the deny as authoritative (consistent with
+    // emitDeny's exit-0 contract).
+    process.exit(isBlockSignal ? 0 : exitCode);
   });
 }
 

--- a/src/commands/portable/codex-hook-wrapper.ts
+++ b/src/commands/portable/codex-hook-wrapper.ts
@@ -197,6 +197,24 @@ function sanitizeOutput(obj, rules) {
   return result;
 }
 
+/**
+ * True when the given event's scrub rules allow a permissionDecision of "deny".
+ * Used to translate Claude Code's exit-code protocol (exit 2 = block) into
+ * Codex's JSON protocol ({permissionDecision: "deny"}).
+ */
+function eventSupportsDeny(rules) {
+  if (!rules || rules.allowedPermissionValues === null) return false;
+  return rules.allowedPermissionValues.indexOf("deny") !== -1;
+}
+
+function emitDeny(reason) {
+  process.stdout.write(JSON.stringify({
+    permissionDecision: "deny",
+    reason: reason && reason.length > 0 ? reason : "Hook blocked this operation",
+  }));
+  process.exit(0);
+}
+
 function main() {
   // Collect stdin
   const stdinChunks = [];
@@ -204,6 +222,7 @@ function main() {
   process.stdin.on("end", () => {
     const stdinData = Buffer.concat(stdinChunks).toString("utf8");
     const event = getEventFromStdin(stdinData);
+    const rules = event && SCRUB_RULES[event];
 
     // Spawn original hook with same stdin/env
     const result = spawnSync(process.execPath, [ORIGINAL_HOOK], {
@@ -219,33 +238,54 @@ function main() {
       process.exit(1);
     }
 
-    if (result.stderr) {
-      process.stderr.write(result.stderr);
-    }
+    const stderrText = (result.stderr || "").toString();
+    const rawOutput = (result.stdout || "").toString();
+    const exitCode = result.status ?? 1;
+    // Claude Code protocol: exit 2 + stderr = block. Codex expects JSON instead.
+    // Translate only for events where the Codex capability table allows "deny".
+    const isBlockSignal = exitCode === 2 && eventSupportsDeny(rules);
 
-    const rawOutput = result.stdout || "";
-
-    // If the hook produced no JSON output, pass through as-is
+    // No stdout: either silent allow (exit 0) or Claude-style block (exit 2).
     if (!rawOutput.trim()) {
-      process.exit(result.status ?? 1);
+      if (isBlockSignal) {
+        return emitDeny(stderrText.trim());
+      }
+      // Non-block failure or plain allow: forward stderr and pass exit code through.
+      if (stderrText) process.stderr.write(stderrText);
+      process.exit(exitCode);
     }
 
-    // Try to parse and sanitize JSON output
+    // Try to parse stdout as JSON.
     let parsed;
     try {
       parsed = JSON.parse(rawOutput);
     } catch {
-      // Not valid JSON — pass through unchanged (Codex may handle it)
+      // Non-JSON stdout. If this is a Claude block signal, treat the stdout
+      // (or stderr) as the deny reason. Otherwise forward unchanged.
+      if (isBlockSignal) {
+        const reason = rawOutput.trim() || stderrText.trim();
+        return emitDeny(reason);
+      }
+      if (stderrText) process.stderr.write(stderrText);
       process.stdout.write(rawOutput);
-      process.exit(result.status ?? 1);
+      process.exit(exitCode);
     }
 
+    // Forward stderr for JSON-emitting hooks (diagnostic output). We still
+    // scrub and re-emit the JSON to Codex's stdout.
+    if (stderrText) process.stderr.write(stderrText);
+
     // Apply scrub rules for the detected event
-    const rules = event && SCRUB_RULES[event];
     const sanitized = rules ? sanitizeOutput(parsed, rules) : parsed;
 
+    // If the hook signalled block via exit 2 but didn't emit a deny decision
+    // in the JSON, translate — otherwise Codex ignores the exit code.
+    if (isBlockSignal && (!sanitized || sanitized.permissionDecision !== "deny")) {
+      return emitDeny(stderrText.trim());
+    }
+
     process.stdout.write(JSON.stringify(sanitized));
-    process.exit(result.status ?? 1);
+    process.exit(exitCode);
   });
 }
 


### PR DESCRIPTION
## Summary

Fixes #738. The Codex hook-compat wrapper was faithfully forwarding Claude Code's `exit 2 + stderr` block signal, but Codex speaks a different protocol — it expects `{permissionDecision: "deny", reason: "..."}` on stdout. As shipped, CK safety hooks like scout-block and privacy-block silently failed-open: Codex logged "hook exited with code 1" and let the operation through.

The generated wrapper now translates:

| Scenario | Before | After |
|----------|--------|-------|
| exit 2, empty stdout | exit 2 (ignored) | deny JSON, reason = stderr, exit 0 |
| exit 2, non-JSON stdout | forwarded unchanged | deny JSON, reason = stdout or stderr, exit 0 |
| exit 2, JSON without decision | forwarded, ignored | inject `permissionDecision: "deny"`, exit 0 |
| exit 2, event without "deny" support (e.g. Stop) | exit 2 | exit 2 (no translation — plain pass-through) |
| exit 0, any output | scrubbed, forwarded | scrubbed, forwarded (unchanged) |

Translation gates on the per-event Codex capability table — only events whose `allowedPermissionValues` includes `"deny"` trigger the rewrite. Scrub rules continue to apply to JSON-emitting hooks.

## Test plan
- [x] 6 new behavioral tests (`buildWrapperScript — exit-code → JSON protocol translation`) spawn real wrappers against synthetic hooks and assert stdout shape + exit code
- [x] Existing wrapper tests updated for refactored comment markers
- [x] `bun test` — 4523 pass, 0 fail
- [x] `bun run typecheck` / `bun run lint:fix` / `bun run build` — clean
- [ ] Manual smoke (post-merge on Mac): run `ck migrate` to regenerate wrappers, trigger a scout-block case in Codex, verify Codex honours the deny

Closes #738