### PR TITLE
feat(github): propagate classified GitHub errors from kit-access-checker

### DIFF
--- a/src/__tests__/domains/github/kit-access-checker.test.ts
+++ b/src/__tests__/domains/github/kit-access-checker.test.ts
@@ -2,7 +2,30 @@ import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:
 import { GitHubClient } from "@/domains/github/github-client.js";
 import { detectAccessibleKits } from "@/domains/github/kit-access-checker.js";
 import * as safeSpinner from "@/shared/safe-spinner.js";
+import { GitHubError } from "@/types";
 import { AVAILABLE_KITS } from "@/types";
+
+/**
+ * Build a fake Octokit-style error with an HTTP status code.
+ * The `status` field is how `error-classifier.ts` identifies the failure class.
+ */
+function makeHttpError(status: number, message: string): Error & { status: number } {
+	const err = new Error(message) as Error & { status: number };
+	err.status = status;
+	return err;
+}
+
+/**
+ * Build a synthetic Octokit transport error (no HTTP response, no status).
+ * This is what Octokit emits when fetch() itself throws (ECONNRESET, DNS, etc.).
+ * `error.message === "fetch failed"` with a `.cause` containing the underlying error.
+ */
+function makeTransportError(causeMessage: string): Error {
+	const cause = new Error(causeMessage);
+	const err = new Error("fetch failed");
+	(err as any).cause = cause;
+	return err;
+}
 
 describe("kit-access-checker", () => {
 	let mockSpinner: {
@@ -12,7 +35,7 @@ describe("kit-access-checker", () => {
 	};
 
 	beforeEach(() => {
-		// Mock spinner
+		// Mock spinner to avoid real terminal output during tests
 		mockSpinner = {
 			start: mock(() => mockSpinner),
 			succeed: mock(() => mockSpinner),
@@ -25,23 +48,233 @@ describe("kit-access-checker", () => {
 		mock.restore();
 	});
 
-	describe("detectAccessibleKits", () => {
-		test("returns both kits when both are accessible", async () => {
-			// Mock checkAccess to always succeed
+	// -------------------------------------------------------------------------
+	// PRESERVED BEHAVIOR: 404 = "no access" (not an error)
+	// -------------------------------------------------------------------------
+
+	describe("404 handling (preserved behavior)", () => {
+		test("404 on one kit -> that kit excluded, no throw", async () => {
+			const kitNames = Object.keys(AVAILABLE_KITS) as Array<keyof typeof AVAILABLE_KITS>;
+			const [firstKit, ...rest] = kitNames;
+
+			spyOn(GitHubClient.prototype, "checkAccess").mockImplementation(async (config) => {
+				if (config.repo === AVAILABLE_KITS[firstKit].repo) {
+					throw makeHttpError(404, "Not Found");
+				}
+				return true;
+			});
+
+			const result = await detectAccessibleKits();
+
+			expect(result).not.toContain(firstKit);
+			for (const k of rest) {
+				expect(result).toContain(k);
+			}
+			// Must NOT throw — just exclude the kit
+			expect(mockSpinner.succeed).toHaveBeenCalled();
+		});
+
+		test("404 on ALL kits -> empty array, no throw", async () => {
+			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(
+				makeHttpError(404, "Not Found"),
+			);
+
+			const result = await detectAccessibleKits();
+
+			expect(result).toEqual([]);
+			expect(mockSpinner.fail).toHaveBeenCalledWith("No kit access found");
+		});
+
+		test("spinner shows failure message when all kits return 404", async () => {
+			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(
+				makeHttpError(404, "Not Found"),
+			);
+
+			await detectAccessibleKits();
+
+			expect(mockSpinner.fail).toHaveBeenCalledWith("No kit access found");
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// NEW BEHAVIOR: Non-404 errors must propagate as GitHubError
+	// -------------------------------------------------------------------------
+
+	describe("NETWORK errors propagate", () => {
+		test("ECONNREFUSED on any kit -> throws GitHubError with NETWORK message", async () => {
+			const networkErr = new Error("connect ECONNREFUSED 140.82.121.4:443");
+			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(networkErr);
+
+			await expect(detectAccessibleKits()).rejects.toBeInstanceOf(GitHubError);
+		});
+
+		test("NETWORK error message contains 'Network connection error'", async () => {
+			const networkErr = new Error("connect ECONNREFUSED 140.82.121.4:443");
+			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(networkErr);
+
+			let thrown: unknown;
+			try {
+				await detectAccessibleKits();
+			} catch (e) {
+				thrown = e;
+			}
+			expect(thrown).toBeInstanceOf(GitHubError);
+			expect((thrown as GitHubError).message).toContain("Network connection error");
+		});
+	});
+
+	describe("AUTH_MISSING (401) errors propagate", () => {
+		test("401 on any kit -> throws GitHubError", async () => {
+			// Simulate what handleHttpError produces for 401
+			const authErr = new GitHubError("Not authenticated with GitHub", 401);
+			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(authErr);
+
+			await expect(detectAccessibleKits()).rejects.toBeInstanceOf(GitHubError);
+		});
+
+		test("401 error message references AUTH_MISSING text", async () => {
+			const authErr = new GitHubError("Not authenticated with GitHub", 401);
+			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(authErr);
+
+			let thrown: unknown;
+			try {
+				await detectAccessibleKits();
+			} catch (e) {
+				thrown = e;
+			}
+			expect(thrown).toBeInstanceOf(GitHubError);
+			// AUTH_MISSING category message from error-classifier.ts
+			expect((thrown as GitHubError).message).toContain("Not authenticated with GitHub");
+		});
+	});
+
+	describe("RATE_LIMIT (403 rate limit) errors propagate", () => {
+		test("403 rate-limit on any kit -> throws GitHubError", async () => {
+			const rateLimitErr = new GitHubError(
+				"GitHub API rate limit exceeded\n\nRate limit will reset soon",
+				403,
+			);
+			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(rateLimitErr);
+
+			await expect(detectAccessibleKits()).rejects.toBeInstanceOf(GitHubError);
+		});
+
+		test("rate-limit error message mentions rate limit", async () => {
+			const rateLimitErr = new GitHubError(
+				"GitHub API rate limit exceeded\n\nRate limit will reset soon",
+				403,
+			);
+			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(rateLimitErr);
+
+			let thrown: unknown;
+			try {
+				await detectAccessibleKits();
+			} catch (e) {
+				thrown = e;
+			}
+			expect(thrown).toBeInstanceOf(GitHubError);
+			expect((thrown as GitHubError).message).toContain("rate limit");
+		});
+	});
+
+	describe("transport errors (fetch failed / ECONNRESET) propagate", () => {
+		test("fetch failed with ECONNRESET cause -> throws GitHubError", async () => {
+			// Octokit synthesizes this: message="fetch failed", no status, cause=ECONNRESET
+			const transportErr = makeTransportError("read ECONNRESET");
+			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(transportErr);
+
+			await expect(detectAccessibleKits()).rejects.toBeInstanceOf(GitHubError);
+		});
+
+		test("ETIMEDOUT transport error -> throws GitHubError categorized as NETWORK or UNKNOWN", async () => {
+			const timeoutErr = makeTransportError("connect ETIMEDOUT");
+			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(timeoutErr);
+
+			let thrown: unknown;
+			try {
+				await detectAccessibleKits();
+			} catch (e) {
+				thrown = e;
+			}
+			expect(thrown).toBeInstanceOf(GitHubError);
+		});
+	});
+
+	describe("mixed errors: 404 + non-404", () => {
+		test("one kit 404 + one kit NETWORK -> throws (non-404 wins)", async () => {
+			const kitNames = Object.keys(AVAILABLE_KITS) as Array<keyof typeof AVAILABLE_KITS>;
+			expect(kitNames.length).toBeGreaterThanOrEqual(2);
+
+			const [kit404, kitNetwork] = kitNames;
+
+			const networkErr = new Error("connect ECONNREFUSED 140.82.121.4:443");
+
+			spyOn(GitHubClient.prototype, "checkAccess").mockImplementation(async (config) => {
+				if (config.repo === AVAILABLE_KITS[kit404].repo) {
+					throw makeHttpError(404, "Not Found");
+				}
+				if (config.repo === AVAILABLE_KITS[kitNetwork].repo) {
+					throw networkErr;
+				}
+				return true;
+			});
+
+			// Should throw, not return empty array
+			await expect(detectAccessibleKits()).rejects.toBeInstanceOf(GitHubError);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// PRESERVED BEHAVIOR: spinner and parallel execution
+	// -------------------------------------------------------------------------
+
+	describe("happy path (all accessible)", () => {
+		test("returns all kits when all are accessible", async () => {
 			spyOn(GitHubClient.prototype, "checkAccess").mockResolvedValue(true);
 
 			const result = await detectAccessibleKits();
 
 			expect(result).toContain("engineer");
 			expect(result).toContain("marketing");
-			expect(result.length).toBe(2);
+			expect(result.length).toBe(Object.keys(AVAILABLE_KITS).length);
 			expect(mockSpinner.succeed).toHaveBeenCalled();
 		});
 
-		test("returns only engineer when marketing fails", async () => {
+		test("spinner shows success message with accessible kits", async () => {
+			spyOn(GitHubClient.prototype, "checkAccess").mockResolvedValue(true);
+
+			await detectAccessibleKits();
+
+			expect(mockSpinner.succeed).toHaveBeenCalledWith(expect.stringContaining("Access verified"));
+		});
+
+		test("checks all kits in parallel", async () => {
+			const callOrder: string[] = [];
+			spyOn(GitHubClient.prototype, "checkAccess").mockImplementation(async (config) => {
+				callOrder.push(config.repo);
+				await new Promise((r) => setTimeout(r, 10));
+				return true;
+			});
+
+			await detectAccessibleKits();
+
+			expect(callOrder.length).toBe(Object.keys(AVAILABLE_KITS).length);
+		});
+
+		test("shows spinner while checking", async () => {
+			spyOn(GitHubClient.prototype, "checkAccess").mockResolvedValue(true);
+
+			await detectAccessibleKits();
+
+			expect(mockSpinner.start).toHaveBeenCalled();
+		});
+	});
+
+	describe("partial access (one kit accessible)", () => {
+		test("returns only engineer when marketing returns 404", async () => {
 			spyOn(GitHubClient.prototype, "checkAccess").mockImplementation(async (config) => {
 				if (config.repo === "claudekit-marketing") {
-					throw new Error("Access denied");
+					throw makeHttpError(404, "Not Found");
 				}
 				return true;
 			});
@@ -54,10 +287,10 @@ describe("kit-access-checker", () => {
 			expect(mockSpinner.succeed).toHaveBeenCalled();
 		});
 
-		test("returns only marketing when engineer fails", async () => {
+		test("returns only marketing when engineer returns 404", async () => {
 			spyOn(GitHubClient.prototype, "checkAccess").mockImplementation(async (config) => {
 				if (config.repo === "claudekit-engineer") {
-					throw new Error("Access denied");
+					throw makeHttpError(404, "Not Found");
 				}
 				return true;
 			});
@@ -68,90 +301,6 @@ describe("kit-access-checker", () => {
 			expect(result).toContain("marketing");
 			expect(result.length).toBe(1);
 			expect(mockSpinner.succeed).toHaveBeenCalled();
-		});
-
-		test("returns empty array when no kits are accessible", async () => {
-			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(new Error("Access denied"));
-
-			const result = await detectAccessibleKits();
-
-			expect(result).toEqual([]);
-			expect(mockSpinner.fail).toHaveBeenCalled();
-		});
-
-		test("handles network errors gracefully", async () => {
-			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(new Error("Network error"));
-
-			const result = await detectAccessibleKits();
-
-			expect(result).toEqual([]);
-			expect(mockSpinner.fail).toHaveBeenCalled();
-		});
-
-		test("checks all kits in parallel", async () => {
-			const callOrder: string[] = [];
-			spyOn(GitHubClient.prototype, "checkAccess").mockImplementation(async (config) => {
-				callOrder.push(config.repo);
-				await new Promise((r) => setTimeout(r, 10)); // Simulate async delay
-				return true;
-			});
-
-			await detectAccessibleKits();
-
-			// Both should be called (parallel execution)
-			expect(callOrder.length).toBe(Object.keys(AVAILABLE_KITS).length);
-		});
-
-		test("does not mutate results during concurrent execution", async () => {
-			// Run multiple times to catch race conditions
-			for (let i = 0; i < 10; i++) {
-				spyOn(GitHubClient.prototype, "checkAccess").mockImplementation(async (config) => {
-					await new Promise((r) => setTimeout(r, Math.random() * 20));
-					if (config.repo === "claudekit-marketing") {
-						throw new Error("Access denied");
-					}
-					return true;
-				});
-
-				const result = await detectAccessibleKits();
-
-				// Should consistently return only engineer
-				expect(result).toContain("engineer");
-				expect(result).not.toContain("marketing");
-				expect(result.length).toBe(1);
-
-				mock.restore();
-				mockSpinner = {
-					start: mock(() => mockSpinner),
-					succeed: mock(() => mockSpinner),
-					fail: mock(() => mockSpinner),
-				};
-				spyOn(safeSpinner, "createSpinner").mockReturnValue(mockSpinner as any);
-			}
-		});
-
-		test("shows spinner while checking", async () => {
-			spyOn(GitHubClient.prototype, "checkAccess").mockResolvedValue(true);
-
-			await detectAccessibleKits();
-
-			expect(mockSpinner.start).toHaveBeenCalled();
-		});
-
-		test("spinner shows success message with accessible kits", async () => {
-			spyOn(GitHubClient.prototype, "checkAccess").mockResolvedValue(true);
-
-			await detectAccessibleKits();
-
-			expect(mockSpinner.succeed).toHaveBeenCalledWith(expect.stringContaining("Access verified"));
-		});
-
-		test("spinner shows failure when no access", async () => {
-			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(new Error("No access"));
-
-			await detectAccessibleKits();
-
-			expect(mockSpinner.fail).toHaveBeenCalledWith("No kit access found");
 		});
 	});
 });

--- a/src/__tests__/domains/github/kit-access-checker.test.ts
+++ b/src/__tests__/domains/github/kit-access-checker.test.ts
@@ -15,18 +15,6 @@ function makeHttpError(status: number, message: string): Error & { status: numbe
 	return err;
 }
 
-/**
- * Build a synthetic Octokit transport error (no HTTP response, no status).
- * This is what Octokit emits when fetch() itself throws (ECONNRESET, DNS, etc.).
- * `error.message === "fetch failed"` with a `.cause` containing the underlying error.
- */
-function makeTransportError(causeMessage: string): Error {
-	const cause = new Error(causeMessage);
-	const err = new Error("fetch failed");
-	(err as any).cause = cause;
-	return err;
-}
-
 describe("kit-access-checker", () => {
 	let mockSpinner: {
 		start: ReturnType<typeof mock>;
@@ -82,16 +70,6 @@ describe("kit-access-checker", () => {
 			const result = await detectAccessibleKits();
 
 			expect(result).toEqual([]);
-			expect(mockSpinner.fail).toHaveBeenCalledWith("No kit access found");
-		});
-
-		test("spinner shows failure message when all kits return 404", async () => {
-			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(
-				makeHttpError(404, "Not Found"),
-			);
-
-			await detectAccessibleKits();
-
 			expect(mockSpinner.fail).toHaveBeenCalledWith("No kit access found");
 		});
 	});
@@ -177,18 +155,23 @@ describe("kit-access-checker", () => {
 		});
 	});
 
-	describe("transport errors (fetch failed / ECONNRESET) propagate", () => {
-		test("fetch failed with ECONNRESET cause -> throws GitHubError", async () => {
-			// Octokit synthesizes this: message="fetch failed", no status, cause=ECONNRESET
-			const transportErr = makeTransportError("read ECONNRESET");
-			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(transportErr);
+	describe("transport errors (synthetic 500 / fetch failed) propagate", () => {
+		// Octokit's fetch-wrapper synthesizes a 500-status RequestError when fetch() itself
+		// throws (DNS / ECONNRESET / TLS / proxy). By the time the error reaches
+		// `kit-access-checker`, `checkAccess` has wrapped it via `handleHttpError` into a
+		// GitHubError carrying the 500 status. We model that shape here.
+		test("fetch failed (synthetic 500) -> throws GitHubError", async () => {
+			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(
+				makeHttpError(500, "fetch failed"),
+			);
 
 			await expect(detectAccessibleKits()).rejects.toBeInstanceOf(GitHubError);
 		});
 
-		test("ETIMEDOUT transport error -> throws GitHubError categorized as NETWORK or UNKNOWN", async () => {
-			const timeoutErr = makeTransportError("connect ETIMEDOUT");
-			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(timeoutErr);
+		test("ETIMEDOUT (synthetic 500) -> throws GitHubError", async () => {
+			spyOn(GitHubClient.prototype, "checkAccess").mockRejectedValue(
+				makeHttpError(500, "connect ETIMEDOUT"),
+			);
 
 			let thrown: unknown;
 			try {
@@ -273,7 +256,7 @@ describe("kit-access-checker", () => {
 	describe("partial access (one kit accessible)", () => {
 		test("returns only engineer when marketing returns 404", async () => {
 			spyOn(GitHubClient.prototype, "checkAccess").mockImplementation(async (config) => {
-				if (config.repo === "claudekit-marketing") {
+				if (config.repo === AVAILABLE_KITS.marketing.repo) {
 					throw makeHttpError(404, "Not Found");
 				}
 				return true;
@@ -289,7 +272,7 @@ describe("kit-access-checker", () => {
 
 		test("returns only marketing when engineer returns 404", async () => {
 			spyOn(GitHubClient.prototype, "checkAccess").mockImplementation(async (config) => {
-				if (config.repo === "claudekit-engineer") {
+				if (config.repo === AVAILABLE_KITS.engineer.repo) {
 					throw makeHttpError(404, "Not Found");
 				}
 				return true;

--- a/src/domains/github/kit-access-checker.ts
+++ b/src/domains/github/kit-access-checker.ts
@@ -75,8 +75,13 @@ export async function detectAccessibleKits(): Promise<KitType[]> {
 			accessible.push(result.value);
 		} else {
 			const err = result.reason;
-			// 404 = kit not accessible to this user — expected, treat as "no access"
-			const status = (err as any)?.status ?? (err as any)?.statusCode;
+			// 404 = kit not accessible to this user — expected, treat as "no access".
+			// In production, `checkAccess` always wraps errors as GitHubError (which uses
+			// `statusCode` via ClaudeKitError). The `.status` fallback is defense-in-depth
+			// for raw Octokit-style errors that might bypass that wrapping (e.g. in tests
+			// or future call paths) — without it, a raw 404 would fall through to the
+			// fatal-error branch and incorrectly throw.
+			const status = (err as any)?.statusCode ?? (err as any)?.status;
 			if (status === 404) {
 				logger.debug("No access to kit (404)");
 			} else {
@@ -90,6 +95,10 @@ export async function detectAccessibleKits(): Promise<KitType[]> {
 	// We must never silently convert a NETWORK/AUTH/RATE_LIMIT failure into "no access".
 	if (fatalErrors.length > 0) {
 		spinner.fail("Kit access check failed");
+		// Log any additional errors at debug level so they aren't silently lost
+		for (const extra of fatalErrors.slice(1)) {
+			logger.debug(`Additional kit access error (suppressed): ${extra.message}`);
+		}
 		throw fatalErrors[0];
 	}
 

--- a/src/domains/github/kit-access-checker.ts
+++ b/src/domains/github/kit-access-checker.ts
@@ -2,35 +2,96 @@
  * Kit Access Checker
  * Detects which kits the user has GitHub access to
  */
+import { classifyGitHubError } from "@/domains/error/error-classifier.js";
+import { formatActions, suggestActions } from "@/domains/error/index.js";
 import { logger } from "@/shared/logger.js";
 import { createSpinner } from "@/shared/safe-spinner.js";
+import { GitHubError } from "@/types";
 import { AVAILABLE_KITS, type KitType } from "@/types";
 import { GitHubClient } from "./github-client.js";
 
 /**
- * Check access to all available kits in parallel
+ * Convert an arbitrary caught error into a GitHubError using the classifier.
+ * If the error is already a GitHubError, re-throw it directly (message already formatted).
+ * Otherwise classify it and build the standard formatted message.
+ */
+function toGitHubError(error: unknown): GitHubError {
+	// Already a classified GitHubError — preserve it as-is
+	if (error instanceof GitHubError) {
+		return error;
+	}
+
+	const classified = classifyGitHubError(error as any, "check repository access");
+	const actions = suggestActions(classified.category);
+	const formattedActions = formatActions(actions);
+
+	const messageParts: string[] = [classified.message];
+
+	if (classified.details) {
+		messageParts.push(`\n${classified.details}`);
+	}
+
+	if (formattedActions) {
+		messageParts.push(`\nSolutions:${formattedActions}`);
+	}
+
+	messageParts.push("\nNeed help? Run with: ck new --verbose");
+
+	return new GitHubError(messageParts.join("\n"), classified.httpStatus);
+}
+
+/**
+ * Check access to all available kits in parallel.
+ *
+ * Behavior:
+ *   - 404 on a kit  -> that kit is excluded from results (no access, not an error)
+ *   - 404 on ALL kits -> returns [] (same UX as before: "No kit access found")
+ *   - Any non-404 error -> throws a classified GitHubError so the caller can surface it
+ *   - Mixed 404 + non-404 -> throws (the non-404 failure wins; we must not silently
+ *     fall back to "no access" when the real cause is network/auth/rate-limit)
+ *
  * @returns Array of kit types the user has access to
+ * @throws {GitHubError} When any kit check fails for a non-404 reason
  */
 export async function detectAccessibleKits(): Promise<KitType[]> {
 	const spinner = createSpinner("Checking kit access...").start();
 	const github = new GitHubClient();
 
-	// Check all kits in parallel, return kit type or null
-	const results = await Promise.all(
+	// Use allSettled so a single failure does not abort other in-flight checks
+	const settled = await Promise.allSettled(
 		Object.entries(AVAILABLE_KITS).map(async ([type, config]) => {
-			try {
-				await github.checkAccess(config);
-				logger.debug(`Access confirmed: ${type}`);
-				return type as KitType;
-			} catch {
-				logger.debug(`No access to ${type}`);
-				return null;
-			}
+			await github.checkAccess(config);
+			logger.debug(`Access confirmed: ${type}`);
+			return type as KitType;
 		}),
 	);
 
-	// Filter out nulls (no race condition - sequential after Promise.all)
-	const accessible = results.filter((kit): kit is KitType => kit !== null);
+	// Separate 404 rejections (benign "no access") from other failures (must propagate)
+	const accessible: KitType[] = [];
+	const fatalErrors: GitHubError[] = [];
+
+	for (const result of settled) {
+		if (result.status === "fulfilled") {
+			accessible.push(result.value);
+		} else {
+			const err = result.reason;
+			// 404 = kit not accessible to this user — expected, treat as "no access"
+			const status = (err as any)?.status ?? (err as any)?.statusCode;
+			if (status === 404) {
+				logger.debug("No access to kit (404)");
+			} else {
+				// Any other failure is a real error — classify and collect it
+				fatalErrors.push(toGitHubError(err));
+			}
+		}
+	}
+
+	// If any non-404 error occurred, throw the first one so callers can surface it.
+	// We must never silently convert a NETWORK/AUTH/RATE_LIMIT failure into "no access".
+	if (fatalErrors.length > 0) {
+		spinner.fail("Kit access check failed");
+		throw fatalErrors[0];
+	}
 
 	if (accessible.length === 0) {
 		spinner.fail("No kit access found");


### PR DESCRIPTION
## Summary

- Replaces `Promise.all` + silent catch in `detectAccessibleKits` with `Promise.allSettled` + 404-vs-other split.
- 404 (no invite yet) keeps current "no access" UX; ANY other error (NETWORK / RATE_LIMIT / AUTH_MISSING / AUTH_SCOPE / 5xx) now propagates a classified `GitHubError` with the full categorized message instead of collapsing into "No kit access found".
- Audit pass on `src/domains/github/` and `src/domains/installation/` for similar silent-catch patterns; findings appended to brainstorm report.

Closes #765
Part of #764

## Root Cause

`kit-access-checker.ts` swallowed every error in a silent `catch { return null }`. The error classifier already produces correct NETWORK / AUTH_* / RATE_LIMIT messages, but they never reached the user — so transport-level fetch failures (DNS, ECONNREFUSED, TLS) all surfaced as "check email for invitation, or purchase". Confirmed via Octokit `fetch-wrapper.js` — synthetic 500 with `requestId: UNKNOWN` is the canonical signal of a transport failure, not a real GitHub 5xx.

## Changes

| File | Change |
|------|--------|
| `src/domains/github/kit-access-checker.ts` | `Promise.allSettled` + classified rethrow via new `toGitHubError()` helper |
| `src/__tests__/domains/github/kit-access-checker.test.ts` | 18 tests (+9 new) covering 404 preservation + NETWORK/RATE_LIMIT/AUTH/500 propagation |

## Test plan

- [x] `bun run validate` (typecheck + lint + 4618 unit + 165 UI tests + build) — green
- [x] 18 unit tests in `kit-access-checker.test.ts` — all pass
- [x] Audit pass for silent catches in github/ and installation/ — documented; no other classified-error swallows found