### PR TITLE
fix: improve migrate UX and Codex hooks flag

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.0.0-dev.4",
-	"generatedAt": "2026-05-09T21:01:54.732Z",
+	"version": "4.0.0-dev.5",
+	"generatedAt": "2026-05-10T02:04:09.748Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-09T21:01:58.473Z -->
+<!-- generated: 2026-05-10T02:04:10.074Z -->

--- a/src/commands/migrate/__tests__/migrate-ui-summary.test.ts
+++ b/src/commands/migrate/__tests__/migrate-ui-summary.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+	buildDiscoverySummaryLines,
 	buildPreflightRows,
 	buildProviderScopeSubtitle,
 	buildSourceSummaryLines,
@@ -29,13 +30,34 @@ describe("migrate UI summary helpers", () => {
 		expect(rows[0]?.notes.some((note) => note.includes("share .agents/skills"))).toBe(true);
 	});
 
-	it("summarizes destinations when more than three distinct targets exist", () => {
+	it("lists every destination instead of hiding extra targets", () => {
 		const lines = buildTargetSummaryLines([
 			{ count: 1, destinations: ["a", "b"], label: "Agents", notes: [] },
 			{ count: 1, destinations: ["c", "d"], label: "Skills", notes: [] },
 		]);
 
-		expect(lines).toEqual(["a", "b", "c", "+1 more destination(s)"]);
+		expect(lines).toEqual(["a", "b", "c", "d"]);
+	});
+
+	it("builds structured Found summary lines from preflight rows", () => {
+		const rows = buildPreflightRows(
+			{ agents: 1, commands: 0, config: 1, hooks: 0, rules: 0, skills: 2 },
+			["codex"],
+			{
+				requestedGlobal: true,
+				sourceDisplays: {
+					agents: "~/.claude/agents",
+					config: "~/.claude/CLAUDE.md",
+					skills: "~/.claude/skills",
+				},
+			},
+		);
+
+		expect(buildDiscoverySummaryLines(rows)).toEqual([
+			"Agents   1 agent <- ~/.claude/agents",
+			"Skills   2 skills <- ~/.claude/skills",
+			"Config   config <- ~/.claude/CLAUDE.md",
+		]);
 	});
 
 	it("builds readable provider and source summary lines", () => {

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -14,6 +14,7 @@ import type { KitType } from "../../types/kit.js";
 import type { ClaudeKitMetadata } from "../../types/metadata.js";
 import {
 	formatDisplayPath,
+	renderPanel,
 	renderPreflightRow,
 	renderSourceTargetHeader,
 } from "../../ui/ck-cli-design/index.js";
@@ -80,6 +81,7 @@ import {
 import { resolveMigrationScope } from "./migrate-scope-resolver.js";
 import {
 	type PortableSourceCounts,
+	buildDiscoverySummaryLines,
 	buildPreflightRows,
 	buildProviderScopeSubtitle,
 	buildSourceSummaryLines,
@@ -656,10 +658,6 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			rulesSourcePath,
 			hooksSource,
 		].filter((origin): origin is string => origin !== null);
-		const preflightRows = buildPreflightRows(sourceCounts, selectedProviders, {
-			requestedGlobal,
-		});
-		const discoveryParts: string[] = [];
 		const agentSourceDisplay = agentSource ? formatDisplayPath(agentSource) : "source unavailable";
 		const commandSourceDisplay = commandSource
 			? formatDisplayPath(commandSource)
@@ -669,24 +667,17 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			? formatDisplayPath(rulesSourcePath)
 			: "source unavailable";
 		const hooksSourceDisplay = hooksSource ? formatDisplayPath(hooksSource) : "source unavailable";
-		if (agents.length > 0) {
-			discoveryParts.push(`${agents.length} agent(s) ${pc.dim(`<- ${agentSourceDisplay}`)}`);
-		}
-		if (commands.length > 0) {
-			discoveryParts.push(`${commands.length} command(s) ${pc.dim(`<- ${commandSourceDisplay}`)}`);
-		}
-		if (skills.length > 0) {
-			discoveryParts.push(`${skills.length} skill(s) ${pc.dim(`<- ${skillSourceDisplay}`)}`);
-		}
-		if (configItem) {
-			discoveryParts.push(`config ${pc.dim(`<- ${formatDisplayPath(configItem.sourcePath)}`)}`);
-		}
-		if (ruleItems.length > 0) {
-			discoveryParts.push(`${ruleItems.length} rule(s) ${pc.dim(`<- ${rulesSourceDisplay}`)}`);
-		}
-		if (hookItems.length > 0) {
-			discoveryParts.push(`${hookItems.length} hook(s) ${pc.dim(`<- ${hooksSourceDisplay}`)}`);
-		}
+		const preflightRows = buildPreflightRows(sourceCounts, selectedProviders, {
+			requestedGlobal,
+			sourceDisplays: {
+				agents: agentSourceDisplay,
+				commands: commandSourceDisplay,
+				config: configItem ? formatDisplayPath(configItem.sourcePath) : undefined,
+				hooks: hooksSourceDisplay,
+				rules: rulesSourceDisplay,
+				skills: skillSourceDisplay,
+			},
+		});
 
 		console.log();
 		console.log(
@@ -698,7 +689,13 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			}).join("\n"),
 		);
 		p.log.info(pc.dim(`  CWD: ${process.cwd()}`));
-		p.log.info(`Found: ${discoveryParts.join(", ")}`);
+		console.log();
+		console.log(
+			renderPanel({
+				title: "Found",
+				zones: [{ label: "ITEMS", lines: buildDiscoverySummaryLines(preflightRows) }],
+			}).join("\n"),
+		);
 
 		console.log();
 		p.log.step(pc.bold("Migrate Summary"));

--- a/src/commands/migrate/migrate-ui-summary.ts
+++ b/src/commands/migrate/migrate-ui-summary.ts
@@ -18,6 +18,7 @@ export interface PreflightRowData {
 	destinations: string[];
 	label: string;
 	notes: string[];
+	source?: string;
 }
 
 const PORTABLE_TYPES: Array<{ key: PortableGroup; label: string }> = [
@@ -30,11 +31,18 @@ const PORTABLE_TYPES: Array<{ key: PortableGroup; label: string }> = [
 ];
 
 const MERGE_STRATEGIES = new Set(["merge-single", "yaml-merge", "json-merge"]);
+const DISCOVERY_NOUNS: Record<string, string> = {
+	Agents: "agent",
+	Commands: "command",
+	Hooks: "hook",
+	Rules: "rule",
+	Skills: "skill",
+};
 
 export function buildPreflightRows(
 	counts: PortableSourceCounts,
 	selectedProviders: ProviderType[],
-	options: { requestedGlobal: boolean },
+	options: { requestedGlobal: boolean; sourceDisplays?: Partial<Record<PortableGroup, string>> },
 ): PreflightRowData[] {
 	return PORTABLE_TYPES.flatMap(({ key, label }) => {
 		const count = counts[key];
@@ -89,6 +97,7 @@ export function buildPreflightRows(
 				destinations: Array.from(destinations.keys()),
 				label,
 				notes: Array.from(notes),
+				source: options.sourceDisplays?.[key],
 			},
 		];
 	});
@@ -103,10 +112,17 @@ export function buildTargetSummaryLines(rows: PreflightRowData[]): string[] {
 	if (allDestinations.length === 0) {
 		return ["No compatible destination found for the selected providers"];
 	}
-	if (allDestinations.length <= 3) {
-		return allDestinations;
-	}
-	return [...allDestinations.slice(0, 3), `+${allDestinations.length - 3} more destination(s)`];
+	return allDestinations;
+}
+
+export function buildDiscoverySummaryLines(rows: PreflightRowData[]): string[] {
+	return rows.map((row) => {
+		const noun = DISCOVERY_NOUNS[row.label] ?? row.label.toLowerCase();
+		const count =
+			row.label === "Config" ? "config" : `${row.count} ${noun}${row.count === 1 ? "" : "s"}`;
+		const source = row.source ? ` <- ${row.source}` : "";
+		return `${row.label.padEnd(8)} ${count}${source}`;
+	});
 }
 
 export function buildProviderScopeSubtitle(

--- a/src/commands/portable/__tests__/codex-features-flag.test.ts
+++ b/src/commands/portable/__tests__/codex-features-flag.test.ts
@@ -24,7 +24,8 @@ describe("ensureCodexHooksFeatureFlag", () => {
 
 		const content = readFileSync(configPath, "utf8");
 		expect(content).toContain("[features]");
-		expect(content).toContain("codex_hooks = true");
+		expect(content).toContain("hooks = true");
+		expect(content).not.toContain("codex_hooks");
 		expect(content).toContain("# --- ck-managed-features-start ---");
 		expect(content).toContain("# --- ck-managed-features-end ---");
 	});
@@ -45,7 +46,7 @@ describe("ensureCodexHooksFeatureFlag", () => {
 		expect(occurrences).toBe(1);
 	});
 
-	it("returns already-set when codex_hooks = true already set outside managed block", async () => {
+	it("returns already-set when hooks = true already set outside managed block", async () => {
 		const configPath = join(testDir, "manual-config.toml");
 		writeFileSync(
 			configPath,
@@ -53,7 +54,7 @@ describe("ensureCodexHooksFeatureFlag", () => {
 name = "o4-mini"
 
 [features]
-codex_hooks = true
+hooks = true
 `,
 		);
 
@@ -84,7 +85,8 @@ timeout = 120
 		expect(content).toContain("[model]");
 		expect(content).toContain('name = "o4-mini"');
 		// Feature flag added
-		expect(content).toContain("codex_hooks = true");
+		expect(content).toContain("hooks = true");
+		expect(content).not.toContain("codex_hooks");
 	});
 
 	it("creates parent directory if it does not exist", async () => {
@@ -116,7 +118,8 @@ timeout = 120
 		expect(existsSync(configPath)).toBe(true);
 
 		const content = readFileSync(configPath, "utf8");
-		expect(content).toContain("codex_hooks = true");
+		expect(content).toContain("hooks = true");
+		expect(content).not.toContain("codex_hooks");
 	});
 
 	/**
@@ -124,7 +127,7 @@ timeout = 120
 	 * second `[features]` header to be appended via the managed block, producing
 	 * TOML duplicate-key errors on next Codex load.
 	 */
-	it("merges codex_hooks into user's existing [features] section (no duplicate header)", async () => {
+	it("merges hooks into user's existing [features] section (no duplicate header)", async () => {
 		const configPath = join(testDir, "user-features-merge.toml");
 		writeFileSync(
 			configPath,
@@ -149,7 +152,8 @@ hide_full_access_warning = true
 		const featuresHeaderCount = (content.match(/^\[features\]\s*$/gm) || []).length;
 		expect(featuresHeaderCount).toBe(1);
 		// Flag merged into user's section
-		expect(content).toContain("codex_hooks = true");
+		expect(content).toContain("hooks = true");
+		expect(content).not.toContain("codex_hooks");
 		// Pre-existing user flags preserved
 		expect(content).toContain("unified_exec = true");
 		expect(content).toContain("shell_snapshot = true");
@@ -159,19 +163,19 @@ hide_full_access_warning = true
 		expect(content).toContain("[notice]");
 		// No managed block should be written since we merged into the user's section
 		expect(content).not.toContain("ck-managed-features-start");
-		// Insertion position: codex_hooks goes at the END of the user's section,
+		// Insertion position: hooks goes at the END of the user's section,
 		// not the top — preserves the user's flag ordering.
 		const featuresBlock = content.match(/\[features\][\s\S]*?(?=\n\[|$)/)?.[0] ?? "";
 		const lines = featuresBlock.split("\n").filter((l) => l.trim().length > 0);
-		expect(lines[lines.length - 1]).toBe("codex_hooks = true");
+		expect(lines[lines.length - 1]).toBe("hooks = true");
 	});
 
 	/**
 	 * Self-heal test: user already suffers the bug (two `[features]` sections,
 	 * one user-owned and one managed). Next CLI run must strip the duplicate
-	 * managed block and fold the flag into the user's section.
+	 * managed block and fold the current flag into the user's section.
 	 */
-	it("self-heals a broken config with duplicate [features] (user + managed)", async () => {
+	it("self-heals a broken config with duplicate [features] (user + legacy managed)", async () => {
 		const configPath = join(testDir, "duplicate-features-heal.toml");
 		writeFileSync(
 			configPath,
@@ -202,8 +206,9 @@ codex_hooks = true
 		// Managed block removed
 		expect(content).not.toContain("ck-managed-features-start");
 		expect(content).not.toContain("ck-managed-features-end");
-		// codex_hooks now lives in user section
-		expect(content).toContain("codex_hooks = true");
+		// hooks now lives in user section
+		expect(content).toContain("hooks = true");
+		expect(content).not.toContain("codex_hooks");
 		// User flags preserved
 		expect(content).toContain("unified_exec = true");
 		expect(content).toContain("multi_agent = true");
@@ -211,7 +216,7 @@ codex_hooks = true
 		expect(content).toContain("[notice]");
 	});
 
-	it("updates codex_hooks = false to true inside user's [features] section", async () => {
+	it("migrates deprecated codex_hooks = false to hooks = true inside user's [features] section", async () => {
 		const configPath = join(testDir, "user-features-false.toml");
 		writeFileSync(
 			configPath,
@@ -226,8 +231,8 @@ multi_agent = true
 		expect(result.status).toBe("updated");
 
 		const content = readFileSync(configPath, "utf8");
-		expect(content).toContain("codex_hooks = true");
-		expect(content).not.toContain("codex_hooks = false");
+		expect(content).toContain("hooks = true");
+		expect(content).not.toContain("codex_hooks");
 		// Only one [features] header, other flags preserved
 		const featuresHeaderCount = (content.match(/^\[features\]\s*$/gm) || []).length;
 		expect(featuresHeaderCount).toBe(1);
@@ -235,11 +240,50 @@ multi_agent = true
 		expect(content).toContain("multi_agent = true");
 	});
 
-	it("returns already-set when user's [features] already has codex_hooks = true among other flags", async () => {
+	it("migrates existing user codex_hooks = true to hooks = true", async () => {
+		const configPath = join(testDir, "user-features-legacy-true.toml");
+		writeFileSync(
+			configPath,
+			`[features]
+unified_exec = true
+codex_hooks = true
+shell_tool = true
+`,
+		);
+
+		const result = await ensureCodexHooksFeatureFlag(configPath);
+		expect(result.status).toBe("updated");
+
+		const content = readFileSync(configPath, "utf8");
+		expect(content).toContain("hooks = true");
+		expect(content).not.toContain("codex_hooks");
+		expect(content).toContain("unified_exec = true");
+		expect(content).toContain("shell_tool = true");
+	});
+
+	it("removes deprecated codex_hooks when hooks = true is already present", async () => {
+		const configPath = join(testDir, "user-features-current-and-legacy.toml");
+		writeFileSync(
+			configPath,
+			`[features]
+codex_hooks = true
+hooks = true
+`,
+		);
+
+		const result = await ensureCodexHooksFeatureFlag(configPath);
+		expect(result.status).toBe("updated");
+
+		const content = readFileSync(configPath, "utf8");
+		expect(content).toContain("hooks = true");
+		expect(content).not.toContain("codex_hooks");
+	});
+
+	it("returns already-set when user's [features] already has hooks = true among other flags", async () => {
 		const configPath = join(testDir, "user-features-already.toml");
 		const original = `[features]
 unified_exec = true
-codex_hooks = true
+hooks = true
 multi_agent = true
 `;
 		writeFileSync(configPath, original);
@@ -272,7 +316,8 @@ nested_flag = true
 		expect(result.status).toBe("written");
 
 		const content = readFileSync(configPath, "utf8");
-		expect(content).toContain("codex_hooks = true");
+		expect(content).toContain("hooks = true");
+		expect(content).not.toContain("codex_hooks");
 		// Sub-table preserved
 		expect(content).toContain("[features.sub]");
 		expect(content).toContain("nested_flag = true");
@@ -314,6 +359,8 @@ codex_hooks = true
 		expect(featuresHeaders).toBe(1);
 		expect(content).toContain("[model]");
 		expect(content).toContain("[shell]");
+		expect(content).toContain("hooks = true");
+		expect(content).not.toContain("codex_hooks");
 	});
 
 	it("strips and re-appends managed block when only managed block exists (idempotent update)", async () => {
@@ -339,7 +386,8 @@ timeout = 120
 
 		const content = readFileSync(configPath, "utf8");
 		// Updated to true
-		expect(content).toContain("codex_hooks = true");
+		expect(content).toContain("hooks = true");
+		expect(content).not.toContain("codex_hooks");
 		// Surrounding content preserved
 		expect(content).toContain("[model]");
 		expect(content).toContain("[shell]");

--- a/src/commands/portable/__tests__/codex-hook-compat-integration.test.ts
+++ b/src/commands/portable/__tests__/codex-hook-compat-integration.test.ts
@@ -9,7 +9,7 @@
  *   5. PreToolUse/PostToolUse matcher: only Bash supported
  *   6. permissionDecision: only "deny" accepted (allow|ask must be scrubbed)
  *   7. command paths pointing at $HOME/.claude/hooks — must be rewritten to wrapper paths
- *   8. codex_hooks feature flag not set — hooks.json is inert without it
+ *   8. hooks feature flag not set — hooks.json is inert without it
  *
  * Uses a real tmp filesystem; does not spawn `codex` binary.
  * Each test chdir()s into its own tmp subdir so project-scoped path resolution works.
@@ -706,10 +706,11 @@ describe("codex hook compat — concurrent config.toml write safety (H2)", () =>
 			expect(r.status).not.toBe("failed");
 		}
 
-		// Final file must have exactly one occurrence of codex_hooks = true
+		// Final file must have exactly one occurrence of hooks = true
 		const final = readFileSync(configPath, "utf8");
-		const occurrences = (final.match(/codex_hooks\s*=\s*true/g) ?? []).length;
+		const occurrences = (final.match(/^hooks\s*=\s*true/gm) ?? []).length;
 		expect(occurrences).toBe(1);
+		expect(final).not.toContain("codex_hooks");
 	}, 20000);
 });
 

--- a/src/commands/portable/codex-capabilities.ts
+++ b/src/commands/portable/codex-capabilities.ts
@@ -43,7 +43,7 @@ export interface CodexCapabilities {
 	events: Record<string, CodexEventCapabilities>;
 	/** Whether SessionStart supports "startup"|"resume" matchers only (no "clear"/"compact") */
 	sessionStartMatchersOnly: string[];
-	/** Whether hooks require [features] codex_hooks = true in config.toml */
+	/** Whether hooks require [features] hooks = true in config.toml */
 	requiresFeatureFlag: boolean;
 }
 

--- a/src/commands/portable/codex-features-flag.ts
+++ b/src/commands/portable/codex-features-flag.ts
@@ -1,11 +1,11 @@
 /**
  * Codex config.toml feature-flag writer.
  *
- * Idempotently ensures `[features] codex_hooks = true` in ~/.codex/config.toml.
+ * Idempotently ensures `[features] hooks = true` in ~/.codex/config.toml.
  *
  * Two storage strategies depending on what the file already contains:
  *
- * 1. User already has a `[features]` section — merge `codex_hooks = true`
+ * 1. User already has a `[features]` section — merge `hooks = true`
  *    INTO that section (single-line insertion / in-place update). This avoids
  *    TOML duplicate-key errors for users who already configured `[features]`
  *    themselves (e.g. `unified_exec`, `multi_agent`, `shell_snapshot`).
@@ -13,13 +13,14 @@
  * 2. No `[features]` section — append a self-contained managed block:
  *      # --- ck-managed-features-start ---
  *      [features]
- *      codex_hooks = true
+ *      hooks = true
  *      # --- ck-managed-features-end ---
  *
  * Every run FIRST strips any existing managed block, then decides whether to
  * merge into the user's section or append a new managed block. This self-heals
  * broken configs that already contain duplicate `[features]` headers produced
- * by older versions of this function.
+ * by older versions of this function, and removes the deprecated
+ * `codex_hooks` flag so current Codex builds stop warning.
  */
 import { existsSync } from "node:fs";
 import { readFile, rename, unlink, writeFile } from "node:fs/promises";
@@ -32,16 +33,18 @@ import {
 
 const SENTINEL_START = "# --- ck-managed-features-start ---";
 const SENTINEL_END = "# --- ck-managed-features-end ---";
+const CURRENT_FEATURE_FLAG = "hooks";
+const LEGACY_FEATURE_FLAG = "codex_hooks";
 
 const MANAGED_BLOCK = `${SENTINEL_START}
 [features]
-codex_hooks = true
+${CURRENT_FEATURE_FLAG} = true
 ${SENTINEL_END}`;
 
 export type FeatureFlagWriteStatus =
 	| "written" // Flag was newly added to a file that previously had no managed block or user [features]
 	| "updated" // Managed block was refreshed, merged into user [features], or duplicate cleaned up
-	| "already-set" // codex_hooks = true already present in user [features]; no write needed
+	| "already-set" // hooks = true already present in user [features]; no write needed
 	| "failed"; // I/O error
 
 export interface FeatureFlagWriteResult {
@@ -51,7 +54,7 @@ export interface FeatureFlagWriteResult {
 }
 
 /**
- * Idempotently ensure `[features] codex_hooks = true` is present in config.toml.
+ * Idempotently ensure `[features] hooks = true` is present in config.toml.
  *
  * @param configTomlPath - Absolute path to the Codex config.toml file.
  * @param isGlobal - When true, boundary is set to ~/.codex/ (global install).
@@ -104,7 +107,7 @@ async function _ensureFeatureFlagLocked(configTomlPath: string): Promise<Feature
 		mutated = mutated || changed;
 
 		if (!mutated) {
-			// User already had `codex_hooks = true` and no managed block existed — no-op.
+			// User already had `hooks = true` and no managed block existed — no-op.
 			return { status: "already-set", configPath: configTomlPath };
 		}
 
@@ -149,12 +152,13 @@ function findFeaturesSectionStart(content: string): number {
 
 /**
  * Within the `[features]` section starting at `headerStartIdx`, ensure a line
- * `codex_hooks = true` exists. The section ends at the next `[table]` header
+ * `hooks = true` exists. The section ends at the next `[table]` header
  * (including sub-tables like `[features.foo]`) or EOF.
  *
- * - If line is missing: insert right after the header.
+ * - If line is missing: insert at the end of the section.
  * - If line exists with `= false`: update to `= true`.
  * - If line exists with `= true`: no change.
+ * - If deprecated `codex_hooks` lines exist: remove them.
  */
 function ensureFlagInFeaturesSection(
 	content: string,
@@ -172,14 +176,26 @@ function ensureFlagInFeaturesSection(
 	const bodyEnd = nextHeaderMatch ? bodyStart + nextHeaderMatch.index + 1 : content.length;
 
 	const body = content.slice(bodyStart, bodyEnd);
-	const flagRegex = /^([ \t]*codex_hooks[ \t]*=[ \t]*)(true|false)([ \t]*#[^\r\n]*)?[ \t]*$/m;
-	const flagMatch = flagRegex.exec(body);
+	const legacyFlagRegex = new RegExp(
+		`^[ \\t]*${LEGACY_FEATURE_FLAG}[ \\t]*=[ \\t]*(?:true|false)(?:[ \\t]*#[^\\r\\n]*)?[ \\t]*(?:\\r?\\n|$)`,
+		"gm",
+	);
+	const cleanedBody = body.replace(legacyFlagRegex, "");
+	const changed = cleanedBody !== body;
+	const flagRegex = new RegExp(
+		`^([ \\t]*${CURRENT_FEATURE_FLAG}[ \\t]*=[ \\t]*)(true|false)([ \\t]*#[^\\r\\n]*)?[ \\t]*$`,
+		"m",
+	);
+	const flagMatch = flagRegex.exec(cleanedBody);
 
 	if (flagMatch) {
 		if (flagMatch[2] === "true") {
-			return { updated: content, changed: false };
+			return {
+				updated: content.slice(0, bodyStart) + cleanedBody + content.slice(bodyEnd),
+				changed,
+			};
 		}
-		const newBody = body.replace(
+		const newBody = cleanedBody.replace(
 			flagRegex,
 			(_m, prefix, _v, trailing) => `${prefix}true${trailing ?? ""}`,
 		);
@@ -194,21 +210,22 @@ function ensureFlagInFeaturesSection(
 	// where CK-appended entries go at the bottom rather than jumping to the top.
 	if (headerLineEnd === -1) {
 		// Header has no trailing content at all — append on a fresh line.
-		return { updated: `${content}\ncodex_hooks = true\n`, changed: true };
+		return { updated: `${content}\n${CURRENT_FEATURE_FLAG} = true\n`, changed: true };
 	}
 
 	// Trim a single trailing blank line inside the body (if any) so the new line
 	// sits directly under the last existing flag rather than after a gap.
-	let insertAt = bodyEnd;
-	while (insertAt > bodyStart && content[insertAt - 1] === "\n" && content[insertAt - 2] === "\n") {
+	let insertAt = cleanedBody.length;
+	while (insertAt > 0 && cleanedBody[insertAt - 1] === "\n" && cleanedBody[insertAt - 2] === "\n") {
 		insertAt -= 1;
 	}
 
-	const needsLeadingNewline = insertAt > bodyStart && content[insertAt - 1] !== "\n";
-	const insertion = `${needsLeadingNewline ? "\n" : ""}codex_hooks = true\n`;
+	const needsLeadingNewline = insertAt > 0 && cleanedBody[insertAt - 1] !== "\n";
+	const insertion = `${needsLeadingNewline ? "\n" : ""}${CURRENT_FEATURE_FLAG} = true\n`;
+	const newBody = cleanedBody.slice(0, insertAt) + insertion + cleanedBody.slice(insertAt);
 
 	return {
-		updated: content.slice(0, insertAt) + insertion + content.slice(insertAt),
+		updated: content.slice(0, bodyStart) + newBody + content.slice(bodyEnd),
 		changed: true,
 	};
 }

--- a/src/commands/portable/hooks-settings-merger.ts
+++ b/src/commands/portable/hooks-settings-merger.ts
@@ -76,7 +76,7 @@ export interface MigrateHooksSettingsResult {
 	codexWrapperPaths?: string[];
 	/** Codex-only: detected capability version */
 	codexCapabilitiesVersion?: string;
-	/** Codex-only: whether codex_hooks feature flag was written to config.toml */
+	/** Codex-only: whether hooks feature flag was written to config.toml */
 	codexFeatureFlagWritten?: boolean;
 }
 
@@ -644,7 +644,7 @@ export async function migrateHooksSettings(
  * 6. Convert hooks via claude-to-codex-hooks transformer (event filter, matcher
  *    filter, additionalContext removal, path rewrite → wrapper paths).
  * 7. Merge converted hooks into ~/.codex/hooks.json.
- * 8. Ensure [features] codex_hooks = true in ~/.codex/config.toml.
+ * 8. Ensure [features] hooks = true in ~/.codex/config.toml.
  */
 async function migrateHooksSettingsForCodex(
 	options: MigrateHooksSettingsOptions,
@@ -912,7 +912,7 @@ async function migrateHooksSettingsForCodex(
 		};
 	}
 
-	// Step 8: Ensure [features] codex_hooks = true in config.toml
+	// Step 8: Ensure [features] hooks = true in config.toml
 	let featureFlagWritten = false;
 	if (capabilities.requiresFeatureFlag) {
 		const configTomlPath = isGlobal

--- a/src/ui/ck-cli-design/__tests__/preflight-row.test.ts
+++ b/src/ui/ck-cli-design/__tests__/preflight-row.test.ts
@@ -10,12 +10,14 @@ describe("renderPreflightRow", () => {
 			destinations: [".agents/skills", "~/.agents/skills"],
 			label: "Commands",
 			notes: ["Codex: commands install as skills"],
+			source: ".claude/commands",
 		});
 
 		expect(lines[0]).toContain("Commands");
-		expect(lines[0]).toContain(".agents/skills");
-		expect(lines[1]).toContain("~/.agents/skills");
-		expect(lines[2]).toContain("Codex: commands install as skills");
+		expect(lines[0]).toContain("from .claude/commands");
+		expect(lines[1]).toContain("-> .agents/skills");
+		expect(lines[2]).toContain("-> ~/.agents/skills");
+		expect(lines[3]).toContain("Codex: commands install as skills");
 	});
 
 	it("falls back gracefully when no destination is available", () => {
@@ -27,7 +29,8 @@ describe("renderPreflightRow", () => {
 			notes: ["Cline: unsupported"],
 		});
 
-		expect(lines[0]).toContain("unsupported for selected provider(s)");
-		expect(lines[1]).toContain("Cline: unsupported");
+		expect(lines[0]).toContain("from source unavailable");
+		expect(lines[1]).toContain("unsupported for selected provider(s)");
+		expect(lines[2]).toContain("Cline: unsupported");
 	});
 });

--- a/src/ui/ck-cli-design/preflight-row.ts
+++ b/src/ui/ck-cli-design/preflight-row.ts
@@ -15,6 +15,7 @@ export interface PreflightRowOptions {
 	icon?: string;
 	label: string;
 	notes?: string[];
+	source?: string;
 }
 
 export function renderPreflightRow(options: PreflightRowOptions): string[] {
@@ -22,16 +23,19 @@ export function renderPreflightRow(options: PreflightRowOptions): string[] {
 	const icon = options.icon ?? context.box.bullet;
 	const label = padVisible(options.label, 10);
 	const count = String(options.count).padStart(3, " ");
-	const prefix = `  [${icon}] ${label} ${count} -> `;
-	const availableWidth = Math.max(10, context.width - prefix.length);
+	const prefix = `  [${icon}] ${label} ${count}  `;
+	const flowPrefix = `${" ".repeat(prefix.length)}-> `;
+	const availableWidth = Math.max(10, context.width - flowPrefix.length);
 	const [firstDestination, ...extraDestinations] =
 		options.destinations.length > 0
 			? options.destinations
 			: ["unsupported for selected provider(s)"];
 
-	const lines = [`${prefix}${truncateMiddle(firstDestination, availableWidth)}`];
+	const source = options.source ? `from ${options.source}` : "from source unavailable";
+	const lines = [`${prefix}${truncateMiddle(source, Math.max(10, context.width - prefix.length))}`];
+	lines.push(`${flowPrefix}${truncateMiddle(firstDestination, availableWidth)}`);
 	for (const destination of extraDestinations) {
-		lines.push(`${" ".repeat(prefix.length)}${truncateMiddle(destination, availableWidth)}`);
+		lines.push(`${flowPrefix}${truncateMiddle(destination, availableWidth)}`);
 	}
 	for (const note of options.notes ?? []) {
 		lines.push(`${" ".repeat(prefix.length)}${paint(`(${note})`, "muted", context)}`);


### PR DESCRIPTION
## Summary
- Render ck migrate preflight as explicit source -> destination flows.
- Show every destination instead of hiding extra targets behind +N more destination(s).
- Rework the Found section into the same structured panel style as the summary.
- Migrate Codex hook config from deprecated [features].codex_hooks to [features].hooks for fresh and existing installs.

## Validation
- bun run validate
- bun run test:e2e -- tests/e2e/migrate-install-mode.e2e.ts tests/e2e/migrate-empty-dir-reinstall.e2e.ts tests/e2e/migrate-four-tab-routing.e2e.ts
- isolated temp HOME/CK_TEST_HOME smoke for fresh and upgrade Codex config migration

## Docs
Docs impact: none
Action: no update needed — claudekit-docs has no codex_hooks references and existing migrate docs already describe destination-aware/source-target panels.

Closes #790