### PR TITLE
fix: clarify kit-scoped uninstall flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Remove ClaudeKit installations from your system:
 ck uninstall              # Interactive mode - prompts for scope and confirmation
 ck uninstall --local      # Uninstall only local installation (current project)
 ck uninstall --global     # Uninstall only global installation (~/.claude/)
+ck uninstall -g --kit marketing  # Remove only global Marketing kit
 ck uninstall -l -y        # Local only, skip confirmation
 ck uninstall -g -y        # Global only, skip confirmation
 ck uninstall --yes        # Non-interactive - skip confirmation (for scripts)
@@ -334,7 +335,11 @@ ck uninstall --yes        # Non-interactive - skip confirmation (for scripts)
   - **Local only**: Remove from current project (`.claude/`)
   - **Global only**: Remove from user directory (`~/.claude/`)
   - **Both**: Remove all ClaudeKit installations
+- When multiple kits are installed in the selected scope, interactive uninstall prompts for:
+  - **Marketing kit only** or **Engineer kit only**: Remove one kit and preserve the other
+  - **All ClaudeKit kits**: Remove the full selected installation scope
 - Use `--local` or `--global` flags to skip the prompt
+- Use `--kit engineer` or `--kit marketing` to skip the kit prompt
 
 **What it does:**
 - Detects local `.claude` directory in current project

--- a/__tests__/domains/help/help-commands.test.ts
+++ b/__tests__/domains/help/help-commands.test.ts
@@ -222,7 +222,10 @@ describe("help-commands", () => {
 			expect(help.name).toBe("uninstall");
 			expect(help.description).toContain("Remove");
 			expect(help.usage).toBe("ck uninstall [options]");
-			expect(help.examples).toHaveLength(2);
+			expect(help.examples).toHaveLength(3);
+			expect(help.examples.map((example) => example.command)).toContain(
+				"ck uninstall --global --kit marketing",
+			);
 		});
 	});
 

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.0.0-dev.1",
-	"generatedAt": "2026-05-07T15:41:52.426Z",
+	"version": "4.0.0-dev.2",
+	"generatedAt": "2026-05-09T02:35:34.274Z",
 	"commands": {
 		"agents": {
 			"name": "agents",
@@ -1922,6 +1922,10 @@
 			"description": "Remove ClaudeKit installations (ownership-aware)",
 			"usage": "ck uninstall [options]",
 			"examples": [
+				{
+					"command": "ck uninstall --global --kit marketing",
+					"description": "Remove only the global Marketing kit and preserve Engineer"
+				},
 				{
 					"command": "ck uninstall --local --yes",
 					"description": "Remove local installation without confirmation"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -983,6 +983,7 @@ Remove ClaudeKit installations (ownership-aware)
 
 **Examples:**
 
+- `ck uninstall --global --kit marketing` — Remove only the global Marketing kit and preserve Engineer
 - `ck uninstall --local --yes` — Remove local installation without confirmation
 - `ck uninstall --dry-run` — Preview what would be removed without deleting
 
@@ -1061,4 +1062,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-07T15:41:58.534Z -->
+<!-- generated: 2026-05-09T02:35:37.956Z -->

--- a/src/__tests__/commands/init/phases/selection-handler-multikit.test.ts
+++ b/src/__tests__/commands/init/phases/selection-handler-multikit.test.ts
@@ -49,9 +49,13 @@ function createTestContext(overrides: {
 		prefix: boolean;
 		sync: boolean;
 		useGit: boolean;
+		force: boolean;
+		archive?: string;
+		kitPath?: string;
 	}>;
 	isNonInteractive?: boolean;
 	prompts?: ReturnType<typeof createMockPrompts>;
+	explicitDir?: boolean;
 }) {
 	const prompts = overrides.prompts ?? createMockPrompts();
 	return {
@@ -75,10 +79,11 @@ function createTestContext(overrides: {
 			prefix: true,
 			sync: false,
 			useGit: false,
+			force: false,
 			...overrides.options,
 		},
 		prompts,
-		explicitDir: false,
+		explicitDir: overrides.explicitDir ?? false,
 		isNonInteractive: overrides.isNonInteractive ?? false,
 		customClaudeFiles: [],
 		includePatterns: [],
@@ -282,6 +287,49 @@ describe("selection-handler multi-kit flow", () => {
 			}
 
 			expect(caughtError).toBe(true);
+		});
+
+		it("shows kit-scoped uninstall guidance when user declines alongside install", async () => {
+			const existingMetadata: Metadata = {
+				kits: {
+					marketing: {
+						version: "v1.3.2",
+						installedAt: "2024-01-01T00:00:00.000Z",
+					},
+				},
+			};
+			await writeFile(join(testDir, ".claude", "metadata.json"), JSON.stringify(existingMetadata));
+
+			const mockPrompts = createMockPrompts(false);
+			const ctx = createTestContext({
+				options: {
+					kit: "engineer",
+					dir: testDir,
+					kitPath: testDir,
+				},
+				prompts: mockPrompts,
+				explicitDir: true,
+			});
+			const { handleSelection } = await import("@/commands/init/phases/selection-handler.js");
+
+			const logs: string[] = [];
+			const originalLog = console.log;
+			console.log = (...args: unknown[]) => {
+				logs.push(args.map(String).join(" "));
+			};
+			try {
+				const result = await handleSelection(
+					ctx as unknown as Parameters<typeof handleSelection>[0],
+				);
+				expect(result.cancelled).toBe(true);
+			} finally {
+				console.log = originalLog;
+			}
+
+			const output = logs.join("\n");
+			expect(output).toContain("ck uninstall --local --kit marketing");
+			expect(output).toContain("Then rerun: ck init --dir");
+			expect(output).toContain("--kit engineer");
 		});
 	});
 

--- a/src/__tests__/commands/init/phases/selection-handler-multikit.test.ts
+++ b/src/__tests__/commands/init/phases/selection-handler-multikit.test.ts
@@ -1,10 +1,11 @@
 /**
  * Tests for selection-handler multi-kit prompt flow
  */
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { logger } from "@/shared/logger.js";
 import type { KitType, Metadata } from "@/types";
 
 // Create mock prompts manager
@@ -312,21 +313,18 @@ describe("selection-handler multi-kit flow", () => {
 			});
 			const { handleSelection } = await import("@/commands/init/phases/selection-handler.js");
 
-			const logs: string[] = [];
-			const originalLog = console.log;
-			console.log = (...args: unknown[]) => {
-				logs.push(args.map(String).join(" "));
-			};
+			const loggerInfoSpy = spyOn(logger, "info").mockImplementation(() => {});
+			let output = "";
 			try {
 				const result = await handleSelection(
 					ctx as unknown as Parameters<typeof handleSelection>[0],
 				);
 				expect(result.cancelled).toBe(true);
+				output = loggerInfoSpy.mock.calls.flat().join("\n");
 			} finally {
-				console.log = originalLog;
+				loggerInfoSpy.mockRestore();
 			}
 
-			const output = logs.join("\n");
 			expect(output).toContain("ck uninstall --local --kit marketing");
 			expect(output).toContain("Then rerun: ck init --dir");
 			expect(output).toContain("--kit engineer");

--- a/src/commands/init/phases/selection-handler.ts
+++ b/src/commands/init/phases/selection-handler.ts
@@ -22,6 +22,28 @@ import { isSyncContext } from "../types.js";
 /**
  * Select kit, target directory, and version
  */
+function buildKitScopedUninstallCommands(
+	kits: KitType[],
+	resolvedDir: string,
+	isGlobal: boolean,
+): string[] {
+	const scopeFlag =
+		isGlobal || PathResolver.isLocalSameAsGlobal(resolvedDir) ? "--global" : "--local";
+	return kits.map((kit) => `ck uninstall ${scopeFlag} --kit ${kit}`);
+}
+
+function buildRerunInitCommand(kitType: KitType, resolvedDir: string, isGlobal: boolean): string {
+	const args = ["ck init"];
+	const targetsGlobal = isGlobal || PathResolver.isLocalSameAsGlobal(resolvedDir);
+	if (targetsGlobal) {
+		args.push("--global");
+	} else {
+		args.push(`--dir ${JSON.stringify(resolvedDir)}`);
+	}
+	args.push(`--kit ${kitType}`);
+	return args.join(" ");
+}
+
 export async function handleSelection(ctx: InitContext): Promise<InitContext> {
 	if (ctx.cancelled) return ctx;
 
@@ -312,6 +334,17 @@ export async function handleSelection(ctx: InitContext): Promise<InitContext> {
 							);
 
 							if (!confirmAdd) {
+								logger.info("To remove one installed kit first, run:");
+								for (const command of buildKitScopedUninstallCommands(
+									otherKits,
+									resolvedDir,
+									ctx.options.global,
+								)) {
+									logger.info(`  ${command}`);
+								}
+								logger.info(
+									`Then rerun: ${buildRerunInitCommand(kitType, resolvedDir, ctx.options.global)}`,
+								);
 								logger.warning("Multi-kit installation cancelled by user");
 								return { ...ctx, cancelled: true };
 							}

--- a/src/commands/uninstall/analysis-handler.ts
+++ b/src/commands/uninstall/analysis-handler.ts
@@ -6,7 +6,7 @@
 
 import { readdirSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { getAllTrackedFiles } from "@/domains/migration/metadata-migration.js";
+import { getAllTrackedFiles, getInstalledKits } from "@/domains/migration/metadata-migration.js";
 import { ManifestWriter } from "@/services/file-operations/manifest-writer.js";
 import { OwnershipChecker } from "@/services/file-operations/ownership-checker.js";
 import { logger } from "@/shared/logger.js";
@@ -106,6 +106,10 @@ export async function analyzeInstallation(
 		remainingKits: [],
 	};
 	const metadata = await ManifestWriter.readManifest(installation.path);
+
+	if (kit && (!metadata || !getInstalledKits(metadata).includes(kit))) {
+		return result;
+	}
 
 	// Get uninstall manifest (kit-scoped if specified)
 	const uninstallManifest = await ManifestWriter.getUninstallManifest(installation.path, kit);

--- a/src/commands/uninstall/uninstall-command.ts
+++ b/src/commands/uninstall/uninstall-command.ts
@@ -11,7 +11,7 @@ import { logger } from "@/shared/logger.js";
 import { PathResolver } from "@/shared/path-resolver.js";
 import { withProcessLock } from "@/shared/process-lock.js";
 import { confirm, isCancel, log, select } from "@/shared/safe-prompts.js";
-import { type UninstallCommandOptions, UninstallCommandOptionsSchema } from "@/types";
+import { type KitType, type UninstallCommandOptions, UninstallCommandOptionsSchema } from "@/types";
 import pc from "picocolors";
 import { type Installation, detectInstallations } from "./installation-detector.js";
 import { removeInstallations } from "./removal-handler.js";
@@ -19,6 +19,7 @@ import { removeInstallations } from "./removal-handler.js";
 const prompts = new PromptsManager();
 
 type UninstallScope = "all" | "local" | "global";
+type KitSelection = KitType | "all";
 
 function formatComponentSummary(inst: Installation): string {
 	const parts: string[] = [];
@@ -76,6 +77,67 @@ async function promptScope(installations: Installation[]): Promise<UninstallScop
 		UninstallScope
 	>({
 		message: "Which installation(s) do you want to uninstall?",
+		options,
+	});
+
+	if (isCancel(selected)) {
+		return null;
+	}
+
+	return selected;
+}
+
+async function getInstallationKits(installation: Installation): Promise<KitType[]> {
+	const metadata = await ManifestWriter.readManifest(installation.path);
+	return metadata ? getInstalledKits(metadata) : [];
+}
+
+async function filterInstallationsByKit(
+	installations: Installation[],
+	kit: KitType,
+): Promise<Installation[]> {
+	const filtered: Installation[] = [];
+	for (const installation of installations) {
+		const installedKits = await getInstallationKits(installation);
+		if (installedKits.includes(kit)) {
+			filtered.push(installation);
+		}
+	}
+	return filtered;
+}
+
+async function promptKitSelection(installations: Installation[]): Promise<KitSelection | null> {
+	const installedKitSet = new Set<KitType>();
+	for (const installation of installations) {
+		for (const kit of await getInstallationKits(installation)) {
+			installedKitSet.add(kit);
+		}
+	}
+
+	if (installedKitSet.size < 2) {
+		return "all";
+	}
+
+	const kitOrder: KitType[] = ["marketing", "engineer"];
+	const kitOptions = kitOrder
+		.filter((kit) => installedKitSet.has(kit))
+		.map((kit) => ({
+			value: kit,
+			label: `${kit[0].toUpperCase()}${kit.slice(1)} kit only`,
+			hint: "Preserve other installed kit(s) and customizations",
+		}));
+
+	const options = [
+		...kitOptions,
+		{
+			value: "all" as const,
+			label: "All ClaudeKit kits",
+			hint: "Remove the full selected installation scope",
+		},
+	];
+
+	const selected = await select<typeof options, KitSelection>({
+		message: "Multiple kits are installed. What do you want to uninstall?",
 		options,
 	});
 
@@ -172,7 +234,7 @@ export async function uninstallCommand(options: UninstallCommandOptions): Promis
 			}
 
 			// 8. Filter installations by scope
-			const installations = allInstallations.filter((i) => {
+			let installations = allInstallations.filter((i) => {
 				if (scope === "all") return true;
 				return i.type === scope;
 			});
@@ -183,34 +245,55 @@ export async function uninstallCommand(options: UninstallCommandOptions): Promis
 				return;
 			}
 
-			// 9. Display found installations
-			displayInstallations(installations, scope);
-			if (validOptions.kit) {
-				log.info(pc.cyan(`Kit-scoped uninstall: ${validOptions.kit} kit only`));
+			// 9. Determine kit scope for multi-kit installs.
+			let kitToRemove = validOptions.kit;
+			if (!kitToRemove && !validOptions.yes) {
+				const selectedKit = await promptKitSelection(installations);
+				if (!selectedKit) {
+					logger.info("Uninstall cancelled.");
+					return;
+				}
+				if (selectedKit !== "all") {
+					kitToRemove = selectedKit;
+				}
 			}
 
-			// 10. Dry-run mode - skip confirmation
+			if (kitToRemove) {
+				installations = await filterInstallationsByKit(installations, kitToRemove);
+				if (installations.length === 0) {
+					logger.info(`Kit "${kitToRemove}" is not installed in selected scope.`);
+					return;
+				}
+			}
+
+			// 10. Display found installations
+			displayInstallations(installations, scope);
+			if (kitToRemove) {
+				log.info(pc.cyan(`Kit-scoped uninstall: ${kitToRemove} kit only`));
+			}
+
+			// 11. Dry-run mode - skip confirmation
 			if (validOptions.dryRun) {
 				log.info(pc.yellow("DRY RUN MODE - No files will be deleted"));
 				await removeInstallations(installations, {
 					dryRun: true,
 					forceOverwrite: validOptions.forceOverwrite,
-					kit: validOptions.kit,
+					kit: kitToRemove,
 				});
 				prompts.outro("Dry-run complete. No changes were made.");
 				return;
 			}
 
-			// 11. Force-overwrite warning
+			// 12. Force-overwrite warning
 			if (validOptions.forceOverwrite) {
 				log.warn(
 					`${pc.yellow(pc.bold("FORCE MODE ENABLED"))}\n${pc.yellow("User modifications will be permanently deleted!")}`,
 				);
 			}
 
-			// 12. Confirm deletion
+			// 13. Confirm deletion
 			if (!validOptions.yes) {
-				const kitLabel = validOptions.kit ? ` (${validOptions.kit} kit only)` : "";
+				const kitLabel = kitToRemove ? ` (${kitToRemove} kit only)` : "";
 				const confirmed = await confirmUninstall(scope, kitLabel);
 				if (!confirmed) {
 					logger.info("Uninstall cancelled.");
@@ -218,17 +301,17 @@ export async function uninstallCommand(options: UninstallCommandOptions): Promis
 				}
 			}
 
-			// 13. Remove files using manifest
+			// 14. Remove files using manifest
 			const results = await removeInstallations(installations, {
 				dryRun: false,
 				forceOverwrite: validOptions.forceOverwrite,
-				kit: validOptions.kit,
+				kit: kitToRemove,
 			});
 
 			const hasProtectedFiles = results.some((result) => result.protectedTrackedPaths.length > 0);
 
-			// 14. Success message
-			const kitMsg = validOptions.kit ? ` (${validOptions.kit} kit)` : "";
+			// 15. Success message
+			const kitMsg = kitToRemove ? ` (${kitToRemove} kit)` : "";
 			if (hasProtectedFiles) {
 				prompts.outro(
 					`ClaudeKit${kitMsg} uninstall completed with preserved customizations. Use --force-overwrite for full removal.`,

--- a/src/commands/uninstall/uninstall-command.ts
+++ b/src/commands/uninstall/uninstall-command.ts
@@ -92,6 +92,16 @@ async function getInstallationKits(installation: Installation): Promise<KitType[
 	return metadata ? getInstalledKits(metadata) : [];
 }
 
+async function getInstalledKitSet(installations: Installation[]): Promise<Set<KitType>> {
+	const installedKitSet = new Set<KitType>();
+	for (const installation of installations) {
+		for (const kit of await getInstallationKits(installation)) {
+			installedKitSet.add(kit);
+		}
+	}
+	return installedKitSet;
+}
+
 async function filterInstallationsByKit(
 	installations: Installation[],
 	kit: KitType,
@@ -106,14 +116,8 @@ async function filterInstallationsByKit(
 	return filtered;
 }
 
-async function promptKitSelection(installations: Installation[]): Promise<KitSelection | null> {
-	const installedKitSet = new Set<KitType>();
-	for (const installation of installations) {
-		for (const kit of await getInstallationKits(installation)) {
-			installedKitSet.add(kit);
-		}
-	}
-
+async function promptKitSelection(installedKitSet: Set<KitType>): Promise<KitSelection | null> {
+	// Single-kit installs do not need a kit picker; the selected scope is already specific enough.
 	if (installedKitSet.size < 2) {
 		return "all";
 	}
@@ -247,14 +251,23 @@ export async function uninstallCommand(options: UninstallCommandOptions): Promis
 
 			// 9. Determine kit scope for multi-kit installs.
 			let kitToRemove = validOptions.kit;
-			if (!kitToRemove && !validOptions.yes) {
-				const selectedKit = await promptKitSelection(installations);
-				if (!selectedKit) {
-					logger.info("Uninstall cancelled.");
-					return;
-				}
-				if (selectedKit !== "all") {
-					kitToRemove = selectedKit;
+			if (!kitToRemove) {
+				const installedKitSet = await getInstalledKitSet(installations);
+				if (validOptions.yes) {
+					if (installedKitSet.size > 1) {
+						logger.info(
+							"Removing all installed kits (--yes flag bypasses kit prompt; use --kit to scope).",
+						);
+					}
+				} else {
+					const selectedKit = await promptKitSelection(installedKitSet);
+					if (!selectedKit) {
+						logger.info("Uninstall cancelled.");
+						return;
+					}
+					if (selectedKit !== "all") {
+						kitToRemove = selectedKit;
+					}
 				}
 			}
 

--- a/src/domains/help/commands/uninstall-command-help.ts
+++ b/src/domains/help/commands/uninstall-command-help.ts
@@ -12,6 +12,10 @@ export const uninstallCommandHelp: CommandHelp = {
 	usage: "ck uninstall [options]",
 	examples: [
 		{
+			command: "ck uninstall --global --kit marketing",
+			description: "Remove only the global Marketing kit and preserve Engineer",
+		},
+		{
 			command: "ck uninstall --local --yes",
 			description: "Remove local installation without confirmation",
 		},

--- a/tests/commands/uninstall.test.ts
+++ b/tests/commands/uninstall.test.ts
@@ -498,6 +498,164 @@ describe("uninstall command integration", () => {
 			expect(metadata?.installedFiles).toEqual(["commands/shared.md"]);
 		});
 
+		test("should remove only marketing kit from a global multi-kit install", async () => {
+			await mkdir(join(testGlobalClaudeDir, "commands"), { recursive: true });
+			await mkdir(join(testGlobalClaudeDir, "skills"), { recursive: true });
+			const engineerFile = join(testGlobalClaudeDir, "commands", "engineer.md");
+			const marketingFile = join(testGlobalClaudeDir, "skills", "marketing.md");
+			await writeFile(engineerFile, "engineer");
+			await writeFile(marketingFile, "marketing");
+
+			const { OwnershipChecker } = await import(
+				"../../src/services/file-operations/ownership-checker.js"
+			);
+			const engineerChecksum = await OwnershipChecker.calculateChecksum(engineerFile);
+			const marketingChecksum = await OwnershipChecker.calculateChecksum(marketingFile);
+
+			await writeFile(
+				join(testGlobalClaudeDir, "metadata.json"),
+				JSON.stringify(
+					{
+						kits: {
+							engineer: {
+								version: "1.0.0",
+								installedAt: "2025-01-01T00:00:00.000Z",
+								files: [
+									{
+										path: "commands/engineer.md",
+										checksum: engineerChecksum,
+										ownership: "ck",
+										installedVersion: "1.0.0",
+									},
+								],
+							},
+							marketing: {
+								version: "1.0.0",
+								installedAt: "2025-01-01T00:00:00.000Z",
+								files: [
+									{
+										path: "skills/marketing.md",
+										checksum: marketingChecksum,
+										ownership: "ck",
+										installedVersion: "1.0.0",
+									},
+								],
+							},
+						},
+						scope: "global",
+					},
+					null,
+					2,
+				),
+			);
+
+			const { uninstallCommand } = await import("../../src/commands/uninstall/index.js");
+
+			await uninstallCommand({
+				yes: true,
+				json: false,
+				verbose: false,
+				local: false,
+				global: true,
+				all: false,
+				dryRun: false,
+				forceOverwrite: false,
+				kit: "marketing",
+			});
+
+			expect(existsSync(engineerFile)).toBe(true);
+			expect(existsSync(marketingFile)).toBe(false);
+
+			const metadata = await ManifestWriter.readManifest(testGlobalClaudeDir);
+			expect(Object.keys(metadata?.kits || {})).toEqual(["engineer"]);
+			expect(metadata?.kits?.engineer?.files?.map((file) => file.path)).toEqual([
+				"commands/engineer.md",
+			]);
+		});
+
+		test("should not uninstall installations that do not contain selected kit", async () => {
+			await mkdir(join(testLocalClaudeDir, "commands"), { recursive: true });
+			await mkdir(join(testGlobalClaudeDir, "skills"), { recursive: true });
+			const engineerFile = join(testLocalClaudeDir, "commands", "engineer.md");
+			const marketingFile = join(testGlobalClaudeDir, "skills", "marketing.md");
+			await writeFile(engineerFile, "engineer");
+			await writeFile(marketingFile, "marketing");
+
+			const { OwnershipChecker } = await import(
+				"../../src/services/file-operations/ownership-checker.js"
+			);
+			const engineerChecksum = await OwnershipChecker.calculateChecksum(engineerFile);
+			const marketingChecksum = await OwnershipChecker.calculateChecksum(marketingFile);
+
+			await writeFile(
+				join(testLocalClaudeDir, "metadata.json"),
+				JSON.stringify(
+					{
+						kits: {
+							engineer: {
+								version: "1.0.0",
+								installedAt: "2025-01-01T00:00:00.000Z",
+								files: [
+									{
+										path: "commands/engineer.md",
+										checksum: engineerChecksum,
+										ownership: "ck",
+										installedVersion: "1.0.0",
+									},
+								],
+							},
+						},
+						scope: "local",
+					},
+					null,
+					2,
+				),
+			);
+			await writeFile(
+				join(testGlobalClaudeDir, "metadata.json"),
+				JSON.stringify(
+					{
+						kits: {
+							marketing: {
+								version: "1.0.0",
+								installedAt: "2025-01-01T00:00:00.000Z",
+								files: [
+									{
+										path: "skills/marketing.md",
+										checksum: marketingChecksum,
+										ownership: "ck",
+										installedVersion: "1.0.0",
+									},
+								],
+							},
+						},
+						scope: "global",
+					},
+					null,
+					2,
+				),
+			);
+
+			const { uninstallCommand } = await import("../../src/commands/uninstall/index.js");
+
+			await uninstallCommand({
+				yes: true,
+				json: false,
+				verbose: false,
+				local: false,
+				global: false,
+				all: true,
+				dryRun: false,
+				forceOverwrite: false,
+				kit: "marketing",
+			});
+
+			expect(existsSync(engineerFile)).toBe(true);
+			expect(existsSync(join(testLocalClaudeDir, "metadata.json"))).toBe(true);
+			expect(existsSync(marketingFile)).toBe(false);
+			expect(existsSync(join(testGlobalClaudeDir, "metadata.json"))).toBe(false);
+		});
+
 		test("should create a recovery backup before tracked uninstall", async () => {
 			const metadata = {
 				kits: {

--- a/tests/commands/uninstall.test.ts
+++ b/tests/commands/uninstall.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { existsSync, readdirSync, realpathSync } from "node:fs";
 import { mkdir, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { acquireInstallationStateLock } from "@/services/file-operations/installation-state-lock.js";
 import { ManifestWriter } from "@/services/file-operations/manifest-writer.js";
+import { logger } from "@/shared/logger.js";
 import type { Metadata } from "@/types";
 import { type TestPaths, setupTestPaths } from "../helpers/test-paths.js";
 
@@ -654,6 +655,83 @@ describe("uninstall command integration", () => {
 			expect(existsSync(join(testLocalClaudeDir, "metadata.json"))).toBe(true);
 			expect(existsSync(marketingFile)).toBe(false);
 			expect(existsSync(join(testGlobalClaudeDir, "metadata.json"))).toBe(false);
+		});
+
+		test("should log when --yes skips kit prompt for multi-kit uninstall", async () => {
+			await mkdir(join(testLocalClaudeDir, "commands"), { recursive: true });
+			await mkdir(join(testLocalClaudeDir, "skills"), { recursive: true });
+			const engineerFile = join(testLocalClaudeDir, "commands", "engineer.md");
+			const marketingFile = join(testLocalClaudeDir, "skills", "marketing.md");
+			await writeFile(engineerFile, "engineer");
+			await writeFile(marketingFile, "marketing");
+
+			const { OwnershipChecker } = await import(
+				"../../src/services/file-operations/ownership-checker.js"
+			);
+			const engineerChecksum = await OwnershipChecker.calculateChecksum(engineerFile);
+			const marketingChecksum = await OwnershipChecker.calculateChecksum(marketingFile);
+
+			await writeFile(
+				join(testLocalClaudeDir, "metadata.json"),
+				JSON.stringify(
+					{
+						kits: {
+							engineer: {
+								version: "1.0.0",
+								installedAt: "2025-01-01T00:00:00.000Z",
+								files: [
+									{
+										path: "commands/engineer.md",
+										checksum: engineerChecksum,
+										ownership: "ck",
+										installedVersion: "1.0.0",
+									},
+								],
+							},
+							marketing: {
+								version: "1.0.0",
+								installedAt: "2025-01-01T00:00:00.000Z",
+								files: [
+									{
+										path: "skills/marketing.md",
+										checksum: marketingChecksum,
+										ownership: "ck",
+										installedVersion: "1.0.0",
+									},
+								],
+							},
+						},
+						scope: "local",
+					},
+					null,
+					2,
+				),
+			);
+
+			const loggerInfoSpy = spyOn(logger, "info").mockImplementation(() => {});
+			const { uninstallCommand } = await import("../../src/commands/uninstall/index.js");
+
+			try {
+				await uninstallCommand({
+					yes: true,
+					json: false,
+					verbose: false,
+					local: true,
+					global: false,
+					all: false,
+					dryRun: false,
+					forceOverwrite: false,
+				});
+				expect(loggerInfoSpy).toHaveBeenCalledWith(
+					"Removing all installed kits (--yes flag bypasses kit prompt; use --kit to scope).",
+				);
+			} finally {
+				loggerInfoSpy.mockRestore();
+			}
+
+			expect(existsSync(engineerFile)).toBe(false);
+			expect(existsSync(marketingFile)).toBe(false);
+			expect(existsSync(join(testLocalClaudeDir, "metadata.json"))).toBe(false);
 		});
 
 		test("should create a recovery backup before tracked uninstall", async () => {


### PR DESCRIPTION
## Summary
- Show kit-scoped uninstall commands when `ck init` detects an existing other kit and the user declines side-by-side install.
- Add an interactive kit picker to `ck uninstall` for multi-kit installs, with Marketing listed first.
- Filter `--kit` uninstall scope so `--all --kit marketing` does not touch Engineer-only installs.
- Document `ck uninstall --global --kit marketing` in CLI help and README.

## Root Cause
`ck init` correctly detected that another kit was already installed, but declining the side-by-side prompt only cancelled the install. The existing `ck uninstall --kit marketing` path was not surfaced there, and interactive uninstall only asked for local/global/all scope rather than which kit to remove.

## Validation
- `bun test tests/commands/uninstall.test.ts`
- `bun test src/__tests__/commands/init/phases/selection-handler-multikit.test.ts`
- `bun test __tests__/domains/help/help-commands.test.ts`
- `git diff --check`
- `bun run validate`
- pre-commit quality gate
- pre-push quality gate

Closes #784