### PR TITLE
fix(migrate): don't hijack user to Install mode when reconcile has work

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "3.41.4-dev.52",
-	"generatedAt": "2026-04-24T21:22:35.584Z",
+	"version": "3.41.4-dev.53",
+	"generatedAt": "2026-04-24T22:05:22.546Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1079,4 +1079,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-24T21:22:35.686Z -->
+<!-- generated: 2026-04-24T22:05:22.675Z -->

--- a/src/ui/src/pages/MigratePage.tsx
+++ b/src/ui/src/pages/MigratePage.tsx
@@ -518,13 +518,30 @@ const MigratePageContent: React.FC = () => {
 	/** Selected candidates for Install mode picker */
 	const [selectedCandidates, setSelectedCandidates] = useState<Set<string>>(new Set());
 
-	// Apply smart-default once when suggestedMode arrives from the reconcile endpoint
+	// Apply smart-default once when suggestedMode arrives from the reconcile endpoint.
+	// Gated on the reconcile plan having no actionable work — only auto-flip when
+	// Reconcile mode has literally nothing to do (all skips / empty plan). If the
+	// user kicked off a reconcile with real install/update/delete/conflict actions
+	// pending, honor their choice and keep them on the Reconcile tab instead of
+	// hijacking mid-action. See #746.
 	useEffect(() => {
 		if (smartDefaultAppliedRef.current) return;
 		if (!migration.suggestedMode) return;
+		if (migration.suggestedMode === mode) {
+			smartDefaultAppliedRef.current = true;
+			return;
+		}
+		const summary = migration.plan?.summary;
+		const hasActionableWork = summary
+			? summary.install + summary.update + summary.delete + summary.conflict > 0
+			: false;
+		if (hasActionableWork) {
+			smartDefaultAppliedRef.current = true;
+			return;
+		}
 		smartDefaultAppliedRef.current = true;
 		setMode(migration.suggestedMode);
-	}, [migration.suggestedMode]);
+	}, [migration.suggestedMode, migration.plan, mode]);
 
 	// Initialise selectedCandidates to all-checked when installCandidates first arrive
 	useEffect(() => {


### PR DESCRIPTION
## Summary

Repro: open Migrate dashboard, uncheck Skills, select Codex, keep Reconcile mode, click **Run Migration**. UI flipped to Install tab with a blank picker and a disabled CTA.

## Root cause

\`MigratePage.tsx:521-527\` applied \`suggestedMode\` from the reconcile response unconditionally on first arrival. Since \`suggestedMode\` only arrives in response to a user-triggered reconcile, the auto-flip always hijacks the user mid-action. The Install tab then renders blank because \`installCandidates\` are only fetched by a separate endpoint.

## Fix

Gate the auto-flip on the plan having zero actionable work:

- If \`plan.summary.install + update + delete + conflict > 0\` → user kicked off real reconcile work → stay on Reconcile tab
- Otherwise (empty plan, all skips, registry says \"nothing to do here\") → auto-flip to Install as originally intended

This preserves the original fresh-install UX where an empty registry steers the user to Install mode, while honoring an explicit Reconcile click when there's real work to review.

## Test plan
- [x] \`bun test\` — 4530 pass, 0 fail
- [x] \`bun run typecheck\` / \`lint:fix\` / \`ui:build\` — clean
- [ ] Post-merge manual on Mac: trigger reconcile with pending actions → should stay on Reconcile
- [ ] Post-merge manual on Mac: trigger reconcile with empty plan → should auto-flip to Install

Closes #746