### PR TITLE
refactor(transformers): drop kanban from commands-prefix list (#711)

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "3.42.2-dev.2",
-	"generatedAt": "2026-04-29T14:37:43.210Z",
+	"version": "3.42.2-dev.3",
+	"generatedAt": "2026-04-29T21:03:23.561Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1085,4 +1085,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-29T14:37:43.325Z -->
+<!-- generated: 2026-04-29T21:03:23.688Z -->

--- a/src/__tests__/services/transformers/content-transformer.test.ts
+++ b/src/__tests__/services/transformers/content-transformer.test.ts
@@ -543,6 +543,13 @@ describe("transformCommandContent", () => {
 			expect(transformed).toBe(input);
 			expect(changes).toBe(0);
 		});
+
+		it("does not transform /kanban (retired command — engineer#711)", () => {
+			const input = "Use `/kanban` to view tasks";
+			const { transformed, changes } = transformCommandContent(input);
+			expect(transformed).toBe(input);
+			expect(changes).toBe(0);
+		});
 	});
 
 	describe("code patterns - should NOT transform", () => {

--- a/src/__tests__/services/transformers/content-transformer.test.ts
+++ b/src/__tests__/services/transformers/content-transformer.test.ts
@@ -42,10 +42,10 @@ describe("transformCommandContent", () => {
 			expect(changes).toBe(1);
 		});
 
-		it("transforms /kanban to /ck:kanban", () => {
-			const input = "Open `/kanban` dashboard";
+		it("transforms /journal to /ck:journal", () => {
+			const input = "Open `/journal` dashboard";
 			const { transformed, changes } = transformCommandContent(input);
-			expect(transformed).toBe("Open `/ck:kanban` dashboard");
+			expect(transformed).toBe("Open `/ck:journal` dashboard");
 			expect(changes).toBe(1);
 		});
 
@@ -87,9 +87,9 @@ describe("transformCommandContent", () => {
 		});
 
 		it("transforms command at end of line", () => {
-			const input = "Use this command: /kanban";
+			const input = "Use this command: /journal";
 			const { transformed, changes } = transformCommandContent(input);
-			expect(transformed).toBe("Use this command: /ck:kanban");
+			expect(transformed).toBe("Use this command: /ck:journal");
 			expect(changes).toBe(1);
 		});
 
@@ -128,9 +128,9 @@ describe("transformCommandContent", () => {
 		});
 
 		it("transforms command that is only content", () => {
-			const input = "/kanban";
+			const input = "/journal";
 			const { transformed, changes } = transformCommandContent(input);
-			expect(transformed).toBe("/ck:kanban");
+			expect(transformed).toBe("/ck:journal");
 			expect(changes).toBe(1);
 		});
 
@@ -162,9 +162,9 @@ describe("transformCommandContent", () => {
 		});
 
 		it("transforms mixed commands with and without subcommands", () => {
-			const input = "Run /watzup then /plan:fast then /kanban";
+			const input = "Run /watzup then /plan:fast then /journal";
 			const { transformed, changes } = transformCommandContent(input);
-			expect(transformed).toBe("Run /ck:watzup then /ck:plan:fast then /ck:kanban");
+			expect(transformed).toBe("Run /ck:watzup then /ck:plan:fast then /ck:journal");
 			expect(changes).toBe(3);
 		});
 
@@ -216,9 +216,9 @@ describe("transformCommandContent", () => {
 		});
 
 		it("transforms commands in italic text", () => {
-			const input = "*Try `/kanban` first*";
+			const input = "*Try `/journal` first*";
 			const { transformed } = transformCommandContent(input);
-			expect(transformed).toBe("*Try `/ck:kanban` first*");
+			expect(transformed).toBe("*Try `/ck:journal` first*");
 		});
 
 		it("transforms commands after markdown link syntax", () => {
@@ -378,35 +378,35 @@ describe("transformCommandContent", () => {
 
 	describe("string literals - should NOT transform", () => {
 		it("does not transform single-quoted string literals", () => {
-			const input = `const backUrl = options.dashboardUrl || '/kanban';`;
+			const input = `const backUrl = options.dashboardUrl || '/journal';`;
 			const { transformed, changes } = transformCommandContent(input);
 			expect(transformed).toBe(input);
 			expect(changes).toBe(0);
 		});
 
 		it("does not transform double-quoted string literals", () => {
-			const input = `const url = "/kanban";`;
+			const input = `const url = "/journal";`;
 			const { transformed, changes } = transformCommandContent(input);
 			expect(transformed).toBe(input);
 			expect(changes).toBe(0);
 		});
 
 		it("does not transform template literal URL paths", () => {
-			const input = "const urlPath = `/kanban?dir=${encodeURIComponent(plansDir)}`;";
+			const input = "const urlPath = `/journal?dir=${encodeURIComponent(plansDir)}`;";
 			const { transformed, changes } = transformCommandContent(input);
 			expect(transformed).toBe(input);
 			expect(changes).toBe(0);
 		});
 
 		it("does not transform JSON string values", () => {
-			const input = '{"route": "/kanban", "path": "/preview"}';
+			const input = '{"route": "/journal", "path": "/preview"}';
 			const { transformed, changes } = transformCommandContent(input);
 			expect(transformed).toBe(input);
 			expect(changes).toBe(0);
 		});
 
 		it("does not transform Python string literals", () => {
-			const input = `redirect_url = '/kanban'`;
+			const input = `redirect_url = '/journal'`;
 			const { transformed, changes } = transformCommandContent(input);
 			expect(transformed).toBe(input);
 			expect(changes).toBe(0);
@@ -429,7 +429,7 @@ describe("transformCommandContent", () => {
 		});
 
 		it("does not transform API routes", () => {
-			const input = "const route = '/api/kanban/tasks';";
+			const input = "const route = '/api/journal/tasks';";
 			const { transformed, changes } = transformCommandContent(input);
 			expect(transformed).toBe(input);
 			expect(changes).toBe(0);
@@ -443,14 +443,14 @@ describe("transformCommandContent", () => {
 		});
 
 		it("does not transform URL fragments", () => {
-			const input = "Link to page#/kanban section";
+			const input = "Link to page#/journal section";
 			const { transformed, changes } = transformCommandContent(input);
 			expect(transformed).toBe(input);
 			expect(changes).toBe(0);
 		});
 
 		it("does not transform localhost URLs", () => {
-			const input = "http://localhost:3000/kanban";
+			const input = "http://localhost:3000/journal";
 			const { transformed, changes } = transformCommandContent(input);
 			expect(transformed).toBe(input);
 			expect(changes).toBe(0);
@@ -605,8 +605,8 @@ describe("transformCommandContent", () => {
 
 	describe("real-world code examples - should NOT transform", () => {
 		it("does not transform Express route handlers", () => {
-			const input = `app.get('/kanban', (req, res) => {
-  res.render('kanban');
+			const input = `app.get('/journal', (req, res) => {
+  res.render('journal');
 });`;
 			const { transformed, changes } = transformCommandContent(input);
 			expect(transformed).toBe(input);
@@ -629,7 +629,7 @@ export default function handler(req, res) {}`;
 		});
 
 		it("does not transform fetch calls", () => {
-			const input = `const response = await fetch('/api/kanban/tasks');`;
+			const input = `const response = await fetch('/api/journal/tasks');`;
 			const { transformed, changes } = transformCommandContent(input);
 			expect(transformed).toBe(input);
 			expect(changes).toBe(0);
@@ -643,7 +643,7 @@ export default function handler(req, res) {}`;
 		});
 
 		it("does not transform redirect calls", () => {
-			const input = `router.push('/kanban');`;
+			const input = `router.push('/journal');`;
 			const { transformed, changes } = transformCommandContent(input);
 			expect(transformed).toBe(input);
 			expect(changes).toBe(0);
@@ -680,14 +680,14 @@ export default function handler(req, res) {}`;
 
 	describe("HTTP server URL patterns - should NOT transform", () => {
 		it("does not transform URL path assignments", () => {
-			const input = `const backUrl = options.dashboardUrl || '/kanban';`;
+			const input = `const backUrl = options.dashboardUrl || '/journal';`;
 			const { transformed, changes } = transformCommandContent(input);
 			expect(transformed).toBe(input);
 			expect(changes).toBe(0);
 		});
 
 		it("does not transform template literal URLs", () => {
-			const input = "const urlPath = `/kanban?dir=${encodeURIComponent(plansDir)}`;";
+			const input = "const urlPath = `/journal?dir=${encodeURIComponent(plansDir)}`;";
 			const { transformed, changes } = transformCommandContent(input);
 			expect(transformed).toBe(input);
 			expect(changes).toBe(0);
@@ -701,7 +701,7 @@ export default function handler(req, res) {}`;
 		});
 
 		it("does not transform URL patterns in comments", () => {
-			const input = "// Navigate to /kanban?filter=active";
+			const input = "// Navigate to /journal?filter=active";
 			const { transformed, changes } = transformCommandContent(input);
 			expect(transformed).toBe(input);
 			expect(changes).toBe(0);
@@ -758,13 +758,13 @@ export default function handler(req, res) {}`;
 	describe("mixed content scenarios", () => {
 		it("transforms only valid commands in mixed content", () => {
 			const input = `Documentation: use /plan:fast here.
-Code: const url = '/kanban';
+Code: const url = '/journal';
 More docs: try /watzup next.`;
 			const { transformed, changes } = transformCommandContent(input);
 			expect(changes).toBe(2);
 			expect(transformed).toContain("/ck:plan:fast");
 			expect(transformed).toContain("/ck:watzup");
-			expect(transformed).toContain("'/kanban'"); // unchanged
+			expect(transformed).toContain("'/journal'"); // unchanged
 		});
 
 		it("handles markdown with embedded code blocks", () => {
@@ -773,7 +773,7 @@ More docs: try /watzup next.`;
 Use \`/plan:fast\` to start.
 
 \`\`\`javascript
-const route = '/kanban';
+const route = '/journal';
 \`\`\`
 
 Then run /watzup for status.`;
@@ -781,7 +781,7 @@ Then run /watzup for status.`;
 			expect(changes).toBe(2);
 			expect(transformed).toContain("/ck:plan:fast");
 			expect(transformed).toContain("/ck:watzup");
-			expect(transformed).toContain("'/kanban'"); // unchanged in code block
+			expect(transformed).toContain("'/journal'"); // unchanged in code block
 		});
 
 		it("handles YAML with mixed command references", () => {
@@ -790,13 +790,13 @@ commands:
   - /plan:fast
   - /bootstrap
 routes:
-  dashboard: '/kanban'
+  dashboard: '/journal'
   preview: '/preview'`;
 			const { transformed, changes } = transformCommandContent(input);
 			expect(changes).toBe(2);
 			expect(transformed).toContain("/ck:plan:fast");
 			expect(transformed).toContain("/ck:bootstrap");
-			expect(transformed).toContain("'/kanban'"); // unchanged
+			expect(transformed).toContain("'/journal'"); // unchanged
 			expect(transformed).toContain("'/preview'"); // unchanged
 		});
 	});
@@ -817,9 +817,9 @@ routes:
 		});
 
 		it("handles commands in square brackets", () => {
-			const input = "[see /kanban]";
+			const input = "[see /journal]";
 			const { transformed, changes } = transformCommandContent(input);
-			expect(transformed).toBe("[see /ck:kanban]");
+			expect(transformed).toBe("[see /ck:journal]");
 			expect(changes).toBe(1);
 		});
 

--- a/src/services/transformers/commands-prefix/content-transformer.ts
+++ b/src/services/transformers/commands-prefix/content-transformer.ts
@@ -44,7 +44,10 @@ const TRANSFORMABLE_EXTENSIONS = new Set([
  * are invoked by name and are NOT affected by the --prefix system.
  *
  * Skills excluded: cook, fix, brainstorm, scout, debug (migrated from commands)
- * Removed: code, integrate (no longer exist)
+ * Removed: code, integrate (no longer exist), kanban (slash-command retired
+ *          in claudekit-engineer#711 — `kanban` still exists as a UI view
+ *          mode and `ck plan kanban` subcommand, but is no longer a
+ *          slash-command alias of `/ck:plans-kanban`)
  */
 const COMMAND_ROOTS = [
 	// Primary workflow commands

--- a/src/services/transformers/commands-prefix/content-transformer.ts
+++ b/src/services/transformers/commands-prefix/content-transformer.ts
@@ -56,7 +56,6 @@ const COMMAND_ROOTS = [
 	// Utility commands
 	"test",
 	"preview",
-	"kanban",
 	"journal",
 	"watzup",
 ];
@@ -75,8 +74,8 @@ const COMMAND_ROOTS = [
  * Does NOT match (false positives to avoid):
  * - File paths: `./test.db`, `../code`, `/home/user/`
  * - HTML tags: `</code>`, `</test>`
- * - String literals in code: `'/kanban'`, `"/kanban"`
- * - URL paths: `/kanban?dir=`, `/api/kanban`
+ * - String literals in code: `'/journal'`, `"/journal"`
+ * - URL paths: `/journal?dir=`, `/api/journal`
  * - Already prefixed: `/ck:plan:`
  */
 function buildCommandPatterns(): Array<{ regex: RegExp; replacement: string }> {


### PR DESCRIPTION
## Summary

Companion PR to the engineer-side deletion of `/ck:kanban` (alias of `/ck:plans-kanban`). The commands-prefix transformer no longer needs to preserve `/kanban` as a slash-command — it has been retired upstream.

Refs claudekit/claudekit-engineer#711

## What changed

| File | Change |
|---|---|
| `src/services/transformers/commands-prefix/content-transformer.ts` | `"kanban"` removed from `COMMAND_ROOTS`. Doc-comments updated to use `/journal` as the example for string-literal / URL-path counter-cases. |
| `src/__tests__/services/transformers/content-transformer.test.ts` | 33 fixtures rewritten from `/kanban` → `/journal` so regex-protection coverage stays intact (string literals, URL paths, template literals, JSON values, anchor fragments, Express routes, fetch URLs, `router.push`, etc.). |

## Validation

- [x] `bun run validate` — typecheck + lint + test + build all green
- [x] `bun test src/__tests__/services/transformers/content-transformer.test.ts` — 106/106 pass
- [x] Full suite: 4589 pass, 53 skip, 0 fail

## Why now

Engineer-side PR deletes `claude/skills/kanban/` (the alias of `plans-kanban`). Once that lands and ships through `ck init`, users who get the new install will not have a `/kanban` slash-command — leaving it in the CLI transformer would be misleading and would mask user typos that should fall through.