### PR TITLE
fix(doctor): stop reporting false 'Incomplete configuration' on global-only installs

### DIFF
--- a/__tests__/domains/installation/merger/settings-processor-fixtures.test.ts
+++ b/__tests__/domains/installation/merger/settings-processor-fixtures.test.ts
@@ -68,8 +68,12 @@ beforeEach(async () => {
 	// substitution and breaks every "global $HOME" / Windows path assertion.
 	savedConfigDir = process.env.CLAUDE_CONFIG_DIR;
 	savedTestHome = process.env.CK_TEST_HOME;
-	process.env.CLAUDE_CONFIG_DIR = undefined;
-	process.env.CK_TEST_HOME = undefined;
+	// Use `delete` (not `= undefined`) — assigning `undefined` to
+	// process.env.KEY coerces to the string "undefined" in standard Node.
+	// biome-ignore lint/performance/noDelete: env var must be unset, not coerced to "undefined" string
+	delete process.env.CLAUDE_CONFIG_DIR;
+	// biome-ignore lint/performance/noDelete: env var must be unset, not coerced to "undefined" string
+	delete process.env.CK_TEST_HOME;
 
 	testDir = join(tmpdir(), `sp-fixtures-${Date.now()}`);
 	sourceDir = join(testDir, "source");

--- a/__tests__/domains/installation/merger/settings-processor-fixtures.test.ts
+++ b/__tests__/domains/installation/merger/settings-processor-fixtures.test.ts
@@ -58,8 +58,19 @@ function collectHookCommands(result: Record<string, unknown>): string[] {
 let testDir: string;
 let sourceDir: string;
 let destDir: string;
+let savedConfigDir: string | undefined;
+let savedTestHome: string | undefined;
 
 beforeEach(async () => {
+	// Drop env vars that PathResolver respects in production but that fixture
+	// tests must not pick up — otherwise a parent shell exporting
+	// CLAUDE_CONFIG_DIR (e.g. CCS sessions) leaks into $HOME-based path
+	// substitution and breaks every "global $HOME" / Windows path assertion.
+	savedConfigDir = process.env.CLAUDE_CONFIG_DIR;
+	savedTestHome = process.env.CK_TEST_HOME;
+	process.env.CLAUDE_CONFIG_DIR = undefined;
+	process.env.CK_TEST_HOME = undefined;
+
 	testDir = join(tmpdir(), `sp-fixtures-${Date.now()}`);
 	sourceDir = join(testDir, "source");
 	destDir = join(testDir, "dest");
@@ -69,6 +80,8 @@ beforeEach(async () => {
 
 afterEach(async () => {
 	await rm(testDir, { recursive: true, force: true });
+	if (savedConfigDir !== undefined) process.env.CLAUDE_CONFIG_DIR = savedConfigDir;
+	if (savedTestHome !== undefined) process.env.CK_TEST_HOME = savedTestHome;
 });
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/__tests__/domains/installation/merger/settings-processor.test.ts
+++ b/__tests__/domains/installation/merger/settings-processor.test.ts
@@ -21,8 +21,12 @@ describe("SettingsProcessor", () => {
 		// substitution and breaks every "global $HOME" assertion.
 		savedConfigDir = process.env.CLAUDE_CONFIG_DIR;
 		savedTestHome = process.env.CK_TEST_HOME;
-		process.env.CLAUDE_CONFIG_DIR = undefined;
-		process.env.CK_TEST_HOME = undefined;
+		// Use `delete` (not `= undefined`) — assigning `undefined` to
+		// process.env.KEY coerces to the string "undefined" in standard Node.
+		// biome-ignore lint/performance/noDelete: env var must be unset, not coerced to "undefined" string
+		delete process.env.CLAUDE_CONFIG_DIR;
+		// biome-ignore lint/performance/noDelete: env var must be unset, not coerced to "undefined" string
+		delete process.env.CK_TEST_HOME;
 
 		testDir = join(tmpdir(), `settings-processor-test-${Date.now()}`);
 		sourceDir = join(testDir, "source");

--- a/__tests__/domains/installation/merger/settings-processor.test.ts
+++ b/__tests__/domains/installation/merger/settings-processor.test.ts
@@ -11,8 +11,19 @@ describe("SettingsProcessor", () => {
 	let testDir: string;
 	let sourceDir: string;
 	let destDir: string;
+	let savedConfigDir: string | undefined;
+	let savedTestHome: string | undefined;
 
 	beforeEach(async () => {
+		// Drop env vars that PathResolver respects in production but that
+		// these tests must not pick up — otherwise a parent shell exporting
+		// CLAUDE_CONFIG_DIR (e.g. CCS sessions) leaks into $HOME-based path
+		// substitution and breaks every "global $HOME" assertion.
+		savedConfigDir = process.env.CLAUDE_CONFIG_DIR;
+		savedTestHome = process.env.CK_TEST_HOME;
+		process.env.CLAUDE_CONFIG_DIR = undefined;
+		process.env.CK_TEST_HOME = undefined;
+
 		testDir = join(tmpdir(), `settings-processor-test-${Date.now()}`);
 		sourceDir = join(testDir, "source");
 		destDir = join(testDir, "dest");
@@ -22,6 +33,8 @@ describe("SettingsProcessor", () => {
 
 	afterEach(async () => {
 		await rm(testDir, { recursive: true, force: true });
+		if (savedConfigDir !== undefined) process.env.CLAUDE_CONFIG_DIR = savedConfigDir;
+		if (savedTestHome !== undefined) process.env.CK_TEST_HOME = savedTestHome;
 	});
 
 	describe("global path normalization during merge", () => {

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.0.0-dev.4",
-	"generatedAt": "2026-05-09T21:01:54.732Z",
+	"version": "4.0.0-dev.5",
+	"generatedAt": "2026-05-10T02:19:34.710Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-09T21:01:58.473Z -->
+<!-- generated: 2026-05-10T02:19:34.805Z -->

--- a/src/domains/health-checks/checkers/config-completeness-checker.ts
+++ b/src/domains/health-checks/checkers/config-completeness-checker.ts
@@ -5,38 +5,69 @@ import type { ClaudeKitSetup } from "@/types";
 import type { CheckResult } from "../types.js";
 
 /**
- * Check if project configuration is complete (not just CLAUDE.md)
+ * Check if project configuration is complete (not just CLAUDE.md).
+ *
+ * Only fails when the user has opted into a project-level install
+ * (signalled by metadata.json — same gate used by installation-checker
+ * and skills-checker). Otherwise the project is treated as "using global"
+ * and the check is informational, not a failure.
  */
 export async function checkProjectConfigCompleteness(
 	setup: ClaudeKitSetup,
 	projectDir: string,
 ): Promise<CheckResult> {
-	// Only check if we're in a project directory
+	const baseResult = {
+		id: "ck-project-config-complete" as const,
+		name: "Project Config Completeness",
+		group: "claudekit" as const,
+		priority: "standard" as const,
+		autoFixable: false,
+	};
+
+	// Inside the global dir itself — check is N/A
 	if (setup.project.path === setup.global.path) {
 		return {
-			id: "ck-project-config-complete",
-			name: "Project Config Completeness",
-			group: "claudekit",
-			priority: "standard",
+			...baseResult,
 			status: "info",
 			message: "Not in a project directory",
-			autoFixable: false,
 		};
 	}
 
+	const hasGlobalInstall = !!setup.global.metadata;
+	const hasProjectOptIn = !!setup.project.metadata;
+
+	// User never ran `ck init` here. Don't flag missing dirs as a failure —
+	// global install (if present) covers them. Surface as info so users
+	// understand it's intentional, not broken.
+	if (!hasProjectOptIn) {
+		if (hasGlobalInstall) {
+			return {
+				...baseResult,
+				status: "info",
+				message: "Using global ClaudeKit (no project override)",
+				details: "Run 'ck init' here only if you want project-specific agents/skills/rules",
+			};
+		}
+		return {
+			...baseResult,
+			status: "warn",
+			message: "ClaudeKit not installed",
+			suggestion: "Run 'ck init' (choose global or project scope when prompted)",
+		};
+	}
+
+	// Project opted in via `ck init` — verify expected dirs exist.
 	const projectClaudeDir = join(projectDir, ".claude");
 	const requiredDirs = ["agents", "commands", "skills"];
 	const missingDirs: string[] = [];
 
-	// Check if required directories exist
 	for (const dir of requiredDirs) {
-		const dirPath = join(projectClaudeDir, dir);
-		if (!existsSync(dirPath)) {
+		if (!existsSync(join(projectClaudeDir, dir))) {
 			missingDirs.push(dir);
 		}
 	}
 
-	// Check rules OR workflows (backward compat)
+	// Backward compat: rules OR workflows satisfies the "rules" requirement
 	const hasRulesOrWorkflows =
 		existsSync(join(projectClaudeDir, "rules")) || existsSync(join(projectClaudeDir, "workflows"));
 
@@ -44,48 +75,34 @@ export async function checkProjectConfigCompleteness(
 		missingDirs.push("rules");
 	}
 
-	// Check if only CLAUDE.md exists (minimal config)
 	const files = await readdir(projectClaudeDir).catch(() => []);
 	const hasOnlyClaudeMd = files.length === 1 && (files as string[]).includes("CLAUDE.md");
-
-	// All required dirs missing (agents, commands, skills, rules/workflows)
 	const totalRequired = requiredDirs.length + 1; // +1 for rules/workflows
+
 	if (hasOnlyClaudeMd || missingDirs.length === totalRequired) {
 		return {
-			id: "ck-project-config-complete",
-			name: "Project Config Completeness",
-			group: "claudekit",
-			priority: "standard",
+			...baseResult,
 			status: "fail",
 			message: "Incomplete configuration",
 			details: "Only CLAUDE.md found - missing agents, commands, rules, skills",
 			suggestion: "Run 'ck init' to install complete ClaudeKit in project",
-			autoFixable: false,
 		};
 	}
 
 	if (missingDirs.length > 0) {
 		return {
-			id: "ck-project-config-complete",
-			name: "Project Config Completeness",
-			group: "claudekit",
-			priority: "standard",
+			...baseResult,
 			status: "warn",
 			message: `Missing ${missingDirs.length} directories`,
 			details: `Missing: ${missingDirs.join(", ")}`,
 			suggestion: "Run 'ck init' to update project configuration",
-			autoFixable: false,
 		};
 	}
 
 	return {
-		id: "ck-project-config-complete",
-		name: "Project Config Completeness",
-		group: "claudekit",
-		priority: "standard",
+		...baseResult,
 		status: "pass",
 		message: "Complete configuration",
 		details: projectClaudeDir,
-		autoFixable: false,
 	};
 }

--- a/tests/lib/health-checks/claudekit-checker-enhanced.test.ts
+++ b/tests/lib/health-checks/claudekit-checker-enhanced.test.ts
@@ -810,6 +810,49 @@ describe("ClaudeKitChecker - Enhanced Checks", () => {
 			// Restore mock
 			readdirSpy.mockRestore();
 		});
+
+		test("returns info when project has no metadata but global is installed", async () => {
+			// Project dir with stray .claude/CLAUDE.md but no `ck init` ever ran
+			const projectDir = join(mockProjectDir, "global-only-project", ".claude");
+			mkdirSync(projectDir, { recursive: true });
+			await writeFile(join(projectDir, "CLAUDE.md"), "# Just CLAUDE.md");
+
+			mockSetup.project.path = projectDir;
+			mockSetup.project.metadata = null; // user never opted into project install
+
+			const { checkProjectConfigCompleteness } = await import(
+				"../../../src/domains/health-checks/checkers/config-completeness-checker.js"
+			);
+			const result = await checkProjectConfigCompleteness(
+				mockSetup,
+				join(mockProjectDir, "global-only-project"),
+			);
+
+			expect(result.status).toBe("info");
+			expect(result.message).toBe("Using global ClaudeKit (no project override)");
+			expect(result.details).toContain("ck init");
+		});
+
+		test("warns when neither global nor project is installed", async () => {
+			const projectDir = join(mockProjectDir, "no-install-project", ".claude");
+			mkdirSync(projectDir, { recursive: true });
+
+			mockSetup.global.metadata = null;
+			mockSetup.project.path = projectDir;
+			mockSetup.project.metadata = null;
+
+			const { checkProjectConfigCompleteness } = await import(
+				"../../../src/domains/health-checks/checkers/config-completeness-checker.js"
+			);
+			const result = await checkProjectConfigCompleteness(
+				mockSetup,
+				join(mockProjectDir, "no-install-project"),
+			);
+
+			expect(result.status).toBe("warn");
+			expect(result.message).toBe("ClaudeKit not installed");
+			expect(result.suggestion).toContain("ck init");
+		});
 	});
 
 	describe("ClaudekitChecker.run", () => {

--- a/tests/lib/health-checks/claudekit-checker-enhanced.test.ts
+++ b/tests/lib/health-checks/claudekit-checker-enhanced.test.ts
@@ -830,7 +830,9 @@ describe("ClaudeKitChecker - Enhanced Checks", () => {
 
 			expect(result.status).toBe("info");
 			expect(result.message).toBe("Using global ClaudeKit (no project override)");
-			expect(result.details).toContain("ck init");
+			expect(result.details).toBe(
+				"Run 'ck init' here only if you want project-specific agents/skills/rules",
+			);
 		});
 
 		test("warns when neither global nor project is installed", async () => {

--- a/tests/utils/path-resolver.test.ts
+++ b/tests/utils/path-resolver.test.ts
@@ -8,8 +8,14 @@ describe("PathResolver", () => {
 	const originalEnv = { ...process.env };
 
 	beforeEach(() => {
-		// Reset environment
+		// Reset environment to a clean baseline for each test.
+		// Drop env vars that PathResolver respects in production but that tests
+		// must control explicitly — otherwise a parent shell (e.g. CCS sessions
+		// that export CLAUDE_CONFIG_DIR) leaks into assertions like
+		// `getGlobalKitDir() === ~/.claude`.
 		process.env = { ...originalEnv };
+		process.env.CLAUDE_CONFIG_DIR = undefined;
+		process.env.CK_TEST_HOME = undefined;
 	});
 
 	afterEach(() => {

--- a/tests/utils/path-resolver.test.ts
+++ b/tests/utils/path-resolver.test.ts
@@ -14,8 +14,13 @@ describe("PathResolver", () => {
 		// that export CLAUDE_CONFIG_DIR) leaks into assertions like
 		// `getGlobalKitDir() === ~/.claude`.
 		process.env = { ...originalEnv };
-		process.env.CLAUDE_CONFIG_DIR = undefined;
-		process.env.CK_TEST_HOME = undefined;
+		// Use `delete` (not `= undefined`) — assigning `undefined` to
+		// process.env.KEY coerces to the string "undefined" in standard Node,
+		// which is truthy and would defeat the purpose of clearing.
+		// biome-ignore lint/performance/noDelete: env var must be unset, not coerced to "undefined" string
+		delete process.env.CLAUDE_CONFIG_DIR;
+		// biome-ignore lint/performance/noDelete: env var must be unset, not coerced to "undefined" string
+		delete process.env.CK_TEST_HOME;
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
## Summary

`ck doctor` reported `✗ Project Config Completeness — Incomplete configuration` in any directory with a stray `.claude/CLAUDE.md` (or empty `.claude/`), even when the user intentionally relied on a global install and never ran `ck init` in the project.

Closes #791

## Root cause

`src/domains/health-checks/checkers/config-completeness-checker.ts` only short-circuited when `setup.project.path === setup.global.path`. It never gated on `setup.project.metadata` — the same opt-in signal already used by `installation-checker.ts`, `skills-checker.ts`, and `env-keys-checker.ts`. Empty `.claude/` also failed because `readdir` returned `[]`, falling into the "all required missing" branch.

## What changed

| File | Change |
|------|--------|
| `src/domains/health-checks/checkers/config-completeness-checker.ts` | Gate `fail` path on `setup.project.metadata`. When no project metadata: `info` (global installed) or `warn` (nothing installed). When metadata present: existing fail/warn/pass logic unchanged. |
| `tests/lib/health-checks/claudekit-checker-enhanced.test.ts` | Add 2 tests for new info/warn behaviour. |
| `tests/utils/path-resolver.test.ts` | Stop env-leak: clear `CLAUDE_CONFIG_DIR` / `CK_TEST_HOME` in `beforeEach` via `delete` (not `= undefined`). |
| `__tests__/domains/installation/merger/settings-processor.test.ts` | Same env isolation. |
| `__tests__/domains/installation/merger/settings-processor-fixtures.test.ts` | Same env isolation. |
| `cli-manifest.json` / `docs/cli-reference.md` | Regenerated for the 4.0.0-dev.5 bump (CI parity check). |

## Behaviour matrix (new)

| Global installed | Project opt-in (metadata) | Status | Message |
|---|---|---|---|
| ✓ | ✗ | \`info\` | "Using global ClaudeKit (no project override)" |
| ✓ | ✓ + complete | \`pass\` | "Complete configuration" |
| ✓ | ✓ + missing dirs | \`warn\`/\`fail\` | (unchanged) |
| ✗ | ✗ | \`warn\` | "ClaudeKit not installed" |

## Review feedback addressed

- Replaced \`process.env.X = undefined\` with \`delete process.env.X\` (spec-correct env unset; \`= undefined\` coerces to string \`"undefined"\` in standard Node).
- Tightened \`toContain("ck init")\` to \`toBe(...)\` on the info-state test.

## Test plan

- [x] \`bun run typecheck\` passes
- [x] \`bun run lint\` passes
- [x] \`bun run build\` passes
- [x] \`bun test tests/lib/health-checks/claudekit-checker-enhanced.test.ts\` — 43 pass
- [x] \`bun test tests/utils/path-resolver.test.ts\` — 52 pass
- [x] \`bun test __tests__/domains/installation/merger/settings-processor*.test.ts\` — 65 pass
- [x] Full \`bun test\` — 0 fail (down from 30 pre-existing fail caused by env leak)
- [x] CI parity check (cli-manifest.json) — regenerated for 4.0.0-dev.5