### PR TITLE
fix: prevent Windows kit update extraction stalls

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.0.0-dev.6",
-	"generatedAt": "2026-05-10T02:24:52.621Z",
+	"version": "4.0.0-dev.7",
+	"generatedAt": "2026-05-10T16:01:38.531Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-10T02:24:52.707Z -->
+<!-- generated: 2026-05-10T16:01:38.595Z -->

--- a/src/__tests__/commands/update-cli.test.ts
+++ b/src/__tests__/commands/update-cli.test.ts
@@ -13,6 +13,7 @@ import {
 	parseCliVersionFromOutput,
 	readMetadataFile,
 	redactCommandForLog,
+	resolveCkExecutable,
 	selectKitForUpdate,
 	updateCliCommand,
 } from "@/commands/update-cli.js";
@@ -99,6 +100,17 @@ describe("update-cli", () => {
 		it("does not include --beta flag when beta is undefined", () => {
 			const result = buildInitCommand(false, "engineer");
 			expect(result).toBe("ck init --kit engineer --install-skills");
+		});
+	});
+
+	describe("resolveCkExecutable", () => {
+		it("uses the npm cmd shim on Windows without shell mode", () => {
+			expect(resolveCkExecutable("win32")).toBe("ck.cmd");
+		});
+
+		it("uses ck directly on POSIX platforms", () => {
+			expect(resolveCkExecutable("darwin")).toBe("ck");
+			expect(resolveCkExecutable("linux")).toBe("ck");
 		});
 	});
 

--- a/src/commands/update-cli.ts
+++ b/src/commands/update-cli.ts
@@ -47,6 +47,7 @@ export {
 	promptKitUpdate,
 	promptMigrateUpdate,
 	readMetadataFile,
+	resolveCkExecutable,
 	selectKitForUpdate,
 } from "./update/post-update-handler.js";
 export { redactCommandForLog } from "./update/registry-client.js";

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -127,6 +127,10 @@ export function buildInitCommand(
 	return parts.join(" ");
 }
 
+export function resolveCkExecutable(platformName: NodeJS.Platform = process.platform): string {
+	return platformName === "win32" ? "ck.cmd" : "ck";
+}
+
 // ─── Latest release tag fetcher ───────────────────────────────────────────────
 
 /**
@@ -307,7 +311,10 @@ export async function promptKitUpdate(
 				deps?.spawnInitFn ??
 				((spawnArgs: string[]) =>
 					new Promise<number>((resolve) => {
-						const child = spawn("ck", spawnArgs, { stdio: "inherit", shell: true });
+						const child = spawn(resolveCkExecutable(), spawnArgs, {
+							stdio: "inherit",
+							shell: false,
+						});
 						child.on("close", (code) => resolve(code ?? 1));
 						child.on("error", (err) => {
 							logger.verbose(`Failed to spawn ck init: ${err.message}`);

--- a/src/domains/installation/download-manager.ts
+++ b/src/domains/installation/download-manager.ts
@@ -126,7 +126,7 @@ export class DownloadManager {
 		const spinner = createSpinner("Extracting files...").start();
 
 		const slowExtractionWarning = setTimeout(() => {
-			spinner.text = "Extracting files... still working";
+			spinner.text = "Extracting files... this may take a while";
 			if (isMacOS()) {
 				logger.debug("Slow extraction detected on macOS - Spotlight indexing may be interfering");
 			} else if (isWindows()) {

--- a/src/domains/installation/download-manager.ts
+++ b/src/domains/installation/download-manager.ts
@@ -7,7 +7,7 @@
 import { mkdir, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { isMacOS } from "@/shared/environment.js";
+import { isMacOS, isWindows } from "@/shared/environment.js";
 import { logger } from "@/shared/logger.js";
 import { createSpinner } from "@/shared/safe-spinner.js";
 import { registerTempDir } from "@/shared/temp-cleanup.js";
@@ -126,9 +126,11 @@ export class DownloadManager {
 		const spinner = createSpinner("Extracting files...").start();
 
 		const slowExtractionWarning = setTimeout(() => {
-			spinner.text = "Extracting files... (this may take a while on macOS)";
+			spinner.text = "Extracting files... still working";
 			if (isMacOS()) {
 				logger.debug("Slow extraction detected on macOS - Spotlight indexing may be interfering");
+			} else if (isWindows()) {
+				logger.debug("Slow extraction detected on Windows - antivirus scanning may be interfering");
 			}
 		}, SLOW_EXTRACTION_THRESHOLD_MS);
 

--- a/src/domains/installation/extraction/native-zip-commands.ts
+++ b/src/domains/installation/extraction/native-zip-commands.ts
@@ -1,0 +1,49 @@
+export interface NativeZipCommand {
+	label: string;
+	command: string;
+	args: string[];
+}
+
+export const NATIVE_EXTRACT_TIMEOUT_MS = 120_000;
+
+export function getNativeZipCommands(
+	archivePath: string,
+	destDir: string,
+	platformName: NodeJS.Platform = process.platform,
+): NativeZipCommand[] {
+	if (platformName === "darwin") {
+		return [
+			{
+				label: "native unzip",
+				command: "unzip",
+				args: ["-o", "-q", archivePath, "-d", destDir],
+			},
+		];
+	}
+
+	if (platformName === "win32") {
+		return [
+			{
+				label: "Windows tar.exe",
+				command: "tar.exe",
+				args: ["-xf", archivePath, "-C", destDir],
+			},
+			{
+				label: "PowerShell Expand-Archive",
+				command: "powershell.exe",
+				args: [
+					"-NoProfile",
+					"-NonInteractive",
+					"-ExecutionPolicy",
+					"Bypass",
+					"-Command",
+					"Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force",
+					archivePath,
+					destDir,
+				],
+			},
+		];
+	}
+
+	return [];
+}

--- a/src/domains/installation/extraction/native-zip-commands.ts
+++ b/src/domains/installation/extraction/native-zip-commands.ts
@@ -34,9 +34,9 @@ export function getNativeZipCommands(
 				args: [
 					"-NoProfile",
 					"-NonInteractive",
-					"-ExecutionPolicy",
-					"Bypass",
 					"-Command",
+					// Extra args after -Command are available as $args inside PowerShell,
+					// avoiding unsafe path interpolation and shell quoting problems.
 					"Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force",
 					archivePath,
 					destDir,

--- a/src/domains/installation/extraction/zip-extractor.ts
+++ b/src/domains/installation/extraction/zip-extractor.ts
@@ -1,9 +1,10 @@
 /**
- * ZIP archive extraction with native unzip fallback
+ * ZIP archive extraction with native OS fallback
  */
 import { execFile } from "node:child_process";
 import { copyFile, mkdir, readdir, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { logger } from "@/shared/logger.js";
 import extractZip from "extract-zip";
 import { isWrapperDirectory } from "../utils/archive-utils.js";
@@ -12,6 +13,8 @@ import type { ExclusionFilter } from "../utils/file-utils.js";
 import { moveDirectoryContents } from "../utils/file-utils.js";
 import type { ExtractionSizeTracker } from "../utils/path-security.js";
 import { NATIVE_EXTRACT_TIMEOUT_MS, getNativeZipCommands } from "./native-zip-commands.js";
+
+const execFileAsync = promisify(execFile);
 
 /**
  * Extended extract-zip options type for yauzl support
@@ -40,33 +43,18 @@ export class ZipExtractor {
 		}
 
 		for (const nativeCommand of commands) {
-			const success = await new Promise<boolean>((resolve) => {
-				rm(destDir, { recursive: true, force: true })
-					.then(() => mkdir(destDir, { recursive: true }))
-					.then(() => {
-						execFile(
-							nativeCommand.command,
-							nativeCommand.args,
-							{ timeout: NATIVE_EXTRACT_TIMEOUT_MS, windowsHide: true },
-							(error, _stdout, stderr) => {
-								if (error) {
-									logger.debug(`${nativeCommand.label} failed: ${stderr || error.message}`);
-									resolve(false);
-									return;
-								}
-								logger.debug(`${nativeCommand.label} succeeded`);
-								resolve(true);
-							},
-						);
-					})
-					.catch((err: Error) => {
-						logger.debug(`Failed to prepare directory for ${nativeCommand.label}: ${err.message}`);
-						resolve(false);
-					});
-			});
-
-			if (success) {
+			try {
+				await rm(destDir, { recursive: true, force: true });
+				await mkdir(destDir, { recursive: true });
+				await execFileAsync(nativeCommand.command, nativeCommand.args, {
+					timeout: NATIVE_EXTRACT_TIMEOUT_MS,
+					windowsHide: true,
+				});
+				logger.debug(`${nativeCommand.label} succeeded`);
 				return true;
+			} catch (err) {
+				const error = err as Error & { stderr?: string };
+				logger.debug(`${nativeCommand.label} failed: ${error.stderr || error.message}`);
 			}
 		}
 

--- a/src/domains/installation/extraction/zip-extractor.ts
+++ b/src/domains/installation/extraction/zip-extractor.ts
@@ -4,7 +4,6 @@
 import { execFile } from "node:child_process";
 import { copyFile, mkdir, readdir, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
-import { isMacOS } from "@/shared/environment.js";
 import { logger } from "@/shared/logger.js";
 import extractZip from "extract-zip";
 import { isWrapperDirectory } from "../utils/archive-utils.js";
@@ -12,6 +11,7 @@ import { normalizeZipEntryName } from "../utils/encoding-utils.js";
 import type { ExclusionFilter } from "../utils/file-utils.js";
 import { moveDirectoryContents } from "../utils/file-utils.js";
 import type { ExtractionSizeTracker } from "../utils/path-security.js";
+import { NATIVE_EXTRACT_TIMEOUT_MS, getNativeZipCommands } from "./native-zip-commands.js";
 
 /**
  * Extended extract-zip options type for yauzl support
@@ -23,43 +23,56 @@ interface ExtractZipOptions {
 }
 
 /**
- * ZIP archive extractor with native unzip fallback on macOS
+ * ZIP archive extractor with native OS fallback on macOS and Windows
  */
 export class ZipExtractor {
 	/**
-	 * Try to extract zip using native unzip command (faster on macOS)
+	 * Try to extract zip using native OS tools before JS fallback
 	 * Uses execFile with array arguments to prevent command injection
 	 * @param archivePath - Path to ZIP archive
 	 * @param destDir - Destination directory
-	 * @returns true if successful, false if native unzip unavailable or failed
+	 * @returns true if successful, false if native extraction unavailable or failed
 	 */
-	private async tryNativeUnzip(archivePath: string, destDir: string): Promise<boolean> {
-		// Only try native unzip on macOS where extract-zip has known performance issues
-		if (!isMacOS()) {
+	private async tryNativeExtraction(archivePath: string, destDir: string): Promise<boolean> {
+		const commands = getNativeZipCommands(archivePath, destDir);
+		if (commands.length === 0) {
 			return false;
 		}
 
-		return new Promise((resolve) => {
-			// Ensure destination exists
-			mkdir(destDir, { recursive: true })
-				.then(() => {
-					// Use execFile with array arguments to prevent command injection
-					// -o: overwrite without prompting, -q: quiet mode
-					execFile("unzip", ["-o", "-q", archivePath, "-d", destDir], (error, _stdout, stderr) => {
-						if (error) {
-							logger.debug(`Native unzip failed: ${stderr || error.message}`);
-							resolve(false);
-							return;
-						}
-						logger.debug("Native unzip succeeded");
-						resolve(true);
+		for (const nativeCommand of commands) {
+			const success = await new Promise<boolean>((resolve) => {
+				rm(destDir, { recursive: true, force: true })
+					.then(() => mkdir(destDir, { recursive: true }))
+					.then(() => {
+						execFile(
+							nativeCommand.command,
+							nativeCommand.args,
+							{ timeout: NATIVE_EXTRACT_TIMEOUT_MS, windowsHide: true },
+							(error, _stdout, stderr) => {
+								if (error) {
+									logger.debug(`${nativeCommand.label} failed: ${stderr || error.message}`);
+									resolve(false);
+									return;
+								}
+								logger.debug(`${nativeCommand.label} succeeded`);
+								resolve(true);
+							},
+						);
+					})
+					.catch((err: Error) => {
+						logger.debug(`Failed to prepare directory for ${nativeCommand.label}: ${err.message}`);
+						resolve(false);
 					});
-				})
-				.catch((err: Error) => {
-					logger.debug(`Failed to create directory for native unzip: ${err.message}`);
-					resolve(false);
-				});
-		});
+			});
+
+			if (success) {
+				return true;
+			}
+		}
+
+		await rm(destDir, { recursive: true, force: true });
+		await mkdir(destDir, { recursive: true });
+		return false;
 	}
 
 	/**
@@ -80,8 +93,8 @@ export class ZipExtractor {
 		await mkdir(tempExtractDir, { recursive: true });
 
 		try {
-			// Try native unzip on macOS first (faster, avoids known issues)
-			const nativeSuccess = await this.tryNativeUnzip(archivePath, tempExtractDir);
+			// Native tools avoid long JS extraction stalls on macOS and Windows.
+			const nativeSuccess = await this.tryNativeExtraction(archivePath, tempExtractDir);
 
 			if (!nativeSuccess) {
 				// Fall back to extract-zip

--- a/tests/lib/download.test.ts
+++ b/tests/lib/download.test.ts
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { DownloadManager } from "@/domains/installation/download-manager.js";
+import { getNativeZipCommands } from "@/domains/installation/extraction/native-zip-commands.js";
 import {
 	ExtractionSizeTracker,
 	detectArchiveType,
@@ -287,6 +288,30 @@ describe("Installation utilities", () => {
 			expect(() => {
 				detectArchiveType("project-v1.0.0.rar");
 			}).toThrow(ExtractionError);
+		});
+	});
+
+	describe("native zip extraction commands", () => {
+		test("uses Windows native extractors before JS fallback", () => {
+			const commands = getNativeZipCommands("C:\\Temp\\kit.zip", "C:\\Temp\\out", "win32");
+
+			expect(commands.map((command) => command.command)).toEqual(["tar.exe", "powershell.exe"]);
+			expect(commands[0]?.args).toEqual(["-xf", "C:\\Temp\\kit.zip", "-C", "C:\\Temp\\out"]);
+			expect(commands[1]?.args).toContain(
+				"Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force",
+			);
+		});
+
+		test("keeps native unzip on macOS", () => {
+			const commands = getNativeZipCommands("/tmp/kit.zip", "/tmp/out", "darwin");
+
+			expect(commands).toHaveLength(1);
+			expect(commands[0]?.command).toBe("unzip");
+			expect(commands[0]?.args).toEqual(["-o", "-q", "/tmp/kit.zip", "-d", "/tmp/out"]);
+		});
+
+		test("does not use platform native commands on Linux", () => {
+			expect(getNativeZipCommands("/tmp/kit.zip", "/tmp/out", "linux")).toEqual([]);
 		});
 	});
 });

--- a/tests/lib/download.test.ts
+++ b/tests/lib/download.test.ts
@@ -297,9 +297,14 @@ describe("Installation utilities", () => {
 
 			expect(commands.map((command) => command.command)).toEqual(["tar.exe", "powershell.exe"]);
 			expect(commands[0]?.args).toEqual(["-xf", "C:\\Temp\\kit.zip", "-C", "C:\\Temp\\out"]);
-			expect(commands[1]?.args).toContain(
+			expect(commands[1]?.args).toEqual([
+				"-NoProfile",
+				"-NonInteractive",
+				"-Command",
 				"Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force",
-			);
+				"C:\\Temp\\kit.zip",
+				"C:\\Temp\\out",
+			]);
 		});
 
 		test("keeps native unzip on macOS", () => {


### PR DESCRIPTION
## Summary
- use native Windows ZIP extraction (`tar.exe`, then PowerShell `Expand-Archive`) before the JS extractor fallback
- keep native macOS unzip behavior and reset temp extraction dirs between native attempts
- spawn post-update `ck init` without shell mode, using `ck.cmd` on Windows to avoid Node shell+args warnings
- make slow extraction messaging platform-neutral

## Root Cause
Windows kit ZIP installs always used the JS `extract-zip` path. That path can stall on some Windows machines during `ck update`, leaving users stuck at `Extracting files...`. The post-update interactive init also spawned `ck` with `shell: true` and args, causing the Node deprecation warning visible in the report.

## Test Plan
- `bun run validate`
- pre-commit quality gate
- pre-push quality gate

Closes #794