### PR TITLE
fix(migrate): repair inline Codex agent config entries

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.0.0-dev.9",
-	"generatedAt": "2026-05-11T02:41:31.523Z",
+	"version": "4.0.0-dev.10",
+	"generatedAt": "2026-05-11T03:54:48.267Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-11T02:41:31.615Z -->
+<!-- generated: 2026-05-11T03:54:51.251Z -->

--- a/src/__tests__/domains/web-server/routes/migration-routes.test.ts
+++ b/src/__tests__/domains/web-server/routes/migration-routes.test.ts
@@ -185,7 +185,7 @@ async function teardownServer(ctx: TestServer): Promise<void> {
 	await rm(ctx.testHome, { recursive: true, force: true });
 }
 
-describe("migration reconcile route", () => {
+describe.serial("migration reconcile route", () => {
 	let ctx!: TestServer;
 	let hasCtx = false;
 

--- a/src/__tests__/services/transformers/commands-prefix-cleaner-kit-aware.test.ts
+++ b/src/__tests__/services/transformers/commands-prefix-cleaner-kit-aware.test.ts
@@ -373,14 +373,9 @@ describe("cleanupCommandsDirectory - kit-aware", () => {
  */
 async function calculateChecksum(filePath: string): Promise<string> {
 	const { createHash } = await import("node:crypto");
-	const { createReadStream } = await import("node:fs");
+	const { readFile } = await import("node:fs/promises");
 
-	return new Promise((resolve, reject) => {
-		const hash = createHash("sha256");
-		const stream = createReadStream(filePath);
-
-		stream.on("data", (chunk) => hash.update(chunk));
-		stream.on("end", () => resolve(hash.digest("hex")));
-		stream.on("error", reject);
-	});
+	return createHash("sha256")
+		.update(await readFile(filePath))
+		.digest("hex");
 }

--- a/src/commands/portable/__tests__/codex-config-cleanup.test.ts
+++ b/src/commands/portable/__tests__/codex-config-cleanup.test.ts
@@ -196,6 +196,31 @@ describe("cleanupStaleCodexConfigEntries", () => {
 		expect(content).toContain(`[agents.${slug}]`);
 	});
 
+	it("repairs inline legacy agent entries even when no stale entries are removed", async () => {
+		const slug = "code_simplifier";
+		await writeFile(join(agentsDir, `${slug}.toml`), "# exists", "utf-8");
+		await writeFile(
+			configTomlPath,
+			[
+				'model = "gpt-5.3-codex"',
+				'trust_level = "trusted"[agents.code_simplifier]',
+				'description = "Simplify code"',
+				`config_file = "agents/${slug}.toml"`,
+			].join("\n"),
+			"utf-8",
+		);
+
+		const removed = await cleanupStaleCodexConfigEntries({
+			global: false,
+			provider: "codex",
+		});
+
+		expect(removed).toEqual([]);
+		const content = await readFile(configTomlPath, "utf-8");
+		expect(content).toContain('trust_level = "trusted"\n[agents.code_simplifier]');
+		expect(content).not.toContain('"trusted"[agents');
+	});
+
 	it("removes both sentinel-managed and legacy stale entries in one pass", async () => {
 		const managedSlug = "managed_stale";
 		const legacySlug = "legacy_stale";

--- a/src/commands/portable/__tests__/fm-to-codex-toml.test.ts
+++ b/src/commands/portable/__tests__/fm-to-codex-toml.test.ts
@@ -233,6 +233,34 @@ describe("mergeConfigToml", () => {
 		expect(result).not.toContain("[agents.two]");
 	});
 
+	it("collapses multiple managed blocks after inline repair shifts offsets", () => {
+		const existing = [
+			'trust_level = "trusted"[agents.legacy_inline]',
+			'description = "Legacy inline"',
+			'config_file = "agents/legacy_inline.toml"',
+			"",
+			"# --- ck-managed-agents-start ---",
+			"[agents.one]",
+			'description = "one"',
+			'config_file = "agents/one.toml"',
+			"# --- ck-managed-agents-end ---",
+			"",
+			"# --- ck-managed-agents-start ---",
+			"[agents.two]",
+			'description = "two"',
+			'config_file = "agents/two.toml"',
+			"# --- ck-managed-agents-end ---",
+		].join("\n");
+		const result = mergeConfigTomlWithDiagnostics(existing, block);
+
+		expect(result.error).toBeUndefined();
+		expect((result.content.match(/# --- ck-managed-agents-start ---/g) ?? []).length).toBe(1);
+		expect(result.content).toContain('trust_level = "trusted"\n[agents.legacy_inline]');
+		expect(result.content).toContain("[agents.test]");
+		expect(result.content).not.toContain("[agents.one]");
+		expect(result.content).not.toContain("[agents.two]");
+	});
+
 	it("preserves CRLF line endings", () => {
 		const existing = 'model = "gpt-5.3-codex"\r\n\r\n[features]\r\nmulti_agent = true\r\n';
 		const result = mergeConfigToml(existing, block);
@@ -262,6 +290,15 @@ describe("mergeConfigToml", () => {
 
 		expect(result.content).toContain(existing.trimEnd());
 		expect(result.content).not.toContain("see \n[agents.code_simplifier]");
+		expect(result.warnings.some((warning) => warning.includes("inline [agents.*]"))).toBe(false);
+	});
+
+	it("does not rewrite agent-like text at the end of string values", () => {
+		const existing = 'notice = "[agents.code_simplifier]"\n';
+		const result = mergeConfigTomlWithDiagnostics(existing, block);
+
+		expect(result.content).toContain(existing.trimEnd());
+		expect(result.content).not.toContain('notice = "\n[agents.code_simplifier]');
 		expect(result.warnings.some((warning) => warning.includes("inline [agents.*]"))).toBe(false);
 	});
 

--- a/src/commands/portable/__tests__/fm-to-codex-toml.test.ts
+++ b/src/commands/portable/__tests__/fm-to-codex-toml.test.ts
@@ -240,6 +240,31 @@ describe("mergeConfigToml", () => {
 		expect(result.includes("\n# --- ck-managed-agents-start ---\n")).toBe(false);
 	});
 
+	it("repairs inline legacy agent table headers before merging", () => {
+		const existing = [
+			'model = "gpt-5.3-codex"',
+			'trust_level = "trusted"[agents.code_simplifier]',
+			'description = "Simplify code"',
+			'config_file = "agents/code_simplifier.toml"',
+		].join("\n");
+		const result = mergeConfigTomlWithDiagnostics(existing, block);
+
+		expect(result.error).toBeUndefined();
+		expect(result.content).toContain('trust_level = "trusted"\n[agents.code_simplifier]');
+		expect(result.content).not.toContain('"trusted"[agents');
+		expect(result.content).toContain("[agents.test]");
+		expect(result.warnings.some((warning) => warning.includes("inline [agents.*]"))).toBe(true);
+	});
+
+	it("does not rewrite agent-like text inside string values", () => {
+		const existing = 'notice = "see [agents.code_simplifier] before editing"\n';
+		const result = mergeConfigTomlWithDiagnostics(existing, block);
+
+		expect(result.content).toContain(existing.trimEnd());
+		expect(result.content).not.toContain("see \n[agents.code_simplifier]");
+		expect(result.warnings.some((warning) => warning.includes("inline [agents.*]"))).toBe(false);
+	});
+
 	it("returns diagnostic error for malformed unmatched sentinels", () => {
 		const existing =
 			'# --- ck-managed-agents-start ---\n[agents.old]\ndescription = "Old"\nconfig_file = "agents/old.toml"\n';

--- a/src/commands/portable/__tests__/portable-installer.test.ts
+++ b/src/commands/portable/__tests__/portable-installer.test.ts
@@ -1625,6 +1625,57 @@ describe("codex-toml agent installer", () => {
 		}
 	});
 
+	test("repairs broken installed config when legacy agent table is inline", async () => {
+		const tempDir = await mkdtemp(join(process.cwd(), ".tmp-codex-toml-inline-repair-"));
+		const agentsPath = join(tempDir, ".codex", "agents");
+		const configPath = join(tempDir, ".codex", "config.toml");
+		const pathConfig = getPathConfig("codex", "agents");
+		const originalPath = pathConfig.projectPath;
+
+		try {
+			await mkdir(agentsPath, { recursive: true });
+			await writeFile(join(agentsPath, "code_simplifier.toml"), "# already installed", "utf-8");
+			await writeFile(
+				configPath,
+				[
+					'model = "gpt-5.3-codex"',
+					'trust_level = "trusted"[agents.code_simplifier]',
+					'description = "Simplify code"',
+					'config_file = "agents/code_simplifier.toml"',
+				].join("\n"),
+				"utf-8",
+			);
+			pathConfig.projectPath = agentsPath;
+
+			const results = await installPortableItems(
+				[
+					makePortableItem({
+						type: "agent",
+						name: "code-simplifier",
+						body: "Already installed.",
+						frontmatter: { name: "Code Simplifier", tools: "Read,Edit" },
+					}),
+				],
+				["codex"],
+				"agent",
+				{ global: false },
+			);
+
+			expect(results[0].success).toBe(true);
+			expect(results[0].warnings?.some((warning) => warning.includes("inline [agents.*]"))).toBe(
+				true,
+			);
+
+			const config = await readFile(configPath, "utf-8");
+			expect(config).toContain('trust_level = "trusted"\n[agents.code_simplifier]');
+			expect(config).not.toContain('"trusted"[agents');
+			expect(addPortableInstallationMock).not.toHaveBeenCalled();
+		} finally {
+			pathConfig.projectPath = originalPath;
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	test("rolls back written files when registry update fails", async () => {
 		const tempDir = await mkdtemp(join(process.cwd(), ".tmp-codex-toml-rollback-"));
 		const agentsPath = join(tempDir, ".codex", "agents");

--- a/src/commands/portable/codex-toml-installer.ts
+++ b/src/commands/portable/codex-toml-installer.ts
@@ -30,6 +30,7 @@ interface ManagedBlockRange {
 
 interface AnalyzeConfigTomlResult {
 	lineEnding: "\n" | "\r\n";
+	normalizedContent: string;
 	unmanagedContent: string;
 	warnings: string[];
 	error?: string;
@@ -123,6 +124,22 @@ function isManagedAgentBlock(content: string): boolean {
 	return hasAgentTable && (hasDescription || hasAgentConfig);
 }
 
+function repairInlineAgentTableHeaders(
+	content: string,
+	lineEnding: "\n" | "\r\n",
+): { content: string; repairedCount: number } {
+	let repairedCount = 0;
+	const repairedContent = content.replace(
+		/([^\r\n])(\[agents\.(?:"[^"\r\n]+"|[^\]\r\n]+)\][ \t]*(?:#[^\r\n]*)?)(?=\r?\n|$)/g,
+		(_match, prefix: string, header: string) => {
+			repairedCount += 1;
+			return `${prefix}${lineEnding}${header}`;
+		},
+	);
+
+	return { content: repairedContent, repairedCount };
+}
+
 function extractManagedAgentEntries(existing: string): Map<string, string> {
 	const entries = new Map<string, string>();
 	const escapedStart = escapeRegExp(SENTINEL_START);
@@ -191,19 +208,27 @@ function stripRanges(content: string, ranges: ManagedBlockRange[]): string {
 function analyzeConfigToml(existing: string): AnalyzeConfigTomlResult {
 	const lineEnding = detectLineEnding(existing);
 	const warnings: string[] = [];
+	const repairResult = repairInlineAgentTableHeaders(existing, lineEnding);
+	const normalizedContent = repairResult.content;
+	if (repairResult.repairedCount > 0) {
+		warnings.push(
+			`Repaired ${repairResult.repairedCount} inline [agents.*] table header(s) in config.toml`,
+		);
+	}
+
 	const escapedStart = escapeRegExp(SENTINEL_START);
 	const escapedEnd = escapeRegExp(SENTINEL_END);
 	const startLineRegex = new RegExp(`^${escapedStart}\\s*$`, "gm");
 	const endLineRegex = new RegExp(`^${escapedEnd}\\s*$`, "gm");
-	const startCount = [...existing.matchAll(startLineRegex)].length;
-	const endCount = [...existing.matchAll(endLineRegex)].length;
+	const startCount = [...normalizedContent.matchAll(startLineRegex)].length;
+	const endCount = [...normalizedContent.matchAll(endLineRegex)].length;
 
 	const blockRegex = new RegExp(
 		`^${escapedStart}\\s*\\r?\\n[\\s\\S]*?^${escapedEnd}\\s*(?:\\r?\\n)?`,
 		"gm",
 	);
 	const candidateRanges: ManagedBlockRange[] = [];
-	let match: RegExpExecArray | null = blockRegex.exec(existing);
+	let match: RegExpExecArray | null = blockRegex.exec(normalizedContent);
 	while (match) {
 		candidateRanges.push({
 			start: match.index,
@@ -219,7 +244,8 @@ function analyzeConfigToml(existing: string): AnalyzeConfigTomlResult {
 	if (unmatchedStart > 0 || unmatchedEnd > 0) {
 		return {
 			lineEnding,
-			unmanagedContent: existing,
+			normalizedContent,
+			unmanagedContent: normalizedContent,
 			warnings,
 			error:
 				"Malformed CK managed agent sentinels in config.toml (unmatched start/end markers). Please clean up sentinels manually.",
@@ -233,9 +259,10 @@ function analyzeConfigToml(existing: string): AnalyzeConfigTomlResult {
 		);
 	}
 
-	const unmanagedContent = stripRanges(existing, managedRanges);
+	const unmanagedContent = stripRanges(normalizedContent, managedRanges);
 	return {
 		lineEnding,
+		normalizedContent,
 		unmanagedContent,
 		warnings,
 	};
@@ -470,6 +497,7 @@ export async function installCodexToml(
 
 				const existingConfig = configSnapshot.content ?? "";
 				const configAnalysis = analyzeConfigToml(existingConfig);
+				const normalizedConfig = configAnalysis.normalizedContent;
 				allWarnings.push(...configAnalysis.warnings);
 				if (configAnalysis.error) {
 					return {
@@ -482,7 +510,7 @@ export async function installCodexToml(
 					};
 				}
 
-				const existingManagedEntries = extractManagedAgentEntries(existingConfig);
+				const existingManagedEntries = extractManagedAgentEntries(normalizedConfig);
 				const unmanagedAgentSlugs = extractUnmanagedAgentSlugs(configAnalysis.unmanagedContent);
 
 				for (const item of items) {
@@ -558,6 +586,9 @@ export async function installCodexToml(
 				}
 
 				if (pendingInstalls.length === 0) {
+					if (normalizedConfig !== existingConfig) {
+						await writeFile(configTomlPath, normalizedConfig, "utf-8");
+					}
 					return {
 						provider,
 						providerDisplayName: config.displayName,
@@ -581,7 +612,7 @@ export async function installCodexToml(
 					.sort(([leftSlug], [rightSlug]) => leftSlug.localeCompare(rightSlug))
 					.map(([, entry]) => entry);
 				const managedBlock = sortedEntries.join("\n\n");
-				const mergeResult = mergeConfigTomlWithDiagnostics(existingConfig, managedBlock);
+				const mergeResult = mergeConfigTomlWithDiagnostics(normalizedConfig, managedBlock);
 				allWarnings.push(...mergeResult.warnings);
 				if (mergeResult.error) {
 					return {
@@ -699,7 +730,13 @@ export async function cleanupStaleCodexConfigEntries(options: {
 		// Read + write inside lock to prevent TOCTOU race with concurrent ck migrate
 		return await withCodexTargetLock(configTomlPath, async () => {
 			let content = await readFile(configTomlPath, "utf-8");
+			let contentChanged = false;
 			const allStaleSlugs: string[] = [];
+			const initialAnalysis = analyzeConfigToml(content);
+			if (!initialAnalysis.error && initialAnalysis.normalizedContent !== content) {
+				content = initialAnalysis.normalizedContent;
+				contentChanged = true;
+			}
 
 			// Phase 1: Clean managed entries (inside sentinel blocks)
 			const managedEntries = extractManagedAgentEntries(content);
@@ -719,6 +756,7 @@ export async function cleanupStaleCodexConfigEntries(options: {
 					if (validEntries.size === 0) {
 						const analysis = analyzeConfigToml(content);
 						content = analysis.unmanagedContent;
+						contentChanged = true;
 					} else {
 						const sortedEntries = [...validEntries.entries()]
 							.sort(([a], [b]) => a.localeCompare(b))
@@ -731,6 +769,7 @@ export async function cleanupStaleCodexConfigEntries(options: {
 							logger.verbose(`[codex-cleanup] Phase 1 merge failed: ${mergeResult.error}`);
 						} else {
 							content = mergeResult.content;
+							contentChanged = true;
 						}
 					}
 				}
@@ -764,15 +803,20 @@ export async function cleanupStaleCodexConfigEntries(options: {
 				}
 				// Normalize consecutive blank lines left by removed blocks
 				content = content.replace(/\n{3,}/g, "\n\n");
+				contentChanged = true;
 				allStaleSlugs.push(...legacyStaleSlugs);
 			}
 
-			if (allStaleSlugs.length === 0) return [];
+			if (allStaleSlugs.length === 0 && !contentChanged) return [];
 
 			await writeFile(configTomlPath, content, "utf-8");
-			logger.verbose(
-				`[codex-cleanup] Removed ${allStaleSlugs.length} stale config.toml entries: ${allStaleSlugs.join(", ")}`,
-			);
+			if (allStaleSlugs.length > 0) {
+				logger.verbose(
+					`[codex-cleanup] Removed ${allStaleSlugs.length} stale config.toml entries: ${allStaleSlugs.join(", ")}`,
+				);
+			} else {
+				logger.verbose("[codex-cleanup] Repaired malformed inline agent table headers");
+			}
 
 			return allStaleSlugs;
 		});

--- a/src/commands/portable/codex-toml-installer.ts
+++ b/src/commands/portable/codex-toml-installer.ts
@@ -235,7 +235,7 @@ function analyzeConfigToml(existing: string): AnalyzeConfigTomlResult {
 			end: match.index + match[0].length,
 			content: match[0],
 		});
-		match = blockRegex.exec(existing);
+		match = blockRegex.exec(normalizedContent);
 	}
 
 	const candidateCount = candidateRanges.length;

--- a/src/services/file-operations/ownership-checker.ts
+++ b/src/services/file-operations/ownership-checker.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
-import { createReadStream } from "node:fs";
-import { stat } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import { relative } from "node:path";
 import { getAllTrackedFiles } from "@/domains/migration/metadata-migration.js";
 import { mapWithLimit } from "@/shared/concurrent-file-ops.js";
@@ -28,27 +27,23 @@ export interface OwnershipCheckResult {
  */
 export class OwnershipChecker {
 	/**
-	 * Calculate SHA-256 checksum of file using streaming
-	 * Memory efficient for large files
+	 * Calculate SHA-256 checksum of a tracked file
+	 * Uses direct reads because tracked ClaudeKit assets are small and Bun's
+	 * Node stream shim can stall under large concurrent test runs.
 	 *
 	 * @param filePath Absolute path to file
 	 * @returns Hex string (64 chars)
 	 * @throws Error if file doesn't exist or can't be read
 	 */
 	static async calculateChecksum(filePath: string): Promise<string> {
-		return new Promise((resolve, reject) => {
-			const hash = createHash("sha256");
-			const stream = createReadStream(filePath);
-
-			stream.on("data", (chunk) => hash.update(chunk));
-			stream.on("end", () => {
-				resolve(hash.digest("hex"));
-			});
-			stream.on("error", (err) => {
-				stream.destroy(); // Only needed in error handler for cleanup
-				reject(new Error(operationError("Checksum calculation", filePath, err.message)));
-			});
-		});
+		try {
+			return createHash("sha256")
+				.update(await readFile(filePath))
+				.digest("hex");
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			throw new Error(operationError("Checksum calculation", filePath, message));
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Repair malformed Codex config entries where `[agents.*]` is glued to the prior TOML key.
- Apply the repair during install and stale cleanup so already-broken Codex installs can recover on rerun.
- Refresh generated CLI manifest/reference artifacts for the current dev version.
- Stabilize two flaky local/CI test paths that blocked this fix from shipping cleanly.

Closes #800

## Root Cause
Codex config merge/cleanup only detected agent tables at the start of a line. A malformed installed config like `trust_level = "trusted"[agents.code_simplifier]` stayed invalid because the agent header was not normalized before merge or cleanup.

## Changes
| File | Change |
|------|--------|
| `src/commands/portable/codex-toml-installer.ts` | Normalize inline `[agents.*]` headers before merge/cleanup and write the repaired config even when no new agents are installed. |
| `src/commands/portable/__tests__/*` | Cover merge repair, cleanup-only repair, already-installed broken config repair, and string false-positive guard. |
| `cli-manifest.json`, `docs/cli-reference.md` | Refresh generated artifacts to `4.0.0-dev.10`. |
| `src/services/file-operations/ownership-checker.ts` | Use direct file reads for checksum hashing to avoid Bun stream stalls on small tracked files. |
| `src/__tests__/domains/web-server/routes/migration-routes.test.ts` | Serialize shared-server migration route tests to avoid cross-test `ctx` races. |

## Test plan
- [x] `bun test src/commands/portable/__tests__/fm-to-codex-toml.test.ts src/commands/portable/__tests__/portable-installer.test.ts src/commands/portable/__tests__/codex-config-cleanup.test.ts`
- [x] `bun test src/__tests__/services/transformers/commands-prefix-cleaner-kit-aware.test.ts`
- [x] `bun test tests/services/file-operations/ownership-checker.test.ts tests/integration/ownership-aware-operations.test.ts tests/integration/cleanup-dry-run.test.ts`
- [x] `bun test src/__tests__/domains/web-server/routes/migration-routes.test.ts`
- [x] `bun run help:check-parity`
- [x] `bun run validate`
- [x] pre-push quality gate