### PR TITLE
fix: count skill when_to_use in budget estimates

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.0.0",
-	"generatedAt": "2026-05-07T12:55:54.975Z",
+	"version": "4.0.0-dev.1",
+	"generatedAt": "2026-05-07T15:41:52.426Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1061,4 +1061,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-07T12:55:55.092Z -->
+<!-- generated: 2026-05-07T15:41:58.534Z -->

--- a/src/__tests__/domains/health-checks/checkers/skill-budget-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/skill-budget-checker.test.ts
@@ -78,6 +78,30 @@ describe("checkSkillBudget", () => {
 		expect(settings.skillListingMaxDescChars).toBe(512);
 	});
 
+	test("counts when_to_use in the active skill listing budget estimate", async () => {
+		for (let index = 0; index < 60; index++) {
+			await writeSkill(join(projectDir, ".claude", "skills"), `project-${index}`, {
+				description: "x".repeat(300),
+				whenToUse: "y".repeat(199),
+				userInvocable: true,
+			});
+		}
+
+		const results = await checkSkillBudget(createEngineerSetup(), projectDir);
+		const budget = resultById(results, "ck-skill-listing-budget");
+
+		expect(budget.status).toBe("fail");
+		expect(budget.message).toContain("skillListingBudgetFraction >= 0.039");
+
+		const fix = await budget.fix?.execute();
+		expect(fix?.success).toBe(true);
+
+		const settings = JSON.parse(
+			await readFile(join(projectDir, ".claude", "settings.json"), "utf8"),
+		);
+		expect(settings.skillListingBudgetFraction).toBe(0.039);
+	});
+
 	test("computes budget against ClaudeKit cap when existing max description setting is too high", async () => {
 		for (let index = 0; index < 60; index++) {
 			await writeSkill(join(projectDir, ".claude", "skills"), `project-${index}`, {
@@ -356,18 +380,20 @@ function createNonEngineerSetup(): ClaudeKitSetup {
 async function writeSkill(
 	skillsDir: string,
 	name: string,
-	options: { description?: string; userInvocable?: boolean },
+	options: { description?: string; whenToUse?: string; userInvocable?: boolean },
 ): Promise<void> {
 	const skillDir = join(skillsDir, name);
 	await mkdir(skillDir, { recursive: true });
 	const userInvocable =
 		options.userInvocable === undefined ? "" : `user-invocable: ${options.userInvocable}\n`;
+	const whenToUse = options.whenToUse === undefined ? "" : `when_to_use: "${options.whenToUse}"`;
 	await writeFile(
 		join(skillDir, "SKILL.md"),
 		[
 			"---",
 			`name: ck:${name}`,
 			`description: "${options.description ?? `Skill for ${name}`}"`,
+			whenToUse,
 			userInvocable.trimEnd(),
 			"---",
 			"",

--- a/src/domains/health-checks/checkers/skill-budget-checker.ts
+++ b/src/domains/health-checks/checkers/skill-budget-checker.ts
@@ -187,7 +187,7 @@ function buildSkillOverridesCheck(settingsPath: string, read: SettingsRead): Che
 		"ck-skill-overrides-policy",
 		"Skill Overrides Policy",
 		"Project settings contain skillOverrides",
-		[{ id: "skillOverrides", description: "", file: settingsPath }],
+		[{ id: "skillOverrides", description: "", whenToUse: "", file: settingsPath }],
 		"Remove skillOverrides and manage listing pressure with skillListingBudgetFraction, skillListingMaxDescChars, and inventory cleanup.",
 	);
 }

--- a/src/domains/health-checks/checkers/skill-budget-scanner.ts
+++ b/src/domains/health-checks/checkers/skill-budget-scanner.ts
@@ -10,6 +10,7 @@ const SKIP_DIRS = new Set([".git", ".venv", "__pycache__", "node_modules", "scri
 export interface SkillMeta {
 	id: string;
 	description: string;
+	whenToUse: string;
 	file: string;
 	userInvocable?: boolean;
 }
@@ -28,6 +29,7 @@ export async function scanSkills(skillsDir: string): Promise<SkillMeta[]> {
 			skills.push({
 				id: normalizeSkillId(rawName, fallbackId),
 				description: typeof data.description === "string" ? data.description : "",
+				whenToUse: typeof data.when_to_use === "string" ? data.when_to_use : "",
 				file,
 				userInvocable:
 					typeof data["user-invocable"] === "boolean" ? data["user-invocable"] : undefined,

--- a/src/domains/health-checks/checkers/skill-budget-settings.ts
+++ b/src/domains/health-checks/checkers/skill-budget-settings.ts
@@ -31,7 +31,7 @@ export async function readProjectSettings(settingsPath: string): Promise<Setting
 }
 
 export function estimateListingChars(
-	skills: { id: string; description: string }[],
+	skills: { id: string; description: string; whenToUse?: string }[],
 	maxDescChars: number,
 ) {
 	if (skills.length === 0) return 0;
@@ -40,9 +40,15 @@ export function estimateListingChars(
 			sum +
 			skill.id.length +
 			LISTING_OVERHEAD_PER_SKILL +
-			Math.min(skill.description.length, maxDescChars)
+			Math.min(getListingText(skill).length, maxDescChars)
 		);
 	}, skills.length - 1);
+}
+
+function getListingText(skill: { description: string; whenToUse?: string }): string {
+	if (!skill.whenToUse) return skill.description;
+	if (!skill.description) return skill.whenToUse;
+	return `${skill.description}\n${skill.whenToUse}`;
 }
 
 export function requiredBudgetFraction(listingChars: number, contextTokens = CONTEXT_FLOOR_TOKENS) {

--- a/src/domains/skills/skill-schema.json
+++ b/src/domains/skills/skill-schema.json
@@ -19,6 +19,11 @@
 			"maxLength": 512,
 			"description": "Human-readable description of the skill and when to use it"
 		},
+		"when_to_use": {
+			"type": "string",
+			"maxLength": 1024,
+			"description": "Additional invocation context appended to description in Claude Code skill listings"
+		},
 		"user-invocable": {
 			"type": "boolean",
 			"description": "Whether the skill appears in the user slash-command menu. False keeps it available for agent invocation."


### PR DESCRIPTION
Closes #782

## Summary
- parse SKILL.md `when_to_use` into skill budget inventory metadata
- include `description + when_to_use` in listing-budget estimation before the configured listing cap is applied
- allow `when_to_use` in the shipped skill schema and cover the large-inventory regression
- refresh the generated CLI manifest version after CI caught the stale artifact

## Root cause
The budget doctor recognized skill descriptions but did not carry optional `when_to_use` text into its listing-size estimate, so it could understate Claude Code skill-listing pressure once Engineer skills add routing metadata.

## Validation
- `bun test src/__tests__/domains/health-checks/checkers/skill-budget-checker.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run help:check-parity`
- `git diff --check`
- pre-push quality gate: lint, typecheck, build, UI build, full test suite, UI tests
