### PR TITLE
fix: preserve Codex migrate project scope

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "3.42.2-dev.3",
-	"generatedAt": "2026-04-29T21:03:23.561Z",
+	"version": "3.42.2-dev.4",
+	"generatedAt": "2026-04-30T18:53:49.445Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1085,4 +1085,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-29T21:03:23.688Z -->
+<!-- generated: 2026-04-30T18:53:57.433Z -->

--- a/src/__tests__/domains/web-server/routes/health-routes.test.ts
+++ b/src/__tests__/domains/web-server/routes/health-routes.test.ts
@@ -15,6 +15,10 @@ async function setupServer(): Promise<TestServer> {
 	registerHealthRoutes(app);
 
 	const server = app.listen(0);
+	await new Promise<void>((resolveServer, rejectServer) => {
+		server.once("listening", () => resolveServer());
+		server.once("error", (error) => rejectServer(error));
+	});
 	const address = server.address();
 	if (!address || typeof address === "string") {
 		throw new Error("Failed to start test server");

--- a/src/__tests__/domains/web-server/routes/migration-result-utils.test.ts
+++ b/src/__tests__/domains/web-server/routes/migration-result-utils.test.ts
@@ -3,6 +3,7 @@ import type { ProviderPathCollision } from "@/commands/portable/provider-registr
 import type { PortableInstallResult } from "@/commands/portable/types.js";
 import {
 	annotateResultsWithCollisions,
+	dedupeProviderPathCollisions,
 	emptyDiscoveryCounts,
 	toDiscoveryCounts,
 } from "@/domains/web-server/routes/migration-result-utils.js";
@@ -276,6 +277,34 @@ describe("migration-result-utils", () => {
 			// Now add project collision — project result gets annotated
 			annotateResultsWithCollisions(results, [projectCollision]);
 			expect(projectResult.collidingProviders).toEqual(["amp"]);
+		});
+	});
+
+	describe("dedupeProviderPathCollisions", () => {
+		it("deduplicates same collision reported from multiple scopes", () => {
+			const collisions: ProviderPathCollision[] = [
+				{
+					path: ".agents/skills",
+					portableType: "skills",
+					global: false,
+					providers: ["codex", "amp"],
+				},
+				{
+					path: ".agents/skills",
+					portableType: "skills",
+					global: true,
+					providers: ["amp", "codex"],
+				},
+			];
+
+			expect(dedupeProviderPathCollisions(collisions)).toEqual([
+				{
+					path: ".agents/skills",
+					portableType: "skills",
+					global: false,
+					providers: ["codex", "amp"],
+				},
+			]);
 		});
 	});
 });

--- a/src/__tests__/domains/web-server/routes/migration-routes.test.ts
+++ b/src/__tests__/domains/web-server/routes/migration-routes.test.ts
@@ -955,7 +955,7 @@ describe("migration reconcile route", () => {
 			counts: { installed: number; skipped: number; failed: number };
 		};
 		expect(body.warnings).toContain(
-			"Codex commands are global-only; command scope was automatically switched to global.",
+			"Codex commands are global-only; they will be installed globally while other content stays project-local.",
 		);
 		expect(body.counts.installed).toBe(2);
 

--- a/src/__tests__/domains/web-server/routes/migration-routes.test.ts
+++ b/src/__tests__/domains/web-server/routes/migration-routes.test.ts
@@ -20,6 +20,7 @@ type PortableRegistryResult = Awaited<
 type AgentDiscoveryResult = Awaited<ReturnType<typeof actualAgentDiscovery.discoverAgents>>;
 type CommandDiscoveryResult = Awaited<ReturnType<typeof actualCommandDiscovery.discoverCommands>>;
 type SkillDiscoveryResult = Awaited<ReturnType<typeof actualSkillDiscovery.discoverSkills>>;
+type ConfigDiscoveryResult = Awaited<ReturnType<typeof actualConfigDiscovery.discoverConfig>>;
 type HookDiscoveryResult = Awaited<ReturnType<typeof actualConfigDiscovery.discoverHooks>>;
 type PortableInstallBatch = Awaited<
 	ReturnType<typeof actualPortableInstaller.installPortableItems>
@@ -49,7 +50,7 @@ mock.module("@/commands/skills/skills-discovery.js", () => ({
 	getSkillSourcePath: getSkillSourcePathMock,
 }));
 
-const discoverConfigMock = mock(async () => null);
+const discoverConfigMock = mock(async (): Promise<ConfigDiscoveryResult> => null);
 const discoverRulesMock = mock(async () => []);
 const discoverHooksMock = mock(
 	async (): Promise<HookDiscoveryResult> => ({
@@ -71,6 +72,7 @@ const installPortableItemsMock = mock(
 		_items: unknown[],
 		_providers: unknown[],
 		_type: unknown,
+		_options?: unknown,
 	): Promise<PortableInstallBatch> => [],
 );
 mock.module("@/commands/portable/portable-installer.js", () => ({
@@ -892,6 +894,75 @@ describe("migration reconcile route", () => {
 		} finally {
 			process.chdir(originalCwd);
 		}
+	});
+
+	test("legacy execution scopes Codex commands globally without globalizing config", async () => {
+		getCommandSourcePathMock.mockReturnValueOnce("/tmp/commands");
+		discoverCommandsMock.mockResolvedValueOnce([
+			{
+				name: "plan",
+				displayName: "Plan",
+				description: "",
+				type: "command",
+				sourcePath: "/tmp/commands/plan.md",
+				frontmatter: {},
+				body: "plan",
+			},
+		]);
+		discoverConfigMock.mockResolvedValueOnce({
+			name: "AGENTS",
+			displayName: "AGENTS",
+			description: "",
+			type: "config",
+			sourcePath: "/tmp/AGENTS.md",
+			frontmatter: {},
+			body: "config",
+		});
+		installPortableItemsMock.mockImplementation(
+			async (items: unknown[], providers: unknown[], type: unknown, options?: unknown) =>
+				providers.map((provider) => {
+					const item = items[0] as { name?: string } | undefined;
+					const installOptions = options as { global?: boolean } | undefined;
+					return {
+						provider: provider as PortableInstallBatch[number]["provider"],
+						providerDisplayName: String(provider),
+						success: true,
+						path: `/tmp/${String(provider)}/${String(type)}/${installOptions?.global ? "global" : "project"}/${item?.name ?? "item"}`,
+					};
+				}),
+		);
+
+		const res = await fetch(`${ctx.baseUrl}/api/migrate/execute`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				providers: ["codex"],
+				include: {
+					agents: false,
+					commands: true,
+					skills: false,
+					config: true,
+					rules: false,
+					hooks: false,
+				},
+				global: false,
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			warnings: string[];
+			counts: { installed: number; skipped: number; failed: number };
+		};
+		expect(body.warnings).toContain(
+			"Codex commands are global-only; command scope was automatically switched to global.",
+		);
+		expect(body.counts.installed).toBe(2);
+
+		const commandCall = installPortableItemsMock.mock.calls.find((call) => call[2] === "command");
+		const configCall = installPortableItemsMock.mock.calls.find((call) => call[2] === "config");
+		expect(commandCall?.[3]).toEqual({ global: true });
+		expect(configCall?.[3]).toEqual({ global: false });
 	});
 
 	test("validates providers query and sanitizes unknown provider tokens", async () => {

--- a/src/commands/migrate/__tests__/migrate-provider-scopes.test.ts
+++ b/src/commands/migrate/__tests__/migrate-provider-scopes.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildScopedProviderConfigs,
+	resolvePortableGroupGlobal,
+	resolvePortableTypeGlobal,
+} from "../migrate-provider-scopes.js";
+import type { MigrationScope } from "../migrate-scope-resolver.js";
+
+const allTypes: MigrationScope = {
+	agents: true,
+	commands: true,
+	skills: true,
+	config: true,
+	rules: true,
+	hooks: true,
+};
+
+describe("migrate provider scopes", () => {
+	it("keeps Codex project-scope content project-local while forcing commands global", () => {
+		const configs = buildScopedProviderConfigs(["codex"], allTypes, false);
+
+		expect(configs).toContainEqual({
+			provider: "codex",
+			global: false,
+			types: ["agent", "skill", "config", "rules", "hooks"],
+		});
+		expect(configs).toContainEqual({
+			provider: "codex",
+			global: true,
+			types: ["command"],
+		});
+	});
+
+	it("uses the requested global scope when global was explicitly selected", () => {
+		const configs = buildScopedProviderConfigs(["codex"], allTypes, true);
+
+		expect(configs).toEqual([
+			{
+				provider: "codex",
+				global: true,
+				types: ["agent", "command", "skill", "config", "rules", "hooks"],
+			},
+		]);
+	});
+
+	it("resolves Codex command destinations as global in project migration summaries", () => {
+		expect(resolvePortableTypeGlobal("codex", "command", false)).toBe(true);
+		expect(resolvePortableGroupGlobal("codex", "commands", false)).toBe(true);
+		expect(resolvePortableGroupGlobal("codex", "config", false)).toBe(false);
+	});
+});

--- a/src/commands/migrate/__tests__/migrate-ui-summary.test.ts
+++ b/src/commands/migrate/__tests__/migrate-ui-summary.test.ts
@@ -11,7 +11,7 @@ describe("migrate UI summary helpers", () => {
 		const rows = buildPreflightRows(
 			{ agents: 0, commands: 4, config: 0, hooks: 0, rules: 0, skills: 0 },
 			["codex"],
-			{ actualGlobal: true, requestedGlobal: false },
+			{ actualGlobal: false, requestedGlobal: false },
 		);
 
 		expect(rows[0]?.destinations).toContain("~/.codex/prompts");

--- a/src/commands/migrate/__tests__/migrate-ui-summary.test.ts
+++ b/src/commands/migrate/__tests__/migrate-ui-summary.test.ts
@@ -11,7 +11,7 @@ describe("migrate UI summary helpers", () => {
 		const rows = buildPreflightRows(
 			{ agents: 0, commands: 4, config: 0, hooks: 0, rules: 0, skills: 0 },
 			["codex"],
-			{ actualGlobal: false, requestedGlobal: false },
+			{ requestedGlobal: false },
 		);
 
 		expect(rows[0]?.destinations).toContain("~/.codex/prompts");
@@ -22,7 +22,7 @@ describe("migrate UI summary helpers", () => {
 		const rows = buildPreflightRows(
 			{ agents: 0, commands: 0, config: 0, hooks: 0, rules: 0, skills: 3 },
 			["codex", "gemini-cli"],
-			{ actualGlobal: false, requestedGlobal: false },
+			{ requestedGlobal: false },
 		);
 
 		expect(rows[0]?.destinations).toEqual([".agents/skills"]);
@@ -48,5 +48,18 @@ describe("migrate UI summary helpers", () => {
 				["/Users/test/.claude/agents", "/Users/test/.claude/skills"],
 			)[0],
 		).toContain("2 agents");
+	});
+
+	it("shows mixed scope when Codex project migrations include global-only commands", () => {
+		expect(
+			buildProviderScopeSubtitle(["codex"], false, {
+				agents: 0,
+				commands: 1,
+				config: 1,
+				hooks: 0,
+				rules: 0,
+				skills: 0,
+			}),
+		).toBe("Codex -> mixed");
 	});
 });

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -644,7 +644,7 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		if (codexCommandsRequireGlobal && !installGlobally) {
 			p.log.info(
 				pc.dim(
-					"Codex commands are global-only; they will install globally while other content stays project-local.",
+					"Codex commands are global-only; they will be installed globally while other content stays project-local.",
 				),
 			);
 		}

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -68,6 +68,12 @@ import type { PortableInstallResult, PortableItem, ProviderType } from "../porta
 import { discoverSkills, getSkillSourcePath } from "../skills/skills-discovery.js";
 import type { SkillInfo } from "../skills/types.js";
 import { createMigrateProgressSink } from "./migrate-progress.js";
+import {
+	buildScopedProviderConfigs,
+	getEnabledPortableTypes,
+	providerConfigAppliesToType,
+	resolvePortableTypeGlobal,
+} from "./migrate-provider-scopes.js";
 import { resolveMigrationScope } from "./migrate-scope-resolver.js";
 import {
 	type PortableSourceCounts,
@@ -636,8 +642,7 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			providers.codex.commands !== null &&
 			providers.codex.commands.projectPath === null;
 		if (codexCommandsRequireGlobal && !installGlobally) {
-			installGlobally = true;
-			p.log.info(pc.dim("Codex commands are global-only; scope adjusted to global."));
+			p.log.info(pc.dim("Codex commands are global-only; command scope adjusted to global."));
 		}
 
 		const sourceCounts: PortableSourceCounts = {
@@ -786,18 +791,18 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			selectedProviders,
 		);
 
-		const targetStates = await computeTargetStates(selectedProviders, installGlobally);
-
-		const providerConfigs: ReconcileProviderInput[] = selectedProviders.map((provider) => ({
-			provider,
-			global: installGlobally,
-		}));
+		const providerConfigs = buildScopedProviderConfigs(selectedProviders, scope, installGlobally);
+		const targetStates = await computeTargetStates(providerConfigs);
 
 		// Compute directory states for empty-dir override logic (P1 feature)
-		const portableTypes = ["agent", "command", "config", "rules", "hooks"] as const;
+		const portableTypes = getEnabledPortableTypes(scope).filter((type) => type !== "skill");
 		const typeDirectoryStates = buildTypeDirectoryStates(
-			selectedProviders.map((provider) => ({ provider, global: installGlobally })),
-			[...portableTypes],
+			providerConfigs.map((config) => ({
+				provider: config.provider as ProviderType,
+				global: config.global,
+				types: config.types?.filter((type) => type !== "skill"),
+			})),
+			portableTypes,
 		);
 
 		// Determine reinstallEmptyDirs: default true unless --respect-deletions set
@@ -908,7 +913,6 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		}
 
 		let allResults: PortableInstallResult[] = [];
-		const installOpts = { global: installGlobally };
 		const agentByName = new Map(effectiveAgents.map((item) => [item.name, item]));
 		const commandByName = new Map(effectiveCommands.map((item) => [item.name, item]));
 		const skillByName = new Map(effectiveSkills.map((item) => [item.name, item]));
@@ -917,7 +921,7 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		);
 		const ruleByName = new Map(effectiveRuleItems.map((item) => [item.name, item]));
 		const hookByName = new Map(effectiveHookItems.map((item) => [item.name, item]));
-		const successfulHookFiles = new Map<ProviderType, string[]>();
+		const successfulHookFiles = new Map<ProviderType, { files: string[]; global: boolean }>();
 		// Absolute paths of installed hook files, per target provider.
 		// Passed to migrateHooksSettings so it can generate Codex wrapper scripts.
 		const successfulHookAbsPaths = new Map<ProviderType, string[]>();
@@ -927,11 +931,13 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 					item: PortableItem;
 					provider: ProviderType;
 					type: "agent" | "command" | "config" | "rules" | "hooks";
+					global: boolean;
 			  }
 			| {
 					item: SkillInfo;
 					provider: ProviderType;
 					type: "skill";
+					global: boolean;
 			  }
 		> = [];
 
@@ -942,42 +948,42 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			if (action.type === "agent") {
 				const item = agentByName.get(action.item);
 				if (!item || !getProvidersSupporting("agents").includes(provider)) continue;
-				writeTasks.push({ item, provider, type: "agent" });
+				writeTasks.push({ item, provider, type: "agent", global: action.global });
 				continue;
 			}
 
 			if (action.type === "command") {
 				const item = commandByName.get(action.item);
 				if (!item || !getProvidersSupporting("commands").includes(provider)) continue;
-				writeTasks.push({ item, provider, type: "command" });
+				writeTasks.push({ item, provider, type: "command", global: action.global });
 				continue;
 			}
 
 			if (action.type === "skill") {
 				const item = skillByName.get(action.item);
 				if (!item || !getProvidersSupporting("skills").includes(provider)) continue;
-				writeTasks.push({ item, provider, type: "skill" });
+				writeTasks.push({ item, provider, type: "skill", global: action.global });
 				continue;
 			}
 
 			if (action.type === "config") {
 				const item = configByName.get(action.item);
 				if (!item || !getProvidersSupporting("config").includes(provider)) continue;
-				writeTasks.push({ item, provider, type: "config" });
+				writeTasks.push({ item, provider, type: "config", global: action.global });
 				continue;
 			}
 
 			if (action.type === "rules") {
 				const item = ruleByName.get(action.item);
 				if (!item || !getProvidersSupporting("rules").includes(provider)) continue;
-				writeTasks.push({ item, provider, type: "rules" });
+				writeTasks.push({ item, provider, type: "rules", global: action.global });
 				continue;
 			}
 
 			if (action.type === "hooks") {
 				const item = hookByName.get(action.item);
 				if (!item || !getProvidersSupporting("hooks").includes(provider)) continue;
-				writeTasks.push({ item, provider, type: "hooks" });
+				writeTasks.push({ item, provider, type: "hooks", global: action.global });
 			}
 		}
 
@@ -992,7 +998,12 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			);
 			for (const provider of skillProviders) {
 				for (const skill of effectiveSkills) {
-					writeTasks.push({ item: skill, provider, type: "skill" });
+					writeTasks.push({
+						item: skill,
+						provider,
+						type: "skill",
+						global: resolvePortableTypeGlobal(provider, "skill", installGlobally),
+					});
 				}
 			}
 		}
@@ -1000,15 +1011,16 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		const progressSink = createMigrateProgressSink(writeTasks.length + plannedDeleteActions.length);
 		const writtenPaths = new Set<string>();
 		for (const task of writeTasks) {
+			const taskInstallOpts = { global: task.global };
 			const taskResults =
 				task.type === "skill"
 					? annotateInstallResults(
-							await installSkillDirectories([task.item], [task.provider], installOpts),
+							await installSkillDirectories([task.item], [task.provider], taskInstallOpts),
 							"skill",
 							task.item.name,
 						)
 					: annotateInstallResults(
-							await installPortableItems([task.item], [task.provider], task.type, installOpts),
+							await installPortableItems([task.item], [task.provider], task.type, taskInstallOpts),
 							task.type,
 							task.item.name,
 						);
@@ -1018,8 +1030,11 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 					writtenPaths.add(resolve(result.path));
 				}
 				if (task.type === "hooks") {
-					const existing = successfulHookFiles.get(task.provider) ?? [];
-					existing.push(basename(result.path));
+					const existing = successfulHookFiles.get(task.provider) ?? {
+						files: [],
+						global: task.global,
+					};
+					existing.files.push(basename(result.path));
 					successfulHookFiles.set(task.provider, existing);
 					// Track absolute paths for Codex wrapper generation
 					if (result.path.length > 0) {
@@ -1059,9 +1074,9 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		// provider's hooks directory so that `require('./lib/*.cjs')` calls inside hooks
 		// resolve correctly. This runs after per-file hook installs and before settings merger.
 		if (hooksSource && successfulHookFiles.size > 0) {
-			for (const hooksProvider of successfulHookFiles.keys()) {
+			for (const [hooksProvider, entry] of successfulHookFiles) {
 				const providerCfg = providers[hooksProvider];
-				const targetHooksDir = installGlobally
+				const targetHooksDir = entry.global
 					? providerCfg.hooks?.globalPath
 					: providerCfg.hooks?.projectPath;
 				if (!targetHooksDir) continue;
@@ -1090,14 +1105,14 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		}
 
 		// After all actions executed, merge hooks into target settings.json per provider
-		for (const [hooksProvider, files] of successfulHookFiles) {
-			if (files.length === 0) continue;
+		for (const [hooksProvider, entry] of successfulHookFiles) {
+			if (entry.files.length === 0) continue;
 			const mergeResult = await migrateHooksSettings({
 				sourceProvider: "claude-code",
 				targetProvider: hooksProvider,
-				installedHookFiles: files,
+				installedHookFiles: entry.files,
 				installedHookAbsolutePaths: successfulHookAbsPaths.get(hooksProvider),
-				global: installGlobally,
+				global: entry.global,
 			});
 			if (mergeResult.success && mergeResult.hooksRegistered > 0) {
 				logger.verbose(
@@ -1145,24 +1160,35 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			const providerConfig = providers[provider];
 			if (providerConfig.agents?.writeStrategy !== "codex-toml") continue;
 
-			const staleSlugs = await cleanupStaleCodexConfigEntries({
-				global: installGlobally,
-				provider,
-			});
+			const providerScopes = [
+				...new Set(
+					plan.actions
+						.filter((action) => action.provider === provider)
+						.map((action) => action.global),
+				),
+			];
+			if (providerScopes.length === 0) providerScopes.push(installGlobally);
 
-			if (staleSlugs.length > 0) {
-				// Batch registry cleanup under lock (consistent with syncPortableRegistry pattern).
-				// Matches stale slugs by basename() for cross-platform path support.
-				const staleSlugSet = new Set(staleSlugs.map((s) => `${s}.toml`));
-				const removed = await removeInstallationsByFilter(
-					(i) =>
-						i.type === "agent" &&
-						i.provider === provider &&
-						i.global === installGlobally &&
-						staleSlugSet.has(basename(i.path)),
-				);
-				for (const entry of removed) {
-					logger.verbose(`[migrate] Cleaned stale registry entry: ${entry.item} (${provider})`);
+			for (const scope of providerScopes) {
+				const staleSlugs = await cleanupStaleCodexConfigEntries({
+					global: scope,
+					provider,
+				});
+
+				if (staleSlugs.length > 0) {
+					// Batch registry cleanup under lock (consistent with syncPortableRegistry pattern).
+					// Matches stale slugs by basename() for cross-platform path support.
+					const staleSlugSet = new Set(staleSlugs.map((s) => `${s}.toml`));
+					const removed = await removeInstallationsByFilter(
+						(i) =>
+							i.type === "agent" &&
+							i.provider === provider &&
+							i.global === scope &&
+							staleSlugSet.has(basename(i.path)),
+					);
+					for (const entry of removed) {
+						logger.verbose(`[migrate] Cleaned stale registry entry: ${entry.item} (${provider})`);
+					}
 				}
 			}
 		}
@@ -1318,13 +1344,17 @@ async function computeSourceStates(
  * Compute target states (what exists on disk) for registry entries
  */
 async function computeTargetStates(
-	selectedProviders: ProviderType[],
-	global: boolean,
+	providerConfigs: ReconcileProviderInput[],
 ): Promise<Map<string, TargetFileState>> {
 	const registry = await readPortableRegistry();
 	const relevantEntries = registry.installations.filter((entry) => {
-		if (!selectedProviders.includes(entry.provider as ProviderType)) return false;
-		if (entry.global !== global) return false;
+		const matchingConfig = providerConfigs.some(
+			(config) =>
+				config.provider === entry.provider &&
+				config.global === entry.global &&
+				providerConfigAppliesToType(config, entry.type),
+		);
+		if (!matchingConfig) return false;
 		return entry.type !== "skill";
 	});
 
@@ -1431,7 +1461,9 @@ function buildDryRunFallbackResults(
 	for (const provider of selectedProviders.filter((entry) =>
 		getProvidersSupporting("skills").includes(entry),
 	)) {
-		const basePath = getPortableBasePath(provider, "skills", { global: installGlobally });
+		const basePath = getPortableBasePath(provider, "skills", {
+			global: resolvePortableTypeGlobal(provider, "skill", installGlobally),
+		});
 		if (!basePath) continue;
 		for (const skill of skills) {
 			results.push({

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -662,7 +662,6 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			hooksSource,
 		].filter((origin): origin is string => origin !== null);
 		const preflightRows = buildPreflightRows(sourceCounts, selectedProviders, {
-			actualGlobal: installGlobally,
 			requestedGlobal,
 		});
 		const discoveryParts: string[] = [];
@@ -698,7 +697,7 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		console.log(
 			renderSourceTargetHeader({
 				sourceLines: buildSourceSummaryLines(sourceCounts, sourceOrigins),
-				subtitle: buildProviderScopeSubtitle(selectedProviders, installGlobally),
+				subtitle: buildProviderScopeSubtitle(selectedProviders, requestedGlobal, sourceCounts),
 				targetLines: buildTargetSummaryLines(preflightRows),
 				title: "ck migrate",
 			}).join("\n"),

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -642,7 +642,11 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			providers.codex.commands !== null &&
 			providers.codex.commands.projectPath === null;
 		if (codexCommandsRequireGlobal && !installGlobally) {
-			p.log.info(pc.dim("Codex commands are global-only; command scope adjusted to global."));
+			p.log.info(
+				pc.dim(
+					"Codex commands are global-only; they will install globally while other content stays project-local.",
+				),
+			);
 		}
 
 		const sourceCounts: PortableSourceCounts = {

--- a/src/commands/migrate/migrate-provider-scopes.ts
+++ b/src/commands/migrate/migrate-provider-scopes.ts
@@ -1,4 +1,5 @@
 import { providers } from "../portable/provider-registry.js";
+export { providerConfigAppliesToType } from "../portable/reconcile-types.js";
 import type { ReconcileAction, ReconcileProviderInput } from "../portable/reconcile-types.js";
 import type { ProviderType } from "../portable/types.js";
 import type { MigrationScope } from "./migrate-scope-resolver.js";
@@ -91,11 +92,4 @@ export function buildScopedProviderConfigs(
 	}
 
 	return configs;
-}
-
-export function providerConfigAppliesToType(
-	config: ReconcileProviderInput,
-	type: ReconcilePortableType,
-): boolean {
-	return config.types === undefined || config.types.includes(type);
 }

--- a/src/commands/migrate/migrate-provider-scopes.ts
+++ b/src/commands/migrate/migrate-provider-scopes.ts
@@ -1,0 +1,101 @@
+import { providers } from "../portable/provider-registry.js";
+import type { ReconcileAction, ReconcileProviderInput } from "../portable/reconcile-types.js";
+import type { ProviderType } from "../portable/types.js";
+import type { MigrationScope } from "./migrate-scope-resolver.js";
+
+export type PortableGroup = "agents" | "commands" | "skills" | "config" | "rules" | "hooks";
+export type ReconcilePortableType = ReconcileAction["type"];
+
+export const RECONCILE_PORTABLE_TYPES: ReconcilePortableType[] = [
+	"agent",
+	"command",
+	"skill",
+	"config",
+	"rules",
+	"hooks",
+];
+
+const TYPE_TO_GROUP: Record<ReconcilePortableType, PortableGroup> = {
+	agent: "agents",
+	command: "commands",
+	skill: "skills",
+	config: "config",
+	rules: "rules",
+	hooks: "hooks",
+};
+
+const GROUP_TO_TYPE: Record<PortableGroup, ReconcilePortableType> = {
+	agents: "agent",
+	commands: "command",
+	skills: "skill",
+	config: "config",
+	rules: "rules",
+	hooks: "hooks",
+};
+
+export function portableTypeToGroup(type: ReconcilePortableType): PortableGroup {
+	return TYPE_TO_GROUP[type];
+}
+
+export function portableGroupToType(group: PortableGroup): ReconcilePortableType {
+	return GROUP_TO_TYPE[group];
+}
+
+export function getEnabledPortableTypes(include: MigrationScope): ReconcilePortableType[] {
+	return RECONCILE_PORTABLE_TYPES.filter((type) => include[portableTypeToGroup(type)]);
+}
+
+export function resolvePortableTypeGlobal(
+	provider: ProviderType,
+	type: ReconcilePortableType,
+	requestedGlobal: boolean,
+): boolean {
+	if (requestedGlobal) return true;
+
+	const providerConfig = providers[provider];
+	const group = portableTypeToGroup(type);
+	const pathConfig = providerConfig?.[group];
+	if (pathConfig?.projectPath === null && pathConfig.globalPath !== null) {
+		return true;
+	}
+
+	return false;
+}
+
+export function resolvePortableGroupGlobal(
+	provider: ProviderType,
+	group: PortableGroup,
+	requestedGlobal: boolean,
+): boolean {
+	return resolvePortableTypeGlobal(provider, portableGroupToType(group), requestedGlobal);
+}
+
+export function buildScopedProviderConfigs(
+	selectedProviders: ProviderType[],
+	include: MigrationScope,
+	requestedGlobal: boolean,
+): ReconcileProviderInput[] {
+	const enabledTypes = getEnabledPortableTypes(include);
+	const configs: ReconcileProviderInput[] = [];
+
+	for (const provider of selectedProviders) {
+		const typesByScope = new Map<boolean, ReconcilePortableType[]>();
+		for (const type of enabledTypes) {
+			const isGlobal = resolvePortableTypeGlobal(provider, type, requestedGlobal);
+			typesByScope.set(isGlobal, [...(typesByScope.get(isGlobal) ?? []), type]);
+		}
+
+		for (const [global, types] of typesByScope) {
+			configs.push({ provider, global, types });
+		}
+	}
+
+	return configs;
+}
+
+export function providerConfigAppliesToType(
+	config: ReconcileProviderInput,
+	type: ReconcilePortableType,
+): boolean {
+	return config.types === undefined || config.types.includes(type);
+}

--- a/src/commands/migrate/migrate-ui-summary.ts
+++ b/src/commands/migrate/migrate-ui-summary.ts
@@ -2,6 +2,7 @@ import { formatDisplayPath } from "../../ui/ck-cli-design/index.js";
 import { getPortableBasePath, providers } from "../portable/provider-registry.js";
 import type { ReconcileAction, ReconcileBanner } from "../portable/reconcile-types.js";
 import type { ProviderType } from "../portable/types.js";
+import { resolvePortableGroupGlobal } from "./migrate-provider-scopes.js";
 
 type PortableGroup = "agents" | "commands" | "skills" | "config" | "rules" | "hooks";
 
@@ -51,9 +52,10 @@ export function buildPreflightRows(
 				continue;
 			}
 
-			const destination = getPortableBasePath(provider, key, { global: options.actualGlobal });
+			const actualGlobal = resolvePortableGroupGlobal(provider, key, options.requestedGlobal);
+			const destination = getPortableBasePath(provider, key, { global: actualGlobal });
 			if (!destination) {
-				const note = options.actualGlobal ? "project-only" : "global-only";
+				const note = actualGlobal ? "project-only" : "global-only";
 				notes.add(`${providers[provider].displayName}: ${note}`);
 				continue;
 			}

--- a/src/commands/migrate/migrate-ui-summary.ts
+++ b/src/commands/migrate/migrate-ui-summary.ts
@@ -2,9 +2,7 @@ import { formatDisplayPath } from "../../ui/ck-cli-design/index.js";
 import { getPortableBasePath, providers } from "../portable/provider-registry.js";
 import type { ReconcileAction, ReconcileBanner } from "../portable/reconcile-types.js";
 import type { ProviderType } from "../portable/types.js";
-import { resolvePortableGroupGlobal } from "./migrate-provider-scopes.js";
-
-type PortableGroup = "agents" | "commands" | "skills" | "config" | "rules" | "hooks";
+import { type PortableGroup, resolvePortableGroupGlobal } from "./migrate-provider-scopes.js";
 
 export interface PortableSourceCounts {
 	agents: number;
@@ -36,7 +34,7 @@ const MERGE_STRATEGIES = new Set(["merge-single", "yaml-merge", "json-merge"]);
 export function buildPreflightRows(
 	counts: PortableSourceCounts,
 	selectedProviders: ProviderType[],
-	options: { actualGlobal: boolean; requestedGlobal: boolean },
+	options: { requestedGlobal: boolean },
 ): PreflightRowData[] {
 	return PORTABLE_TYPES.flatMap(({ key, label }) => {
 		const count = counts[key];
@@ -113,9 +111,26 @@ export function buildTargetSummaryLines(rows: PreflightRowData[]): string[] {
 
 export function buildProviderScopeSubtitle(
 	selectedProviders: ProviderType[],
-	global: boolean,
+	requestedGlobal: boolean,
+	counts?: PortableSourceCounts,
 ): string {
-	const scope = global ? "global" : "project";
+	const activeTypes = PORTABLE_TYPES.filter(({ key }) => !counts || counts[key] > 0);
+	const resolvedScopes = new Set<boolean>();
+
+	for (const provider of selectedProviders) {
+		for (const { key } of activeTypes) {
+			if (!providers[provider][key]) continue;
+			resolvedScopes.add(resolvePortableGroupGlobal(provider, key, requestedGlobal));
+		}
+	}
+
+	const scope =
+		resolvedScopes.size > 1
+			? "mixed"
+			: (resolvedScopes.values().next().value ?? requestedGlobal)
+				? "global"
+				: "project";
+
 	if (selectedProviders.length === 1) {
 		return `${providers[selectedProviders[0]].displayName} -> ${scope}`;
 	}

--- a/src/commands/portable/__tests__/fm-to-codex-toml.test.ts
+++ b/src/commands/portable/__tests__/fm-to-codex-toml.test.ts
@@ -67,11 +67,11 @@ describe("convertFmToCodexToml", () => {
 		expect(result.warnings).toEqual([]);
 	});
 
-	it("resolves known model via taxonomy (opus → gpt-5.4, effort commented)", () => {
+	it("resolves known model via taxonomy (opus → gpt-5.4, reasoning effort)", () => {
 		const result = convertFmToCodexToml(makeItem());
 		expect(result.content).toContain('model = "gpt-5.4"');
-		// effort is commented out — Codex doesn't support this field yet
-		expect(result.content).toContain('# effort = "xhigh"');
+		expect(result.content).toContain('model_reasoning_effort = "xhigh"');
+		expect(result.content).not.toContain("# effort");
 		expect(result.content).not.toMatch(/\neffort = /);
 		expect(result.content).not.toContain('# model = "opus"');
 		expect(result.warnings).toEqual([]);

--- a/src/commands/portable/__tests__/reconciler.test.ts
+++ b/src/commands/portable/__tests__/reconciler.test.ts
@@ -87,6 +87,69 @@ function makeInput(
 }
 
 describe("reconciler - core decision matrix", () => {
+	it("honors type-scoped provider configs for mixed-scope migrations", () => {
+		const agent = makeSourceItem("reviewer", "agent", "agent-source", { codex: "agent-codex" });
+		const command = makeSourceItem("plan", "command", "command-source", {
+			codex: "command-codex",
+		});
+		const registry = makeRegistry([]);
+		const input = makeInput([agent, command], registry, new Map(), [
+			{ provider: "codex", global: false, types: ["agent"] },
+			{ provider: "codex", global: true, types: ["command"] },
+		]);
+
+		const plan = reconcile(input);
+
+		expect(
+			plan.actions.some(
+				(action) => action.item === "reviewer" && action.type === "agent" && action.global === true,
+			),
+		).toBe(false);
+		expect(
+			plan.actions.some(
+				(action) => action.item === "plan" && action.type === "command" && action.global === false,
+			),
+		).toBe(false);
+		expect(plan.actions).toContainEqual(
+			expect.objectContaining({ item: "reviewer", type: "agent", global: false }),
+		);
+		expect(plan.actions).toContainEqual(
+			expect.objectContaining({ item: "plan", type: "command", global: true }),
+		);
+	});
+
+	it("does not orphan-delete inactive types from a scoped provider config", () => {
+		const command = makeSourceItem("plan", "command", "command-source", {
+			codex: "command-codex",
+		});
+		const registry = makeRegistry([
+			{
+				item: "old-agent",
+				type: "agent",
+				provider: "codex",
+				global: true,
+				path: "/tmp/.codex/agents/old_agent.toml",
+				sourcePath: "/tmp/.claude/agents/old-agent.md",
+				sourceChecksum: "old-source",
+				targetChecksum: "old-target",
+				installSource: "kit",
+				installedAt: "2026-01-01T00:00:00.000Z",
+			},
+		]);
+		const input = makeInput([command], registry, new Map(), [
+			{ provider: "codex", global: true, types: ["command"] },
+		]);
+
+		const plan = reconcile(input);
+
+		expect(
+			plan.actions.some(
+				(action) =>
+					action.action === "delete" && action.item === "old-agent" && action.type === "agent",
+			),
+		).toBe(false);
+	});
+
 	it("case A: new item → install", () => {
 		const source = makeSourceItem("new-skill");
 		const registry = makeRegistry([]);

--- a/src/commands/portable/converters/fm-to-codex-toml.ts
+++ b/src/commands/portable/converters/fm-to-codex-toml.ts
@@ -98,9 +98,8 @@ export function convertFmToCodexToml(item: PortableItem): ConversionResult {
 	}
 	if (modelResult.resolved) {
 		lines.push(`model = ${JSON.stringify(modelResult.resolved.model)}`);
-		// effort is tracked in taxonomy but not yet supported by Codex — comment out for future use
 		if (modelResult.resolved.effort) {
-			lines.push(`# effort = ${JSON.stringify(modelResult.resolved.effort)}`);
+			lines.push(`model_reasoning_effort = ${JSON.stringify(modelResult.resolved.effort)}`);
 		}
 	} else if (
 		typeof item.frontmatter.model === "string" &&

--- a/src/commands/portable/reconcile-state-builders.ts
+++ b/src/commands/portable/reconcile-state-builders.ts
@@ -174,16 +174,18 @@ const portableTypeToProviderPathKey = getProviderPathKeyForPortableType;
  * @param types - portable types to check for each provider pair
  */
 export function buildTypeDirectoryStates(
-	providerConfigs: Array<{ provider: ProviderType; global: boolean }>,
+	providerConfigs: Array<{ provider: ProviderType; global: boolean; types?: PortableType[] }>,
 	types: PortableType[],
 ): TargetDirectoryState[] {
 	const results: TargetDirectoryState[] = [];
 
-	for (const { provider, global: isGlobal } of providerConfigs) {
+	for (const { provider, global: isGlobal, types: configTypes } of providerConfigs) {
 		const providerConfig = providers[provider];
 		if (!providerConfig) continue;
 
 		for (const type of types) {
+			if (configTypes !== undefined && !configTypes.includes(type)) continue;
+
 			const pathKey = portableTypeToProviderPathKey(type);
 			const pathConfig = providerConfig[pathKey];
 			if (!pathConfig) continue;

--- a/src/commands/portable/reconcile-types.ts
+++ b/src/commands/portable/reconcile-types.ts
@@ -209,6 +209,11 @@ export interface ReconcileBanner {
 export interface ReconcileProviderInput {
 	provider: string; // Provider name
 	global: boolean; // Global vs project-level install
+	/**
+	 * Optional content-type filter for mixed-scope migrations. When omitted,
+	 * the provider config applies to every portable type (back-compat).
+	 */
+	types?: ReconcileAction["type"][];
 }
 
 /** Input to reconcile function */

--- a/src/commands/portable/reconcile-types.ts
+++ b/src/commands/portable/reconcile-types.ts
@@ -216,6 +216,13 @@ export interface ReconcileProviderInput {
 	types?: ReconcileAction["type"][];
 }
 
+export function providerConfigAppliesToType(
+	config: ReconcileProviderInput,
+	type: ReconcileAction["type"],
+): boolean {
+	return config.types === undefined || config.types.includes(type);
+}
+
 /** Input to reconcile function */
 export interface ReconcileInput {
 	sourceItems: SourceItemState[];

--- a/src/commands/portable/reconciler.ts
+++ b/src/commands/portable/reconciler.ts
@@ -10,6 +10,7 @@ import {
 	getReasonCopy,
 	isUnknownChecksum,
 	normalizeChecksum,
+	providerConfigAppliesToType,
 } from "./reconcile-types.js";
 import type {
 	ReconcileAction,
@@ -90,25 +91,16 @@ function makeDirStateKey(provider: string, type: ReconcileAction["type"], global
 	return JSON.stringify([provider, type, global]);
 }
 
-function providerConfigAppliesToType(
-	config: ReconcileProviderInput,
-	type: ReconcileAction["type"],
-): boolean {
-	return config.types === undefined || config.types.includes(type);
-}
-
 function dedupeProviderConfigs(
 	providerConfigs: ReconcileProviderInput[],
 ): ReconcileProviderInput[] {
-	const unique: ReconcileProviderInput[] = [];
+	const unique = new Map<string, ReconcileProviderInput>();
 
 	for (const config of providerConfigs) {
 		const key = makeProviderConfigKey(config.provider, config.global);
-		const existing = unique.find(
-			(entry) => makeProviderConfigKey(entry.provider, entry.global) === key,
-		);
+		const existing = unique.get(key);
 		if (!existing) {
-			unique.push(config.types ? { ...config, types: [...config.types] } : { ...config });
+			unique.set(key, config.types ? { ...config, types: [...config.types] } : { ...config });
 			continue;
 		}
 
@@ -120,7 +112,7 @@ function dedupeProviderConfigs(
 		existing.types = Array.from(new Set([...existing.types, ...config.types]));
 	}
 
-	return unique;
+	return Array.from(unique.values());
 }
 
 function providerConfigIsActiveForEntry(

--- a/src/commands/portable/reconciler.ts
+++ b/src/commands/portable/reconciler.ts
@@ -90,20 +90,56 @@ function makeDirStateKey(provider: string, type: ReconcileAction["type"], global
 	return JSON.stringify([provider, type, global]);
 }
 
+function providerConfigAppliesToType(
+	config: ReconcileProviderInput,
+	type: ReconcileAction["type"],
+): boolean {
+	return config.types === undefined || config.types.includes(type);
+}
+
 function dedupeProviderConfigs(
 	providerConfigs: ReconcileProviderInput[],
 ): ReconcileProviderInput[] {
-	const seen = new Set<string>();
 	const unique: ReconcileProviderInput[] = [];
 
 	for (const config of providerConfigs) {
 		const key = makeProviderConfigKey(config.provider, config.global);
-		if (seen.has(key)) continue;
-		seen.add(key);
-		unique.push(config);
+		const existing = unique.find(
+			(entry) => makeProviderConfigKey(entry.provider, entry.global) === key,
+		);
+		if (!existing) {
+			unique.push(config.types ? { ...config, types: [...config.types] } : { ...config });
+			continue;
+		}
+
+		if (existing.types === undefined || config.types === undefined) {
+			existing.types = undefined;
+			continue;
+		}
+
+		existing.types = Array.from(new Set([...existing.types, ...config.types]));
 	}
 
 	return unique;
+}
+
+function providerConfigIsActiveForEntry(
+	providerConfigs: ReconcileProviderInput[],
+	entry: {
+		provider: string;
+		global: boolean;
+		type: ReconcileAction["type"];
+	},
+	options: { emptyMeansAll?: boolean } = {},
+): boolean {
+	if (options.emptyMeansAll && providerConfigs.length === 0) return true;
+
+	return providerConfigs.some(
+		(config) =>
+			config.provider === entry.provider &&
+			config.global === entry.global &&
+			providerConfigAppliesToType(config, entry.type),
+	);
 }
 
 function buildTargetStateIndex(
@@ -371,6 +407,7 @@ export function reconcile(input: ReconcileInput): ReconcilePlan {
 	// Step 3: For each source item × provider, determine action
 	for (const sourceItem of input.sourceItems) {
 		for (const providerConfig of uniqueProviderConfigs) {
+			if (!providerConfigAppliesToType(providerConfig, sourceItem.type)) continue;
 			const action = determineAction(
 				sourceItem,
 				providerConfig,
@@ -755,20 +792,15 @@ function findRegistryEntry(
 function detectOrphans(input: ReconcileInput, renamedFromKeys: Set<string>): ReconcileAction[] {
 	const actions: ReconcileAction[] = [];
 	const sourceItemKeys = new Set(input.sourceItems.map((s) => makeItemTypeKey(s.item, s.type)));
-	const activeProviderKeys = new Set(
-		input.providerConfigs.map((provider) =>
-			makeProviderConfigKey(provider.provider, provider.global),
-		),
-	);
+	const activeProviderConfigs = dedupeProviderConfigs(input.providerConfigs);
 	const hasConfigSource = input.sourceItems.some((source) => source.type === "config");
 
 	for (const entry of input.registry.installations) {
 		const key = makeRegistryIdentityKey(entry);
 		const sourceItemKey = makeItemTypeKey(entry.item, entry.type);
-		const providerKey = makeProviderConfigKey(entry.provider, entry.global);
 
 		// Only consider registry entries in the current execution scope.
-		if (!activeProviderKeys.has(providerKey)) continue;
+		if (!providerConfigIsActiveForEntry(activeProviderConfigs, entry)) continue;
 
 		// Skip items already handled by rename detection
 		if (renamedFromKeys.has(key)) continue;
@@ -819,6 +851,7 @@ function detectRenames(
 	);
 
 	const actions: Array<{ deleteAction: ReconcileAction; newItem: string }> = [];
+	const activeProviderConfigs = dedupeProviderConfigs(input.providerConfigs);
 
 	for (const rename of applicable) {
 		// Path traversal validation (defense in depth — schema already rejects)
@@ -836,7 +869,9 @@ function detectRenames(
 
 		// Find registry entries with old source path
 		const oldEntries = input.registry.installations.filter(
-			(e) => normalizePortablePath(e.sourcePath) === normalizedFrom,
+			(e) =>
+				normalizePortablePath(e.sourcePath) === normalizedFrom &&
+				providerConfigIsActiveForEntry(activeProviderConfigs, e, { emptyMeansAll: true }),
 		);
 
 		for (const oldEntry of oldEntries) {
@@ -876,6 +911,7 @@ function detectPathMigrations(input: ReconcileInput): Array<{ deleteAction: Reco
 	);
 
 	const actions: Array<{ deleteAction: ReconcileAction }> = [];
+	const activeProviderConfigs = dedupeProviderConfigs(input.providerConfigs);
 
 	for (const migration of applicable) {
 		// Find registry entries affected by this path migration
@@ -885,7 +921,8 @@ function detectPathMigrations(input: ReconcileInput): Array<{ deleteAction: Reco
 			(e) =>
 				e.provider === migration.provider &&
 				e.type === migration.type &&
-				pathContainsSegments(e.path, migration.from),
+				pathContainsSegments(e.path, migration.from) &&
+				providerConfigIsActiveForEntry(activeProviderConfigs, e, { emptyMeansAll: true }),
 		);
 
 		for (const entry of affectedEntries) {

--- a/src/domains/web-server/routes/migration-result-utils.ts
+++ b/src/domains/web-server/routes/migration-result-utils.ts
@@ -133,3 +133,19 @@ export function annotateResultsWithCollisions(
 		}
 	}
 }
+
+export function dedupeProviderPathCollisions(
+	collisions: ProviderPathCollision[],
+): ProviderPathCollision[] {
+	const unique = new Map<string, ProviderPathCollision>();
+
+	for (const collision of collisions) {
+		const providersKey = [...collision.providers].sort().join("\0");
+		const key = JSON.stringify([collision.path, collision.portableType, providersKey]);
+		if (!unique.has(key)) {
+			unique.set(key, { ...collision, providers: [...collision.providers] });
+		}
+	}
+
+	return Array.from(unique.values());
+}

--- a/src/domains/web-server/routes/migration-routes.ts
+++ b/src/domains/web-server/routes/migration-routes.ts
@@ -8,6 +8,11 @@ import { homedir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { discoverAgents, getAgentSourcePath } from "@/commands/agents/agents-discovery.js";
 import { discoverCommands, getCommandSourcePath } from "@/commands/commands/commands-discovery.js";
+import {
+	buildScopedProviderConfigs,
+	getEnabledPortableTypes,
+	resolvePortableTypeGlobal,
+} from "@/commands/migrate/migrate-provider-scopes.js";
 import { installSkillDirectories } from "@/commands/migrate/skill-directory-installer.js";
 import { cleanupStaleCodexConfigEntries } from "@/commands/portable/codex-toml-installer.js";
 import {
@@ -665,6 +670,24 @@ function providerSupportsType(provider: ProviderTypeValue, type: PortableType): 
 	return false;
 }
 
+function groupProvidersByTypeScope(
+	selectedProviders: ProviderTypeValue[],
+	type: PortableType,
+	requestedGlobal: boolean,
+): Array<{ providers: ProviderTypeValue[]; global: boolean }> {
+	const grouped = new Map<boolean, ProviderTypeValue[]>();
+	for (const provider of selectedProviders) {
+		if (!providerSupportsType(provider, type)) continue;
+		const global = resolvePortableTypeGlobal(provider, type, requestedGlobal);
+		grouped.set(global, [...(grouped.get(global) ?? []), provider]);
+	}
+
+	return Array.from(grouped, ([global, providersForScope]) => ({
+		global,
+		providers: providersForScope,
+	}));
+}
+
 function createSkippedActionResult(
 	action: { provider: string; type: PortableType; item: string; targetPath: string },
 	reason: string,
@@ -1188,36 +1211,22 @@ export function registerMigrationRoutes(app: Express): void {
 				: null;
 
 			// 6. Build provider configs
-			const providerConfigs: ReconcileProviderInput[] = selectedProviders.map((provider) => ({
-				provider,
-				global: globalParam,
-			}));
+			const providerConfigs: ReconcileProviderInput[] = buildScopedProviderConfigs(
+				selectedProviders,
+				include,
+				globalParam,
+			);
 
 			// P2: Build type directory states for empty-dir override logic.
 			// Only computed when reinstallEmptyDirs is enabled (default: true).
-			const enabledTypes = (
-				["agent", "command", "skill", "config", "rules", "hooks"] as const
-			).filter((type) => {
-				const key =
-					type === "agent"
-						? "agents"
-						: type === "command"
-							? "commands"
-							: type === "skill"
-								? "skills"
-								: type === "config"
-									? "config"
-									: type === "rules"
-										? "rules"
-										: "hooks";
-				return include[key as keyof typeof include];
-			});
+			const enabledTypes = getEnabledPortableTypes(include);
 
 			const typeDirectoryStates = reinstallEmptyDirs
 				? buildTypeDirectoryStates(
 						providerConfigs.map((p) => ({
 							provider: p.provider as ProviderTypeValue,
 							global: p.global,
+							types: p.types,
 						})),
 						enabledTypes,
 					)
@@ -1344,13 +1353,14 @@ export function registerMigrationRoutes(app: Express): void {
 				for (const item of items) {
 					const sourcePath = item.sourcePath ?? item.path ?? "";
 					for (const provider of selectedProviders) {
+						const candidateGlobal = resolvePortableTypeGlobal(provider, type, globalParam);
 						// Check registry for any installation of this item+type+provider combo
 						const registryEntry = registry.installations.find(
 							(inst) =>
 								inst.item === item.name &&
 								inst.type === type &&
 								inst.provider === provider &&
-								inst.global === globalParam,
+								inst.global === candidateGlobal,
 						);
 						const alreadyInstalled = registryEntry !== undefined;
 
@@ -1358,7 +1368,7 @@ export function registerMigrationRoutes(app: Express): void {
 							item: item.name,
 							type,
 							provider,
-							global: globalParam,
+							global: candidateGlobal,
 							isDirectoryItem,
 							description: item.description,
 							sourcePath,
@@ -1439,27 +1449,16 @@ export function registerMigrationRoutes(app: Express): void {
 			}
 
 			// Build type directory states for banner parity
-			const providerConfigs = selectedProviders.map((provider) => ({
-				provider: provider as ProviderTypeValue,
-				global: globalParam,
+			const providerConfigs = buildScopedProviderConfigs(
+				selectedProviders,
+				include,
+				globalParam,
+			).map((config) => ({
+				provider: config.provider as ProviderTypeValue,
+				global: config.global,
+				types: config.types,
 			}));
-			const enabledTypes = (
-				["agent", "command", "skill", "config", "rules", "hooks"] as const
-			).filter((type) => {
-				const key =
-					type === "agent"
-						? "agents"
-						: type === "command"
-							? "commands"
-							: type === "skill"
-								? "skills"
-								: type === "config"
-									? "config"
-									: type === "rules"
-										? "rules"
-										: "hooks";
-				return include[key as keyof typeof include];
-			});
+			const enabledTypes = getEnabledPortableTypes(include);
 			const typeDirectoryStates = buildTypeDirectoryStates(providerConfigs, enabledTypes);
 
 			res.status(200).json({ candidates, typeDirectoryStates });
@@ -1691,13 +1690,18 @@ export function registerMigrationRoutes(app: Express): void {
 						providerSupportsType(provider, "skill"),
 					);
 					if (skillProviders.length > 0) {
-						const globalFromPlan = plan.actions[0]?.global ?? false;
 						for (const skill of plannedSkills) {
-							const batch = await installSkillDirectories([skill], skillProviders, {
-								global: globalFromPlan,
-							});
-							tagResults(batch, "skills", skill.name);
-							allResults.push(...batch);
+							for (const provider of skillProviders) {
+								const globalFromPlan =
+									plan.actions.find(
+										(action) => action.provider === provider && action.type === "skill",
+									)?.global ?? false;
+								const batch = await installSkillDirectories([skill], [provider], {
+									global: globalFromPlan,
+								});
+								tagResults(batch, "skills", skill.name);
+								allResults.push(...batch);
+							}
 						}
 					}
 				}
@@ -1839,12 +1843,12 @@ export function registerMigrationRoutes(app: Express): void {
 				selectedProviders.includes("codex") &&
 				providers.codex.commands !== null &&
 				providers.codex.commands.projectPath === null;
-			const effectiveGlobal = requestedGlobal || codexCommandsRequireGlobal;
+			const effectiveGlobal = requestedGlobal;
 			const warnings: string[] = [];
 
 			if (codexCommandsRequireGlobal && !requestedGlobal) {
 				warnings.push(
-					"Codex commands are global-only; scope was automatically switched to global.",
+					"Codex commands are global-only; command scope was automatically switched to global.",
 				);
 			}
 
@@ -1878,10 +1882,12 @@ export function registerMigrationRoutes(app: Express): void {
 				return;
 			}
 
-			const installOptions = { global: effectiveGlobal };
 			const results: Awaited<ReturnType<typeof installPortableItems>> = [];
 			const hookRegistrationResults: PortableInstallResult[] = [];
-			const successfulHookFiles = new Map<ProviderTypeValue, string[]>();
+			const successfulHookFiles = new Map<
+				ProviderTypeValue,
+				{ files: string[]; global: boolean }
+			>();
 			// Absolute paths per provider — needed for Codex wrapper generation.
 			const successfulHookAbsPaths = new Map<ProviderTypeValue, string[]>();
 
@@ -1919,18 +1925,16 @@ export function registerMigrationRoutes(app: Express): void {
 			};
 
 			if (include.agents && discovered.agents.length > 0) {
-				const providersForType = selectedProviders.filter((provider) =>
-					getProvidersSupporting("agents").includes(provider),
-				);
-				if (providersForType.length > 0) {
+				for (const group of groupProvidersByTypeScope(
+					selectedProviders,
+					"agent",
+					requestedGlobal,
+				)) {
 					const batches = await Promise.all(
 						discovered.agents.map(async (agent) => {
-							const batch = await installPortableItems(
-								[agent],
-								providersForType,
-								"agent",
-								installOptions,
-							);
+							const batch = await installPortableItems([agent], group.providers, "agent", {
+								global: group.global,
+							});
 							tagResults(batch, "agents", agent.name);
 							return batch;
 						}),
@@ -1942,18 +1946,16 @@ export function registerMigrationRoutes(app: Express): void {
 			}
 
 			if (include.commands && discovered.commands.length > 0) {
-				const providersForType = selectedProviders.filter((provider) =>
-					getProvidersSupporting("commands").includes(provider),
-				);
-				if (providersForType.length > 0) {
+				for (const group of groupProvidersByTypeScope(
+					selectedProviders,
+					"command",
+					requestedGlobal,
+				)) {
 					const batches = await Promise.all(
 						discovered.commands.map(async (command) => {
-							const batch = await installPortableItems(
-								[command],
-								providersForType,
-								"command",
-								installOptions,
-							);
+							const batch = await installPortableItems([command], group.providers, "command", {
+								global: group.global,
+							});
 							tagResults(batch, "commands", command.name);
 							return batch;
 						}),
@@ -1965,17 +1967,16 @@ export function registerMigrationRoutes(app: Express): void {
 			}
 
 			if (include.skills && discovered.skills.length > 0) {
-				const providersForType = selectedProviders.filter((provider) =>
-					getProvidersSupporting("skills").includes(provider),
-				);
-				if (providersForType.length > 0) {
+				for (const group of groupProvidersByTypeScope(
+					selectedProviders,
+					"skill",
+					requestedGlobal,
+				)) {
 					const batches = await Promise.all(
 						discovered.skills.map(async (skill) => {
-							const batch = await installSkillDirectories(
-								[skill],
-								providersForType,
-								installOptions,
-							);
+							const batch = await installSkillDirectories([skill], group.providers, {
+								global: group.global,
+							});
 							tagResults(batch, "skills", skill.name);
 							return batch;
 						}),
@@ -1987,15 +1988,16 @@ export function registerMigrationRoutes(app: Express): void {
 			}
 
 			if (include.config && discovered.configItem) {
-				const providersForType = selectedProviders.filter((provider) =>
-					getProvidersSupporting("config").includes(provider),
-				);
-				if (providersForType.length > 0) {
+				for (const group of groupProvidersByTypeScope(
+					selectedProviders,
+					"config",
+					requestedGlobal,
+				)) {
 					const batch = await installPortableItems(
 						[discovered.configItem],
-						providersForType,
+						group.providers,
 						"config",
-						installOptions,
+						{ global: group.global },
 					);
 					tagResults(batch, "config");
 					results.push(...batch);
@@ -2003,18 +2005,16 @@ export function registerMigrationRoutes(app: Express): void {
 			}
 
 			if (include.rules && discovered.ruleItems.length > 0) {
-				const providersForType = selectedProviders.filter((provider) =>
-					getProvidersSupporting("rules").includes(provider),
-				);
-				if (providersForType.length > 0) {
+				for (const group of groupProvidersByTypeScope(
+					selectedProviders,
+					"rules",
+					requestedGlobal,
+				)) {
 					const batches = await Promise.all(
 						discovered.ruleItems.map(async (rule) => {
-							const batch = await installPortableItems(
-								[rule],
-								providersForType,
-								"rules",
-								installOptions,
-							);
+							const batch = await installPortableItems([rule], group.providers, "rules", {
+								global: group.global,
+							});
 							tagResults(batch, "rules", rule.name);
 							return batch;
 						}),
@@ -2026,22 +2026,23 @@ export function registerMigrationRoutes(app: Express): void {
 			}
 
 			if (include.hooks && discovered.hookItems.length > 0) {
-				const providersForType = selectedProviders.filter((provider) =>
-					getProvidersSupporting("hooks").includes(provider),
-				);
-				if (providersForType.length > 0) {
+				for (const group of groupProvidersByTypeScope(
+					selectedProviders,
+					"hooks",
+					requestedGlobal,
+				)) {
 					const batches = await Promise.all(
 						discovered.hookItems.map(async (hook) => {
-							const batch = await installPortableItems(
-								[hook],
-								providersForType,
-								"hooks",
-								installOptions,
-							);
+							const batch = await installPortableItems([hook], group.providers, "hooks", {
+								global: group.global,
+							});
 							tagResults(batch, "hooks", hook.name);
 							for (const result of batch.filter((entry) => entry.success && !entry.skipped)) {
-								const existing = successfulHookFiles.get(result.provider) ?? [];
-								existing.push(basename(result.path));
+								const existing = successfulHookFiles.get(result.provider) ?? {
+									files: [],
+									global: group.global,
+								};
+								existing.files.push(basename(result.path));
 								successfulHookFiles.set(result.provider, existing);
 								// Track absolute paths for Codex wrapper generation
 								if (result.path.length > 0) {
@@ -2059,14 +2060,14 @@ export function registerMigrationRoutes(app: Express): void {
 				}
 			}
 
-			for (const [provider, files] of successfulHookFiles) {
-				if (files.length === 0) continue;
+			for (const [provider, entry] of successfulHookFiles) {
+				if (entry.files.length === 0) continue;
 				const mergeResult = await migrateHooksSettings({
 					sourceProvider: "claude-code",
 					targetProvider: provider,
-					installedHookFiles: files,
+					installedHookFiles: entry.files,
 					installedHookAbsolutePaths: successfulHookAbsPaths.get(provider),
-					global: effectiveGlobal,
+					global: entry.global,
 				});
 				recordHookRegistrationOutcome(provider, mergeResult, warnings, hookRegistrationResults);
 			}
@@ -2074,7 +2075,16 @@ export function registerMigrationRoutes(app: Express): void {
 			const responseResults = [...results, ...hookRegistrationResults];
 			const sortedResults = sortPortableInstallResults(responseResults);
 			const counts = toExecutionCounts(sortedResults);
-			const providerCollisions = detectProviderPathCollisions(selectedProviders, installOptions);
+			const providerScopes = [
+				...new Set(
+					buildScopedProviderConfigs(selectedProviders, include, requestedGlobal).map(
+						(p) => p.global,
+					),
+				),
+			];
+			const providerCollisions = providerScopes.flatMap((scope) =>
+				detectProviderPathCollisions(selectedProviders, { global: scope }),
+			);
 			annotateResultsWithCollisions(sortedResults, providerCollisions);
 
 			res.status(200).json({

--- a/src/domains/web-server/routes/migration-routes.ts
+++ b/src/domains/web-server/routes/migration-routes.ts
@@ -1851,7 +1851,7 @@ export function registerMigrationRoutes(app: Express): void {
 
 			if (codexCommandsRequireGlobal && !requestedGlobal) {
 				warnings.push(
-					"Codex commands are global-only; command scope was automatically switched to global.",
+					"Codex commands are global-only; they will be installed globally while other content stays project-local.",
 				);
 			}
 

--- a/src/domains/web-server/routes/migration-routes.ts
+++ b/src/domains/web-server/routes/migration-routes.ts
@@ -66,6 +66,7 @@ import type { Express, Request, Response } from "express";
 import { z } from "zod";
 import {
 	annotateResultsWithCollisions,
+	dedupeProviderPathCollisions,
 	emptyDiscoveryCounts,
 	toDiscoveryCounts,
 } from "./migration-result-utils.js";
@@ -1794,8 +1795,10 @@ export function registerMigrationRoutes(app: Express): void {
 						plan.actions.map((a) => a.global).filter((s): s is boolean => s !== undefined),
 					),
 				];
-				const providerCollisions = planScopes.flatMap((scope) =>
-					detectProviderPathCollisions(allPlanProviders, { global: scope }),
+				const providerCollisions = dedupeProviderPathCollisions(
+					planScopes.flatMap((scope) =>
+						detectProviderPathCollisions(allPlanProviders, { global: scope }),
+					),
 				);
 				annotateResultsWithCollisions(sortedResults, providerCollisions);
 
@@ -2082,8 +2085,10 @@ export function registerMigrationRoutes(app: Express): void {
 					),
 				),
 			];
-			const providerCollisions = providerScopes.flatMap((scope) =>
-				detectProviderPathCollisions(selectedProviders, { global: scope }),
+			const providerCollisions = dedupeProviderPathCollisions(
+				providerScopes.flatMap((scope) =>
+					detectProviderPathCollisions(selectedProviders, { global: scope }),
+				),
 			);
 			annotateResultsWithCollisions(sortedResults, providerCollisions);
 

--- a/tests/lib/package-manager-detector.test.ts
+++ b/tests/lib/package-manager-detector.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -658,17 +658,21 @@ describe("PackageManagerDetector", () => {
 			const cacheDir = join(testHomeDir, ".claudekit");
 			mkdirSync(cacheDir, { recursive: true });
 
-			// Exactly 30 days minus 1ms - should still be valid (TTL is >30 days, not >=)
-			// Using -1ms to avoid timing edge case where test execution makes it slightly over
+			const now = 1_800_000_000_000;
+			const nowSpy = spyOn(Date, "now").mockImplementation(() => now);
 			const exactlyThirtyDays = {
 				packageManager: "npm",
-				detectedAt: Date.now() - 30 * 24 * 60 * 60 * 1000 + 1,
+				detectedAt: now - 30 * 24 * 60 * 60 * 1000,
 			};
 			writeFileSync(join(cacheDir, "install-info.json"), JSON.stringify(exactlyThirtyDays));
 
-			const result = await PackageManagerDetector.readCachedPm();
-			// Should be valid at exactly 30 days (expires AFTER 30 days)
-			expect(result).toBe("npm");
+			try {
+				const result = await PackageManagerDetector.readCachedPm();
+				// Should be valid at exactly 30 days (expires AFTER 30 days)
+				expect(result).toBe("npm");
+			} finally {
+				nowSpy.mockRestore();
+			}
 		});
 
 		test("handles cache boundary - just over 30 days old", async () => {


### PR DESCRIPTION
Closes #760

## Summary
- keep Codex project-scope migrations project-local except for global-only commands
- write Codex reasoning effort as `model_reasoning_effort`
- apply the same scoped behavior across CLI migrate and dashboard migration routes

## Validation
- bun run validate