### PR TITLE
fix(install): make ck init --fresh tolerate metadata.json self-tracking

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "3.42.2-dev.10",
-	"generatedAt": "2026-05-05T16:16:42.513Z",
+	"version": "3.42.2-dev.11",
+	"generatedAt": "2026-05-05T16:48:44.844Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1057,4 +1057,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-05T16:16:42.634Z -->
+<!-- generated: 2026-05-05T16:48:45.217Z -->

--- a/src/__tests__/domains/installation/fresh-installer.test.ts
+++ b/src/__tests__/domains/installation/fresh-installer.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Tests for fresh-installer.ts — the metadata.json self-tracking bug (#777)
+ *
+ * Fixtures:
+ *   A. metadata.json self-tracked in kits.*.files[] → must NOT throw
+ *   B. metadata.json missing mid-cleanup (race) → must NOT throw
+ *   C. Happy path — metadata.json not self-tracked
+ *   D. Mixed ownership — ck, ck-modified, user; metadata.json self-tracked
+ *   E. Legacy format (no kits) — metadata.json self-tracked
+ *
+ * NOTE: mock.module calls must appear before the static import of the module
+ * under test. Bun hoists static `import` declarations but not mock.module —
+ * the server.test.ts pattern places mock.module calls first and the
+ * `import { ... }` after them (at the bottom of the preamble section).
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { type TestPaths, setupTestPaths } from "../../../../tests/helpers/test-paths.js";
+
+// ─── Module mocks — must be resolved before the SUT import below ─────────────
+
+// NOTE: ora mock intentionally omitted — safe-spinner is mocked below, which
+// covers the only transitive ora usage in this code path.
+
+// Spinner stub — avoids TTY checks and ora transitive dep
+// NOTE: backup, lock, and proper-lockfile are NOT mocked here.
+// CK_TEST_HOME (set by setupTestPaths in beforeEach) isolates all file-system
+// operations to a per-test tmpdir so the real implementations run safely.
+mock.module("@/shared/safe-spinner.js", () => ({
+	createSpinner: () => ({
+		start: () => ({ succeed: () => {}, fail: () => {}, stop: () => {} }),
+		succeed: () => {},
+		fail: () => {},
+		stop: () => {},
+	}),
+}));
+
+// ─── Import SUT after mocks are registered ────────────────────────────────────
+
+import { handleFreshInstallation } from "@/domains/installation/fresh-installer.js";
+import type { PromptsManager } from "@/domains/ui/prompts.js";
+
+// ─── Fixtures / helpers ───────────────────────────────────────────────────────
+
+const FAKE_CHECKSUM = "a".repeat(64);
+const FAKE_VERSION = "1.0.0";
+const FAKE_DATE = "2024-01-01T00:00:00.000Z";
+
+const autoConfirmPrompts = {
+	promptFreshConfirmation: async () => true,
+} as unknown as PromptsManager;
+
+function makeTrackedFile(path: string, ownership: "ck" | "ck-modified" | "user" = "ck") {
+	return {
+		path,
+		checksum: FAKE_CHECKSUM,
+		ownership,
+		installedVersion: FAKE_VERSION,
+		installedAt: FAKE_DATE,
+	};
+}
+
+function makeMultiKitMetadata(
+	files: ReturnType<typeof makeTrackedFile>[],
+	selfTrackMetadata = false,
+) {
+	const fileList = selfTrackMetadata ? [makeTrackedFile("metadata.json", "ck"), ...files] : files;
+	return {
+		kits: {
+			engineer: { version: FAKE_VERSION, installedAt: FAKE_DATE, files: fileList },
+		},
+	};
+}
+
+function makeLegacyMetadata(
+	files: ReturnType<typeof makeTrackedFile>[],
+	selfTrackMetadata = false,
+) {
+	const fileList = selfTrackMetadata ? [makeTrackedFile("metadata.json", "ck"), ...files] : files;
+	return {
+		name: "claudekit-engineer",
+		version: FAKE_VERSION,
+		installedAt: FAKE_DATE,
+		files: fileList,
+	};
+}
+
+function writeMetadata(claudeDir: string, metadata: object) {
+	writeFileSync(join(claudeDir, "metadata.json"), JSON.stringify(metadata, null, 2));
+}
+
+function writeTrackedFile(claudeDir: string, relativePath: string) {
+	const fullPath = join(claudeDir, relativePath);
+	const parts = relativePath.split("/");
+	if (parts.length > 1) {
+		mkdirSync(join(claudeDir, ...parts.slice(0, -1)), { recursive: true });
+	}
+	writeFileSync(fullPath, `# ${relativePath}`);
+}
+
+async function runFreshInstall(claudeDir: string): Promise<{ success: boolean; error?: string }> {
+	try {
+		const result = await handleFreshInstallation(claudeDir, autoConfirmPrompts);
+		return { success: result };
+	} catch (err) {
+		return { success: false, error: err instanceof Error ? err.message : String(err) };
+	}
+}
+
+// ─── Test lifecycle ───────────────────────────────────────────────────────────
+
+// testPaths sets process.env.CK_TEST_HOME so PathResolver roots all directories
+// (backups, locks, config) under an isolated tmpdir — prevents pollution of the
+// real ~/.claudekit and avoids interference with other test files.
+let testPaths: TestPaths;
+let claudeDir: string;
+
+beforeEach(() => {
+	testPaths = setupTestPaths();
+	// claudeDir lives inside testHome so backup/lock subsystems stay within CK_TEST_HOME
+	claudeDir = testPaths.claudeDir;
+	mkdirSync(claudeDir, { recursive: true });
+});
+
+afterEach(() => {
+	testPaths.cleanup();
+});
+
+// Restore all mock.module stubs so subsequent test files in the same Bun worker
+// get the real implementations (backup, lock, proper-lockfile, safe-spinner).
+afterAll(() => {
+	mock.restore();
+});
+
+// ─── Fixture A: metadata.json self-tracked ────────────────────────────────────
+
+describe("Fixture A — metadata.json self-tracked in kits.engineer.files", () => {
+	test("handleFreshInstallation returns true without throwing", async () => {
+		writeMetadata(
+			claudeDir,
+			makeMultiKitMetadata(
+				[makeTrackedFile("commands/test.md", "ck")],
+				true, // metadata.json listed as ck-owned tracked file
+			),
+		);
+		writeTrackedFile(claudeDir, "commands/test.md");
+
+		const result = await runFreshInstall(claudeDir);
+
+		expect(result.success).toBe(true);
+		expect(result.error).toBeUndefined();
+	});
+
+	test("does not emit 'metadata.json is missing' error", async () => {
+		writeMetadata(
+			claudeDir,
+			makeMultiKitMetadata([makeTrackedFile("commands/test.md", "ck")], true),
+		);
+		writeTrackedFile(claudeDir, "commands/test.md");
+
+		const result = await runFreshInstall(claudeDir);
+
+		expect(result.error ?? "").not.toContain("metadata.json is missing");
+	});
+
+	test("CK-owned tracked files are removed", async () => {
+		writeMetadata(
+			claudeDir,
+			makeMultiKitMetadata([makeTrackedFile("commands/ck-file.md", "ck")], true),
+		);
+		writeTrackedFile(claudeDir, "commands/ck-file.md");
+
+		await runFreshInstall(claudeDir);
+
+		expect(existsSync(join(claudeDir, "commands/ck-file.md"))).toBe(false);
+	});
+});
+
+// ─── Fixture B: metadata.json missing mid-cleanup (race) ─────────────────────
+
+describe("Fixture B — metadata.json missing mid-cleanup (race condition)", () => {
+	test("tolerates no metadata.json on disk (fallback path, no throw)", async () => {
+		// No metadata → analyzeFreshInstallation returns hasMetadata:false
+		// → fallback removeSubdirectoriesFallback is taken; must succeed
+		writeTrackedFile(claudeDir, "commands/leftover.md");
+		const metaPath = join(claudeDir, "metadata.json");
+		if (existsSync(metaPath)) unlinkSync(metaPath);
+
+		const result = await runFreshInstall(claudeDir);
+
+		expect(result.success).toBe(true);
+		expect(result.error ?? "").not.toContain("metadata.json is missing");
+	});
+
+	test("metadata.json deleted before run still succeeds via fallback", async () => {
+		// Valid metadata written then immediately deleted — simulates worst-case race
+		writeMetadata(claudeDir, makeMultiKitMetadata([makeTrackedFile("commands/a.md", "ck")]));
+		writeTrackedFile(claudeDir, "commands/a.md");
+		unlinkSync(join(claudeDir, "metadata.json"));
+
+		const result = await runFreshInstall(claudeDir);
+
+		expect(result.success).toBe(true);
+		expect(result.error ?? "").not.toContain("metadata.json is missing");
+	});
+});
+
+// ─── Fixture C: Happy path ────────────────────────────────────────────────────
+
+describe("Fixture C — happy path (metadata.json NOT self-tracked)", () => {
+	test("returns true and metadata.json post-run has empty kit files array", async () => {
+		writeMetadata(
+			claudeDir,
+			makeMultiKitMetadata([
+				makeTrackedFile("commands/cmd.md", "ck"),
+				makeTrackedFile("rules/rule.md", "ck"),
+			]),
+		);
+		writeTrackedFile(claudeDir, "commands/cmd.md");
+		writeTrackedFile(claudeDir, "rules/rule.md");
+
+		const result = await runFreshInstall(claudeDir);
+
+		expect(result.success).toBe(true);
+		expect(result.error).toBeUndefined();
+		expect(existsSync(join(claudeDir, "metadata.json"))).toBe(true);
+		const meta = JSON.parse(readFileSync(join(claudeDir, "metadata.json"), "utf-8"));
+		expect(meta.kits?.engineer?.files).toEqual([]);
+	});
+
+	test("tracked CK files are removed", async () => {
+		writeMetadata(claudeDir, makeMultiKitMetadata([makeTrackedFile("commands/cmd.md", "ck")]));
+		writeTrackedFile(claudeDir, "commands/cmd.md");
+
+		await runFreshInstall(claudeDir);
+
+		expect(existsSync(join(claudeDir, "commands/cmd.md"))).toBe(false);
+	});
+
+	test("user-owned files are preserved", async () => {
+		writeMetadata(
+			claudeDir,
+			makeMultiKitMetadata([
+				makeTrackedFile("commands/ck.md", "ck"),
+				makeTrackedFile("commands/user.md", "user"),
+			]),
+		);
+		writeTrackedFile(claudeDir, "commands/ck.md");
+		writeTrackedFile(claudeDir, "commands/user.md");
+
+		await runFreshInstall(claudeDir);
+
+		expect(existsSync(join(claudeDir, "commands/user.md"))).toBe(true);
+	});
+});
+
+// ─── Fixture D: Mixed ownership, metadata.json self-tracked ──────────────────
+
+describe("Fixture D — mixed ownership, metadata.json self-tracked", () => {
+	test("ck and ck-modified removed, user preserved, no throw", async () => {
+		writeMetadata(
+			claudeDir,
+			makeMultiKitMetadata(
+				[
+					makeTrackedFile("commands/ck.md", "ck"),
+					makeTrackedFile("commands/modified.md", "ck-modified"),
+					makeTrackedFile("commands/user.md", "user"),
+				],
+				true, // metadata.json self-tracked as ck-owned
+			),
+		);
+		writeTrackedFile(claudeDir, "commands/ck.md");
+		writeTrackedFile(claudeDir, "commands/modified.md");
+		writeTrackedFile(claudeDir, "commands/user.md");
+
+		const result = await runFreshInstall(claudeDir);
+
+		expect(result.success).toBe(true);
+		expect(result.error).toBeUndefined();
+		// ck + ck-modified removed (handleFreshInstallation passes includeModified=true)
+		expect(existsSync(join(claudeDir, "commands/ck.md"))).toBe(false);
+		expect(existsSync(join(claudeDir, "commands/modified.md"))).toBe(false);
+		// user-owned preserved
+		expect(existsSync(join(claudeDir, "commands/user.md"))).toBe(true);
+	});
+});
+
+// ─── Fixture E: Legacy metadata (no kits), metadata.json self-tracked ────────
+
+describe("Fixture E — legacy format (no kits), metadata.json self-tracked", () => {
+	test("succeeds without throwing", async () => {
+		writeMetadata(
+			claudeDir,
+			makeLegacyMetadata(
+				[makeTrackedFile("commands/legacy.md", "ck")],
+				true, // metadata.json self-tracked in legacy files[]
+			),
+		);
+		writeTrackedFile(claudeDir, "commands/legacy.md");
+
+		const result = await runFreshInstall(claudeDir);
+
+		expect(result.success).toBe(true);
+		expect(result.error).toBeUndefined();
+	});
+
+	test("does not throw 'metadata.json is missing' error", async () => {
+		writeMetadata(
+			claudeDir,
+			makeLegacyMetadata([makeTrackedFile("commands/legacy.md", "ck")], true),
+		);
+		writeTrackedFile(claudeDir, "commands/legacy.md");
+
+		const result = await runFreshInstall(claudeDir);
+
+		expect(result.error ?? "").not.toContain("metadata.json is missing");
+	});
+
+	test("CK files removed", async () => {
+		writeMetadata(
+			claudeDir,
+			makeLegacyMetadata([makeTrackedFile("commands/legacy.md", "ck")], true),
+		);
+		writeTrackedFile(claudeDir, "commands/legacy.md");
+
+		await runFreshInstall(claudeDir);
+
+		expect(existsSync(join(claudeDir, "commands/legacy.md"))).toBe(false);
+	});
+});

--- a/src/domains/installation/fresh-installer.ts
+++ b/src/domains/installation/fresh-installer.ts
@@ -13,7 +13,13 @@ import { readManifest } from "@/services/file-operations/manifest/manifest-reade
 import { logger } from "@/shared/logger.js";
 import { createSpinner } from "@/shared/safe-spinner.js";
 import type { KitType, Metadata, TrackedFile } from "@/types";
-import { pathExists, readFile, writeFile } from "fs-extra";
+import { pathExists, writeFile } from "fs-extra";
+
+/**
+ * The metadata manifest file name — managed exclusively by updateMetadataAfterFresh,
+ * never deleted as a regular tracked file during the removal loop.
+ */
+const KIT_MANIFEST_FILE = "metadata.json";
 
 /**
  * ClaudeKit-managed subdirectories (fallback when no metadata)
@@ -28,6 +34,9 @@ export interface FreshAnalysisResult {
 	ckModifiedFiles: TrackedFile[]; // CK files modified by user (need confirmation)
 	userFiles: TrackedFile[]; // User-created files (will be preserved)
 	hasMetadata: boolean;
+	/** In-memory snapshot of the parsed metadata — used to avoid re-reading metadata.json
+	 *  after tracked files (potentially including metadata.json itself) are deleted. */
+	metadata: Metadata | null;
 }
 
 /**
@@ -47,7 +56,9 @@ interface FreshBackupTargets {
 }
 
 /**
- * Analyze files for fresh installation based on ownership
+ * Analyze files for fresh installation based on ownership.
+ * Returns the parsed metadata in-memory so callers can write it back
+ * without re-reading the file (which may be gone after the delete loop).
  */
 export async function analyzeFreshInstallation(claudeDir: string): Promise<FreshAnalysisResult> {
 	const metadata = await readManifest(claudeDir);
@@ -58,6 +69,7 @@ export async function analyzeFreshInstallation(claudeDir: string): Promise<Fresh
 			ckModifiedFiles: [],
 			userFiles: [],
 			hasMetadata: false,
+			metadata: null,
 		};
 	}
 
@@ -69,6 +81,7 @@ export async function analyzeFreshInstallation(claudeDir: string): Promise<Fresh
 			ckModifiedFiles: [],
 			userFiles: [],
 			hasMetadata: false,
+			metadata: null,
 		};
 	}
 
@@ -95,6 +108,7 @@ export async function analyzeFreshInstallation(claudeDir: string): Promise<Fresh
 		ckModifiedFiles,
 		userFiles,
 		hasMetadata: true,
+		metadata,
 	};
 }
 
@@ -127,7 +141,15 @@ function cleanupEmptyDirectories(filePath: string, claudeDir: string): void {
 }
 
 /**
- * Remove files by ownership tracking (smart removal)
+ * Remove files by ownership tracking (smart removal).
+ *
+ * Defense-in-depth against the metadata.json self-tracking bug (#777):
+ * 1. metadata.json is excluded from the delete loop — it is managed exclusively
+ *    by updateMetadataAfterFresh.
+ * 2. updateMetadataAfterFresh operates on the in-memory metadata snapshot captured
+ *    by analyzeFreshInstallation, so it never re-reads metadata.json from disk.
+ * 3. If metadata.json is absent at write time (race / prior partial run), it is
+ *    recreated from the in-memory snapshot rather than throwing.
  */
 async function removeFilesByOwnership(
 	claudeDir: string,
@@ -138,7 +160,7 @@ async function removeFilesByOwnership(
 	const preservedFiles: string[] = [];
 
 	// Determine which files to remove
-	const filesToRemove = includeModified
+	const allFilesToRemove = includeModified
 		? [...analysis.ckFiles, ...analysis.ckModifiedFiles]
 		: analysis.ckFiles;
 
@@ -146,7 +168,17 @@ async function removeFilesByOwnership(
 		? analysis.userFiles
 		: [...analysis.ckModifiedFiles, ...analysis.userFiles];
 
-	// Remove CK-owned files
+	// Defense layer 2: exclude metadata.json from the delete loop.
+	// It is managed solely by updateMetadataAfterFresh below.
+	const filesToRemove = allFilesToRemove.filter((f) => f.path !== KIT_MANIFEST_FILE);
+	const selfTrackedManifest = allFilesToRemove.some((f) => f.path === KIT_MANIFEST_FILE);
+	if (selfTrackedManifest) {
+		logger.debug(
+			`${KIT_MANIFEST_FILE} was self-tracked; skipping from delete loop — will be rewritten by updateMetadataAfterFresh`,
+		);
+	}
+
+	// Remove CK-owned files (metadata.json excluded above)
 	for (const file of filesToRemove) {
 		const fullPath = join(claudeDir, file.path);
 		if (!existsSync(fullPath)) {
@@ -172,9 +204,9 @@ async function removeFilesByOwnership(
 		preservedFiles.push(file.path);
 	}
 
-	// Update metadata.json to remove tracking for deleted files
-	if (removedFiles.length > 0) {
-		await updateMetadataAfterFresh(claudeDir, removedFiles);
+	// Update metadata.json using the in-memory snapshot (defense layer 1 + 3)
+	if (analysis.metadata) {
+		await updateMetadataAfterFresh(claudeDir, removedFiles, analysis.metadata);
 	}
 
 	return {
@@ -188,38 +220,26 @@ async function removeFilesByOwnership(
 
 /**
  * Update metadata.json after fresh install to remove deleted file entries.
+ *
+ * Operates on the in-memory metadata snapshot from analyzeFreshInstallation to
+ * avoid a second disk read — which would fail if metadata.json was self-tracked
+ * and deleted during the removal loop.
+ *
+ * Defense layer 3: if metadata.json is absent on disk (race condition / partial
+ * prior run), it is recreated from the in-memory snapshot with a warning instead
+ * of throwing.
+ *
  * Callers must already hold the installation-state lock for claudeDir.
  */
-async function updateMetadataAfterFresh(claudeDir: string, removedFiles: string[]): Promise<void> {
-	const metadataPath = join(claudeDir, "metadata.json");
-
-	if (!(await pathExists(metadataPath))) {
-		throw new Error("metadata.json is missing during fresh install cleanup");
-	}
-
-	// Read metadata file
-	let content: string;
-	try {
-		content = await readFile(metadataPath, "utf-8");
-	} catch (readError) {
-		throw new Error(
-			`Failed to read metadata.json: ${readError instanceof Error ? readError.message : String(readError)}`,
-		);
-	}
-
-	// Parse metadata JSON
-	let metadata: Metadata;
-	try {
-		metadata = JSON.parse(content);
-	} catch (parseError) {
-		throw new Error(
-			`Failed to parse metadata.json: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-		);
-	}
-
+async function updateMetadataAfterFresh(
+	claudeDir: string,
+	removedFiles: string[],
+	metadata: Metadata,
+): Promise<void> {
+	const metadataPath = join(claudeDir, KIT_MANIFEST_FILE);
 	const removedSet = new Set(removedFiles);
 
-	// Update each kit's files array
+	// Filter removed files out of the in-memory snapshot
 	if (metadata.kits) {
 		for (const kitName of Object.keys(metadata.kits)) {
 			const kit = metadata.kits[kitName as KitType];
@@ -234,13 +254,20 @@ async function updateMetadataAfterFresh(claudeDir: string, removedFiles: string[
 		metadata.files = metadata.files.filter((f) => !removedSet.has(f.path));
 	}
 
-	// Write updated metadata
+	// Defense layer 3: tolerate absence — recreate from in-memory snapshot
+	if (!(await pathExists(metadataPath))) {
+		logger.warning(
+			`${KIT_MANIFEST_FILE} was absent at write time (self-tracked or race condition) — recreating from in-memory snapshot`,
+		);
+	}
+
+	// Write updated metadata (create or overwrite)
 	try {
 		await writeFile(metadataPath, JSON.stringify(metadata, null, 2));
-		logger.debug(`Updated metadata.json, removed ${removedFiles.length} file entries`);
+		logger.debug(`Updated ${KIT_MANIFEST_FILE}, removed ${removedFiles.length} file entries`);
 	} catch (writeError) {
 		throw new Error(
-			`Failed to write metadata.json: ${writeError instanceof Error ? writeError.message : String(writeError)}`,
+			`Failed to write ${KIT_MANIFEST_FILE}: ${writeError instanceof Error ? writeError.message : String(writeError)}`,
 		);
 	}
 }


### PR DESCRIPTION
## Summary

`ck init -g --fresh` aborted with `Failed to remove files: metadata.json is missing during fresh install cleanup` even though the file existed before the run. After this PR fresh installs complete end-to-end against any well-formed multi-kit metadata, including the case where `metadata.json` is itself listed in tracked files.

Closes #777
Part of #775

## Root Cause

`removeFilesByOwnership` deleted every entry in `getAllTrackedFiles(metadata)`. On installs whose multi-kit metadata listed `metadata.json` in `kits.<kit>.files[]`, the loop unlinked the manifest mid-pass; the follow-up `updateMetadataAfterFresh` then failed its `pathExists(metadataPath)` guard at `fresh-installer.ts:196` and threw the error users saw.

## What changed

Three layers of defense in `src/domains/installation/fresh-installer.ts`:

1. **In-memory snapshot.** `analyzeFreshInstallation` now carries the parsed `Metadata` object forward in its return value. `removeFilesByOwnership` and `updateMetadataAfterFresh` operate on that snapshot instead of re-reading `metadata.json` from disk. The second `readFile` is gone.
2. **Filter manifest from delete loop.** New `KIT_MANIFEST_FILE = \"metadata.json\"` const; `removeFilesByOwnership` filters it out of `filesToRemove`. The manifest is managed exclusively by `updateMetadataAfterFresh`.
3. **Tolerate absent manifest on write.** `updateMetadataAfterFresh` logs a warning and recreates the file from the in-memory snapshot instead of throwing. Recovery backup already protects the original via `getFreshBackupTargets` `mutatePaths`.

| File | Change |
|------|--------|
| `src/domains/installation/fresh-installer.ts` | +66 / −39. Three-layer fix above. Public `analyzeFreshInstallation` shape extended (added `metadata` field) — backwards-compatible. |
| `src/__tests__/domains/installation/fresh-installer.test.ts` | New, 12 fixtures: self-tracked manifest, mid-cleanup race, happy path, mixed ownership, legacy format. Uses `CK_TEST_HOME` via `setupTestPaths()` so backup/lock subsystems run under isolated tmpdirs. |

## Test plan

- [x] Pre-fix: 5 of 12 fixtures fail on baseline dev. Fixture E reproduces the exact error string.
- [x] Post-fix: 12/12 new fixtures pass.
- [x] Full suite → 4589 pass, 54 skip, 0 fail
- [x] bun run validate → exit 0

## Notes

destructive-operation-backup.ts, manifest-writer.ts, and installation-state-lock.ts are intentionally untouched — out of scope. The recovery-backup path through getFreshBackupTargets still snapshots metadata.json in mutatePaths, so rollback is unaffected.