### PR TITLE
fix(codex): self-heal missed Codex-format commands in hooks.json

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "3.41.4-dev.51",
-	"generatedAt": "2026-04-24T21:06:34.128Z",
+	"version": "3.41.4-dev.52",
+	"generatedAt": "2026-04-24T21:22:35.584Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1079,4 +1079,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-24T21:06:34.277Z -->
+<!-- generated: 2026-04-24T21:22:35.686Z -->

--- a/src/commands/portable/__tests__/codex-hook-compat-integration.test.ts
+++ b/src/commands/portable/__tests__/codex-hook-compat-integration.test.ts
@@ -18,7 +18,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { CODEX_CAPABILITY_TABLE } from "../codex-capabilities.js";
 import { buildWrapperScript } from "../codex-hook-wrapper.js";
 import { migrateHooksSettings } from "../hooks-settings-merger.js";
@@ -305,7 +305,13 @@ describe("codex hook compat integration — upgrade from previous ck migrate", (
 		const dir = setupTestDir("upgrade");
 		writeFileSync(join(dir, ".claude", "settings.json"), makeSourceSettings(FULL_CLAUDE_HOOKS));
 
-		// Simulate legacy hooks.json with wrong content (direct-copied SubagentStart)
+		// Simulate legacy hooks.json with wrong content (direct-copied SubagentStart).
+		// Point the command at a real file inside the test dir so self-heal keeps
+		// it — this test asserts pipeline behavior for unsupported events, not
+		// the self-heal path. Self-heal's dedicated tests live elsewhere.
+		const legacySubagentHook = join(dir, ".claude", "hooks", "subagent-init.cjs");
+		mkdirSync(dirname(legacySubagentHook), { recursive: true });
+		writeFileSync(legacySubagentHook, "// test fixture");
 		writeFileSync(
 			join(dir, ".codex", "hooks.json"),
 			JSON.stringify({
@@ -315,7 +321,7 @@ describe("codex hook compat integration — upgrade from previous ck migrate", (
 							hooks: [
 								{
 									type: "command",
-									command: `node "${homedir()}/.claude/hooks/subagent-init.cjs"`,
+									command: `node "${legacySubagentHook}"`,
 								},
 							],
 						},

--- a/src/commands/portable/__tests__/hooks-settings-merger.test.ts
+++ b/src/commands/portable/__tests__/hooks-settings-merger.test.ts
@@ -305,6 +305,46 @@ describe("mergeHooksIntoSettings", () => {
 		expect(commands).toContain(userHook); // user-owned preserved
 		expect(commands).not.toContain(ckStaleHook); // ck-owned pruned
 	});
+
+	it('prunes Codex-format commands — node "/ck-path/hook.cjs" shape (#739 regression)', async () => {
+		// Codex rewrites CK hook registrations as `node "/path"`. The first
+		// whitespace-split token is "node", not an absolute path — so the
+		// earlier extractor silently skipped every Codex entry. Regression
+		// scenario caught live on 2026-04-24 during E2E validation.
+		const ckHooksDir = join(testDir, ".codex", "hooks");
+		await Bun.write(join(ckHooksDir, ".keep"), "");
+		const path = join(testDir, "merge-codex-format.json");
+		const liveHook = join(ckHooksDir, "codex-live.cjs");
+		const staleHook = join(ckHooksDir, "codex-stale.cjs");
+		writeFileSync(liveHook, "// live");
+
+		const liveCommand = `node "${liveHook}"`;
+		const staleCommand = `node "${staleHook}"`;
+
+		writeFileSync(
+			path,
+			JSON.stringify({
+				hooks: {
+					SessionStart: [
+						{
+							matcher: "startup",
+							hooks: [
+								{ type: "command", command: staleCommand }, // stale — prune
+								{ type: "command", command: liveCommand }, // live — keep
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		await mergeHooksIntoSettings(path, {});
+
+		const content = JSON.parse(await Bun.file(path).text());
+		const commands = content.hooks.SessionStart[0].hooks.map((h: { command: string }) => h.command);
+		expect(commands).not.toContain(staleCommand);
+		expect(commands).toContain(liveCommand);
+	});
 });
 
 describe("migrateHooksSettings", () => {

--- a/src/commands/portable/hooks-settings-merger.ts
+++ b/src/commands/portable/hooks-settings-merger.ts
@@ -7,7 +7,7 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import type { CodexCapabilities } from "./codex-capabilities.js";
 import { detectCodexCapabilities } from "./codex-capabilities.js";
 import { ensureCodexHooksFeatureFlag } from "./codex-features-flag.js";
@@ -325,25 +325,6 @@ export async function mergeHooksIntoSettings(
 }
 
 /**
- * Extract the leading file-path token from a command string, if any.
- * Returns null for commands that don't start with an absolute path.
- * Examples:
- *   "/Users/x/.codex/hooks/abc.cjs"          → "/Users/x/.codex/hooks/abc.cjs"
- *   "/Users/x/hook.cjs --flag"                → "/Users/x/hook.cjs"
- *   "node /Users/x/hook.cjs"                  → null (first token is "node")
- *   "npm run lint"                            → null
- */
-function extractLeadingAbsolutePath(command: string): string | null {
-	const trimmed = command.trim();
-	if (trimmed.length === 0) return null;
-	// Take first whitespace-delimited token
-	const firstToken = trimmed.split(/\s+/)[0];
-	if (!firstToken) return null;
-	if (!isAbsolute(firstToken)) return null;
-	return firstToken;
-}
-
-/**
  * True if the absolute path looks like a CK-managed hook install location.
  * We only self-heal ck-owned entries to avoid silently dropping a user's
  * own absolute-path hook whose file is temporarily unavailable (network
@@ -360,10 +341,41 @@ function isCkManagedHookPath(absPath: string): boolean {
 }
 
 /**
- * Drop CK-managed hook entries whose command references a missing file on
- * disk. Only paths that look like CK install locations are evaluated —
- * shell expressions, PATH-resolved binaries, and user-owned absolute-path
- * hooks are preserved verbatim.
+ * Extract every absolute-path reference inside a command string, whether
+ * leading, quoted, or positioned after an interpreter. Used by self-heal
+ * to detect CK-managed hook references across all Codex/Claude command
+ * shapes:
+ *
+ *   /path/to/hook.cjs                    → ["/path/to/hook.cjs"]
+ *   "/path/to/hook.cjs"                  → ["/path/to/hook.cjs"]
+ *   node "/path/to/hook.cjs"             → ["/path/to/hook.cjs"]
+ *   /usr/bin/env node /path/to/hook.cjs  → ["/usr/bin/env", "/path/to/hook.cjs"]
+ *   npm run lint                         → []
+ *
+ * Regex matches POSIX-style absolute paths. Windows drive-letter paths
+ * are intentionally out of scope — Codex hooks on Windows are disabled.
+ */
+function extractAbsolutePaths(command: string): string[] {
+	const matches: string[] = [];
+	// Absolute path = leading "/" until whitespace / closing quote / closing paren.
+	// Anchor the preceding character to whitespace, quote, "(", or start-of-string
+	// to avoid matching paths that are substrings of URLs or other constructs.
+	const pathPattern = /(?:^|[\s"'(])(\/[^\s"'()]+)/g;
+	let match = pathPattern.exec(command);
+	while (match !== null) {
+		matches.push(match[1]);
+		match = pathPattern.exec(command);
+	}
+	return matches;
+}
+
+/**
+ * Drop CK-managed hook entries whose referenced file is missing on disk.
+ * A hook is considered stale when its command references at least one
+ * CK-managed absolute path AND every such reference points at a missing
+ * file. This catches both the bare `/abs/path` shape and Codex's
+ * `node "/abs/path"` shape (#739). Shell expressions, PATH-resolved
+ * binaries, and user-owned absolute-path hooks are preserved verbatim.
  */
 function pruneStaleFileHooks(existing: HooksSection): HooksSection {
 	const result: HooksSection = {};
@@ -371,10 +383,11 @@ function pruneStaleFileHooks(existing: HooksSection): HooksSection {
 		const prunedGroups: HookGroup[] = [];
 		for (const group of groups) {
 			const survivingHooks = group.hooks.filter((h) => {
-				const path = extractLeadingAbsolutePath(h.command);
-				if (path === null) return true; // Not a file-path command — keep
-				if (!isCkManagedHookPath(path)) return true; // Not CK-owned — keep
-				return existsSync(path);
+				const paths = extractAbsolutePaths(h.command);
+				const ckPaths = paths.filter(isCkManagedHookPath);
+				if (ckPaths.length === 0) return true; // No CK-managed reference — keep
+				// Hook is stale iff every CK-managed reference is missing.
+				return ckPaths.some((p) => existsSync(p));
 			});
 			if (survivingHooks.length > 0) {
 				prunedGroups.push({ ...group, hooks: survivingHooks });


### PR DESCRIPTION
## Summary

Follow-up hotfix to #739 caught during E2E validation on Mac. After merging PR #743, I purged \`~/.codex/hooks/\`, injected a stale \`node \"/Users/kaitran/.codex/hooks/deadbeef-stale-hook.cjs\"\` entry into \`hooks.json\`, and ran \`ck migrate --agent codex --global --hooks --yes\`. **The stale entry survived.**

Root cause: Codex rewrites CK hook registrations as \`node \"/abs/path\"\`. The earlier extractor (\`extractLeadingAbsolutePath\`) took the first whitespace-split token — \`node\` — saw it wasn't absolute, and returned null → the entry was classified as "not a file-path command" and preserved. So the self-heal silently no-op'd for every real Codex entry, defeating the whole fix.

## Fix

Rewrote the extractor to scan the full command for every absolute-path reference (\`/abs/path\`, \`"/abs/path"\`, \`node "/abs/path"\`, \`/usr/bin/env node /abs/path\`). A hook is considered stale when it references at least one CK-managed path AND every such reference points at a missing file. Shell expressions, PATH-resolved binaries, and user-owned absolute-path hooks (outside \`~/.claude/hooks/\`, \`~/.codex/hooks/\`, \`~/.gemini/hooks/\`) are preserved verbatim.

## Test plan
- [x] New regression test using the exact \`node "/abs/path"\` shape production Codex writes
- [x] Existing self-heal tests still pass
- [x] \`bun test\` — 4530 pass, 0 fail
- [x] \`bun run typecheck\` / \`lint:fix\` / \`build\` — clean
- [ ] Post-merge: re-run the E2E reproduction on Mac — inject stale \`node "/…/.codex/hooks/deadbeef.cjs"\` entry, migrate, verify pruned
- [ ] Mirror on \`ssh i9-bootcamp\` Windows machine

Related: #739 (original self-heal). No new issue filed — this is a direct regression fix.