### PR TITLE
hotfix: ck migrate -g reads SOURCE from CWD instead of global

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.0.0-dev.10",
-	"generatedAt": "2026-05-11T03:54:48.267Z",
+	"version": "4.1.0",
+	"generatedAt": "2026-05-11T16:20:04.261Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-11T03:54:51.251Z -->
+<!-- generated: 2026-05-11T16:20:04.344Z -->

--- a/src/commands/agents/agents-discovery.ts
+++ b/src/commands/agents/agents-discovery.ts
@@ -9,16 +9,21 @@ import { logger } from "../../shared/logger.js";
 import { parseFrontmatterFile } from "../portable/frontmatter-parser.js";
 import type { PortableItem } from "../portable/types.js";
 
-const home = homedir();
-
 /**
- * Get the agent source directory
- * Priority: project .claude/agents > global ~/.claude/agents
+ * Get the agent source directory.
+ *
+ * @param globalOnly When true, skip project (CWD) candidates and resolve directly
+ *   to ~/.claude/agents. Used by `ck migrate -g` so SOURCE follows DESTINATION scope.
+ *   Defaults to false: project .claude/agents > global ~/.claude/agents.
  */
-export function getAgentSourcePath(): string | null {
+export function getAgentSourcePath(globalOnly = false): string | null {
+	const globalPath = join(homedir(), ".claude/agents");
+	if (globalOnly) {
+		return findFirstExistingPath([globalPath]);
+	}
 	return findFirstExistingPath([
 		...getProjectLayoutCandidates(process.cwd(), "agents"),
-		join(home, ".claude/agents"),
+		globalPath,
 	]);
 }
 

--- a/src/commands/commands/commands-discovery.ts
+++ b/src/commands/commands/commands-discovery.ts
@@ -10,19 +10,24 @@ import { logger } from "../../shared/logger.js";
 import { parseFrontmatterFile } from "../portable/frontmatter-parser.js";
 import type { PortableItem } from "../portable/types.js";
 
-const home = homedir();
-
 // Directories to skip during discovery
 const SKIP_DIRS = ["node_modules", ".git", "dist", "build"];
 
 /**
- * Get the command source directory
- * Priority: project .claude/commands > global ~/.claude/commands
+ * Get the command source directory.
+ *
+ * @param globalOnly When true, skip project (CWD) candidates and resolve directly
+ *   to ~/.claude/commands. Used by `ck migrate -g` so SOURCE follows DESTINATION scope.
+ *   Defaults to false: project .claude/commands > global ~/.claude/commands.
  */
-export function getCommandSourcePath(): string | null {
+export function getCommandSourcePath(globalOnly = false): string | null {
+	const globalPath = join(homedir(), ".claude/commands");
+	if (globalOnly) {
+		return findFirstExistingPath([globalPath]);
+	}
 	return findFirstExistingPath([
 		...getProjectLayoutCandidates(process.cwd(), "commands"),
-		join(home, ".claude/commands"),
+		globalPath,
 	]);
 }
 

--- a/src/commands/migrate/__tests__/migrate-global-source.integration.test.ts
+++ b/src/commands/migrate/__tests__/migrate-global-source.integration.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Integration tests for `ck migrate -g` SOURCE scope behavior.
+ *
+ * Bug (issue #803): `ck migrate -a codex -g` was reading SOURCE files
+ * (agents/commands/skills/CLAUDE.md/rules/hooks) from the CWD `.claude/`
+ * directory instead of `~/.claude/`. The `-g` flag only flipped DESTINATION;
+ * SOURCE silently inherited CWD.
+ *
+ * Fix: source-path resolvers now accept an optional `globalOnly` parameter.
+ * When true, they bypass CWD discovery and resolve directly to `~/.claude/<type>`.
+ *
+ * These tests build a sandbox HOME and CWD with fixture `.claude/` trees,
+ * then assert each resolver returns the expected path under both modes.
+ */
+import { afterAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import * as os from "node:os";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getAgentSourcePath } from "../../agents/agents-discovery.js";
+import { getCommandSourcePath } from "../../commands/commands-discovery.js";
+import {
+	getConfigSourcePath,
+	getHooksSourcePath,
+	getRulesSourcePath,
+} from "../../portable/config-discovery.js";
+import { getSkillSourcePath } from "../../skills/skills-discovery.js";
+
+interface Sandbox {
+	root: string;
+	home: string;
+	cwd: string;
+}
+
+function seedClaudeDir(
+	base: string,
+	types: Array<"agents" | "commands" | "skills" | "hooks" | "rules">,
+): void {
+	mkdirSync(join(base, ".claude"), { recursive: true });
+	for (const type of types) {
+		const dir = join(base, ".claude", type);
+		mkdirSync(dir, { recursive: true });
+		// Seed a marker file so directory exists for findFirstExistingPath
+		writeFileSync(join(dir, ".keep"), "");
+	}
+	// Seed CLAUDE.md (config) at .claude/ root
+	writeFileSync(join(base, ".claude", "CLAUDE.md"), "# fixture");
+}
+
+function seedSandbox(opts: {
+	homeTypes: Array<"agents" | "commands" | "skills" | "hooks" | "rules">;
+	cwdTypes: Array<"agents" | "commands" | "skills" | "hooks" | "rules">;
+	cwdHasClaudeMd?: boolean;
+}): Sandbox {
+	// realpathSync resolves macOS /var/folders -> /private/var/folders symlink so
+	// that process.cwd() (which returns the resolved path) matches our recorded
+	// sandbox paths exactly.
+	const root = realpathSync(mkdtempSync(join(tmpdir(), "ck-migrate-global-source-")));
+	const home = join(root, "home");
+	const cwd = join(root, "project");
+	mkdirSync(home, { recursive: true });
+	mkdirSync(cwd, { recursive: true });
+	if (opts.homeTypes.length > 0) seedClaudeDir(home, opts.homeTypes);
+	if (opts.cwdTypes.length > 0) seedClaudeDir(cwd, opts.cwdTypes);
+	if (opts.cwdHasClaudeMd === false) {
+		// Remove CLAUDE.md if caller wants no project config
+		try {
+			rmSync(join(cwd, ".claude", "CLAUDE.md"));
+		} catch {
+			// ignore
+		}
+	}
+	return { root, home, cwd };
+}
+
+const ORIGINAL_CWD = process.cwd();
+const sandboxes: string[] = [];
+// Bun's os.homedir() does not honor $HOME, so we spy on it directly. The spy is
+// (re)installed in activate() so each test gets a clean override pointing at its
+// own sandbox HOME.
+let homedirSpy: ReturnType<typeof spyOn> | null = null;
+
+function activate(sb: Sandbox): void {
+	if (homedirSpy) homedirSpy.mockRestore();
+	homedirSpy = spyOn(os, "homedir").mockReturnValue(sb.home);
+	process.chdir(sb.cwd);
+	sandboxes.push(sb.root);
+}
+
+afterAll(() => {
+	if (homedirSpy) homedirSpy.mockRestore();
+	process.chdir(ORIGINAL_CWD);
+	for (const root of sandboxes) {
+		try {
+			rmSync(root, { recursive: true, force: true });
+		} catch {
+			// best-effort cleanup
+		}
+	}
+});
+
+beforeEach(() => {
+	// Restore homedir between tests so a forgotten activate() in a test doesn't
+	// silently inherit the previous sandbox.
+	if (homedirSpy) {
+		homedirSpy.mockRestore();
+		homedirSpy = null;
+	}
+	process.chdir(ORIGINAL_CWD);
+});
+
+// ---------------------------------------------------------------------------
+// T1: Bug repro — CWD has .claude/, global also has .claude/, run with -g
+//     → ALL sources MUST come from global, not CWD.
+// ---------------------------------------------------------------------------
+describe("ck migrate -g: SOURCE scope (issue #803)", () => {
+	it("T1: with globalOnly=true, every resolver returns ~/.claude/<type> even when CWD has .claude/", () => {
+		const sb = seedSandbox({
+			homeTypes: ["agents", "commands", "skills", "hooks", "rules"],
+			cwdTypes: ["agents", "commands", "skills", "hooks", "rules"],
+		});
+		activate(sb);
+
+		expect(getAgentSourcePath(true)).toBe(join(sb.home, ".claude/agents"));
+		expect(getCommandSourcePath(true)).toBe(join(sb.home, ".claude/commands"));
+		expect(getSkillSourcePath(true)).toBe(join(sb.home, ".claude/skills"));
+		expect(getHooksSourcePath(true)).toBe(join(sb.home, ".claude/hooks"));
+		expect(getRulesSourcePath(true)).toBe(join(sb.home, ".claude/rules"));
+		expect(getConfigSourcePath(true)).toBe(join(sb.home, ".claude/CLAUDE.md"));
+	});
+
+	// -------------------------------------------------------------------------
+	// T2: Empty CWD, global has content, run with -g → global sources.
+	// -------------------------------------------------------------------------
+	it("T2: globalOnly=true with empty CWD still resolves to ~/.claude/", () => {
+		const sb = seedSandbox({
+			homeTypes: ["agents", "commands", "skills", "hooks", "rules"],
+			cwdTypes: [],
+		});
+		activate(sb);
+
+		expect(getAgentSourcePath(true)).toBe(join(sb.home, ".claude/agents"));
+		expect(getCommandSourcePath(true)).toBe(join(sb.home, ".claude/commands"));
+		expect(getSkillSourcePath(true)).toBe(join(sb.home, ".claude/skills"));
+		expect(getHooksSourcePath(true)).toBe(join(sb.home, ".claude/hooks"));
+		expect(getRulesSourcePath(true)).toBe(join(sb.home, ".claude/rules"));
+		expect(getConfigSourcePath(true)).toBe(join(sb.home, ".claude/CLAUDE.md"));
+	});
+
+	// -------------------------------------------------------------------------
+	// T3: Project without -g → CWD-first behavior preserved.
+	// -------------------------------------------------------------------------
+	it("T3: globalOnly=false with full CWD .claude/ resolves to CWD paths (legacy behavior)", () => {
+		const sb = seedSandbox({
+			homeTypes: ["agents", "commands", "skills", "hooks", "rules"],
+			cwdTypes: ["agents", "commands", "skills", "hooks", "rules"],
+		});
+		activate(sb);
+
+		expect(getAgentSourcePath(false)).toBe(join(sb.cwd, ".claude/agents"));
+		expect(getCommandSourcePath(false)).toBe(join(sb.cwd, ".claude/commands"));
+		// Skill resolver has bundled-engineer priority that uses CWD/node_modules.
+		// In this sandbox there is no node_modules so it falls through to CWD .claude/skills.
+		expect(getSkillSourcePath(false)).toBe(join(sb.cwd, ".claude/skills"));
+		expect(getHooksSourcePath(false)).toBe(join(sb.cwd, ".claude/hooks"));
+		expect(getRulesSourcePath(false)).toBe(join(sb.cwd, ".claude/rules"));
+		expect(getConfigSourcePath(false)).toBe(join(sb.cwd, ".claude/CLAUDE.md"));
+	});
+
+	// -------------------------------------------------------------------------
+	// T4: No CWD .claude/, run without -g → global fallback (legacy behavior).
+	// -------------------------------------------------------------------------
+	it("T4: globalOnly=false falls back to global when CWD has no .claude/", () => {
+		const sb = seedSandbox({
+			homeTypes: ["agents", "commands", "skills", "hooks", "rules"],
+			cwdTypes: [],
+		});
+		activate(sb);
+
+		expect(getAgentSourcePath(false)).toBe(join(sb.home, ".claude/agents"));
+		expect(getCommandSourcePath(false)).toBe(join(sb.home, ".claude/commands"));
+		expect(getSkillSourcePath(false)).toBe(join(sb.home, ".claude/skills"));
+		expect(getHooksSourcePath(false)).toBe(join(sb.home, ".claude/hooks"));
+		expect(getRulesSourcePath(false)).toBe(join(sb.home, ".claude/rules"));
+		expect(getConfigSourcePath(false)).toBe(join(sb.home, ".claude/CLAUDE.md"));
+	});
+
+	// -------------------------------------------------------------------------
+	// T5: Partial CWD (only agents/) + -g → CWD agents/ IGNORED.
+	// -------------------------------------------------------------------------
+	it("T5: globalOnly=true ignores CWD even when only some types exist there", () => {
+		const sb = seedSandbox({
+			homeTypes: ["agents", "commands", "skills", "hooks", "rules"],
+			cwdTypes: ["agents"],
+		});
+		activate(sb);
+
+		// Without -g this would be CWD .claude/agents (project takes priority).
+		// With globalOnly=true the resolver must skip CWD entirely.
+		expect(getAgentSourcePath(true)).toBe(join(sb.home, ".claude/agents"));
+		expect(getAgentSourcePath(false)).toBe(join(sb.cwd, ".claude/agents"));
+	});
+
+	// -------------------------------------------------------------------------
+	// T6: globalOnly=true returns null when global path is also missing.
+	//     (resolvers that return string | null preserve that contract).
+	// -------------------------------------------------------------------------
+	it("T6: globalOnly=true returns null when ~/.claude/<type> does not exist", () => {
+		const sb = seedSandbox({
+			homeTypes: ["agents"], // only agents exists globally
+			cwdTypes: ["commands"], // commands exists in CWD but should be ignored
+		});
+		activate(sb);
+
+		// Agents global exists → returned.
+		expect(getAgentSourcePath(true)).toBe(join(sb.home, ".claude/agents"));
+		// Commands missing globally → null even though CWD has it.
+		expect(getCommandSourcePath(true)).toBeNull();
+		// Skills missing globally → null.
+		expect(getSkillSourcePath(true)).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// T7: Config resolver returns global path string even when global file is missing.
+	//     (getConfigSourcePath / getRulesSourcePath / getHooksSourcePath return `string`,
+	//     not `string | null`, by their original API contract.)
+	// -------------------------------------------------------------------------
+	it("T7: string-returning resolvers always return global path under globalOnly=true", () => {
+		const sb = seedSandbox({
+			homeTypes: [],
+			cwdTypes: ["hooks", "rules"],
+		});
+		activate(sb);
+
+		// Even though global files don't exist, the API returns the expected global path
+		// (caller checks existsSync downstream).
+		expect(getConfigSourcePath(true)).toBe(join(sb.home, ".claude/CLAUDE.md"));
+		expect(getRulesSourcePath(true)).toBe(join(sb.home, ".claude/rules"));
+		expect(getHooksSourcePath(true)).toBe(join(sb.home, ".claude/hooks"));
+	});
+
+	// -------------------------------------------------------------------------
+	// T8: Default param (no arg) preserves legacy behavior.
+	// -------------------------------------------------------------------------
+	it("T8: calling resolvers with no argument preserves CWD-first legacy behavior", () => {
+		const sb = seedSandbox({
+			homeTypes: ["agents", "commands", "skills", "hooks", "rules"],
+			cwdTypes: ["agents", "commands", "skills", "hooks", "rules"],
+		});
+		activate(sb);
+
+		// No-argument calls must behave identically to globalOnly=false.
+		expect(getAgentSourcePath()).toBe(join(sb.cwd, ".claude/agents"));
+		expect(getCommandSourcePath()).toBe(join(sb.cwd, ".claude/commands"));
+		expect(getSkillSourcePath()).toBe(join(sb.cwd, ".claude/skills"));
+		expect(getHooksSourcePath()).toBe(join(sb.cwd, ".claude/hooks"));
+		expect(getRulesSourcePath()).toBe(join(sb.cwd, ".claude/rules"));
+		expect(getConfigSourcePath()).toBe(join(sb.cwd, ".claude/CLAUDE.md"));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// T9: Sanity — globalOnly=true never resolves to a CWD-rooted path.
+//      Regression guard: if a future refactor reintroduces CWD probing under -g,
+//      this fails.
+// ---------------------------------------------------------------------------
+describe("ck migrate -g: regression guards", () => {
+	it("T9: under globalOnly=true, no resolver ever returns a CWD-rooted path", () => {
+		const sb = seedSandbox({
+			homeTypes: ["agents", "commands", "skills", "hooks", "rules"],
+			cwdTypes: ["agents", "commands", "skills", "hooks", "rules"],
+		});
+		activate(sb);
+
+		const results = [
+			getAgentSourcePath(true),
+			getCommandSourcePath(true),
+			getSkillSourcePath(true),
+			getHooksSourcePath(true),
+			getRulesSourcePath(true),
+			getConfigSourcePath(true),
+		];
+
+		for (const path of results) {
+			if (path === null) continue;
+			expect(path.startsWith(sb.cwd)).toBe(false);
+			expect(path.startsWith(sb.home)).toBe(true);
+		}
+	});
+});

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -26,6 +26,7 @@ import {
 	discoverConfig,
 	discoverHooks,
 	discoverRules,
+	getConfigSourcePath,
 	getHooksSourcePath,
 	getRulesSourcePath,
 } from "../portable/config-discovery.js";
@@ -485,17 +486,26 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		const spinner = p.spinner();
 		spinner.start("Discovering portable items...");
 
-		const agentSource = scope.agents ? getAgentSourcePath() : null;
-		const commandSource = scope.commands ? getCommandSourcePath() : null;
-		const skillSource = scope.skills ? getSkillSourcePath() : null;
-		const hooksSource = scope.hooks ? getHooksSourcePath() : null;
+		// Honor explicit -g / --global on SOURCE discovery so both SOURCE and
+		// DESTINATION follow the same scope. Without this, SOURCE silently
+		// inherits CWD even when the user asked for a pure global migration.
+		// When --source is provided, it always wins for config (explicit override).
+		const sourceGlobalOnly = options.global === true;
+		const agentSource = scope.agents ? getAgentSourcePath(sourceGlobalOnly) : null;
+		const commandSource = scope.commands ? getCommandSourcePath(sourceGlobalOnly) : null;
+		const skillSource = scope.skills ? getSkillSourcePath(sourceGlobalOnly) : null;
+		const hooksSource = scope.hooks ? getHooksSourcePath(sourceGlobalOnly) : null;
 		// Resolve rules source path for origin tracking (only needed when rules in scope)
-		const rulesSourcePath = scope.rules ? getRulesSourcePath() : null;
+		const rulesSourcePath = scope.rules ? getRulesSourcePath(sourceGlobalOnly) : null;
 
 		const agents = agentSource ? await discoverAgents(agentSource) : [];
 		const commands = commandSource ? await discoverCommands(commandSource) : [];
 		const skills = skillSource ? await discoverSkills(skillSource) : [];
-		const configItem = scope.config ? await discoverConfig(options.source) : null;
+		const configItem = scope.config
+			? await discoverConfig(
+					options.source ?? (sourceGlobalOnly ? getConfigSourcePath(true) : undefined),
+				)
+			: null;
 		// rulesSourcePath is non-null when scope.rules is true (same guard)
 		const ruleItems = rulesSourcePath ? await discoverRules(rulesSourcePath) : [];
 		const { items: hookItems, skippedShellHooks } = hooksSource
@@ -688,7 +698,17 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 				title: "ck migrate",
 			}).join("\n"),
 		);
-		p.log.info(pc.dim(`  CWD: ${process.cwd()}`));
+		// Show CWD only for project-scoped runs. Under -g the CWD is irrelevant for
+		// SOURCE (we read from ~/.claude/), so surfacing it just confuses the scope.
+		if (sourceGlobalOnly) {
+			p.log.info(
+				pc.dim(
+					`  Scope: global (--global / -g) - reading from ${formatDisplayPath(join(homedir(), ".claude"))}`,
+				),
+			);
+		} else {
+			p.log.info(pc.dim(`  CWD: ${process.cwd()}`));
+		}
 		console.log();
 		console.log(
 			renderPanel({

--- a/src/commands/portable/config-discovery.ts
+++ b/src/commands/portable/config-discovery.ts
@@ -178,12 +178,18 @@ export function resolveSourceOrigin(sourcePath: string | null): "project" | "glo
 }
 
 /**
- * Get default config source path — CWD-first, then global fallback.
+ * Get default config source path.
+ *
+ * @param globalOnly When true, bypass CWD discovery and return ~/.claude/CLAUDE.md
+ *   directly. Used by `ck migrate -g` so SOURCE follows DESTINATION scope.
+ *   Defaults to false: CWD/CLAUDE.md or CWD/.claude/CLAUDE.md first, then global.
+ *
  * Checks both CWD/CLAUDE.md and CWD/.claude/CLAUDE.md because Claude Code
  * supports CLAUDE.md at the project root (standard convention) and inside
  * .claude/ (alternative location). Rules only live in .claude/rules/.
  */
-export function getConfigSourcePath(): string {
+export function getConfigSourcePath(globalOnly = false): string {
+	if (globalOnly) return getGlobalConfigSourcePath();
 	return findExistingProjectConfigPath(process.cwd()) ?? getGlobalConfigSourcePath();
 }
 
@@ -192,18 +198,28 @@ export function getGlobalConfigSourcePath(): string {
 	return join(homedir(), ".claude", "CLAUDE.md");
 }
 
-/** Get default rules source path — CWD-first, then global fallback */
-export function getRulesSourcePath(): string {
-	return (
-		findExistingProjectLayoutPath(process.cwd(), "rules") ?? join(homedir(), ".claude", "rules")
-	);
+/**
+ * Get default rules source path.
+ *
+ * @param globalOnly When true, bypass CWD discovery and return ~/.claude/rules directly.
+ *   Defaults to false: CWD .claude/rules first, then global fallback.
+ */
+export function getRulesSourcePath(globalOnly = false): string {
+	const globalPath = join(homedir(), ".claude", "rules");
+	if (globalOnly) return globalPath;
+	return findExistingProjectLayoutPath(process.cwd(), "rules") ?? globalPath;
 }
 
-/** Get default hooks source path (project preferred, then global fallback). */
-export function getHooksSourcePath(): string {
-	return (
-		findExistingProjectLayoutPath(process.cwd(), "hooks") ?? join(homedir(), ".claude", "hooks")
-	);
+/**
+ * Get default hooks source path.
+ *
+ * @param globalOnly When true, bypass CWD discovery and return ~/.claude/hooks directly.
+ *   Defaults to false: CWD .claude/hooks first, then global fallback.
+ */
+export function getHooksSourcePath(globalOnly = false): string {
+	const globalPath = join(homedir(), ".claude", "hooks");
+	if (globalOnly) return globalPath;
+	return findExistingProjectLayoutPath(process.cwd(), "hooks") ?? globalPath;
 }
 
 /** Discover CLAUDE.md config file */

--- a/src/commands/skills/skills-discovery.ts
+++ b/src/commands/skills/skills-discovery.ts
@@ -10,22 +10,27 @@ import { validateSkillFrontmatter } from "../../domains/skills/skill-frontmatter
 import { logger } from "../../shared/logger.js";
 import type { EnrichedSkillInfo, SkillInfo } from "./types.js";
 
-const home = homedir();
-
 // Directories to skip during discovery
 const SKIP_DIRS = ["node_modules", ".git", "dist", "build", ".venv", "__pycache__", "common"];
 
 /**
- * Get the skill source directory
- * Priority: bundled with engineer package > global ~/.claude/skills
+ * Get the skill source directory.
+ *
+ * @param globalOnly When true, skip bundled and CWD candidates and resolve directly
+ *   to ~/.claude/skills. Used by `ck migrate -g` so SOURCE follows DESTINATION scope.
+ *   Defaults to false: bundled engineer > project .claude/skills > global ~/.claude/skills.
  */
-export function getSkillSourcePath(): string | null {
+export function getSkillSourcePath(globalOnly = false): string | null {
+	const globalPath = join(homedir(), ".claude/skills");
+	if (globalOnly) {
+		return findFirstExistingPath([globalPath]);
+	}
 	const bundledRoot = join(process.cwd(), "node_modules", "claudekit-engineer");
 	return findFirstExistingPath([
 		join(bundledRoot, "skills"),
 		...getProjectLayoutCandidates(bundledRoot, "skills"),
 		...getProjectLayoutCandidates(process.cwd(), "skills"),
-		join(home, ".claude/skills"),
+		globalPath,
 	]);
 }
 

--- a/src/domains/web-server/routes/migration-routes.ts
+++ b/src/domains/web-server/routes/migration-routes.ts
@@ -904,14 +904,17 @@ function warnConversionFallback(warning: ConversionFallbackWarning): void {
 async function discoverMigrationItems(
 	include: MigrationIncludeOptions,
 	configSource?: string,
+	globalOnly = false,
 ): Promise<DiscoveryResult> {
-	const agentsSource = include.agents ? getAgentSourcePath() : null;
-	const commandsSource = include.commands ? getCommandSourcePath() : null;
-	const skillsSource = include.skills ? getSkillSourcePath() : null;
-	const hooksSource = include.hooks ? getHooksSourcePath() : null;
+	const agentsSource = include.agents ? getAgentSourcePath(globalOnly) : null;
+	const commandsSource = include.commands ? getCommandSourcePath(globalOnly) : null;
+	const skillsSource = include.skills ? getSkillSourcePath(globalOnly) : null;
+	const hooksSource = include.hooks ? getHooksSourcePath(globalOnly) : null;
 	// Resolve config/rules source paths for origin tracking
-	const configSourcePath = include.config ? (configSource ?? getConfigSourcePath()) : null;
-	const rulesSourcePath = include.rules ? getRulesSourcePath() : null;
+	const configSourcePath = include.config
+		? (configSource ?? getConfigSourcePath(globalOnly))
+		: null;
+	const rulesSourcePath = include.rules ? getRulesSourcePath(globalOnly) : null;
 
 	const [agents, commands, skills, configItem, ruleItems, hookItems] = await Promise.all([
 		agentsSource ? discoverAgents(agentsSource) : Promise.resolve([]),
@@ -1920,7 +1923,9 @@ export function registerMigrationRoutes(app: Express): void {
 			const effectiveGlobal = requestedGlobal;
 			const warnings: string[] = [];
 
-			const discovered = await discoverMigrationItems(include, configSource);
+			// When the dashboard requests global scope, mirror the CLI's -g behavior:
+			// SOURCE follows DESTINATION so users get a pure global→global migration.
+			const discovered = await discoverMigrationItems(include, configSource, requestedGlobal);
 
 			const hasItems =
 				discovered.agents.length > 0 ||


### PR DESCRIPTION
## Summary

`ck migrate -a codex -g` was silently reading SOURCE files (agents/commands/skills/`CLAUDE.md`/rules/hooks) from the CWD `.claude/` directory instead of `~/.claude/`. The `-g` flag only flipped DESTINATION; SOURCE inherited CWD via project-first fallback, so a user in any dir with a `.claude/` tree got a mixed-scope migration. Pure global→global was unreachable through `-g`.

Closes #803

## Root Cause

All six source resolvers hard-coded "project-first, global-fallback" via `process.cwd()` and never received the `--global` flag:

- `getAgentSourcePath()` (`src/commands/agents/agents-discovery.ts`)
- `getCommandSourcePath()` (`src/commands/commands/commands-discovery.ts`)
- `getSkillSourcePath()` (`src/commands/skills/skills-discovery.ts`)
- `getConfigSourcePath()` / `getRulesSourcePath()` / `getHooksSourcePath()` (`src/commands/portable/config-discovery.ts`)

`-g` only flowed into destination computation; the two scopes were wired independently.

## Fix

Add an optional `globalOnly` parameter to all six resolvers. When `true`, skip CWD candidates and resolve directly to `~/.claude/<type>`. Default `false` preserves existing CWD-first behavior — no impact on callers that omit the arg.

Wire `options.global === true` through:
1. `migrate-command.ts` SOURCE discovery (lines around 488).
2. `migration-routes.ts` dashboard `/reconcile-plan` endpoint (passes `requestedGlobal` to `discoverMigrationItems`).

### Readability

Under `-g`, the panel now shows an explicit scope line:
```
Scope: global (--global / -g) - reading from ~/.claude
```
instead of the misleading `CWD: ...` line.

## Decision Matrix

| Invocation | CWD has `.claude/` | SOURCE | DESTINATION |
|---|---|---|---|
| `ck migrate -a codex -g` | yes or no | `~/.claude/` (global) | `~/.codex/` (global) |
| `ck migrate -a codex` | yes | CWD `.claude/` (project) | CWD `.codex/` (project) |
| `ck migrate -a codex` | no | `~/.claude/` (fallback) | interactive prompt |
| `ck migrate -a codex --source <path>` | — | explicit path (config only) | per other flags |

## What Changed

| File | Change |
|------|--------|
| `src/commands/agents/agents-discovery.ts` | Add `globalOnly` param |
| `src/commands/commands/commands-discovery.ts` | Add `globalOnly` param |
| `src/commands/skills/skills-discovery.ts` | Add `globalOnly` param |
| `src/commands/portable/config-discovery.ts` | Add `globalOnly` param to 3 resolvers |
| `src/commands/migrate/migrate-command.ts` | Plumb `options.global` to resolvers; add scope banner |
| `src/domains/web-server/routes/migration-routes.ts` | Mirror fix for dashboard endpoint |
| `src/commands/migrate/__tests__/migrate-global-source.integration.test.ts` | 9 new integration tests |

## Validation

- [x] `bun run validate` passes (typecheck + lint + 4718 tests + build)
- [x] 9 new integration tests cover bug repro + 8 regression guards
- [x] Default-arg compatibility: no-arg callers behave identically to legacy
- [x] Architecture report: `plans/reports/architecture-260511-1057-migrate-global-source-scope.html`

## Test plan (manual repro)

```bash
# From any dir with a .claude/ subdir
ck migrate -a codex -g --dry-run
```
- BEFORE: SOURCE block shows CWD paths despite `Codex → global`.
- AFTER: SOURCE block lists `~/.claude/*` only; CWD line replaced with `Scope: global - reading from ~/.claude`.
