### PR TITLE
fix(doctor): eliminate checker/fixer divergence in hook command paths

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "3.42.2-dev.5",
-	"generatedAt": "2026-05-01T19:05:33.845Z",
+	"version": "3.42.2-dev.6",
+	"generatedAt": "2026-05-04T15:21:56.758Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1085,4 +1085,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-01T19:05:33.957Z -->
+<!-- generated: 2026-05-04T15:21:56.876Z -->

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -283,8 +283,25 @@ bun run typecheck && bun run lint:fix && bun test && bun run build && bun run ui
 
 All must pass. No exceptions.
 
+## Checker/Fixer Parity for autoFixable health checks
+
+Every health checker with `autoFixable: true` MUST maintain parity between its detection and fix logic. Violations cause `ck doctor --fix` to report success while leaving stale entries intact (issue #767).
+
+**Rules:**
+
+1. **Single source of truth** — Extract one function that identifies stale entries. Both the checker's report path and its `fix.execute()` path MUST call this same function. No duplicated traversal logic.
+2. **Post-fix re-check** — After applying repairs, re-run detection. If any findings remain, throw `FixerDidNotConvergeError` (a typed error class, not a generic `Error`) listing all unresolved entries with their commands.
+3. **Parity test required** — Every `autoFixable: true` checker MUST have a test that uses `expectFixerConvergence` from `src/__tests__/helpers/checker-fixer-parity.ts`:
+   ```ts
+   await expectFixerConvergence({ detect, fix, fixture });
+   // Asserts: detect(fixture).length > 0 → fix(fixture) → detect(fixture).length === 0
+   ```
+
+**Reference implementation:** `src/domains/health-checks/checkers/hook-health-checker.ts` — `findStaleHookCommandsInFile` (single source) + `repairHookCommandsInSettingsFile` (post-fix re-check + `FixerDidNotConvergeError`).
+
 ## Recent Standards Updates
 
+- **#767 Checker/fixer parity**: Single source of truth + post-fix re-check for `autoFixable` checkers
 - **#346 Process-lock safety**: Throw errors instead of `process.exit(1)` inside `withProcessLock()`
 - **#344 Installation detection**: Fallback support for installs without metadata.json
 - **Skills rename**: Command renamed from `skill` to `skills`

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker-parity.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker-parity.test.ts
@@ -1,0 +1,318 @@
+/**
+ * hook-health-checker-parity.test.ts
+ *
+ * Checker/fixer parity tests for the hook command path checker.
+ *
+ * Validates that `ck doctor --fix` fully resolves everything that
+ * `ck doctor` flags — the root cause of issue #767 (anhhoangpham report:
+ * 16 stale entries remain after --fix).
+ *
+ * Uses `expectFixerConvergence` from the shared helper to enforce the
+ * detect→fix→detect convergence contract.
+ *
+ * @see src/__tests__/helpers/checker-fixer-parity.ts
+ * @see docs/code-standards.md — "Checker/Fixer Parity for autoFixable health checks"
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expectFixerConvergence } from "@/__tests__/helpers/checker-fixer-parity.js";
+import {
+	checkHookCommandPaths,
+	findStaleHookCommandsInFile,
+} from "@/domains/health-checks/checkers/hook-health-checker.js";
+
+// ---------------------------------------------------------------------------
+// Shared setup helpers
+// ---------------------------------------------------------------------------
+
+interface TestContext {
+	tempDir: string;
+	projectDir: string;
+	originalCkTestHome: string | undefined;
+}
+
+async function setupTestContext(): Promise<TestContext> {
+	const tempDir = join(
+		tmpdir(),
+		`hook-parity-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	const projectDir = join(tempDir, "project");
+	await mkdir(projectDir, { recursive: true });
+	const originalCkTestHome = process.env.CK_TEST_HOME;
+	process.env.CK_TEST_HOME = tempDir;
+	return { tempDir, projectDir, originalCkTestHome };
+}
+
+async function teardownTestContext(ctx: TestContext): Promise<void> {
+	await rm(ctx.tempDir, { recursive: true, force: true });
+	if (ctx.originalCkTestHome === undefined) {
+		process.env.CK_TEST_HOME = undefined;
+	} else {
+		process.env.CK_TEST_HOME = ctx.originalCkTestHome;
+	}
+}
+
+/**
+ * Build a settings.local.json fixture with 16 stale hook command paths,
+ * mirroring the exact user report (anhhoangpham — issue #767).
+ *
+ * Mixes:
+ * - 8 PreToolUse nested hooks (raw-relative)
+ * - 4 PostToolUse nested hooks (raw-relative)
+ * - 2 UserPromptSubmit flat commands (raw-relative)
+ * - 2 PreToolUse flat commands (raw-relative)
+ * Total: 16 stale entries
+ */
+function buildSixteenStaleHooksFixture(): object {
+	const makeNestedHook = (script: string) => ({
+		type: "command",
+		command: `node .claude/hooks/${script}`,
+	});
+	const makeFlatCommand = (script: string) => ({
+		type: "command",
+		command: `node .claude/hooks/${script}`,
+	});
+
+	return {
+		hooks: {
+			PreToolUse: [
+				{
+					matcher: "Read",
+					hooks: [makeNestedHook("scout-block.cjs"), makeNestedHook("privacy-block.cjs")],
+				},
+				{
+					matcher: "Write",
+					hooks: [makeNestedHook("write-guard.cjs"), makeNestedHook("path-validator.cjs")],
+				},
+				{
+					matcher: "Bash",
+					hooks: [makeNestedHook("bash-guard.cjs"), makeNestedHook("command-filter.cjs")],
+				},
+				{
+					matcher: "Edit",
+					hooks: [makeNestedHook("edit-guard.cjs"), makeNestedHook("ownership-check.cjs")],
+				},
+				// flat commands
+				makeFlatCommand("pre-tool-logger.cjs"),
+				makeFlatCommand("pre-tool-audit.cjs"),
+			],
+			PostToolUse: [
+				{
+					matcher: "Read",
+					hooks: [makeNestedHook("post-read-tracker.cjs")],
+				},
+				{
+					matcher: "Write",
+					hooks: [makeNestedHook("post-write-tracker.cjs")],
+				},
+				{
+					matcher: "Bash",
+					hooks: [makeNestedHook("post-bash-tracker.cjs")],
+				},
+				{
+					matcher: "Edit",
+					hooks: [makeNestedHook("post-edit-tracker.cjs")],
+				},
+			],
+			UserPromptSubmit: [
+				makeFlatCommand("session-state.cjs"),
+				makeFlatCommand("token-counter.cjs"),
+			],
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Parity tests
+// ---------------------------------------------------------------------------
+
+describe("hook-health-checker parity: checkHookCommandPaths detect→fix→detect convergence", () => {
+	let ctx: TestContext;
+
+	beforeEach(async () => {
+		ctx = await setupTestContext();
+	});
+
+	afterEach(async () => {
+		await teardownTestContext(ctx);
+	});
+
+	test("fixer converges: 16 stale entries all resolved after --fix (issue #767 regression)", async () => {
+		const settingsPath = join(ctx.projectDir, ".claude", "settings.local.json");
+		await mkdir(join(ctx.projectDir, ".claude"), { recursive: true });
+		await writeFile(settingsPath, JSON.stringify(buildSixteenStaleHooksFixture()));
+
+		// Build the settingsFile descriptor the same way the checker does.
+		const settingsFile = {
+			path: settingsPath,
+			label: "project settings.local.json",
+			root: "$CLAUDE_PROJECT_DIR",
+		};
+
+		await expectFixerConvergence({
+			// detect: read file from disk via the exported canonical function
+			detect: async (sf) => findStaleHookCommandsInFile(sf),
+			// fix: invoke the --fix path via the public checkHookCommandPaths API
+			fix: async (sf) => {
+				const result = await checkHookCommandPaths(ctx.projectDir);
+				expect(result.fix).toBeDefined();
+				const fixResult = await result.fix?.execute();
+				expect(fixResult?.success).toBe(true);
+				// Suppress "sf unused" — the fixture IS the settingsFile descriptor used by detect.
+				void sf;
+			},
+			fixture: settingsFile,
+		});
+	});
+
+	test("initial detection finds exactly 16 stale entries before fix", async () => {
+		const settingsPath = join(ctx.projectDir, ".claude", "settings.local.json");
+		await mkdir(join(ctx.projectDir, ".claude"), { recursive: true });
+		await writeFile(settingsPath, JSON.stringify(buildSixteenStaleHooksFixture()));
+
+		const settingsFile = {
+			path: settingsPath,
+			label: "project settings.local.json",
+			root: "$CLAUDE_PROJECT_DIR",
+		};
+
+		const findings = await findStaleHookCommandsInFile(settingsFile);
+		expect(findings).toHaveLength(16);
+	});
+
+	test("all 16 findings are raw-relative issues", async () => {
+		const settingsPath = join(ctx.projectDir, ".claude", "settings.local.json");
+		await mkdir(join(ctx.projectDir, ".claude"), { recursive: true });
+		await writeFile(settingsPath, JSON.stringify(buildSixteenStaleHooksFixture()));
+
+		const settingsFile = {
+			path: settingsPath,
+			label: "project settings.local.json",
+			root: "$CLAUDE_PROJECT_DIR",
+		};
+
+		const findings = await findStaleHookCommandsInFile(settingsFile);
+		for (const finding of findings) {
+			expect(finding.issue).toBe("raw-relative");
+		}
+	});
+
+	test("repaired commands all use canonical $CLAUDE_PROJECT_DIR form", async () => {
+		const settingsPath = join(ctx.projectDir, ".claude", "settings.local.json");
+		await mkdir(join(ctx.projectDir, ".claude"), { recursive: true });
+		await writeFile(settingsPath, JSON.stringify(buildSixteenStaleHooksFixture()));
+
+		const result = await checkHookCommandPaths(ctx.projectDir);
+		await result.fix?.execute();
+
+		// After fix, all expected values should be in canonical form
+		const settingsFile = {
+			path: settingsPath,
+			label: "project settings.local.json",
+			root: "$CLAUDE_PROJECT_DIR",
+		};
+		const remaining = await findStaleHookCommandsInFile(settingsFile);
+		expect(remaining).toHaveLength(0);
+
+		// Verify the file contains canonical paths
+		const repaired = JSON.parse(await Bun.file(settingsPath).text()) as {
+			hooks: {
+				PreToolUse: Array<{ hooks?: Array<{ command: string }>; command?: string }>;
+			};
+		};
+		// Check first nested hook has canonical form
+		const firstNestedHook = repaired.hooks.PreToolUse[0]?.hooks?.[0];
+		expect(firstNestedHook?.command).toMatch(/\$CLAUDE_PROJECT_DIR/);
+	});
+});
+
+describe("hook-health-checker parity: expectFixerConvergence helper catches divergence", () => {
+	let ctx: TestContext;
+
+	beforeEach(async () => {
+		ctx = await setupTestContext();
+	});
+
+	afterEach(async () => {
+		await teardownTestContext(ctx);
+	});
+
+	test("helper throws when fixer is a no-op (divergence proof)", async () => {
+		const settingsPath = join(ctx.projectDir, ".claude", "settings.local.json");
+		await mkdir(join(ctx.projectDir, ".claude"), { recursive: true });
+		await writeFile(
+			settingsPath,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Read",
+							hooks: [{ type: "command", command: "node .claude/hooks/scout-block.cjs" }],
+						},
+					],
+				},
+			}),
+		);
+
+		const settingsFile = {
+			path: settingsPath,
+			label: "project settings.local.json",
+			root: "$CLAUDE_PROJECT_DIR",
+		};
+
+		// A no-op fixer should cause expectFixerConvergence to fail
+		await expect(
+			expectFixerConvergence({
+				detect: async (sf) => findStaleHookCommandsInFile(sf),
+				fix: async (_sf) => {
+					// Intentionally does nothing — simulates a broken fixer
+				},
+				fixture: settingsFile,
+			}),
+		).rejects.toThrow();
+	});
+
+	test("helper throws when fixture has no stale entries (vacuous fixture guard)", async () => {
+		const settingsPath = join(ctx.projectDir, ".claude", "settings.local.json");
+		await mkdir(join(ctx.projectDir, ".claude"), { recursive: true });
+		await writeFile(
+			settingsPath,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Read",
+							hooks: [
+								{
+									type: "command",
+									// Already canonical — no stale entries
+									command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/scout-block.cjs',
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		const settingsFile = {
+			path: settingsPath,
+			label: "project settings.local.json",
+			root: "$CLAUDE_PROJECT_DIR",
+		};
+
+		// expectFixerConvergence should throw because before.length === 0
+		await expect(
+			expectFixerConvergence({
+				detect: async (sf) => findStaleHookCommandsInFile(sf),
+				fix: async (_sf) => {
+					// no-op
+				},
+				fixture: settingsFile,
+			}),
+		).rejects.toThrow();
+	});
+});

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker-parity.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker-parity.test.ts
@@ -20,6 +20,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expectFixerConvergence } from "@/__tests__/helpers/checker-fixer-parity.js";
 import {
+	type ClaudeSettingsFile,
 	checkHookCommandPaths,
 	findStaleHookCommandsInFile,
 } from "@/domains/health-checks/checkers/hook-health-checker.js";
@@ -49,7 +50,11 @@ async function setupTestContext(): Promise<TestContext> {
 async function teardownTestContext(ctx: TestContext): Promise<void> {
 	await rm(ctx.tempDir, { recursive: true, force: true });
 	if (ctx.originalCkTestHome === undefined) {
-		process.env.CK_TEST_HOME = undefined;
+		// Must use `delete` — assigning `undefined` to process.env coerces it to
+		// the string "undefined", causing test pollution (PathResolver would see
+		// CK_TEST_HOME as a non-empty string instead of unset).
+		// biome-ignore lint/performance/noDelete: process.env semantics require delete to truly unset
+		delete process.env.CK_TEST_HOME;
 	} else {
 		process.env.CK_TEST_HOME = ctx.originalCkTestHome;
 	}
@@ -146,7 +151,7 @@ describe("hook-health-checker parity: checkHookCommandPaths detect→fix→detec
 		await writeFile(settingsPath, JSON.stringify(buildSixteenStaleHooksFixture()));
 
 		// Build the settingsFile descriptor the same way the checker does.
-		const settingsFile = {
+		const settingsFile: ClaudeSettingsFile = {
 			path: settingsPath,
 			label: "project settings.local.json",
 			root: "$CLAUDE_PROJECT_DIR",
@@ -173,7 +178,7 @@ describe("hook-health-checker parity: checkHookCommandPaths detect→fix→detec
 		await mkdir(join(ctx.projectDir, ".claude"), { recursive: true });
 		await writeFile(settingsPath, JSON.stringify(buildSixteenStaleHooksFixture()));
 
-		const settingsFile = {
+		const settingsFile: ClaudeSettingsFile = {
 			path: settingsPath,
 			label: "project settings.local.json",
 			root: "$CLAUDE_PROJECT_DIR",
@@ -188,7 +193,7 @@ describe("hook-health-checker parity: checkHookCommandPaths detect→fix→detec
 		await mkdir(join(ctx.projectDir, ".claude"), { recursive: true });
 		await writeFile(settingsPath, JSON.stringify(buildSixteenStaleHooksFixture()));
 
-		const settingsFile = {
+		const settingsFile: ClaudeSettingsFile = {
 			path: settingsPath,
 			label: "project settings.local.json",
 			root: "$CLAUDE_PROJECT_DIR",
@@ -209,7 +214,7 @@ describe("hook-health-checker parity: checkHookCommandPaths detect→fix→detec
 		await result.fix?.execute();
 
 		// After fix, all expected values should be in canonical form
-		const settingsFile = {
+		const settingsFile: ClaudeSettingsFile = {
 			path: settingsPath,
 			label: "project settings.local.json",
 			root: "$CLAUDE_PROJECT_DIR",
@@ -257,7 +262,7 @@ describe("hook-health-checker parity: expectFixerConvergence helper catches dive
 			}),
 		);
 
-		const settingsFile = {
+		const settingsFile: ClaudeSettingsFile = {
 			path: settingsPath,
 			label: "project settings.local.json",
 			root: "$CLAUDE_PROJECT_DIR",
@@ -298,7 +303,7 @@ describe("hook-health-checker parity: expectFixerConvergence helper catches dive
 			}),
 		);
 
-		const settingsFile = {
+		const settingsFile: ClaudeSettingsFile = {
 			path: settingsPath,
 			label: "project settings.local.json",
 			root: "$CLAUDE_PROJECT_DIR",

--- a/src/__tests__/helpers/checker-fixer-parity.ts
+++ b/src/__tests__/helpers/checker-fixer-parity.ts
@@ -1,0 +1,73 @@
+/**
+ * checker-fixer-parity.ts
+ *
+ * Generic test helper that asserts detect→fix→detect convergence for any
+ * `autoFixable: true` health checker.
+ *
+ * Usage pattern (TDD):
+ *   1. Build a fixture that contains known stale entries.
+ *   2. Call `expectFixerConvergence` — it will:
+ *      a. Assert the detect function returns at least one finding (fixture is valid).
+ *      b. Call the fixer.
+ *      c. Assert the detect function now returns zero findings (fixer converged).
+ *
+ * If the fixer fails to converge the helper throws, proving the bug surfaced by
+ * anhhoangpham's report (ck doctor --fix → still 16 stale entries).
+ *
+ * @see docs/code-standards.md — "Checker/Fixer Parity for autoFixable health checks"
+ */
+
+import { expect } from "bun:test";
+
+/**
+ * Options for `expectFixerConvergence`.
+ *
+ * @template TFixture - The settings/config object the checker and fixer operate on.
+ * @template TFinding - The individual finding type returned by the detect function.
+ */
+export interface FixerConvergenceOptions<TFixture, TFinding> {
+	/**
+	 * Detect function: reads the fixture and returns all current findings.
+	 * Must return a non-empty array before the fix is applied (validates the fixture).
+	 */
+	detect: (fixture: TFixture) => TFinding[] | Promise<TFinding[]>;
+
+	/**
+	 * Fix function: mutates the fixture in place (or writes to disk) to resolve findings.
+	 * Called once between the two detect passes.
+	 */
+	fix: (fixture: TFixture) => void | Promise<void>;
+
+	/**
+	 * The fixture to pass to both detect and fix.
+	 * Typically a settings object, a temp-dir path, or an in-memory structure.
+	 */
+	fixture: TFixture;
+}
+
+/**
+ * Assert that a fixer fully resolves everything the detector flags.
+ *
+ * Fails if:
+ * - `detect(fixture)` returns zero findings before fix (bad fixture — test would be vacuous).
+ * - `detect(fixture)` returns any findings after fix (fixer did not converge).
+ *
+ * @throws {Error} If the fixture produces no initial findings (test authoring error).
+ * @throws {Error} If the fixer does not converge to zero findings.
+ */
+export async function expectFixerConvergence<TFixture, TFinding>(
+	options: FixerConvergenceOptions<TFixture, TFinding>,
+): Promise<void> {
+	const { detect, fix, fixture } = options;
+
+	// Phase 1: confirm the fixture is non-trivially stale.
+	const before = await detect(fixture);
+	expect(before.length).toBeGreaterThan(0);
+
+	// Phase 2: apply the fixer.
+	await fix(fixture);
+
+	// Phase 3: re-detect — fixer must have resolved ALL findings.
+	const after = await detect(fixture);
+	expect(after).toEqual([]);
+}

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -15,7 +15,7 @@ const HOOK_CHECK_TIMEOUT_MS = 5000;
 const PYTHON_CHECK_TIMEOUT_MS = 3000;
 const MAX_LOG_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
 
-interface ClaudeSettingsFile {
+export interface ClaudeSettingsFile {
 	path: string;
 	label: string;
 	root: string;

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -21,7 +21,7 @@ interface ClaudeSettingsFile {
 	root: string;
 }
 
-interface HookCommandFinding {
+export interface HookCommandFinding {
 	path: string;
 	label: string;
 	eventName: string;
@@ -29,6 +29,28 @@ interface HookCommandFinding {
 	command: string;
 	expected: string;
 	issue: "raw-relative" | "invalid-format";
+}
+
+/**
+ * Thrown when `repairHookCommandsInSettingsFile` applies fixes but a post-fix
+ * re-detection pass still finds stale entries. This indicates the fixer and
+ * detector have diverged — a checker/fixer parity violation.
+ *
+ * @see docs/code-standards.md — "Checker/Fixer Parity for autoFixable health checks"
+ */
+export class FixerDidNotConvergeError extends Error {
+	readonly unresolved: HookCommandFinding[];
+
+	constructor(unresolved: HookCommandFinding[]) {
+		const lines = unresolved
+			.map((f) => `  ${f.label} :: ${f.eventName} :: ${f.command}`)
+			.join("\n");
+		super(
+			`ck doctor --fix: fixer did not converge — ${unresolved.length} stale hook command path(s) remain after repair:\n${lines}\n\nThis is a bug. Please open an issue at https://github.com/mrgoonie/claudekit-cli`,
+		);
+		this.name = "FixerDidNotConvergeError";
+		this.unresolved = unresolved;
+	}
 }
 
 /**
@@ -141,19 +163,50 @@ function collectHookCommandFindings(
 	return findings;
 }
 
+/**
+ * Read a settings file from disk and return all stale hook command findings.
+ *
+ * This is the single canonical detect function used by both `checkHookCommandPaths`
+ * (reporting) and `repairHookCommandsInSettingsFile` (fixing). Keeping them on the
+ * same code path prevents checker/fixer divergence.
+ *
+ * @see docs/code-standards.md — "Checker/Fixer Parity for autoFixable health checks"
+ */
+export async function findStaleHookCommandsInFile(
+	settingsFile: ClaudeSettingsFile,
+): Promise<HookCommandFinding[]> {
+	const settings = await SettingsMerger.readSettingsFile(settingsFile.path);
+	if (!settings) {
+		return [];
+	}
+	return collectHookCommandFindings(settings, settingsFile);
+}
+
 async function repairHookCommandsInSettingsFile(settingsFile: ClaudeSettingsFile): Promise<number> {
 	const settings = await SettingsMerger.readSettingsFile(settingsFile.path);
 	if (!settings?.hooks) {
 		return 0;
 	}
 
+	// Phase 1: identify stale entries using the canonical detect function.
+	// This is the single source of truth — the same logic the checker uses.
+	const findings = collectHookCommandFindings(settings, settingsFile);
+	if (findings.length === 0) {
+		return 0;
+	}
+
+	// Phase 2: apply repairs. Build a lookup from stale command → expected command
+	// to avoid re-running repairClaudeNodeCommandPath independently (which would
+	// create a second divergence point).
+	const repairMap = new Map<string, string>(findings.map((f) => [f.command, f.expected]));
+
 	let repaired = 0;
 	for (const entries of Object.values(settings.hooks)) {
 		for (const entry of entries) {
 			if ("command" in entry && typeof entry.command === "string") {
-				const repair = repairClaudeNodeCommandPath(entry.command, settingsFile.root);
-				if (repair.changed) {
-					entry.command = repair.command;
+				const fixed = repairMap.get(entry.command);
+				if (fixed !== undefined) {
+					entry.command = fixed;
 					repaired++;
 				}
 			}
@@ -166,10 +219,9 @@ async function repairHookCommandsInSettingsFile(settingsFile: ClaudeSettingsFile
 				if (!hook.command) {
 					continue;
 				}
-
-				const repair = repairClaudeNodeCommandPath(hook.command, settingsFile.root);
-				if (repair.changed) {
-					hook.command = repair.command;
+				const fixed = repairMap.get(hook.command);
+				if (fixed !== undefined) {
+					hook.command = fixed;
 					repaired++;
 				}
 			}
@@ -178,6 +230,13 @@ async function repairHookCommandsInSettingsFile(settingsFile: ClaudeSettingsFile
 
 	if (repaired > 0) {
 		await SettingsMerger.writeSettingsFile(settingsFile.path, settings);
+	}
+
+	// Phase 3: post-fix verification — re-detect using the same canonical function.
+	// If the fixer is missing a code path the detector has, this will catch it.
+	const remaining = collectHookCommandFindings(settings, settingsFile);
+	if (remaining.length > 0) {
+		throw new FixerDidNotConvergeError(remaining);
 	}
 
 	return repaired;


### PR DESCRIPTION
## Summary

- Extracts `findStaleHookCommandsInFile` as the single source of truth used by both detect AND repair paths in `hook-health-checker.ts`. Previously both paths traversed independently and could drift — producing the user-reported case where `ck doctor` flags 16 stale hook command paths and `ck doctor --fix` runs but `ck doctor` still reports the same 16.
- Adds post-fix re-detect: if any stale entries remain after `repairHookCommandsInSettingsFile`, throw a typed `FixerDidNotConvergeError` listing the unresolved entries. Fixer can no longer claim false success.
- Introduces `expectFixerConvergence` test helper for any future `autoFixable: true` checker.

Closes #767
Part of #764

## Root Cause

`hook-health-checker.ts` (1411 LOC) had two independent traversals over `settings.hooks` — one to detect stale paths, one to repair them. Each called `repairClaudeNodeCommandPath` separately. When the traversals diverged on what counted as "stale" (e.g. due to subtle ordering or filter-condition drift), the fixer could no-op on entries the checker still flagged. There was no post-fix verification, so the inconsistency was invisible to the user.

## Changes

| File | Change |
|------|--------|
| `src/domains/health-checks/checkers/hook-health-checker.ts` | Single-source-of-truth `findStaleHookCommandsInFile` + post-fix convergence guard; new `FixerDidNotConvergeError` type |
| `src/__tests__/helpers/checker-fixer-parity.ts` (NEW) | Generic `expectFixerConvergence` helper for any autoFixable checker |
| `src/__tests__/domains/health-checks/checkers/hook-health-checker-parity.test.ts` (NEW) | 6 parity tests: 4 convergence (incl. the 16-stale fixture matching reported case) + 2 divergence-proof |
| `docs/code-standards.md` | New rule: every `autoFixable: true` checker MUST have a parity test |

## Test plan

- [x] `bun run validate` (typecheck + lint + 4616 unit + 165 UI tests + build) — green
- [x] 6 new parity tests pass + 41 existing hook-health-checker tests still pass
- [x] Manual repro: 16-stale-paths fixture → run fixer → re-detect → reports 0 stale