### PR TITLE
fix(migrate): restore native skill paths for windsurf and cursor

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "3.42.1",
-	"generatedAt": "2026-04-28T17:19:07.016Z",
+	"version": "3.42.2",
+	"generatedAt": "2026-04-28T19:30:24.512Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1079,4 +1079,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-28T17:19:07.136Z -->
+<!-- generated: 2026-04-28T19:30:24.631Z -->

--- a/src/commands/migrate/__tests__/fixtures/windsurf-cursor-upgrade/manifest-stub.json
+++ b/src/commands/migrate/__tests__/fixtures/windsurf-cursor-upgrade/manifest-stub.json
@@ -1,0 +1,22 @@
+{
+	"version": "1.0",
+	"cliVersion": "3.43.0",
+	"renames": [],
+	"providerPathMigrations": [
+		{
+			"provider": "cursor",
+			"type": "skill",
+			"from": ".agents/skills",
+			"to": ".cursor/skills",
+			"since": "3.43.0"
+		},
+		{
+			"provider": "windsurf",
+			"type": "skill",
+			"from": ".agents/skills",
+			"to": ".windsurf/skills",
+			"since": "3.43.0"
+		}
+	],
+	"sectionRenames": []
+}

--- a/src/commands/migrate/__tests__/fixtures/windsurf-cursor-upgrade/registry-pre-343.json
+++ b/src/commands/migrate/__tests__/fixtures/windsurf-cursor-upgrade/registry-pre-343.json
@@ -1,5 +1,0 @@
-{
-	"version": "3.0",
-	"installations": [],
-	"appliedManifestVersion": "3.42.2"
-}

--- a/src/commands/migrate/__tests__/fixtures/windsurf-cursor-upgrade/registry-pre-343.json
+++ b/src/commands/migrate/__tests__/fixtures/windsurf-cursor-upgrade/registry-pre-343.json
@@ -1,0 +1,5 @@
+{
+	"version": "3.0",
+	"installations": [],
+	"appliedManifestVersion": "3.42.2"
+}

--- a/src/commands/migrate/__tests__/fixtures/windsurf-cursor-upgrade/skill-foo/SKILL.md
+++ b/src/commands/migrate/__tests__/fixtures/windsurf-cursor-upgrade/skill-foo/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: skill-foo
+description: A sample skill for integration testing of windsurf/cursor migration
+version: 1.0.0
+---
+
+# Skill Foo
+
+This is a minimal skill fixture used for windsurf/cursor migration integration tests.
+
+## Overview
+
+Sample skill content for testing path migration scenarios.

--- a/src/commands/migrate/__tests__/migrate-windsurf-cursor-upgrade.integration.test.ts
+++ b/src/commands/migrate/__tests__/migrate-windsurf-cursor-upgrade.integration.test.ts
@@ -1,0 +1,584 @@
+/**
+ * Integration tests — windsurf + cursor migration path correctness
+ *
+ * Phase 05 deliverable: 6 tests across 3 scenarios × 2 providers.
+ *
+ * Scenarios:
+ *   1. Fresh install — Cursor: skills land at .cursor/skills/<name>/SKILL.md
+ *   2. Fresh install — Windsurf: skills land at .windsurf/skills/<name>/SKILL.md
+ *   3. Upgrade-from-prior — Cursor: .agents/skills → .cursor/skills (old path cleaned)
+ *   4. Upgrade-from-prior — Windsurf: .agents/skills → .windsurf/skills (old path cleaned)
+ *   5. Idempotent rerun — Cursor: already native, registry @3.43.0 → plan all-skip
+ *   6. Idempotent rerun — Windsurf: already native, registry @3.43.0 → plan all-skip
+ *
+ * Architecture:
+ *   - Fresh/idempotent: call installSkillDirectories() with patched providers paths.
+ *   - Upgrade: build ReconcileInput + call reconcile() to confirm delete actions,
+ *     then verify installSkillDirectories() writes to native path.
+ *   - Registry mock: intercept addPortableInstallation so no writes to ~/.claudekit.
+ *   - No real HOME writes — provider paths are fully redirected to tmpdir.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { cp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Mock portable-registry before importing modules that use it
+// ---------------------------------------------------------------------------
+const addPortableInstallationMock = mock(async () => undefined);
+const actualPortableRegistry = await import("../../portable/portable-registry.js");
+
+mock.module("../../portable/portable-registry.js", () => ({
+	...actualPortableRegistry,
+	addPortableInstallation: addPortableInstallationMock,
+}));
+
+// Import after mock so skill-directory-installer picks up the mock
+const { installSkillDirectories } = await import("../skill-directory-installer.js");
+
+// Pure modules — no mock needed
+const { reconcile } = await import("../../portable/reconciler.js");
+
+// providers object is mutable — we patch paths to tmp dirs
+const { providers } = await import("../../portable/provider-registry.js");
+
+// ---------------------------------------------------------------------------
+// Fixture paths
+// ---------------------------------------------------------------------------
+const FIXTURES_DIR = join(import.meta.dir, "fixtures", "windsurf-cursor-upgrade");
+const SKILL_FOO_SOURCE = join(FIXTURES_DIR, "skill-foo");
+const MANIFEST_STUB_PATH = join(FIXTURES_DIR, "manifest-stub.json");
+
+// ---------------------------------------------------------------------------
+// Shared sandbox state
+// ---------------------------------------------------------------------------
+let sandboxRoot: string;
+
+// Saved original provider skill path configs (restored in afterEach)
+type SkillPathSave = {
+	projectPath: string | null;
+	globalPath: string | null;
+};
+let savedCursorSkills: SkillPathSave;
+let savedWindsurfSkills: SkillPathSave;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a fresh tmp sandbox for a test. Returns project + home dirs.
+ */
+function makeSandbox(label: string): { projectDir: string; homeDir: string } {
+	const base = join(sandboxRoot, label);
+	const projectDir = join(base, "project");
+	const homeDir = join(base, "home");
+	mkdirSync(projectDir, { recursive: true });
+	mkdirSync(homeDir, { recursive: true });
+	return { projectDir, homeDir };
+}
+
+/** Copy the skill-foo fixture into a source directory. */
+async function copySkillFooToSource(sourceSkillsDir: string): Promise<void> {
+	await mkdir(sourceSkillsDir, { recursive: true });
+	await cp(SKILL_FOO_SOURCE, join(sourceSkillsDir, "skill-foo"), {
+		recursive: true,
+		force: true,
+	});
+}
+
+/** Read manifest-stub.json fixture. */
+function loadManifestStub() {
+	return JSON.parse(readFileSync(MANIFEST_STUB_PATH, "utf-8"));
+}
+
+/** Minimal SkillInfo shape accepted by installSkillDirectories. */
+function makeSkillInfo(name: string, sourcePath: string) {
+	return { name, path: sourcePath, files: [] } as unknown as Parameters<
+		typeof installSkillDirectories
+	>[0][number];
+}
+
+/** Patch cursor provider's skill paths to use sandbox dirs. */
+function patchCursorPaths(projectDir: string, homeDir: string) {
+	savedCursorSkills = {
+		projectPath: providers.cursor.skills?.projectPath ?? null,
+		globalPath: providers.cursor.skills?.globalPath ?? null,
+	};
+	if (providers.cursor.skills) {
+		providers.cursor.skills = {
+			...providers.cursor.skills,
+			projectPath: join(projectDir, ".cursor", "skills"),
+			globalPath: join(homeDir, ".cursor", "skills"),
+		};
+	}
+}
+
+/** Patch windsurf provider's skill paths to use sandbox dirs. */
+function patchWindsurfPaths(projectDir: string, homeDir: string) {
+	savedWindsurfSkills = {
+		projectPath: providers.windsurf.skills?.projectPath ?? null,
+		globalPath: providers.windsurf.skills?.globalPath ?? null,
+	};
+	if (providers.windsurf.skills) {
+		providers.windsurf.skills = {
+			...providers.windsurf.skills,
+			projectPath: join(projectDir, ".windsurf", "skills"),
+			globalPath: join(homeDir, ".codeium", "windsurf", "skills"),
+		};
+	}
+}
+
+/** Restore cursor provider's skill paths. */
+function restoreCursorPaths() {
+	if (providers.cursor.skills && savedCursorSkills) {
+		providers.cursor.skills = {
+			...providers.cursor.skills,
+			projectPath: savedCursorSkills.projectPath,
+			globalPath: savedCursorSkills.globalPath,
+		};
+	}
+}
+
+/** Restore windsurf provider's skill paths. */
+function restoreWindsurfPaths() {
+	if (providers.windsurf.skills && savedWindsurfSkills) {
+		providers.windsurf.skills = {
+			...providers.windsurf.skills,
+			projectPath: savedWindsurfSkills.projectPath,
+			globalPath: savedWindsurfSkills.globalPath,
+		};
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+	sandboxRoot = join(tmpdir(), `ck-migration-integ-${Date.now()}`);
+	mkdirSync(sandboxRoot, { recursive: true });
+});
+
+afterAll(() => {
+	// Clean up ALL sandbox dirs created during the run
+	try {
+		rmSync(sandboxRoot, { recursive: true, force: true });
+	} catch {
+		// Best-effort cleanup
+	}
+	mock.restore();
+});
+
+beforeEach(() => {
+	addPortableInstallationMock.mockClear();
+	addPortableInstallationMock.mockImplementation(async () => undefined);
+});
+
+afterEach(() => {
+	restoreCursorPaths();
+	restoreWindsurfPaths();
+});
+
+// ---------------------------------------------------------------------------
+// Test 1 — Fresh install, Cursor
+// ---------------------------------------------------------------------------
+
+describe("Fresh install — Cursor", () => {
+	it("installs skill-foo at .cursor/skills/skill-foo/SKILL.md; .agents/skills does not exist", async () => {
+		const { projectDir } = makeSandbox("fresh-cursor");
+
+		// Source dir mimics a downloaded kit's .claude/skills/
+		const sourceSkillsDir = join(projectDir, "kit-source", "skills");
+		await copySkillFooToSource(sourceSkillsDir);
+
+		// Patch cursor provider to use sandbox project dir
+		patchCursorPaths(projectDir, join(projectDir, "fake-home"));
+
+		const skill = makeSkillInfo("skill-foo", join(sourceSkillsDir, "skill-foo"));
+		const results = await installSkillDirectories([skill], ["cursor"], { global: false });
+
+		// Verify install result
+		expect(results).toHaveLength(1);
+		expect(results[0].success).toBe(true);
+		expect(results[0].provider).toBe("cursor");
+
+		// Verify native path exists
+		const nativePath = join(projectDir, ".cursor", "skills", "skill-foo", "SKILL.md");
+		expect(existsSync(nativePath)).toBe(true);
+
+		// Verify .agents/skills was never created
+		const agentsPath = join(projectDir, ".agents", "skills");
+		expect(existsSync(agentsPath)).toBe(false);
+
+		// Verify registry mock was called
+		expect(addPortableInstallationMock).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test 2 — Fresh install, Windsurf
+// ---------------------------------------------------------------------------
+
+describe("Fresh install — Windsurf", () => {
+	it("installs skill-foo at .windsurf/skills/skill-foo/SKILL.md; .agents/skills does not exist", async () => {
+		const { projectDir, homeDir } = makeSandbox("fresh-windsurf");
+
+		const sourceSkillsDir = join(projectDir, "kit-source", "skills");
+		await copySkillFooToSource(sourceSkillsDir);
+
+		patchWindsurfPaths(projectDir, homeDir);
+
+		const skill = makeSkillInfo("skill-foo", join(sourceSkillsDir, "skill-foo"));
+		const results = await installSkillDirectories([skill], ["windsurf"], { global: false });
+
+		expect(results).toHaveLength(1);
+		expect(results[0].success).toBe(true);
+		expect(results[0].provider).toBe("windsurf");
+
+		// Verify native project path
+		const nativePath = join(projectDir, ".windsurf", "skills", "skill-foo", "SKILL.md");
+		expect(existsSync(nativePath)).toBe(true);
+
+		// .agents/skills must not exist
+		const agentsPath = join(projectDir, ".agents", "skills");
+		expect(existsSync(agentsPath)).toBe(false);
+
+		expect(addPortableInstallationMock).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test 3 — Upgrade from prior, Cursor
+// ---------------------------------------------------------------------------
+
+describe("Upgrade-from-prior — Cursor", () => {
+	it("reconciler emits delete for .agents/skills; install goes to .cursor/skills", async () => {
+		const { projectDir } = makeSandbox("upgrade-cursor");
+
+		// Pre-seed old path: .agents/skills/skill-foo/SKILL.md
+		const oldSkillDir = join(projectDir, ".agents", "skills", "skill-foo");
+		mkdirSync(oldSkillDir, { recursive: true });
+		writeFileSync(join(oldSkillDir, "SKILL.md"), "# Old skill-foo");
+
+		// Build registry pointing to old path with appliedManifestVersion = 3.42.2
+		const registry: import("../../portable/portable-registry.js").PortableRegistryV3 = {
+			version: "3.0",
+			installations: [
+				{
+					item: "skill-foo",
+					type: "skill",
+					provider: "cursor",
+					global: false,
+					path: oldSkillDir, // directory path (skills are dir-based)
+					installedAt: "2025-01-01T00:00:00.000Z",
+					sourcePath: ".claude/skills/skill-foo",
+					sourceChecksum: "abc123",
+					targetChecksum: "def456",
+					installSource: "kit",
+				},
+			],
+			appliedManifestVersion: "3.42.2",
+		};
+
+		const manifest = loadManifestStub();
+
+		// Build reconcile input — path migration from .agents/skills → .cursor/skills
+		const reconcileInput: import("../../portable/reconcile-types.js").ReconcileInput = {
+			sourceItems: [],
+			registry,
+			targetStates: new Map(),
+			manifest,
+			providerConfigs: [{ provider: "cursor", global: false }],
+		};
+
+		const plan = reconcile(reconcileInput);
+
+		// Reconciler should detect the path migration and produce a delete action
+		const deleteActions = plan.actions.filter((a) => a.action === "delete");
+		expect(deleteActions.length).toBeGreaterThan(0);
+
+		const pathMigratedDelete = deleteActions.find(
+			(a) => a.item === "skill-foo" && a.provider === "cursor",
+		);
+		expect(pathMigratedDelete).toBeDefined();
+		expect(pathMigratedDelete?.reasonCode).toBe("path-migrated-cleanup");
+		expect(pathMigratedDelete?.previousPath).toBe(oldSkillDir);
+
+		// Execute the delete action manually (simulates what migrate-command.ts does)
+		if (existsSync(oldSkillDir)) {
+			await rm(oldSkillDir, { recursive: true, force: true });
+		}
+		expect(existsSync(oldSkillDir)).toBe(false);
+
+		// Now install to native cursor path
+		patchCursorPaths(projectDir, join(projectDir, "fake-home"));
+		const sourceSkillsDir = join(projectDir, "kit-source", "skills");
+		await copySkillFooToSource(sourceSkillsDir);
+
+		const skill = makeSkillInfo("skill-foo", join(sourceSkillsDir, "skill-foo"));
+		const installResults = await installSkillDirectories([skill], ["cursor"], { global: false });
+
+		expect(installResults[0].success).toBe(true);
+
+		const nativePath = join(projectDir, ".cursor", "skills", "skill-foo", "SKILL.md");
+		expect(existsSync(nativePath)).toBe(true);
+
+		// Old .agents/skills still absent
+		expect(existsSync(join(projectDir, ".agents", "skills", "skill-foo"))).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test 4 — Upgrade from prior, Windsurf
+// ---------------------------------------------------------------------------
+
+describe("Upgrade-from-prior — Windsurf", () => {
+	it("reconciler emits delete for .agents/skills; install goes to .windsurf/skills", async () => {
+		const { projectDir, homeDir } = makeSandbox("upgrade-windsurf");
+
+		// Pre-seed old project path: .agents/skills/skill-foo/
+		const oldProjectSkillDir = join(projectDir, ".agents", "skills", "skill-foo");
+		mkdirSync(oldProjectSkillDir, { recursive: true });
+		writeFileSync(join(oldProjectSkillDir, "SKILL.md"), "# Old skill-foo windsurf");
+
+		const registry: import("../../portable/portable-registry.js").PortableRegistryV3 = {
+			version: "3.0",
+			installations: [
+				{
+					item: "skill-foo",
+					type: "skill",
+					provider: "windsurf",
+					global: false,
+					path: oldProjectSkillDir,
+					installedAt: "2025-01-01T00:00:00.000Z",
+					sourcePath: ".claude/skills/skill-foo",
+					sourceChecksum: "abc123",
+					targetChecksum: "def456",
+					installSource: "kit",
+				},
+			],
+			appliedManifestVersion: "3.42.2",
+		};
+
+		const manifest = loadManifestStub();
+
+		const reconcileInput: import("../../portable/reconcile-types.js").ReconcileInput = {
+			sourceItems: [],
+			registry,
+			targetStates: new Map(),
+			manifest,
+			providerConfigs: [{ provider: "windsurf", global: false }],
+		};
+
+		const plan = reconcile(reconcileInput);
+
+		// Verify delete actions for windsurf old path
+		const deleteActions = plan.actions.filter((a) => a.action === "delete");
+		expect(deleteActions.length).toBeGreaterThan(0);
+
+		const pathMigratedDelete = deleteActions.find(
+			(a) => a.item === "skill-foo" && a.provider === "windsurf",
+		);
+		expect(pathMigratedDelete).toBeDefined();
+		expect(pathMigratedDelete?.reasonCode).toBe("path-migrated-cleanup");
+
+		// Execute delete
+		if (existsSync(oldProjectSkillDir)) {
+			await rm(oldProjectSkillDir, { recursive: true, force: true });
+		}
+		expect(existsSync(oldProjectSkillDir)).toBe(false);
+
+		// Install to native windsurf path
+		patchWindsurfPaths(projectDir, homeDir);
+		const sourceSkillsDir = join(projectDir, "kit-source", "skills");
+		await copySkillFooToSource(sourceSkillsDir);
+
+		const skill = makeSkillInfo("skill-foo", join(sourceSkillsDir, "skill-foo"));
+		const installResults = await installSkillDirectories([skill], ["windsurf"], {
+			global: false,
+		});
+
+		expect(installResults[0].success).toBe(true);
+
+		const nativePath = join(projectDir, ".windsurf", "skills", "skill-foo", "SKILL.md");
+		expect(existsSync(nativePath)).toBe(true);
+
+		// Old path absent
+		expect(existsSync(join(projectDir, ".agents", "skills", "skill-foo"))).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test 5 — Idempotent rerun, Cursor
+// ---------------------------------------------------------------------------
+
+describe("Idempotent rerun — Cursor", () => {
+	it("reconcile plan all-skip when native path populated and registry at 3.43.0", async () => {
+		const { projectDir } = makeSandbox("idempotent-cursor");
+
+		// Pre-seed native cursor path
+		const nativeSkillDir = join(projectDir, ".cursor", "skills", "skill-foo");
+		mkdirSync(nativeSkillDir, { recursive: true });
+		writeFileSync(join(nativeSkillDir, "SKILL.md"), "# skill-foo at native path");
+
+		// Registry already up-to-date at 3.43.0, pointing to native path
+		const registry: import("../../portable/portable-registry.js").PortableRegistryV3 = {
+			version: "3.0",
+			installations: [
+				{
+					item: "skill-foo",
+					type: "skill",
+					provider: "cursor",
+					global: false,
+					path: nativeSkillDir,
+					installedAt: "2025-06-01T00:00:00.000Z",
+					sourcePath: ".claude/skills/skill-foo",
+					sourceChecksum: "abc123",
+					targetChecksum: "abc123", // same — no drift
+					installSource: "kit",
+				},
+			],
+			appliedManifestVersion: "3.43.0",
+		};
+
+		const manifest = loadManifestStub();
+
+		// Source item checksum matches registry — source unchanged
+		const sourceItems: import("../../portable/reconcile-types.js").SourceItemState[] = [
+			{
+				item: "skill-foo",
+				type: "skill",
+				sourceChecksum: "abc123",
+				convertedChecksums: { cursor: "abc123" },
+			},
+		];
+
+		// Target state: native path exists with matching checksum
+		const targetStates = new Map([
+			[
+				nativeSkillDir,
+				{
+					path: nativeSkillDir,
+					exists: true,
+					currentChecksum: "abc123",
+				},
+			],
+		]);
+
+		const reconcileInput: import("../../portable/reconcile-types.js").ReconcileInput = {
+			sourceItems,
+			registry,
+			targetStates,
+			manifest,
+			providerConfigs: [{ provider: "cursor", global: false }],
+		};
+
+		const plan = reconcile(reconcileInput);
+
+		// No delete actions from path migrations (registry already at 3.43.0 — no applicable entries)
+		const deleteActions = plan.actions.filter((a) => a.action === "delete");
+		const pathMigrationDeletes = deleteActions.filter(
+			(a) => a.reasonCode === "path-migrated-cleanup",
+		);
+		expect(pathMigrationDeletes).toHaveLength(0);
+
+		// All skills should be skipped (no writes, no deletes for skill-foo)
+		const skillActions = plan.actions.filter(
+			(a) => a.item === "skill-foo" && a.provider === "cursor",
+		);
+		for (const action of skillActions) {
+			expect(action.action).toBe("skip");
+		}
+
+		// Verify native file is untouched
+		const content = readFileSync(join(nativeSkillDir, "SKILL.md"), "utf-8");
+		expect(content).toContain("native path");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test 6 — Idempotent rerun, Windsurf
+// ---------------------------------------------------------------------------
+
+describe("Idempotent rerun — Windsurf", () => {
+	it("reconcile plan all-skip when native path populated and registry at 3.43.0", async () => {
+		const { projectDir } = makeSandbox("idempotent-windsurf");
+
+		// Pre-seed native windsurf path
+		const nativeSkillDir = join(projectDir, ".windsurf", "skills", "skill-foo");
+		mkdirSync(nativeSkillDir, { recursive: true });
+		writeFileSync(join(nativeSkillDir, "SKILL.md"), "# skill-foo at native windsurf path");
+
+		const registry: import("../../portable/portable-registry.js").PortableRegistryV3 = {
+			version: "3.0",
+			installations: [
+				{
+					item: "skill-foo",
+					type: "skill",
+					provider: "windsurf",
+					global: false,
+					path: nativeSkillDir,
+					installedAt: "2025-06-01T00:00:00.000Z",
+					sourcePath: ".claude/skills/skill-foo",
+					sourceChecksum: "abc123",
+					targetChecksum: "abc123",
+					installSource: "kit",
+				},
+			],
+			appliedManifestVersion: "3.43.0",
+		};
+
+		const manifest = loadManifestStub();
+
+		const sourceItems: import("../../portable/reconcile-types.js").SourceItemState[] = [
+			{
+				item: "skill-foo",
+				type: "skill",
+				sourceChecksum: "abc123",
+				convertedChecksums: { windsurf: "abc123" },
+			},
+		];
+
+		const targetStates = new Map([
+			[
+				nativeSkillDir,
+				{
+					path: nativeSkillDir,
+					exists: true,
+					currentChecksum: "abc123",
+				},
+			],
+		]);
+
+		const reconcileInput: import("../../portable/reconcile-types.js").ReconcileInput = {
+			sourceItems,
+			registry,
+			targetStates,
+			manifest,
+			providerConfigs: [{ provider: "windsurf", global: false }],
+		};
+
+		const plan = reconcile(reconcileInput);
+
+		// No path-migrated-cleanup deletes (already applied 3.43.0)
+		const pathMigrationDeletes = plan.actions.filter(
+			(a) => a.action === "delete" && a.reasonCode === "path-migrated-cleanup",
+		);
+		expect(pathMigrationDeletes).toHaveLength(0);
+
+		// All windsurf skill actions should be skip
+		const skillActions = plan.actions.filter(
+			(a) => a.item === "skill-foo" && a.provider === "windsurf",
+		);
+		for (const action of skillActions) {
+			expect(action.action).toBe("skip");
+		}
+
+		// File untouched
+		const content = readFileSync(join(nativeSkillDir, "SKILL.md"), "utf-8");
+		expect(content).toContain("native windsurf path");
+	});
+});

--- a/src/commands/migrate/__tests__/skill-directory-installer.test.ts
+++ b/src/commands/migrate/__tests__/skill-directory-installer.test.ts
@@ -143,4 +143,96 @@ describe("installSkillDirectories", () => {
 		expect(results[0].success).toBe(false);
 		expect(results[0].error).toContain("does not support skills");
 	});
+
+	// Phase 04: verify installer reads paths from registry (no hardcoded strings)
+	it("cursor: installs skill to path derived from registry (.cursor/skills/<name>)", async () => {
+		const customPath = join(testDir, ".cursor", "skills");
+		const skill = makeSkill("my-skill", join(sourceDir, "my-skill"));
+
+		// Patch cursor provider to use testDir-relative path
+		const origCursorSkills = originalProviders.cursor.skills;
+		if (origCursorSkills) {
+			originalProviders.cursor.skills = { ...origCursorSkills, projectPath: customPath };
+		}
+
+		const results = await installSkillDirectories([skill], ["cursor"], { global: false });
+
+		originalProviders.cursor.skills = origCursorSkills;
+
+		expect(results).toHaveLength(1);
+		expect(results[0].success).toBe(true);
+		// Path must come from registry-derived customPath, not any hardcoded string
+		expect(results[0].path).toBe(join(customPath, "my-skill"));
+		expect(existsSync(join(customPath, "my-skill", "SKILL.md"))).toBe(true);
+		// addPortableInstallation called with correct targetDir from registry
+		expect(addPortableInstallationMock).toHaveBeenCalledWith(
+			"my-skill",
+			"skill",
+			"cursor",
+			false,
+			join(customPath, "my-skill"),
+			expect.any(String),
+		);
+	});
+
+	it("windsurf: installs skill to path derived from registry (.windsurf/skills/<name>)", async () => {
+		const customPath = join(testDir, ".windsurf", "skills");
+		const skill = makeSkill("my-skill", join(sourceDir, "my-skill"));
+
+		// Patch windsurf provider to use testDir-relative path
+		const origWindsurfSkills = originalProviders.windsurf.skills;
+		if (origWindsurfSkills) {
+			originalProviders.windsurf.skills = { ...origWindsurfSkills, projectPath: customPath };
+		}
+
+		const results = await installSkillDirectories([skill], ["windsurf"], { global: false });
+
+		originalProviders.windsurf.skills = origWindsurfSkills;
+
+		expect(results).toHaveLength(1);
+		expect(results[0].success).toBe(true);
+		// Path must come from registry-derived customPath, not any hardcoded string
+		expect(results[0].path).toBe(join(customPath, "my-skill"));
+		expect(existsSync(join(customPath, "my-skill", "SKILL.md"))).toBe(true);
+		// addPortableInstallation called with correct targetDir from registry
+		expect(addPortableInstallationMock).toHaveBeenCalledWith(
+			"my-skill",
+			"skill",
+			"windsurf",
+			false,
+			join(customPath, "my-skill"),
+			expect.any(String),
+		);
+	});
+
+	it("windsurf global: installs skill to global path derived from registry", async () => {
+		const globalCustomPath = join(testDir, ".codeium", "windsurf", "skills");
+		const skill = makeSkill("my-skill", join(sourceDir, "my-skill"));
+
+		// Patch windsurf provider global path
+		const origWindsurfSkills = originalProviders.windsurf.skills;
+		if (origWindsurfSkills) {
+			originalProviders.windsurf.skills = {
+				...origWindsurfSkills,
+				globalPath: globalCustomPath,
+			};
+		}
+
+		const results = await installSkillDirectories([skill], ["windsurf"], { global: true });
+
+		originalProviders.windsurf.skills = origWindsurfSkills;
+
+		expect(results).toHaveLength(1);
+		expect(results[0].success).toBe(true);
+		expect(results[0].path).toBe(join(globalCustomPath, "my-skill"));
+		// addPortableInstallation called with isGlobal=true
+		expect(addPortableInstallationMock).toHaveBeenCalledWith(
+			"my-skill",
+			"skill",
+			"windsurf",
+			true,
+			join(globalCustomPath, "my-skill"),
+			expect.any(String),
+		);
+	});
 });

--- a/src/commands/portable/__tests__/fixtures/path-migration/manifest.json
+++ b/src/commands/portable/__tests__/fixtures/path-migration/manifest.json
@@ -1,0 +1,50 @@
+{
+	"version": "1.0",
+	"cliVersion": "3.43.0",
+	"renames": [],
+	"providerPathMigrations": [
+		{
+			"provider": "gemini-cli",
+			"type": "skill",
+			"from": ".gemini/skills",
+			"to": ".agents/skills",
+			"since": "3.37.0"
+		},
+		{
+			"provider": "windsurf",
+			"type": "skill",
+			"from": ".windsurf/skills",
+			"to": ".agents/skills",
+			"since": "3.37.0"
+		},
+		{
+			"provider": "windsurf",
+			"type": "skill",
+			"from": ".codeium/windsurf/skills",
+			"to": ".agents/skills",
+			"since": "3.37.0"
+		},
+		{
+			"provider": "cursor",
+			"type": "skill",
+			"from": ".cursor/skills",
+			"to": ".agents/skills",
+			"since": "3.37.0"
+		},
+		{
+			"provider": "windsurf",
+			"type": "skill",
+			"from": ".agents/skills",
+			"to": ".windsurf/skills",
+			"since": "3.43.0"
+		},
+		{
+			"provider": "cursor",
+			"type": "skill",
+			"from": ".agents/skills",
+			"to": ".cursor/skills",
+			"since": "3.43.0"
+		}
+	],
+	"sectionRenames": []
+}

--- a/src/commands/portable/__tests__/fixtures/path-migration/registry-post-343.json
+++ b/src/commands/portable/__tests__/fixtures/path-migration/registry-post-343.json
@@ -1,0 +1,30 @@
+{
+	"version": "3.0",
+	"appliedManifestVersion": "3.43.0",
+	"installations": [
+		{
+			"item": "foo",
+			"type": "skill",
+			"provider": "cursor",
+			"global": false,
+			"path": ".cursor/skills/foo",
+			"installedAt": "2024-01-01T00:00:00.000Z",
+			"sourcePath": "skills/foo",
+			"sourceChecksum": "source-abc",
+			"targetChecksum": "target-abc",
+			"installSource": "kit"
+		},
+		{
+			"item": "bar",
+			"type": "skill",
+			"provider": "windsurf",
+			"global": false,
+			"path": ".windsurf/skills/bar",
+			"installedAt": "2024-01-01T00:00:00.000Z",
+			"sourcePath": "skills/bar",
+			"sourceChecksum": "source-def",
+			"targetChecksum": "target-def",
+			"installSource": "kit"
+		}
+	]
+}

--- a/src/commands/portable/__tests__/fixtures/path-migration/registry-pre-343.json
+++ b/src/commands/portable/__tests__/fixtures/path-migration/registry-pre-343.json
@@ -1,0 +1,30 @@
+{
+	"version": "3.0",
+	"appliedManifestVersion": "3.42.5",
+	"installations": [
+		{
+			"item": "foo",
+			"type": "skill",
+			"provider": "cursor",
+			"global": false,
+			"path": ".agents/skills/foo",
+			"installedAt": "2024-01-01T00:00:00.000Z",
+			"sourcePath": "skills/foo",
+			"sourceChecksum": "source-abc",
+			"targetChecksum": "target-abc",
+			"installSource": "kit"
+		},
+		{
+			"item": "bar",
+			"type": "skill",
+			"provider": "windsurf",
+			"global": false,
+			"path": ".agents/skills/bar",
+			"installedAt": "2024-01-01T00:00:00.000Z",
+			"sourcePath": "skills/bar",
+			"sourceChecksum": "source-def",
+			"targetChecksum": "target-def",
+			"installSource": "kit"
+		}
+	]
+}

--- a/src/commands/portable/__tests__/portable-registry.test.ts
+++ b/src/commands/portable/__tests__/portable-registry.test.ts
@@ -9,7 +9,10 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import {
 	type PortableRegistryV3,
+	addPortableInstallation,
 	readPortableRegistry,
+	removeInstallationsByFilter,
+	updateAppliedManifestVersion,
 	writePortableRegistry,
 } from "../portable-registry.js";
 
@@ -328,6 +331,202 @@ describe("empty registry initialization", () => {
 		expect(loaded.installations).toEqual([]);
 		expect(loaded.lastReconciled).toBeUndefined();
 		expect(loaded.appliedManifestVersion).toBeUndefined();
+	});
+});
+
+// Phase 04: appliedManifestVersion advancement and stale entry cleanup
+describe("updateAppliedManifestVersion", () => {
+	test("writes appliedManifestVersion to registry atomically", async () => {
+		// Start with empty registry
+		await writePortableRegistry({ version: "3.0", installations: [] });
+
+		await updateAppliedManifestVersion("3.43.0");
+
+		const loaded = await readPortableRegistry();
+		expect(loaded.appliedManifestVersion).toBe("3.43.0");
+	});
+
+	test("overwrites previous appliedManifestVersion on re-run (idempotency)", async () => {
+		await writePortableRegistry({
+			version: "3.0",
+			installations: [],
+			appliedManifestVersion: "3.42.2",
+		});
+
+		await updateAppliedManifestVersion("3.43.0");
+
+		const loaded = await readPortableRegistry();
+		// Must advance from old value to new value — re-run is safe
+		expect(loaded.appliedManifestVersion).toBe("3.43.0");
+	});
+
+	test("preserves existing installations when updating appliedManifestVersion", async () => {
+		await writePortableRegistry({
+			version: "3.0",
+			installations: [
+				{
+					item: "scout",
+					type: "skill",
+					provider: "cursor",
+					global: false,
+					path: ".cursor/skills/scout",
+					installedAt: new Date().toISOString(),
+					sourcePath: ".claude/skills/scout",
+					sourceChecksum: "a".repeat(64),
+					targetChecksum: "b".repeat(64),
+					installSource: "kit",
+				},
+			],
+		});
+
+		await updateAppliedManifestVersion("3.43.0");
+
+		const loaded = await readPortableRegistry();
+		expect(loaded.appliedManifestVersion).toBe("3.43.0");
+		expect(loaded.installations).toHaveLength(1);
+		expect(loaded.installations[0].item).toBe("scout");
+	});
+});
+
+describe("removeInstallationsByFilter (stale entry cleanup)", () => {
+	test("removes stale registry entry at old path (.agents/skills) leaving new-path entry intact", async () => {
+		await writePortableRegistry({
+			version: "3.0",
+			installations: [
+				{
+					item: "scout",
+					type: "skill",
+					provider: "cursor",
+					global: false,
+					// stale entry: old .agents/skills path
+					path: ".agents/skills/scout",
+					installedAt: new Date().toISOString(),
+					sourcePath: ".claude/skills/scout",
+					sourceChecksum: "a".repeat(64),
+					targetChecksum: "b".repeat(64),
+					installSource: "kit",
+				},
+				{
+					item: "debug",
+					type: "skill",
+					provider: "windsurf",
+					global: false,
+					// current entry: new native path
+					path: ".windsurf/skills/debug",
+					installedAt: new Date().toISOString(),
+					sourcePath: ".claude/skills/debug",
+					sourceChecksum: "c".repeat(64),
+					targetChecksum: "d".repeat(64),
+					installSource: "kit",
+				},
+			],
+		});
+
+		// Simulate detectPathMigrations delete action: remove entries at stale path
+		const removed = await removeInstallationsByFilter((entry) =>
+			entry.path.includes(".agents/skills"),
+		);
+
+		expect(removed).toHaveLength(1);
+		expect(removed[0].item).toBe("scout");
+
+		const loaded = await readPortableRegistry();
+		// stale entry gone
+		expect(loaded.installations.some((i) => i.path.includes(".agents/skills"))).toBe(false);
+		// new-path entry survives
+		expect(loaded.installations).toHaveLength(1);
+		expect(loaded.installations[0].item).toBe("debug");
+	});
+
+	test("returns empty array when no entries match filter", async () => {
+		await writePortableRegistry({
+			version: "3.0",
+			installations: [
+				{
+					item: "scout",
+					type: "skill",
+					provider: "cursor",
+					global: false,
+					path: ".cursor/skills/scout",
+					installedAt: new Date().toISOString(),
+					sourcePath: ".claude/skills/scout",
+					sourceChecksum: "a".repeat(64),
+					targetChecksum: "b".repeat(64),
+					installSource: "kit",
+				},
+			],
+		});
+
+		const removed = await removeInstallationsByFilter((entry) =>
+			entry.path.includes(".agents/skills"),
+		);
+
+		expect(removed).toHaveLength(0);
+
+		const loaded = await readPortableRegistry();
+		expect(loaded.installations).toHaveLength(1);
+	});
+});
+
+describe("addPortableInstallation (path alignment for cursor/windsurf)", () => {
+	test("records cursor skill at .cursor/skills/<name> path", async () => {
+		await writePortableRegistry({ version: "3.0", installations: [] });
+
+		await addPortableInstallation(
+			"scout",
+			"skill",
+			"cursor",
+			false,
+			".cursor/skills/scout",
+			".claude/skills/scout",
+		);
+
+		const loaded = await readPortableRegistry();
+		const entry = loaded.installations.find((i) => i.item === "scout");
+		expect(entry).toBeDefined();
+		expect(entry?.path).toBe(".cursor/skills/scout");
+		expect(entry?.provider).toBe("cursor");
+		expect(entry?.type).toBe("skill");
+	});
+
+	test("records windsurf skill at .windsurf/skills/<name> path (project scope)", async () => {
+		await writePortableRegistry({ version: "3.0", installations: [] });
+
+		await addPortableInstallation(
+			"debug",
+			"skill",
+			"windsurf",
+			false,
+			".windsurf/skills/debug",
+			".claude/skills/debug",
+		);
+
+		const loaded = await readPortableRegistry();
+		const entry = loaded.installations.find((i) => i.item === "debug");
+		expect(entry).toBeDefined();
+		expect(entry?.path).toBe(".windsurf/skills/debug");
+		expect(entry?.provider).toBe("windsurf");
+		expect(entry?.global).toBe(false);
+	});
+
+	test("records windsurf skill at ~/.codeium/windsurf/skills/<name> path (global scope)", async () => {
+		await writePortableRegistry({ version: "3.0", installations: [] });
+
+		const globalPath = `${process.env.HOME}/.codeium/windsurf/skills/debug`;
+		await addPortableInstallation(
+			"debug",
+			"skill",
+			"windsurf",
+			true,
+			globalPath,
+			".claude/skills/debug",
+		);
+
+		const loaded = await readPortableRegistry();
+		const entry = loaded.installations.find((i) => i.item === "debug" && i.global === true);
+		expect(entry).toBeDefined();
+		expect(entry?.path).toBe(globalPath);
+		expect(entry?.global).toBe(true);
 	});
 });
 

--- a/src/commands/portable/__tests__/portable-registry.test.ts
+++ b/src/commands/portable/__tests__/portable-registry.test.ts
@@ -512,7 +512,7 @@ describe("addPortableInstallation (path alignment for cursor/windsurf)", () => {
 	test("records windsurf skill at ~/.codeium/windsurf/skills/<name> path (global scope)", async () => {
 		await writePortableRegistry({ version: "3.0", installations: [] });
 
-		const globalPath = `${process.env.HOME}/.codeium/windsurf/skills/debug`;
+		const globalPath = join(homedir(), ".codeium", "windsurf", "skills", "debug");
 		await addPortableInstallation(
 			"debug",
 			"skill",

--- a/src/commands/portable/__tests__/provider-registry.test.ts
+++ b/src/commands/portable/__tests__/provider-registry.test.ts
@@ -239,7 +239,51 @@ describe("provider-registry", () => {
 		});
 	});
 
-	describe("skills path consolidation to .agents/skills", () => {
+	describe("skills paths — native provider paths (post-consolidation-revert)", () => {
+		// Cursor: native .cursor/skills paths (upstream cursor.com/docs/skills)
+		it("cursor skills projectPath is .cursor/skills", () => {
+			expect(providers.cursor.skills?.projectPath).toBe(".cursor/skills");
+		});
+
+		it("cursor skills globalPath ends with .cursor/skills (home-prefixed)", () => {
+			const globalPath = providers.cursor.skills?.globalPath?.replace(/\\/g, "/") ?? "";
+			expect(globalPath).toContain(".cursor/skills");
+		});
+
+		// Windsurf: native .windsurf/skills + ~/.codeium/windsurf/skills paths (upstream docs.windsurf.com)
+		it("windsurf skills projectPath is .windsurf/skills", () => {
+			expect(providers.windsurf.skills?.projectPath).toBe(".windsurf/skills");
+		});
+
+		it("windsurf skills globalPath ends with .codeium/windsurf/skills", () => {
+			const globalPath = providers.windsurf.skills?.globalPath?.replace(/\\/g, "/") ?? "";
+			expect(globalPath).toContain(".codeium/windsurf/skills");
+		});
+
+		// Guard: agent rule paths must be unchanged
+		it("cursor agents projectPath is .cursor/rules (unchanged)", () => {
+			expect(providers.cursor.agents?.projectPath).toBe(".cursor/rules");
+		});
+
+		it("windsurf agents projectPath is .windsurf/rules (unchanged)", () => {
+			expect(providers.windsurf.agents?.projectPath).toBe(".windsurf/rules");
+		});
+
+		// Guard: cursor commands stay null (deprecated upstream v2.4)
+		it("cursor commands is null (deprecated)", () => {
+			expect(providers.cursor.commands).toBeNull();
+		});
+
+		// Guard: other providers unchanged
+		it("claude-code skills projectPath is .claude/skills (unchanged)", () => {
+			expect(providers["claude-code"].skills?.projectPath).toBe(".claude/skills");
+		});
+
+		it("codex skills projectPath is .agents/skills (unchanged)", () => {
+			expect(providers.codex.skills?.projectPath).toBe(".agents/skills");
+		});
+
+		// Retained utility tests (non-cursor/windsurf)
 		it("opencode skills projectPath is .claude/skills for native Claude compatibility", () => {
 			expect(providers.opencode.skills?.projectPath).toBe(".claude/skills");
 		});
@@ -258,29 +302,6 @@ describe("provider-registry", () => {
 			const globalPath = providers["gemini-cli"].skills?.globalPath?.replace(/\\/g, "/") ?? "";
 			expect(globalPath).toContain(".agents/skills");
 			expect(globalPath).not.toContain(".gemini/skills");
-		});
-
-		it("windsurf skills projectPath is .agents/skills", () => {
-			expect(providers.windsurf.skills?.projectPath).toBe(".agents/skills");
-		});
-
-		it("windsurf skills globalPath points to .agents/skills (not .codeium)", () => {
-			const globalPath = providers.windsurf.skills?.globalPath?.replace(/\\/g, "/") ?? "";
-			expect(globalPath).toContain(".agents/skills");
-			expect(globalPath).not.toContain(".codeium/windsurf/skills");
-		});
-
-		it("cursor skills projectPath is .agents/skills", () => {
-			expect(providers.cursor.skills?.projectPath).toBe(".agents/skills");
-		});
-
-		it("cursor skills globalPath stays at .cursor/skills (no global .agents/ support)", () => {
-			const globalPath = providers.cursor.skills?.globalPath?.replace(/\\/g, "/") ?? "";
-			expect(globalPath).toContain(".cursor/skills");
-		});
-
-		it("codex skills projectPath remains .agents/skills after detection cleanup", () => {
-			expect(providers.codex.skills?.projectPath).toBe(".agents/skills");
 		});
 
 		it("getPortableBasePath returns the directory base for per-file targets", () => {
@@ -355,22 +376,37 @@ describe("provider-registry", () => {
 			expect(skillCollisions[0].global).toBe(false);
 		});
 
-		it("detects 5-provider .agents/skills collision after consolidation", () => {
-			const allConsolidated: ProviderType[] = ["codex", "amp", "gemini-cli", "windsurf", "cursor"];
-			const collisions = detectProviderPathCollisions(allConsolidated, { global: false });
+		it("detects 3-provider .agents/skills collision (codex, amp, gemini-cli — not cursor/windsurf after path revert)", () => {
+			// cursor now uses .cursor/skills, windsurf uses .windsurf/skills — neither collides on .agents/skills
+			const providers3: ProviderType[] = ["codex", "amp", "gemini-cli"];
+			const collisions = detectProviderPathCollisions(providers3, { global: false });
 			const skillCollisions = collisions.filter((c) => c.portableType === "skills");
 			expect(skillCollisions).toHaveLength(1);
 			expect(skillCollisions[0].path).toBe(".agents/skills");
-			expect(skillCollisions[0].providers).toHaveLength(5);
+			expect(skillCollisions[0].providers).toHaveLength(3);
 		});
 
-		it("global scope: gemini-cli + codex + windsurf collide on ~/.agents/skills", () => {
+		it("cursor and windsurf no longer collide with codex+amp on .agents/skills after path revert", () => {
+			const allFive: ProviderType[] = ["codex", "amp", "gemini-cli", "windsurf", "cursor"];
+			const collisions = detectProviderPathCollisions(allFive, { global: false });
+			const agentsSkillsCollision = collisions.find(
+				(c) => c.portableType === "skills" && c.path === ".agents/skills",
+			);
+			// Only codex, amp, gemini-cli collide on .agents/skills — cursor+windsurf use native paths
+			expect(agentsSkillsCollision?.providers).toHaveLength(3);
+			expect(agentsSkillsCollision?.providers).not.toContain("cursor");
+			expect(agentsSkillsCollision?.providers).not.toContain("windsurf");
+		});
+
+		it("global scope: gemini-cli + codex collide on ~/.agents/skills (windsurf no longer in group after path revert)", () => {
 			const collisions = detectProviderPathCollisions(["codex", "gemini-cli", "windsurf"], {
 				global: true,
 			});
 			const skillCollisions = collisions.filter((c) => c.portableType === "skills");
+			// windsurf now uses ~/.codeium/windsurf/skills globally — only codex+gemini-cli collide on ~/.agents/skills
 			expect(skillCollisions).toHaveLength(1);
-			expect(skillCollisions[0].providers).toHaveLength(3);
+			expect(skillCollisions[0].providers).toHaveLength(2);
+			expect(skillCollisions[0].providers).not.toContain("windsurf");
 		});
 
 		it("global scope: cursor does NOT collide with codex (different global paths)", () => {

--- a/src/commands/portable/__tests__/reconciler.test.ts
+++ b/src/commands/portable/__tests__/reconciler.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import type { PortableManifest } from "../portable-manifest.js";
 import type { PortableRegistryV3 } from "../portable-registry.js";
 import type {
 	ReconcileInput,
@@ -7,6 +8,13 @@ import type {
 	TargetFileState,
 } from "../reconcile-types.js";
 import { reconcile } from "../reconciler.js";
+import manifestFixture from "./fixtures/path-migration/manifest.json" with { type: "json" };
+import registryPost343Fixture from "./fixtures/path-migration/registry-post-343.json" with {
+	type: "json",
+};
+import registryPre343Fixture from "./fixtures/path-migration/registry-pre-343.json" with {
+	type: "json",
+};
 
 /**
  * Helper to create source item state
@@ -959,5 +967,294 @@ describe("reconciler - force mode", () => {
 		expect(plan.actions[0].action).toBe("install");
 		expect(plan.actions[0].reason).toContain("Force overwrite");
 		expect(plan.summary.install).toBe(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// windsurf+cursor path migration (Phase 03 verification)
+// Fixtures: src/commands/portable/__tests__/fixtures/path-migration/
+// Manifest: 3.37.0 forward entries (gemini-cli, windsurf, cursor) +
+//           3.43.0 reversed entries (windsurf .agents→.windsurf, cursor .agents→.cursor)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal ReconcileInput for path-migration tests.
+ * sourceItems is intentionally empty — detectPathMigrations only walks
+ * the registry, it does not need matching source items.
+ */
+function makeMigrationInput(
+	registry: PortableRegistryV3,
+	manifest: PortableManifest,
+	providerConfigs: ReconcileProviderInput[] = [
+		{ provider: "cursor", global: false },
+		{ provider: "windsurf", global: false },
+	],
+): ReconcileInput {
+	return {
+		sourceItems: [],
+		registry,
+		targetStates: new Map(),
+		manifest,
+		providerConfigs,
+	};
+}
+
+/**
+ * Cast JSON fixture to PortableRegistryV3.
+ * Fixtures are validated to match the schema; cast is safe here.
+ */
+function asRegistry(raw: unknown): PortableRegistryV3 {
+	return raw as PortableRegistryV3;
+}
+
+describe("reconciler - windsurf+cursor path migration (3.43.0)", () => {
+	// Test 1: cursor upgrade emits delete for .agents/skills/foo
+	it("cursor 3.43 upgrade: emits delete for skill at .agents/skills", () => {
+		const registry = asRegistry(registryPre343Fixture);
+		// Only keep the cursor entry for isolation
+		const cursorOnlyRegistry: PortableRegistryV3 = {
+			...registry,
+			installations: registry.installations.filter((i) => i.provider === "cursor"),
+		};
+
+		const plan = reconcile(
+			makeMigrationInput(cursorOnlyRegistry, manifestFixture as PortableManifest),
+		);
+
+		const migrationDeletes = plan.actions.filter(
+			(a) => a.action === "delete" && a.reasonCode === "path-migrated-cleanup",
+		);
+		expect(migrationDeletes).toHaveLength(1);
+		expect(migrationDeletes[0].item).toBe("foo");
+		expect(migrationDeletes[0].provider).toBe("cursor");
+		expect(migrationDeletes[0].targetPath).toContain(".agents/skills/foo");
+	});
+
+	// Test 2: windsurf upgrade emits delete for .agents/skills/bar (project-relative path)
+	it("windsurf 3.43 upgrade (project path): emits delete for skill at .agents/skills", () => {
+		const registry = asRegistry(registryPre343Fixture);
+		const windsurfOnlyRegistry: PortableRegistryV3 = {
+			...registry,
+			installations: registry.installations.filter((i) => i.provider === "windsurf"),
+		};
+
+		const plan = reconcile(
+			makeMigrationInput(windsurfOnlyRegistry, manifestFixture as PortableManifest),
+		);
+
+		const migrationDeletes = plan.actions.filter(
+			(a) => a.action === "delete" && a.reasonCode === "path-migrated-cleanup",
+		);
+		expect(migrationDeletes).toHaveLength(1);
+		expect(migrationDeletes[0].item).toBe("bar");
+		expect(migrationDeletes[0].provider).toBe("windsurf");
+		expect(migrationDeletes[0].targetPath).toContain(".agents/skills/bar");
+	});
+
+	// Test 3: windsurf upgrade emits delete for global path containing .agents/skills
+	it("windsurf 3.43 upgrade (global path): emits delete for global skill at .agents/skills", () => {
+		const globalRegistry: PortableRegistryV3 = {
+			version: "3.0",
+			appliedManifestVersion: "3.42.5",
+			installations: [
+				{
+					item: "baz",
+					type: "skill",
+					provider: "windsurf",
+					global: true,
+					// Simulate absolute global path containing .agents/skills segments
+					path: "/home/user/.agents/skills/baz",
+					installedAt: "2024-01-01T00:00:00.000Z",
+					sourcePath: "skills/baz",
+					sourceChecksum: "source-baz",
+					targetChecksum: "target-baz",
+					installSource: "kit",
+				},
+			],
+		};
+
+		const plan = reconcile(
+			makeMigrationInput(globalRegistry, manifestFixture as PortableManifest, [
+				{ provider: "windsurf", global: true },
+			]),
+		);
+
+		const migrationDeletes = plan.actions.filter(
+			(a) => a.action === "delete" && a.reasonCode === "path-migrated-cleanup",
+		);
+		expect(migrationDeletes).toHaveLength(1);
+		expect(migrationDeletes[0].item).toBe("baz");
+		expect(migrationDeletes[0].provider).toBe("windsurf");
+		expect(migrationDeletes[0].targetPath).toBe("/home/user/.agents/skills/baz");
+	});
+
+	// Test 4: idempotency — registry already at native paths, appliedManifestVersion=3.43.0
+	it("idempotent: no migration deletes when registry already at native paths (post-3.43.0)", () => {
+		const registry = asRegistry(registryPost343Fixture);
+
+		const plan = reconcile(makeMigrationInput(registry, manifestFixture as PortableManifest));
+
+		const migrationDeletes = plan.actions.filter(
+			(a) => a.action === "delete" && a.reasonCode === "path-migrated-cleanup",
+		);
+		expect(migrationDeletes).toHaveLength(0);
+	});
+
+	// Test 5: semver boundary — appliedManifestVersion === cliVersion === 3.43.0 → no re-trigger
+	it("semver boundary: appliedManifestVersion === 3.43.0 does not re-trigger reversed entries", () => {
+		// Registry at 3.43.0 but still has .agents/skills paths (edge-case data)
+		const boundaryRegistry: PortableRegistryV3 = {
+			version: "3.0",
+			appliedManifestVersion: "3.43.0",
+			installations: [
+				{
+					item: "edge",
+					type: "skill",
+					provider: "cursor",
+					global: false,
+					path: ".agents/skills/edge",
+					installedAt: "2024-01-01T00:00:00.000Z",
+					sourcePath: "skills/edge",
+					sourceChecksum: "source-edge",
+					targetChecksum: "target-edge",
+					installSource: "kit",
+				},
+			],
+		};
+
+		const plan = reconcile(
+			makeMigrationInput(boundaryRegistry, manifestFixture as PortableManifest),
+		);
+
+		// entry.since (3.43.0) must be STRICTLY GREATER than appliedVersion (3.43.0)
+		// getApplicableEntries uses: since > applied && since <= current
+		// 3.43.0 > 3.43.0 is false → entry not applicable → no delete
+		const migrationDeletes = plan.actions.filter(
+			(a) => a.action === "delete" && a.reasonCode === "path-migrated-cleanup",
+		);
+		expect(migrationDeletes).toHaveLength(0);
+	});
+
+	// Test 6: old 3.37.0 entries and new 3.43.0 entries coexist correctly
+	it("3.37.0 and 3.43.0 entries coexist: both sets filter independently", () => {
+		// User at 3.37.0 applied — installs exist at .agents/skills (forward migration happened)
+		// Now upgrading to 3.43.0 — reversed entries should apply
+		const mixedRegistry: PortableRegistryV3 = {
+			version: "3.0",
+			appliedManifestVersion: "3.37.0",
+			installations: [
+				{
+					item: "alpha",
+					type: "skill",
+					provider: "cursor",
+					global: false,
+					path: ".agents/skills/alpha",
+					installedAt: "2024-01-01T00:00:00.000Z",
+					sourcePath: "skills/alpha",
+					sourceChecksum: "source-alpha",
+					targetChecksum: "target-alpha",
+					installSource: "kit",
+				},
+				{
+					item: "beta",
+					type: "skill",
+					provider: "windsurf",
+					global: false,
+					path: ".agents/skills/beta",
+					installedAt: "2024-01-01T00:00:00.000Z",
+					sourcePath: "skills/beta",
+					sourceChecksum: "source-beta",
+					targetChecksum: "target-beta",
+					installSource: "kit",
+				},
+			],
+		};
+
+		const plan = reconcile(makeMigrationInput(mixedRegistry, manifestFixture as PortableManifest));
+
+		// appliedManifestVersion=3.37.0, cliVersion=3.43.0
+		// 3.43.0 entries: since(3.43.0) > applied(3.37.0) && since(3.43.0) <= current(3.43.0) → TRUE
+		// 3.37.0 entries: since(3.37.0) > applied(3.37.0) is FALSE → not applicable
+		// So only the two 3.43.0 reversed entries fire, matching both .agents/skills installs
+		const migrationDeletes = plan.actions.filter(
+			(a) => a.action === "delete" && a.reasonCode === "path-migrated-cleanup",
+		);
+		expect(migrationDeletes).toHaveLength(2);
+
+		const deletedItems = migrationDeletes.map((a) => a.item).sort();
+		expect(deletedItems).toEqual(["alpha", "beta"]);
+
+		const deletedProviders = migrationDeletes.map((a) => a.provider).sort();
+		expect(deletedProviders).toEqual(["cursor", "windsurf"]);
+	});
+
+	// Test 7: no matching installs → zero delete actions
+	it("no matching installs: no migration delete actions when registry is empty", () => {
+		const emptyRegistry: PortableRegistryV3 = {
+			version: "3.0",
+			appliedManifestVersion: "3.42.5",
+			installations: [],
+		};
+
+		const plan = reconcile(makeMigrationInput(emptyRegistry, manifestFixture as PortableManifest));
+
+		const migrationDeletes = plan.actions.filter(
+			(a) => a.action === "delete" && a.reasonCode === "path-migrated-cleanup",
+		);
+		expect(migrationDeletes).toHaveLength(0);
+		expect(plan.summary.delete).toBe(0);
+	});
+
+	// Test 8: mixed registry — only .agents/skills entry gets delete, .cursor/skills entry is untouched
+	it("mixed registry: only .agents/skills entry gets migration delete, native-path entry is unaffected", () => {
+		const mixedRegistry: PortableRegistryV3 = {
+			version: "3.0",
+			appliedManifestVersion: "3.42.5",
+			installations: [
+				{
+					// Old path — should be cleaned up
+					item: "old-skill",
+					type: "skill",
+					provider: "cursor",
+					global: false,
+					path: ".agents/skills/old-skill",
+					installedAt: "2024-01-01T00:00:00.000Z",
+					sourcePath: "skills/old-skill",
+					sourceChecksum: "source-old",
+					targetChecksum: "target-old",
+					installSource: "kit",
+				},
+				{
+					// Already at native path — must NOT be deleted by migration
+					item: "native-skill",
+					type: "skill",
+					provider: "cursor",
+					global: false,
+					path: ".cursor/skills/native-skill",
+					installedAt: "2024-01-01T00:00:00.000Z",
+					sourcePath: "skills/native-skill",
+					sourceChecksum: "source-native",
+					targetChecksum: "target-native",
+					installSource: "kit",
+				},
+			],
+		};
+
+		const plan = reconcile(makeMigrationInput(mixedRegistry, manifestFixture as PortableManifest));
+
+		const migrationDeletes = plan.actions.filter(
+			(a) => a.action === "delete" && a.reasonCode === "path-migrated-cleanup",
+		);
+		expect(migrationDeletes).toHaveLength(1);
+		expect(migrationDeletes[0].item).toBe("old-skill");
+		expect(migrationDeletes[0].targetPath).toContain(".agents/skills/old-skill");
+
+		// native-skill must appear in actions but NOT as a migration delete
+		const nativeAction = plan.actions.find((a) => a.item === "native-skill");
+		// native-skill is in the registry but not in sourceItems, so it becomes an orphan delete
+		// OR it may not appear at all — either way, it must not be a path-migrated-cleanup
+		if (nativeAction) {
+			expect(nativeAction.reasonCode).not.toBe("path-migrated-cleanup");
+		}
 	});
 });

--- a/src/commands/portable/provider-registry.ts
+++ b/src/commands/portable/provider-registry.ts
@@ -383,8 +383,8 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 		},
 		commands: null, // Cursor does not support commands
 		skills: {
-			projectPath: ".agents/skills", // Cursor reads .agents/skills/ at project level
-			globalPath: join(home, ".cursor/skills"), // Cursor does NOT read ~/.agents/skills/ globally
+			projectPath: ".cursor/skills", // Cursor reads .cursor/skills/ at project level (upstream: cursor.com/docs/skills)
+			globalPath: join(home, ".cursor/skills"), // Cursor global skills at ~/.cursor/skills
 			format: "direct-copy",
 			writeStrategy: "per-file",
 			fileExtension: ".md",
@@ -570,8 +570,8 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			nestedCommands: false, // Windsurf workflows are flat
 		},
 		skills: {
-			projectPath: ".agents/skills", // Windsurf reads .agents/skills/ for cross-agent compat
-			globalPath: join(home, ".agents/skills"), // Consolidated: Windsurf scans both paths
+			projectPath: ".windsurf/skills", // Windsurf reads .windsurf/skills/ at project level (upstream: docs.windsurf.com/windsurf/cascade/skills)
+			globalPath: join(home, ".codeium/windsurf/skills"), // Windsurf global skills at ~/.codeium/windsurf/skills
 			format: "direct-copy",
 			writeStrategy: "per-file",
 			fileExtension: ".md",


### PR DESCRIPTION
## Summary

Reverse the 3.37 path consolidation that pointed cursor + windsurf skills at `.agents/skills`. Per upstream docs ([docs.windsurf.com/windsurf/cascade/skills](https://docs.windsurf.com/windsurf/cascade/skills), [cursor.com/docs/skills](https://cursor.com/docs/skills)) the native primary paths are:

- **Cursor:** `.cursor/skills` + `~/.cursor/skills`
- **Windsurf:** `.windsurf/skills` + `~/.codeium/windsurf/skills`

`.agents/skills` is documented as cross-compat fallback only, not the primary surface. The earlier consolidation produced wrong behavior — Windsurf showed broken skill bundles, Cursor users couldn't find migrated skills under `/ck` autocomplete.

Closes #754

## Companion PR

This PR ships only the CLI registry + tests. The engineer kit needs a matching `providerPathMigrations` reversal so existing users get `.agents/skills` cleaned up on upgrade. **Companion PR in `claudekit-engineer`** must merge in lockstep with the CLI 3.43.0 release tag.

## Root Cause

Engineer kit commit `d91d059` (refs claudekit-cli#477, March 2026) consolidated cursor + windsurf skill targets to `.agents/skills` and added forward `providerPathMigrations` entries. That direction is opposite to what the upstream docs say. Researcher report: `plans/reports/researcher-260428-1412-windsurf-cursor-capability-database.md`.

## What changed

| File | Change |
|------|--------|
| `src/commands/portable/provider-registry.ts` | cursor + windsurf `skills.projectPath` and windsurf `skills.globalPath` flipped to native paths (4 lines). Other providers untouched |
| `src/commands/portable/__tests__/provider-registry.test.ts` | +8 phase-01 TDD assertions, 2 stale collision tests updated |
| `src/commands/portable/__tests__/reconciler.test.ts` | +8 path-migration scenarios |
| `src/commands/portable/__tests__/fixtures/path-migration/` | manifest + registry fixtures |
| `src/commands/migrate/__tests__/skill-directory-installer.test.ts` | +3 native-path assertions |
| `src/commands/portable/__tests__/portable-registry.test.ts` | +9 state alignment tests |
| `src/commands/migrate/__tests__/migrate-windsurf-cursor-upgrade.integration.test.ts` | new — 6 integration cases (fresh × 2, upgrade × 2, idempotent × 2) |
| `src/commands/migrate/__tests__/fixtures/windsurf-cursor-upgrade/` | skill + manifest + registry fixtures |

`reconciler.ts`, `skill-directory-installer.ts`, and `portable-registry.ts` source — **no changes needed**. Existing logic correctly handles the reversed manifest entries and idempotency contract.

## Idempotency

- First run on 3.42→3.43 upgrade: reconciler emits `path-migrated-cleanup` deletes for `.agents/skills` artifacts; installer writes new entries at native paths; `appliedManifestVersion` advances to `3.43.0`.
- Subsequent runs: `getApplicableEntries` filter returns empty (since ≤ applied); plan summary all `skip`; zero filesystem writes.

Verified by Phase 03 tests 4 + 5 + Phase 05 tests 5 + 6.

## Out of scope

- Hooks, MCP, settings.json
- Cursor slash commands (deprecated upstream Cursor 2.4 — confirmed by researcher; registry's `commands: null` stays)
- Windsurf workflows
- Per-skill size thinning (the red ⚠ in Windsurf is cosmetic)
- `.agents/skills` cross-agent secondary mirror — separate follow-up if demand surfaces

## Test plan

- [x] `bun run validate` — pass (typecheck + lint + test + build)
- [x] Full suite: 4565 pass / 0 fail
- [x] 31 new test cases written first per TDD
- [x] Phase 03 confirms reversed manifest entries activate correctly with semver gate
- [x] Phase 05 covers fresh install, upgrade-from-prior, idempotent rerun for both providers
- [ ] Manual smoke per `plans/260428-1412-windsurf-cursor-migration-fix/smoke-runbook.md` (recommended before stable 3.43.0 tag)
- [ ] Windows smoke (CI covers Linux + macOS only)

## Plan + research artifacts

- Plan: `plans/260428-1412-windsurf-cursor-migration-fix/plan.md`
- Smoke runbook: `plans/260428-1412-windsurf-cursor-migration-fix/smoke-runbook.md`
- Explainer: `plans/260428-1412-windsurf-cursor-migration-fix/visuals/explain-migration-fix.md`