### PR TITLE
fix(update): launch Windows kit init through shell

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.0.0-dev.7",
-	"generatedAt": "2026-05-10T16:01:38.531Z",
+	"version": "4.0.0-dev.8",
+	"generatedAt": "2026-05-11T02:16:34.422Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-10T16:01:38.595Z -->
+<!-- generated: 2026-05-11T02:16:37.353Z -->

--- a/src/__tests__/commands/update-cli.test.ts
+++ b/src/__tests__/commands/update-cli.test.ts
@@ -15,6 +15,7 @@ import {
 	redactCommandForLog,
 	resolveCkExecutable,
 	selectKitForUpdate,
+	shouldRunCkExecutableInShell,
 	updateCliCommand,
 } from "@/commands/update-cli.js";
 import { compareVersions } from "compare-versions";
@@ -104,13 +105,24 @@ describe("update-cli", () => {
 	});
 
 	describe("resolveCkExecutable", () => {
-		it("uses the npm cmd shim on Windows without shell mode", () => {
+		it("uses the npm cmd shim on Windows", () => {
 			expect(resolveCkExecutable("win32")).toBe("ck.cmd");
 		});
 
 		it("uses ck directly on POSIX platforms", () => {
 			expect(resolveCkExecutable("darwin")).toBe("ck");
 			expect(resolveCkExecutable("linux")).toBe("ck");
+		});
+	});
+
+	describe("shouldRunCkExecutableInShell", () => {
+		it("uses shell mode for Windows cmd shims", () => {
+			expect(shouldRunCkExecutableInShell("win32")).toBe(true);
+		});
+
+		it("does not use shell mode on POSIX platforms", () => {
+			expect(shouldRunCkExecutableInShell("darwin")).toBe(false);
+			expect(shouldRunCkExecutableInShell("linux")).toBe(false);
 		});
 	});
 

--- a/src/commands/update-cli.ts
+++ b/src/commands/update-cli.ts
@@ -49,6 +49,7 @@ export {
 	readMetadataFile,
 	resolveCkExecutable,
 	selectKitForUpdate,
+	shouldRunCkExecutableInShell,
 } from "./update/post-update-handler.js";
 export { redactCommandForLog } from "./update/registry-client.js";
 export type {

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -131,6 +131,12 @@ export function resolveCkExecutable(platformName: NodeJS.Platform = process.plat
 	return platformName === "win32" ? "ck.cmd" : "ck";
 }
 
+export function shouldRunCkExecutableInShell(
+	platformName: NodeJS.Platform = process.platform,
+): boolean {
+	return platformName === "win32";
+}
+
 // ─── Latest release tag fetcher ───────────────────────────────────────────────
 
 /**
@@ -313,7 +319,7 @@ export async function promptKitUpdate(
 					new Promise<number>((resolve) => {
 						const child = spawn(resolveCkExecutable(), spawnArgs, {
 							stdio: "inherit",
-							shell: false,
+							shell: shouldRunCkExecutableInShell(),
 						});
 						child.on("close", (code) => resolve(code ?? 1));
 						child.on("error", (err) => {


### PR DESCRIPTION
## Summary
- run the interactive post-update `ck init` spawn through a shell on Windows so npm `ck.cmd` shims launch correctly
- keep POSIX behavior unchanged
- add regression coverage for the Windows shell decision

Closes #796

## Root Cause
Windows `.cmd` shims are not reliably executable via `spawn(..., { shell: false })`. `ck update` logged `Running: ck init ...`, then the nested interactive init process failed to launch and returned control to PowerShell.

## Changes
| File | Change |
|------|--------|
| `src/commands/update/post-update-handler.ts` | Added Windows shell-mode decision for the interactive init spawn |
| `src/commands/update-cli.ts` | Re-exported the helper for update command tests |
| `src/__tests__/commands/update-cli.test.ts` | Covered Windows shell mode and POSIX non-shell behavior |

## Test plan
- [x] `bun test src/__tests__/commands/update-cli.test.ts src/__tests__/commands/update-cli-auto-init.test.ts src/__tests__/commands/update-cli.windows-integration.test.ts`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun test`
- [x] `bun test src/__tests__/domains/web-server/routes/plan-list-all.test.ts`
