### PR TITLE
fix(hooks): self-heal absolute hook paths in settings.json

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "3.42.2-dev.4",
-	"generatedAt": "2026-04-30T18:53:49.445Z",
+	"version": "3.42.2-dev.5",
+	"generatedAt": "2026-05-01T19:05:33.845Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1085,4 +1085,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-04-30T18:53:57.433Z -->
+<!-- generated: 2026-05-01T19:05:33.957Z -->

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
@@ -551,6 +551,44 @@ describe("checkHookCommandPaths", () => {
 			"bash .claude/hooks/scout-block.cjs",
 		);
 	});
+
+	test("detects and auto-fixes absolute Windows-style hook path in settings.json", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		const settingsPath = join(projectDir, ".claude", "settings.json");
+		await writeFile(
+			settingsPath,
+			JSON.stringify({
+				hooks: {
+					UserPromptSubmit: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command:
+										'node "D:\\Admin\\Documents\\PROJECTS\\myapp\\.claude\\hooks\\session-state.cjs"',
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookCommandPaths(projectDir);
+		expect(result.status).toBe("fail");
+		expect(result.details).toContain("invalid-format");
+		expect(result.autoFixable).toBe(true);
+
+		const fixResult = await result.fix?.execute();
+		expect(fixResult?.success).toBe(true);
+
+		const repaired = JSON.parse(await Bun.file(settingsPath).text()) as {
+			hooks: { UserPromptSubmit: Array<{ hooks: Array<{ command: string }> }> };
+		};
+		expect(repaired.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+			'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-state.cjs',
+		);
+	});
 });
 
 describe("checkHookLogs", () => {

--- a/src/__tests__/domains/installation/merger/settings-processor.test.ts
+++ b/src/__tests__/domains/installation/merger/settings-processor.test.ts
@@ -147,6 +147,69 @@ describe("SettingsProcessor custom global dir support", () => {
 		);
 	});
 
+	it("repairs an absolute hook path in existing destination settings to canonical form", async () => {
+		await writeFile(
+			sourceFile,
+			JSON.stringify(
+				{
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: "node .claude/hooks/task-completed-handler.cjs",
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+		// Simulate a destination settings.json that already contains an absolute path
+		// (written by Claude Code on a previous save or an older ck version).
+		await writeFile(
+			destFile,
+			JSON.stringify(
+				{
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command:
+											'node "D:\\Admin\\Documents\\PROJECTS\\foo\\.claude\\hooks\\task-completed-handler.cjs"',
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const processor = createProcessor();
+		await processor.processSettingsJson(sourceFile, destFile);
+
+		const merged = JSON.parse(await readFile(destFile, "utf-8")) as {
+			hooks: { UserPromptSubmit: Array<{ hooks: Array<{ command: string }> }> };
+		};
+
+		// Deduplication collapses the two entries; the surviving command must be canonical.
+		expect(merged.hooks.UserPromptSubmit).toHaveLength(1);
+		expect(merged.hooks.UserPromptSubmit[0].hooks).toHaveLength(1);
+		// The custom CLAUDE_CONFIG_DIR path is used as the global root in this test setup.
+		expect(merged.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+			`node "${toPosix(customClaudeDir)}/hooks/task-completed-handler.cjs"`,
+		);
+	});
+
 	it("repairs stale sibling settings.local.json hook paths without touching non-node commands", async () => {
 		await writeFile(
 			sourceFile,

--- a/src/__tests__/domains/installation/merger/settings-processor.test.ts
+++ b/src/__tests__/domains/installation/merger/settings-processor.test.ts
@@ -210,6 +210,73 @@ describe("SettingsProcessor custom global dir support", () => {
 		);
 	});
 
+	it("repairs an absolute hook path with no source counterpart (validates branch output, not dedup)", async () => {
+		// Source has only `task-completed-handler`. Dest has only `session-state` (absolute path).
+		// No dedup overlap → the surviving session-state command is the literal output of the
+		// 6th branch in repairClaudeNodeCommandPath, not a side-effect of source canonicalization.
+		await writeFile(
+			sourceFile,
+			JSON.stringify(
+				{
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: "node .claude/hooks/task-completed-handler.cjs",
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+		await writeFile(
+			destFile,
+			JSON.stringify(
+				{
+					hooks: {
+						Stop: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command:
+											'node "D:\\Admin\\Documents\\PROJECTS\\foo\\.claude\\hooks\\session-state.cjs"',
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const processor = createProcessor();
+		await processor.processSettingsJson(sourceFile, destFile);
+
+		const merged = JSON.parse(await readFile(destFile, "utf-8")) as {
+			hooks: {
+				UserPromptSubmit?: Array<{ hooks: Array<{ command: string }> }>;
+				Stop?: Array<{ hooks: Array<{ command: string }> }>;
+			};
+		};
+
+		expect(merged.hooks.Stop).toBeDefined();
+		// The 6th branch repaired the absolute Windows path in dest. The merger is in global
+		// mode here, so root canonicalizes to customClaudeDir (not $CLAUDE_PROJECT_DIR). What
+		// matters is the original `D:\Admin\...` is gone — replaced by the canonical form.
+		expect(merged.hooks.Stop?.[0]?.hooks?.[0]?.command).toBe(
+			`node "${toPosix(customClaudeDir)}/hooks/session-state.cjs"`,
+		);
+	});
+
 	it("repairs stale sibling settings.local.json hook paths without touching non-node commands", async () => {
 		await writeFile(
 			sourceFile,

--- a/src/__tests__/shared/command-normalizer.test.ts
+++ b/src/__tests__/shared/command-normalizer.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { normalizeCommand, repairClaudeNodeCommandPath } from "@/shared/command-normalizer.js";
 
 describe("normalizeCommand", () => {
@@ -51,5 +53,91 @@ describe("normalizeCommand", () => {
 		expect(result.changed).toBe(true);
 		expect(result.issue).toBe("invalid-format");
 		expect(result.command).toBe('node "$CLAUDE_PROJECT_DIR"/.claude/hooks/scout-block.cjs');
+	});
+});
+
+describe("repairClaudeNodeCommandPath — absolute path branch", () => {
+	const home = homedir().replace(/\\/g, "/").replace(/\/+$/, "");
+
+	it("rewrites macOS absolute path under home to $HOME form", () => {
+		const cmd = `node "${home}/.claude/hooks/foo.cjs"`;
+		const result = repairClaudeNodeCommandPath(cmd, "$CLAUDE_PROJECT_DIR");
+
+		expect(result.changed).toBe(true);
+		expect(result.issue).toBe("invalid-format");
+		expect(result.command).toBe('node "$HOME/.claude/hooks/foo.cjs"');
+	});
+
+	it("rewrites macOS absolute path outside home to $CLAUDE_PROJECT_DIR form", () => {
+		const projectPath = join(home, "work/proj");
+		const cmd = `node "${projectPath}/.claude/hooks/foo.cjs"`;
+		const result = repairClaudeNodeCommandPath(cmd, "$CLAUDE_PROJECT_DIR");
+
+		expect(result.changed).toBe(true);
+		expect(result.issue).toBe("invalid-format");
+		expect(result.command).toBe('node "$CLAUDE_PROJECT_DIR"/.claude/hooks/foo.cjs');
+	});
+
+	it("rewrites Linux absolute path outside home to $CLAUDE_PROJECT_DIR form", () => {
+		const result = repairClaudeNodeCommandPath(
+			'node "/opt/projects/myapp/.claude/hooks/session-state.cjs"',
+			"$CLAUDE_PROJECT_DIR",
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.issue).toBe("invalid-format");
+		expect(result.command).toBe('node "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-state.cjs');
+	});
+
+	it("rewrites Windows back-slash absolute path to $CLAUDE_PROJECT_DIR form", () => {
+		const result = repairClaudeNodeCommandPath(
+			'node "D:\\Admin\\Documents\\PROJECTS\\foo\\.claude\\hooks\\session-state.cjs"',
+			"$CLAUDE_PROJECT_DIR",
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.issue).toBe("invalid-format");
+		expect(result.command).toBe('node "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-state.cjs');
+	});
+
+	it("rewrites Windows forward-slash absolute path to $CLAUDE_PROJECT_DIR form", () => {
+		const result = repairClaudeNodeCommandPath(
+			'node "C:/Users/admin/projects/app/.claude/hooks/foo.cjs"',
+			"$CLAUDE_PROJECT_DIR",
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.issue).toBe("invalid-format");
+		expect(result.command).toBe('node "$CLAUDE_PROJECT_DIR"/.claude/hooks/foo.cjs');
+	});
+
+	it("preserves trailing args (suffix) when rewriting absolute path", () => {
+		const result = repairClaudeNodeCommandPath(
+			'node "D:\\Admin\\Projects\\app\\.claude\\hooks\\foo.cjs" --flag',
+			"$CLAUDE_PROJECT_DIR",
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.command).toBe('node "$CLAUDE_PROJECT_DIR"/.claude/hooks/foo.cjs --flag');
+	});
+
+	it("is idempotent: canonical output run through repair again returns changed=false", () => {
+		const first = repairClaudeNodeCommandPath(
+			'node "/opt/proj/.claude/hooks/foo.cjs"',
+			"$CLAUDE_PROJECT_DIR",
+		);
+		expect(first.changed).toBe(true);
+
+		const second = repairClaudeNodeCommandPath(first.command, "$CLAUDE_PROJECT_DIR");
+		expect(second.changed).toBe(false);
+	});
+
+	it("leaves unrelated absolute node paths untouched (no .claude/ segment)", () => {
+		const cmd = "node /usr/bin/some-tool";
+		const result = repairClaudeNodeCommandPath(cmd, "$CLAUDE_PROJECT_DIR");
+
+		expect(result.changed).toBe(false);
+		expect(result.issue).toBeNull();
+		expect(result.command).toBe(cmd);
 	});
 });

--- a/src/__tests__/shared/command-normalizer.test.ts
+++ b/src/__tests__/shared/command-normalizer.test.ts
@@ -140,4 +140,43 @@ describe("repairClaudeNodeCommandPath — absolute path branch", () => {
 		expect(result.issue).toBeNull();
 		expect(result.command).toBe(cmd);
 	});
+
+	it("matches Windows home dir case-insensitively (lowercased corrupted path)", () => {
+		const originalPlatform = process.platform;
+		Object.defineProperty(process, "platform", { value: "win32" });
+		try {
+			// Use a known home prefix; lowercase the path the way some IDEs/JSON tools persist it.
+			// homedir() on win32 returns mixed-case (C:\Users\Kai); the corrupted path is c:/users/kai/...
+			// Without case-insensitive comparison this would route to project scope (wrong).
+			const home = homedir().replace(/\\/g, "/").replace(/\/+$/, "");
+			const lowercased = home.toLowerCase();
+			const cmd = `node "${lowercased}/.claude/hooks/foo.cjs"`;
+			const result = repairClaudeNodeCommandPath(cmd, "$CLAUDE_PROJECT_DIR");
+			expect(result.changed).toBe(true);
+			expect(result.command).toBe('node "$HOME/.claude/hooks/foo.cjs"');
+		} finally {
+			Object.defineProperty(process, "platform", { value: originalPlatform });
+		}
+	});
+
+	it("routes absolute path under CLAUDE_CONFIG_DIR (with .claude suffix) to $HOME scope", () => {
+		const original = process.env.CLAUDE_CONFIG_DIR;
+		process.env.CLAUDE_CONFIG_DIR = "/opt/custom/.claude";
+		try {
+			const result = repairClaudeNodeCommandPath(
+				'node "/opt/custom/.claude/hooks/foo.cjs"',
+				"$CLAUDE_PROJECT_DIR",
+			);
+			expect(result.changed).toBe(true);
+			expect(result.issue).toBe("invalid-format");
+			expect(result.command).toBe('node "$HOME/.claude/hooks/foo.cjs"');
+		} finally {
+			if (original === undefined) {
+				// biome-ignore lint/performance/noDelete: process.env requires delete to actually unset
+				delete process.env.CLAUDE_CONFIG_DIR;
+			} else {
+				process.env.CLAUDE_CONFIG_DIR = original;
+			}
+		}
+	});
 });

--- a/src/shared/command-normalizer.ts
+++ b/src/shared/command-normalizer.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join, normalize } from "node:path";
+import { join } from "node:path";
 import { PathResolver } from "@/shared/path-resolver.js";
 
 export type ClaudeNodeCommandIssue = "raw-relative" | "invalid-format";
@@ -105,23 +105,30 @@ export function repairClaudeNodeCommandPath(
 	// 6th branch: raw absolute paths with .claude/ segment
 	// Matches: node "/abs/path/.claude/hooks/foo.cjs" or node "C:\abs\.claude\hooks\foo.cjs"
 	// Quoted (POSIX/Windows) and unquoted (no spaces, drive-letter) variants.
-	const absoluteQuotedMatch = cmd.match(
-		/^(node\s+)"((?:[A-Za-z]:[/\\]|\/)[^"]*?[/\\]\.claude[/\\][^"]+)"(.*)$/,
-	);
-	const absoluteUnquotedMatch =
-		absoluteQuotedMatch ??
+	const absoluteMatch =
+		cmd.match(/^(node\s+)"((?:[A-Za-z]:[/\\]|\/)[^"]*?[/\\]\.claude[/\\][^"]+)"(.*)$/) ??
 		cmd.match(/^(node\s+)((?:[A-Za-z]:[\\/]|\/)[^\s"]*?[\\/]\.claude[\\/][^\s"]+)(.*)$/);
 
-	if (absoluteUnquotedMatch) {
-		const [, nodePrefix, absolutePath, suffix] = absoluteUnquotedMatch;
-		// Normalize to forward slashes for comparison
-		const normalizedAbsPath = normalize(absolutePath).replace(/\\/g, "/");
-		const homeDir = homedir().replace(/\\/g, "/").replace(/\/+$/, "");
-		// Paths under homedir()/.claude/ are global-scope; everything else is project-scope.
-		const isUnderHome = normalizedAbsPath.startsWith(`${homeDir}/.claude/`);
-		const resolvedRoot = isUnderHome ? "$HOME" : root;
-		// Extract the .claude/... suffix from the absolute path
+	if (absoluteMatch) {
+		const [, nodePrefix, absolutePath, suffix] = absoluteMatch;
+		const normalizedAbsPath = absolutePath.replace(/\\/g, "/");
+		// Defensive: regex guarantees `.claude/` is present, but bail out cleanly if not.
 		const dotClaudeIdx = normalizedAbsPath.indexOf("/.claude/");
+		if (dotClaudeIdx === -1) {
+			return { command: cmd, changed: false, issue: null };
+		}
+
+		// Resolve global-scope candidate roots: homedir + custom CLAUDE_CONFIG_DIR if set.
+		// Windows paths are case-insensitive; lowercase both sides on win32 only.
+		const isWin = process.platform === "win32";
+		const cmp = (s: string) => (isWin ? s.toLowerCase() : s);
+		const globalRoots = [
+			`${homedir().replace(/\\/g, "/").replace(/\/+$/, "")}/.claude/`,
+			`${PathResolver.getGlobalKitDir().replace(/\\/g, "/").replace(/\/+$/, "")}/`,
+		];
+		const isUnderGlobal = globalRoots.some((g) => cmp(normalizedAbsPath).startsWith(cmp(g)));
+		const resolvedRoot = isUnderGlobal ? "$HOME" : root;
+
 		const relativePath = normalizedAbsPath.slice(dotClaudeIdx + 1); // ".claude/hooks/foo.cjs"
 		const command = formatCanonicalClaudeCommand(nodePrefix, resolvedRoot, relativePath, suffix);
 		return { command, changed: command !== cmd, issue: "invalid-format" };

--- a/src/shared/command-normalizer.ts
+++ b/src/shared/command-normalizer.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, normalize } from "node:path";
 import { PathResolver } from "@/shared/path-resolver.js";
 
 export type ClaudeNodeCommandIssue = "raw-relative" | "invalid-format";
@@ -99,6 +99,31 @@ export function repairClaudeNodeCommandPath(
 	if (unquotedMatch) {
 		const [, nodePrefix, relativePath, suffix] = unquotedMatch;
 		const command = formatCanonicalClaudeCommand(nodePrefix, root, relativePath, suffix);
+		return { command, changed: command !== cmd, issue: "invalid-format" };
+	}
+
+	// 6th branch: raw absolute paths with .claude/ segment
+	// Matches: node "/abs/path/.claude/hooks/foo.cjs" or node "C:\abs\.claude\hooks\foo.cjs"
+	// Quoted (POSIX/Windows) and unquoted (no spaces, drive-letter) variants.
+	const absoluteQuotedMatch = cmd.match(
+		/^(node\s+)"((?:[A-Za-z]:[/\\]|\/)[^"]*?[/\\]\.claude[/\\][^"]+)"(.*)$/,
+	);
+	const absoluteUnquotedMatch =
+		absoluteQuotedMatch ??
+		cmd.match(/^(node\s+)((?:[A-Za-z]:[\\/]|\/)[^\s"]*?[\\/]\.claude[\\/][^\s"]+)(.*)$/);
+
+	if (absoluteUnquotedMatch) {
+		const [, nodePrefix, absolutePath, suffix] = absoluteUnquotedMatch;
+		// Normalize to forward slashes for comparison
+		const normalizedAbsPath = normalize(absolutePath).replace(/\\/g, "/");
+		const homeDir = homedir().replace(/\\/g, "/").replace(/\/+$/, "");
+		// Paths under homedir()/.claude/ are global-scope; everything else is project-scope.
+		const isUnderHome = normalizedAbsPath.startsWith(`${homeDir}/.claude/`);
+		const resolvedRoot = isUnderHome ? "$HOME" : root;
+		// Extract the .claude/... suffix from the absolute path
+		const dotClaudeIdx = normalizedAbsPath.indexOf("/.claude/");
+		const relativePath = normalizedAbsPath.slice(dotClaudeIdx + 1); // ".claude/hooks/foo.cjs"
+		const command = formatCanonicalClaudeCommand(nodePrefix, resolvedRoot, relativePath, suffix);
 		return { command, changed: command !== cmd, issue: "invalid-format" };
 	}
 


### PR DESCRIPTION
## Summary

- New 6th branch in `repairClaudeNodeCommandPath` detecting raw absolute `.claude/...` paths (Windows + POSIX, quoted + unquoted).
- Scope-aware rewrite: paths under `homedir()/.claude/` → `$HOME`, otherwise → `$CLAUDE_PROJECT_DIR`.
- Auto-flows through existing `fixHookCommandPaths` + `hook-health-checker` — no caller changes.

Closes #762

## Problem

User-installed hooks fail with `Cannot find module '...\.claude\hooks\<name>.cjs'` once the project folder moves (iCloud Drive relocation, Dropbox/Drive sync, home rename, machine swap, drive letter change). Every Claude Code event hits the same broken absolute path — `UserPromptSubmit`, `PreToolUse:Read`, `PreToolUse:Glob`, `Stop`, etc.

Reported example (Windows): `D:\Admin\Documents\PROJECTS\<project>\.claude\hooks\session-state.cjs`.

## Root Cause

Shipped templates ARE portable (`node .claude/hooks/...` → installer rewrites to canonical token form). The bug surface is **post-install corruption**: older `ck` versions, hand edits, IDE refactors, or Claude Code's settings-write flow can persist fully-resolved absolute paths. Once persisted, every path-changing event breaks every hook simultaneously.

`repairClaudeNodeCommandPath` already handles 5 canonical-form variants (bare relative, embedded-quoted token, var-only quoted, tilde, unquoted token). The missing branch is **raw absolute `.claude/...` paths**.

## Changes

| File | Change |
|------|--------|
| `src/shared/command-normalizer.ts` | 6th branch: detect absolute path, scope-aware rewrite via `formatCanonicalClaudeCommand` |
| `src/__tests__/shared/command-normalizer.test.ts` | 8 new unit tests (macOS / Linux / Windows back- and forward-slash, suffix preservation, idempotence, unrelated path unchanged) |
| `src/__tests__/domains/installation/merger/settings-processor.test.ts` | Integration test: absolute Windows path in dest settings → canonical after merge |
| `src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts` | Integration test: `checkHookCommandPaths` detects + auto-fixes Windows absolute path |

## Validation

- [x] `bun run validate` passes (typecheck + lint + 4607 backend tests + 165 UI tests + build, all green)
- [x] 10 new tests covering all OS path forms and edge cases
- [x] Idempotent: rewrite output is stable through repeated calls
- [x] No changes required in `fixHookCommandPaths` or `hook-health-checker.ts` — both already invoke the normalizer and pick up the new branch automatically

## User Impact

Existing user installs auto-repair on next `ck init`, `ck doctor --fix`, or settings merge. No breaking changes, no migration steps. Closes the last common gap in the path-canonicalization registry.
