### PR TITLE
fix(migrate): repair stale portable registry entries

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.0.0-dev.2",
-	"generatedAt": "2026-05-09T02:35:34.274Z",
+	"version": "4.0.0-dev.3",
+	"generatedAt": "2026-05-09T13:29:21.576Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1062,4 +1062,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-09T02:35:37.956Z -->
+<!-- generated: 2026-05-09T13:29:21.664Z -->

--- a/src/commands/portable/__tests__/portable-registry.test.ts
+++ b/src/commands/portable/__tests__/portable-registry.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
  * Tests for portable registry v3.0 migration (Phase 1)
  * Note: These tests use the real ~/.claudekit/ directory
  */
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
@@ -21,6 +22,7 @@ const MIGRATION_LOCK_PATH = join(homedir(), ".claudekit", ".migration.lock");
 let backupContent: string | null = null;
 let backupMigrationLockContent: string | null = null;
 let hadMigrationLock = false;
+let testFilesToRemove: string[] = [];
 
 beforeEach(async () => {
 	// Backup existing registry if present
@@ -51,6 +53,12 @@ afterEach(async () => {
 	} else if (existsSync(MIGRATION_LOCK_PATH)) {
 		await rm(MIGRATION_LOCK_PATH, { force: true });
 	}
+
+	for (const path of testFilesToRemove) {
+		await rm(path, { force: true });
+	}
+	testFilesToRemove = [];
+
 	hadMigrationLock = false;
 	backupMigrationLockContent = null;
 });
@@ -324,6 +332,44 @@ describe("stale v3.0 registry repair", () => {
 		expect(persistedRaw.installations[0].sourceChecksum).toBe("unknown");
 		expect(persistedRaw.installations[0].targetChecksum).toBe("unknown");
 		expect(persistedRaw.installations[0].installSource).toBe("kit");
+	});
+
+	test("computes target checksum from disk while repairing stale v3.0 entries", async () => {
+		const targetPath = join(homedir(), ".claudekit", `test-stale-v3-target-${process.pid}.md`);
+		testFilesToRemove.push(targetPath);
+		await mkdir(join(homedir(), ".claudekit"), { recursive: true });
+		const targetContent = "# Existing target\n\nContent on disk";
+		const expectedChecksum = createHash("sha256").update(targetContent, "utf-8").digest("hex");
+		await writeFile(targetPath, targetContent, "utf-8");
+
+		const staleRegistry = {
+			version: "3.0",
+			installations: [
+				{
+					item: "disk-backed-skill",
+					type: "skill",
+					provider: "codex",
+					global: true,
+					path: targetPath,
+					installedAt: "2026-05-09T00:00:00.000Z",
+					sourcePath: "/source/disk-backed-skill",
+				},
+			],
+		};
+
+		await writeFile(REGISTRY_PATH, JSON.stringify(staleRegistry, null, 2), "utf-8");
+
+		const loaded = await readPortableRegistry();
+
+		expect(loaded.installations[0].targetChecksum).toBe(expectedChecksum);
+		expect(loaded.installations[0].targetChecksum).toMatch(/^[a-f0-9]{64}$/);
+
+		const persistedRaw = JSON.parse(await readFile(REGISTRY_PATH, "utf-8")) as {
+			installations: Array<{ targetChecksum?: string }>;
+		};
+		expect(persistedRaw.installations[0].targetChecksum).toBe(
+			loaded.installations[0].targetChecksum,
+		);
 	});
 
 	test("returns repaired view without persisting when migration lock is active", async () => {

--- a/src/commands/portable/__tests__/portable-registry.test.ts
+++ b/src/commands/portable/__tests__/portable-registry.test.ts
@@ -265,6 +265,153 @@ describe("v2.0 to v3.0 migration", () => {
 	});
 });
 
+describe("stale v3.0 registry repair", () => {
+	test("repairs v3.0 entries missing idempotency fields", async () => {
+		const staleRegistry = {
+			version: "3.0",
+			installations: [
+				{
+					item: "scout",
+					type: "skill",
+					provider: "codex",
+					global: true,
+					path: "/path/to/scout",
+					installedAt: "2026-05-09T00:00:00.000Z",
+					sourcePath: "/source/scout",
+				},
+				{
+					item: "review",
+					type: "command",
+					provider: "claude-code",
+					global: false,
+					path: "/path/to/review",
+					installedAt: "2026-05-09T00:00:00.000Z",
+					sourcePath: "/source/review",
+					sourceChecksum: "existing-source",
+					targetChecksum: "existing-target",
+					installSource: "manual",
+					ownedSections: ["frontmatter"],
+				},
+			],
+			lastReconciled: "2026-05-09T00:00:00.000Z",
+			customTopLevel: "preserved",
+		};
+
+		await writeFile(REGISTRY_PATH, JSON.stringify(staleRegistry, null, 2), "utf-8");
+
+		const loaded = await readPortableRegistry();
+
+		expect(loaded.version).toBe("3.0");
+		expect(loaded.installations).toHaveLength(2);
+		expect(loaded.installations[0].sourceChecksum).toBe("unknown");
+		expect(loaded.installations[0].targetChecksum).toBe("unknown");
+		expect(loaded.installations[0].installSource).toBe("kit");
+		expect(loaded.installations[1].sourceChecksum).toBe("existing-source");
+		expect(loaded.installations[1].targetChecksum).toBe("existing-target");
+		expect(loaded.installations[1].installSource).toBe("manual");
+		expect(loaded.installations[1].ownedSections).toEqual(["frontmatter"]);
+		expect(loaded.lastReconciled).toBe("2026-05-09T00:00:00.000Z");
+
+		const persistedRaw = JSON.parse(await readFile(REGISTRY_PATH, "utf-8")) as {
+			customTopLevel?: string;
+			installations: Array<{
+				sourceChecksum?: string;
+				targetChecksum?: string;
+				installSource?: string;
+			}>;
+		};
+		expect(persistedRaw.customTopLevel).toBe("preserved");
+		expect(persistedRaw.installations[0].sourceChecksum).toBe("unknown");
+		expect(persistedRaw.installations[0].targetChecksum).toBe("unknown");
+		expect(persistedRaw.installations[0].installSource).toBe("kit");
+	});
+
+	test("returns repaired view without persisting when migration lock is active", async () => {
+		const staleRegistry = {
+			version: "3.0",
+			installations: [
+				{
+					item: "scout",
+					type: "skill",
+					provider: "codex",
+					global: true,
+					path: "/path/to/scout",
+					installedAt: "2026-05-09T00:00:00.000Z",
+					sourcePath: "/source/scout",
+				},
+			],
+		};
+
+		await writeFile(REGISTRY_PATH, JSON.stringify(staleRegistry, null, 2), "utf-8");
+		await writeFile(MIGRATION_LOCK_PATH, String(Date.now()), "utf-8");
+
+		const loaded = await readPortableRegistry();
+
+		expect(loaded.installations[0].sourceChecksum).toBe("unknown");
+		expect(loaded.installations[0].targetChecksum).toBe("unknown");
+		expect(loaded.installations[0].installSource).toBe("kit");
+
+		const persistedRaw = JSON.parse(await readFile(REGISTRY_PATH, "utf-8")) as {
+			installations: Array<{
+				sourceChecksum?: string;
+				targetChecksum?: string;
+				installSource?: string;
+			}>;
+		};
+		expect(persistedRaw.installations[0].sourceChecksum).toBeUndefined();
+		expect(persistedRaw.installations[0].targetChecksum).toBeUndefined();
+		expect(persistedRaw.installations[0].installSource).toBeUndefined();
+	});
+
+	test("rejects corrupted v3.0 idempotency fields", async () => {
+		const corruptedRegistry = {
+			version: "3.0",
+			installations: [
+				{
+					item: "scout",
+					type: "skill",
+					provider: "codex",
+					global: true,
+					path: "/path/to/scout",
+					installedAt: "2026-05-09T00:00:00.000Z",
+					sourcePath: "/source/scout",
+					sourceChecksum: "source",
+					targetChecksum: "target",
+					installSource: "local",
+				},
+			],
+		};
+
+		await writeFile(REGISTRY_PATH, JSON.stringify(corruptedRegistry, null, 2), "utf-8");
+
+		await expect(readPortableRegistry()).rejects.toThrow(
+			"portable-registry.json has unsupported schema/version",
+		);
+	});
+});
+
+describe("invalid registry handling", () => {
+	test("keeps invalid JSON fatal", async () => {
+		await writeFile(REGISTRY_PATH, "{ invalid json", "utf-8");
+
+		await expect(readPortableRegistry()).rejects.toThrow(
+			"portable-registry.json is not valid JSON",
+		);
+	});
+
+	test("keeps unsupported top-level versions fatal", async () => {
+		await writeFile(
+			REGISTRY_PATH,
+			JSON.stringify({ version: "4.0", installations: [] }, null, 2),
+			"utf-8",
+		);
+
+		await expect(readPortableRegistry()).rejects.toThrow(
+			"portable-registry.json has unsupported schema/version",
+		);
+	});
+});
+
 describe("migration lock handling", () => {
 	test("treats invalid lock timestamp as active lock and skips persisted migration", async () => {
 		const v2Registry = {

--- a/src/commands/portable/portable-registry.ts
+++ b/src/commands/portable/portable-registry.ts
@@ -79,6 +79,11 @@ const RepairablePortableRegistrySchemaV3 = z
 	.passthrough();
 type RepairablePortableRegistryV3 = z.infer<typeof RepairablePortableRegistrySchemaV3>;
 
+type PreparedStaleRegistryV3Repair = {
+	sourceContent: string;
+	repairedRegistry: PortableRegistryV3;
+};
+
 // Legacy schema for migration
 const LegacyInstallationSchema = z.object({
 	skill: z.string(),
@@ -225,7 +230,7 @@ function getStringField(item: PortableInstallation, field: string): string | und
 	if (typeof value !== "string") {
 		throw new Error("portable-registry.json has unsupported schema/version");
 	}
-	return typeof value === "string" ? value : undefined;
+	return value;
 }
 
 function getOwnedSections(item: PortableInstallation): string[] | undefined {
@@ -285,7 +290,9 @@ async function repairStaleRegistryV3(
 	});
 }
 
-async function persistCurrentStaleRegistryV3Repair(): Promise<PortableRegistryV3> {
+async function persistCurrentStaleRegistryV3Repair(
+	preparedRepair?: PreparedStaleRegistryV3Repair,
+): Promise<PortableRegistryV3> {
 	return withRegistryLock(async () => {
 		let content: string;
 		try {
@@ -316,7 +323,10 @@ async function persistCurrentStaleRegistryV3Repair(): Promise<PortableRegistryV3
 			return readPortableRegistryInternal({ persistStaleV3Repair: false });
 		}
 
-		const repairedRegistry = await repairStaleRegistryV3(repairableV3Result.data);
+		const repairedRegistry =
+			preparedRepair && preparedRepair.sourceContent === content
+				? preparedRepair.repairedRegistry
+				: await repairStaleRegistryV3(repairableV3Result.data);
 		if (await isMigrationLocked()) {
 			logger.verbose("Migration in progress by another process, using repaired v3 view");
 			return repairedRegistry;
@@ -423,7 +433,10 @@ async function readPortableRegistryInternal(options: {
 				return repairedRegistry;
 			}
 
-			return persistCurrentStaleRegistryV3Repair();
+			return persistCurrentStaleRegistryV3Repair({
+				sourceContent: content,
+				repairedRegistry,
+			});
 		}
 
 		const v2Result = PortableRegistrySchema.safeParse(data);

--- a/src/commands/portable/portable-registry.ts
+++ b/src/commands/portable/portable-registry.ts
@@ -69,6 +69,16 @@ const PortableRegistrySchemaV3 = z.object({
 });
 export type PortableRegistryV3 = z.infer<typeof PortableRegistrySchemaV3>;
 
+const RepairablePortableRegistrySchemaV3 = z
+	.object({
+		version: z.literal("3.0"),
+		installations: z.array(PortableInstallationSchema),
+		lastReconciled: z.string().optional(),
+		appliedManifestVersion: z.string().optional(),
+	})
+	.passthrough();
+type RepairablePortableRegistryV3 = z.infer<typeof RepairablePortableRegistrySchemaV3>;
+
 // Legacy schema for migration
 const LegacyInstallationSchema = z.object({
 	skill: z.string(),
@@ -206,6 +216,118 @@ async function migrateRegistryV2ToV3(v2Registry: PortableRegistry): Promise<Port
 	};
 }
 
+function getStringField(item: PortableInstallation, field: string): string | undefined {
+	const record = item as Record<string, unknown>;
+	if (!(field in record) || record[field] === undefined) {
+		return undefined;
+	}
+	const value = record[field];
+	if (typeof value !== "string") {
+		throw new Error("portable-registry.json has unsupported schema/version");
+	}
+	return typeof value === "string" ? value : undefined;
+}
+
+function getOwnedSections(item: PortableInstallation): string[] | undefined {
+	const record = item as Record<string, unknown>;
+	if (!("ownedSections" in record) || record.ownedSections === undefined) {
+		return undefined;
+	}
+	const value = record.ownedSections;
+	if (!Array.isArray(value) || !value.every((section) => typeof section === "string")) {
+		throw new Error("portable-registry.json has unsupported schema/version");
+	}
+	return value;
+}
+
+function getInstallSource(item: PortableInstallation): "kit" | "manual" {
+	const installSource = getStringField(item, "installSource");
+	if (installSource === undefined) {
+		return "kit";
+	}
+	if (installSource !== "kit" && installSource !== "manual") {
+		throw new Error("portable-registry.json has unsupported schema/version");
+	}
+	return installSource;
+}
+
+async function repairStaleRegistryV3(
+	registry: RepairablePortableRegistryV3,
+): Promise<PortableRegistryV3> {
+	const installations: PortableInstallationV3[] = [];
+
+	for (const item of registry.installations) {
+		let targetChecksum =
+			normalizeChecksum(getStringField(item, "targetChecksum")) || UNKNOWN_CHECKSUM;
+		if (targetChecksum === UNKNOWN_CHECKSUM && existsSync(item.path)) {
+			try {
+				targetChecksum = await computeFileChecksum(item.path);
+			} catch {
+				targetChecksum = UNKNOWN_CHECKSUM;
+			}
+		}
+
+		installations.push({
+			...item,
+			sourceChecksum: normalizeChecksum(getStringField(item, "sourceChecksum")) || UNKNOWN_CHECKSUM,
+			targetChecksum,
+			installSource: getInstallSource(item),
+			ownedSections: getOwnedSections(item),
+		});
+	}
+
+	return normalizePortableRegistryChecksums({
+		...registry,
+		version: "3.0",
+		installations,
+		lastReconciled: registry.lastReconciled,
+		appliedManifestVersion: registry.appliedManifestVersion,
+	});
+}
+
+async function persistCurrentStaleRegistryV3Repair(): Promise<PortableRegistryV3> {
+	return withRegistryLock(async () => {
+		let content: string;
+		try {
+			content = await readFile(REGISTRY_PATH, "utf-8");
+		} catch (error) {
+			if (isErrnoCode(error, "ENOENT")) {
+				return readPortableRegistryInternal({ persistStaleV3Repair: false });
+			}
+			throw error;
+		}
+
+		let data: unknown;
+		try {
+			data = JSON.parse(content);
+		} catch (error) {
+			throw new Error(
+				`portable-registry.json is not valid JSON: ${error instanceof Error ? error.message : "Unknown parse error"}`,
+			);
+		}
+
+		const v3Result = PortableRegistrySchemaV3.safeParse(data);
+		if (v3Result.success) {
+			return normalizePortableRegistryChecksums(v3Result.data);
+		}
+
+		const repairableV3Result = RepairablePortableRegistrySchemaV3.safeParse(data);
+		if (!repairableV3Result.success) {
+			return readPortableRegistryInternal({ persistStaleV3Repair: false });
+		}
+
+		const repairedRegistry = await repairStaleRegistryV3(repairableV3Result.data);
+		if (await isMigrationLocked()) {
+			logger.verbose("Migration in progress by another process, using repaired v3 view");
+			return repairedRegistry;
+		}
+
+		logger.verbose("Repairing stale portable registry v3.0 fields");
+		await writePortableRegistry(repairedRegistry);
+		return repairedRegistry;
+	});
+}
+
 /**
  * Check if migration lock exists and is recent (< 30 seconds)
  * Returns true if we should skip migration (another process is migrating)
@@ -268,6 +390,12 @@ async function removeMigrationLock(): Promise<void> {
  * Read the portable registry, auto-migrating to v3.0 if needed
  */
 export async function readPortableRegistry(): Promise<PortableRegistryV3> {
+	return readPortableRegistryInternal({ persistStaleV3Repair: true });
+}
+
+async function readPortableRegistryInternal(options: {
+	persistStaleV3Repair: boolean;
+}): Promise<PortableRegistryV3> {
 	try {
 		const content = await readFile(REGISTRY_PATH, "utf-8");
 		let data: unknown;
@@ -282,6 +410,20 @@ export async function readPortableRegistry(): Promise<PortableRegistryV3> {
 		const v3Result = PortableRegistrySchemaV3.safeParse(data);
 		if (v3Result.success) {
 			return normalizePortableRegistryChecksums(v3Result.data);
+		}
+
+		const repairableV3Result = RepairablePortableRegistrySchemaV3.safeParse(data);
+		if (repairableV3Result.success) {
+			const repairedRegistry = await repairStaleRegistryV3(repairableV3Result.data);
+			if (!options.persistStaleV3Repair) {
+				return repairedRegistry;
+			}
+			if (await isMigrationLocked()) {
+				logger.verbose("Migration in progress by another process, using repaired v3 view");
+				return repairedRegistry;
+			}
+
+			return persistCurrentStaleRegistryV3Repair();
 		}
 
 		const v2Result = PortableRegistrySchema.safeParse(data);
@@ -332,6 +474,10 @@ export async function readPortableRegistry(): Promise<PortableRegistryV3> {
 	}
 
 	return { version: "3.0", installations: [] };
+}
+
+async function readPortableRegistryWithinRegistryLock(): Promise<PortableRegistryV3> {
+	return readPortableRegistryInternal({ persistStaleV3Repair: false });
 }
 
 /**
@@ -401,7 +547,7 @@ export async function addPortableInstallation(
 	},
 ): Promise<void> {
 	await withRegistryLock(async () => {
-		const registry = await readPortableRegistry();
+		const registry = await readPortableRegistryWithinRegistryLock();
 
 		// Remove existing entry for same combo (update case)
 		registry.installations = registry.installations.filter(
@@ -438,7 +584,7 @@ export async function removePortableInstallation(
 	global: boolean,
 ): Promise<PortableInstallationV3 | null> {
 	return withRegistryLock(async () => {
-		const registry = await readPortableRegistry();
+		const registry = await readPortableRegistryWithinRegistryLock();
 
 		const index = registry.installations.findIndex(
 			(i) => i.item === item && i.type === type && i.provider === provider && i.global === global,
@@ -487,7 +633,7 @@ export function getInstallationsByType(
  */
 export async function updateAppliedManifestVersion(version: string): Promise<void> {
 	await withRegistryLock(async () => {
-		const registry = await readPortableRegistry();
+		const registry = await readPortableRegistryWithinRegistryLock();
 		registry.appliedManifestVersion = version;
 		await writePortableRegistry(registry);
 	});
@@ -501,7 +647,7 @@ export async function removeInstallationsByFilter(
 	predicate: (entry: PortableInstallationV3) => boolean,
 ): Promise<PortableInstallationV3[]> {
 	return withRegistryLock(async () => {
-		const registry = await readPortableRegistry();
+		const registry = await readPortableRegistryWithinRegistryLock();
 		const removed: PortableInstallationV3[] = [];
 
 		registry.installations = registry.installations.filter((entry) => {
@@ -527,7 +673,7 @@ export async function syncPortableRegistry(): Promise<{
 	removed: PortableInstallationV3[];
 }> {
 	return withRegistryLock(async () => {
-		const registry = await readPortableRegistry();
+		const registry = await readPortableRegistryWithinRegistryLock();
 		const removed: PortableInstallationV3[] = [];
 
 		registry.installations = registry.installations.filter((i) => {


### PR DESCRIPTION
Closes #786

## Summary
- repair stale portable-registry.json v3.0 entries that are missing idempotency fields
- persist repaired registries under the normal registry lock to avoid racing registry writers
- preserve existing registry metadata and keep invalid/corrupt schemas fatal

## Validation
- bun test src/commands/portable/__tests__/portable-registry.test.ts --test-name-pattern "stale v3.0|invalid registry"
- bun test src/commands/portable/__tests__/portable-registry.test.ts
- bun run validate
- pre-commit quality gate
- pre-push quality gate