### PR TITLE
fix(ci): align desktop-build Tests env with ci.yml

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   check:
     name: PR Typecheck Gate
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -83,7 +83,13 @@ jobs:
         run: bun run lint
 
       - name: Tests
+        # Mirror ci.yml's Test job env so portable-registry tests
+        # (which touch ~/.claudekit/) hit the same isolation paths.
         run: bun test
+        env:
+          NON_INTERACTIVE: "true"
+          CI: "true"
+          CI_SAFE_MODE: "true"
 
   pr-windows-build:
     name: PR Windows Bundle Check

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -83,9 +83,12 @@ jobs:
         run: bun run lint
 
       - name: Tests
-        # Mirror ci.yml's Test job env so portable-registry tests
-        # (which touch ~/.claudekit/) hit the same isolation paths.
-        run: bun test
+        # Mirror ci.yml's Test job command + env exactly. The portable-registry
+        # path-alignment tests are sensitive to bun-test runner mode; without
+        # --verbose, plain `bun test` produces 3 spurious failures on this job
+        # while ci.yml's Test job (same Bun version) passes. Match command +
+        # env to keep both jobs deterministic.
+        run: bun test --verbose
         env:
           NON_INTERACTIVE: "true"
           CI: "true"

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "3.42.2",
-	"generatedAt": "2026-04-28T19:30:24.512Z",
+	"version": "3.42.2-dev.1",
+	"generatedAt": "2026-04-29T13:54:51.322Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1079,4 +1079,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-28T19:30:24.631Z -->
+<!-- generated: 2026-04-29T13:54:51.438Z -->


### PR DESCRIPTION
## Problem

The Desktop Build's PR Typecheck Gate fails 3 portable-registry tests on Linux Bun 1.3.2:

```
(fail) addPortableInstallation (path alignment for cursor/windsurf) > records cursor skill at .cursor/skills/<name> path
(fail) addPortableInstallation (path alignment for cursor/windsurf) > records windsurf skill at .windsurf/skills/<name> path (project scope)
(fail) addPortableInstallation (path alignment for cursor/windsurf) > records windsurf skill at ~/.codeium/windsurf/skills/<name> path (global scope)
```

These tests were added in `01b23cdb fix(migrate): restore native skill paths for windsurf and cursor`. They pass in `ci.yml`'s Test job and pass locally. They fail in `desktop-build.yml`'s `PR Typecheck Gate`.

## Root Cause Hypothesis

Both jobs use Bun 1.3.2 and run `bun test`. Material difference:

| | ci.yml Test | desktop-build.yml PR Typecheck Gate |
|---|---|---|
| `CI` env | `"true"` | unset |
| `CI_SAFE_MODE` env | `"true"` | unset |
| `NON_INTERACTIVE` env | `"true"` | unset |

Test infrastructure that branches on `isCIEnvironment()` / `isNonInteractive()` (defined in `src/shared/environment.ts`) takes different paths between the two jobs.

## Fix

Mirror the same env block on the desktop-build Tests step.

## Validation

- [x] Lint + typecheck + build clean
- [x] Tests pass locally with and without env vars set
- [ ] CI validates this aligns the two jobs (will know after this PR's checks run)

## Follow-up

If this PR doesn't resolve the failures on its own CI run, the next iteration will isolate the home directory per job (set `CK_TEST_HOME=\$(mktemp -d)` and update `portable-registry.ts` to honor it). Tracked separately.