### PR TITLE
fix: show system remediation for skill tool failures

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.0.0-dev.8",
-	"generatedAt": "2026-05-11T02:16:34.422Z",
+	"version": "4.0.0-dev.9",
+	"generatedAt": "2026-05-11T02:41:31.523Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-11T02:16:37.353Z -->
+<!-- generated: 2026-05-11T02:41:31.615Z -->

--- a/src/services/package-installer/install-error-handler.ts
+++ b/src/services/package-installer/install-error-handler.ts
@@ -13,10 +13,20 @@ export interface InstallErrorSummary {
 	skipped: string[];
 	remediation: {
 		sudo_packages: string;
+		winget_packages?: string;
 		build_tools: string;
 		pip_retry: string;
 	};
 }
+
+const WINDOWS_SYSTEM_PACKAGES = {
+	ffmpeg: "Gyan.FFmpeg",
+	imagemagick: "ImageMagick.ImageMagick",
+	librsvg: "GNOME.librsvg",
+	"rsvg-convert": "GNOME.librsvg",
+} as const;
+type SystemToolKey = keyof typeof WINDOWS_SYSTEM_PACKAGES;
+const SYSTEM_TOOL_KEYS = Object.keys(WINDOWS_SYSTEM_PACKAGES) as SystemToolKey[];
 
 /**
  * Parse "name: reason" strings safely, handling multiple colons
@@ -28,6 +38,52 @@ function parseNameReason(str: string): [string, string | undefined] {
 		return [str.trim(), undefined];
 	}
 	return [str.slice(0, colonIndex).trim(), str.slice(colonIndex + 1).trim()];
+}
+
+function matchesSystemToolName(name: string, toolName: SystemToolKey): boolean {
+	return name === toolName || name.startsWith(`${toolName} `) || name.includes(`(${toolName})`);
+}
+
+function getSystemToolKey(failure: string): SystemToolKey | undefined {
+	const [name] = parseNameReason(failure);
+	const lowerName = name.toLowerCase().replace(/\s+/g, " ");
+	for (const toolName of SYSTEM_TOOL_KEYS) {
+		if (matchesSystemToolName(lowerName, toolName)) {
+			return toolName;
+		}
+	}
+	return undefined;
+}
+
+function isSystemToolFailure(failure: string): boolean {
+	return getSystemToolKey(failure) !== undefined;
+}
+
+function isWindowsSummary(summary: InstallErrorSummary): boolean {
+	return Boolean(
+		summary.remediation.winget_packages ||
+			summary.remediation.pip_retry.includes(".ps1") ||
+			summary.remediation.pip_retry.includes("\\"),
+	);
+}
+
+function getSystemPackageCommand(
+	summary: InstallErrorSummary,
+	systemFailures: string[],
+): string | undefined {
+	if (isWindowsSummary(summary)) {
+		const packageIds = new Set<string>();
+		for (const failure of systemFailures) {
+			const key = getSystemToolKey(failure);
+			if (key) packageIds.add(WINDOWS_SYSTEM_PACKAGES[key]);
+		}
+		if (packageIds.size > 0) {
+			return `winget install ${Array.from(packageIds).join(" ")}`;
+		}
+		return summary.remediation.winget_packages;
+	}
+
+	return summary.remediation.sudo_packages || undefined;
 }
 
 /**
@@ -56,6 +112,13 @@ export function displayInstallErrors(skillsDir: string): void {
 	}
 
 	try {
+		const systemOptionalFailures = summary.optional_failures.filter(isSystemToolFailure);
+		const pythonOptionalFailures = summary.optional_failures.filter((f) => !isSystemToolFailure(f));
+		const systemPackageCommand = getSystemPackageCommand(summary, [
+			...systemOptionalFailures,
+			...summary.skipped,
+		]);
+
 		// Display based on failure type
 		if (summary.critical_failures.length > 0) {
 			logger.error("");
@@ -95,7 +158,7 @@ export function displayInstallErrors(skillsDir: string): void {
 
 		// Check for build tool related failures (more specific patterns to avoid false matches)
 		if (
-			summary.optional_failures.some(
+			pythonOptionalFailures.some(
 				(f) => f.includes("no wheel") || f.includes("build tools") || f.includes("build failed"),
 			) &&
 			summary.remediation.build_tools
@@ -105,13 +168,13 @@ export function displayInstallErrors(skillsDir: string): void {
 			logger.info("");
 		}
 
-		if (summary.skipped.length > 0 && summary.remediation.sudo_packages) {
+		if ((summary.skipped.length > 0 || systemOptionalFailures.length > 0) && systemPackageCommand) {
 			logger.info("Install system packages:");
-			logger.info(`  ${summary.remediation.sudo_packages}`);
+			logger.info(`  ${systemPackageCommand}`);
 			logger.info("");
 		}
 
-		if (summary.optional_failures.length > 0 && summary.remediation.pip_retry) {
+		if (pythonOptionalFailures.length > 0 && summary.remediation.pip_retry) {
 			logger.info("Then retry failed packages manually:");
 			logger.info(`  ${summary.remediation.pip_retry}`);
 		}

--- a/tests/utils/install-error-handler.test.ts
+++ b/tests/utils/install-error-handler.test.ts
@@ -137,6 +137,63 @@ describe("install-error-handler", () => {
 			expect(loggerInfoSpy).toHaveBeenCalledWith("  sudo apt-get install -y ffmpeg");
 		});
 
+		it("should show winget remediation for Windows system tool failures without pip retry", () => {
+			const pipRetry =
+				'.\\.claude\\skills\\.venv\\Scripts\\Activate.ps1; python -m pip install "<package>"';
+			const summary: InstallErrorSummary = {
+				exit_code: 2,
+				timestamp: new Date().toISOString(),
+				critical_failures: [],
+				optional_failures: [
+					"FFmpeg: installation failed",
+					"librsvg (rsvg-convert): installation failed",
+				],
+				skipped: [],
+				remediation: {
+					sudo_packages: "",
+					winget_packages: "winget install Gyan.FFmpeg ImageMagick.ImageMagick",
+					build_tools: "",
+					pip_retry: pipRetry,
+				},
+			};
+
+			writeFileSync(join(testDir, ".install-error-summary.json"), JSON.stringify(summary));
+			displayInstallErrors(testDir);
+
+			expect(loggerInfoSpy).toHaveBeenCalledWith("Install system packages:");
+			expect(loggerInfoSpy).toHaveBeenCalledWith("  winget install Gyan.FFmpeg GNOME.librsvg");
+			expect(loggerInfoSpy).not.toHaveBeenCalledWith("Then retry failed packages manually:");
+			expect(loggerInfoSpy).not.toHaveBeenCalledWith(`  ${pipRetry}`);
+		});
+
+		it("should show both system and pip remediation for mixed optional failures", () => {
+			const pipRetry =
+				'.\\.claude\\skills\\.venv\\Scripts\\Activate.ps1; python -m pip install "<package>"';
+			const summary: InstallErrorSummary = {
+				exit_code: 2,
+				timestamp: new Date().toISOString(),
+				critical_failures: [],
+				optional_failures: [
+					"FFmpeg: installation failed",
+					"ai-multimodal (pytest-mock>=3.12.0): Package install failed",
+				],
+				skipped: [],
+				remediation: {
+					sudo_packages: "",
+					winget_packages: "winget install Gyan.FFmpeg ImageMagick.ImageMagick",
+					build_tools: "",
+					pip_retry: pipRetry,
+				},
+			};
+
+			writeFileSync(join(testDir, ".install-error-summary.json"), JSON.stringify(summary));
+			displayInstallErrors(testDir);
+
+			expect(loggerInfoSpy).toHaveBeenCalledWith("  winget install Gyan.FFmpeg");
+			expect(loggerInfoSpy).toHaveBeenCalledWith("Then retry failed packages manually:");
+			expect(loggerInfoSpy).toHaveBeenCalledWith(`  ${pipRetry}`);
+		});
+
 		it("should handle malformed JSON gracefully", () => {
 			writeFileSync(join(testDir, ".install-error-summary.json"), "{ invalid json }");
 			displayInstallErrors(testDir);


### PR DESCRIPTION
Closes #798

## Summary
- classify optional skill install failures as system tools vs Python packages
- show Windows winget remediation for FFmpeg, ImageMagick, and librsvg failures
- only show pip retry instructions when Python package failures are present

## Validation
- bun test tests/utils/install-error-handler.test.ts
- bun run lint
- bun run typecheck
- bun run build
- bun test src/__tests__/domains/installation/selective-merger.test.ts
- pre-push gate: lint, typecheck, build, backend tests, UI build, UI tests

Docs impact: none
Action: no update needed — CLI remediation text only; no command, config, or docs contract change.