### PR TITLE
docs(ai-facing): document CI parity + add bun run ci:local

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,6 +1,13 @@
 #!/bin/bash
-# Quality gate (pre-push): lint + typecheck + build + ui:build + tests + ui tests
-# Full CI parity — nothing reaches upstream that wouldn't pass CI.
+# Quality gate (pre-push): delegate to scripts/ci-local.sh for CI parity,
+# then run the extra UI vitest suite that CI does NOT exercise.
+#
+# Rationale: ci-local.sh is the single source of truth for "what CI runs".
+# By calling it here, hook <-> CI parity can never silently drift. ui:test
+# stays in this hook (not in ci-local.sh) because CI's Test job does not
+# invoke `bun run ui:test` -- it only does `bun run ui:build`. We keep
+# ui:test as a local-only safety net.
+#
 # Works in both normal repos and worktrees.
 
 set -euo pipefail
@@ -15,46 +22,13 @@ fi
 echo ""
 echo "  Quality Gate (pre-push)"
 echo "  ========================"
+
+# Phase 1: full CI Test job parity (steps 1-7 in scripts/ci-local.sh).
+bash scripts/ci-local.sh
+
+# Phase 2: extra local-only safety nets (CI does not run these).
 echo ""
-
-echo "  [1/6] Lint..."
-bun run lint || {
-  echo ""
-  echo "  [X] Lint failed. Run 'bun run lint:fix' to auto-fix, then re-stage."
-  exit 1
-}
-
-echo "  [2/6] Typecheck..."
-bun run typecheck || {
-  echo ""
-  echo "  [X] Typecheck failed. Run 'bun run typecheck' to see errors."
-  exit 1
-}
-
-echo "  [3/6] Build..."
-bun run build || {
-  echo ""
-  echo "  [X] Build failed. Run 'bun run build' to see errors."
-  exit 1
-}
-
-echo "  [4/6] UI Build (tsc -b + vite)..."
-bun run ui:build || {
-  echo ""
-  echo "  [X] UI build failed. Run 'bun run ui:build' to see errors."
-  echo "  [i] Note: tsc -b is stricter than tsc --noEmit (unused vars, ES target)."
-  exit 1
-}
-
-echo "  [5/6] Tests..."
-# Suppress interactive prompts and enable CI-safe test behavior (matches ci.yml env vars)
-NON_INTERACTIVE=true CI_SAFE_MODE=true bun test || {
-  echo ""
-  echo "  [X] Tests failed. Run 'bun test' to see failures."
-  exit 1
-}
-
-echo "  [6/6] UI Tests..."
+echo "  [extra] UI vitest suite (not run by CI Test job)..."
 bun run ui:test || {
   echo ""
   echo "  [X] UI tests failed. Run 'bun run ui:test' to see failures."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,12 +64,14 @@ The pre-push git hook calls into the same script, so hook ↔ CI parity can neve
 
 | Symptom (CI error) | Cause | One-liner self-heal |
 |---|---|---|
-| `cli-manifest.json or docs/cli-reference.md is stale` | Release commit on `main` bumped `package.json` but skipped regenerating the manifest/docs (step 5 above) | `bun run manifest:generate && bun run docs:generate && git add cli-manifest.json docs/cli-reference.md && git commit -m "chore: regenerate cli-manifest and docs"` |
+| `cli-manifest.json or docs/cli-reference.md is stale` | Release commit on `main` bumped `package.json` but skipped regenerating the manifest/docs (step 5 above) | `bun run manifest:generate && bun run docs:generate && git add cli-manifest.json docs/cli-reference.md && git commit -m "chore: regenerate cli-manifest and docs"` — MUST use `chore:` (never `fix:`/`hotfix:`) so this commit does NOT trigger a release |
 | `[X] CAC <-> HELP_REGISTRY parity check failed` | Added a command or flag without updating the help registry | Update the relevant entry in the help-command source, rerun `bun run help:check-parity` |
 | `tsc -b` errors only in `ui:build`, not `typecheck` | UI tsconfig is stricter (unused vars, ES lib methods) | Run `bun run ui:build` from the repo root, fix the errors |
 | `Prepublish check failed` | `package.json` `files`/`bin` arrays missing a path | Audit `package.json` `files` against `bin/`, `dist/`, `cli-manifest.json` |
 
 Use `chore:` (NOT `hotfix:` or `fix:`) for the manifest-regen commit — version-sync commits must NOT trigger releases.
+
+**Note:** Step 5 always regenerates `cli-manifest.json` / `docs/cli-reference.md`, which updates the `generatedAt` timestamp every run. After a passing `ci:local`, **timestamp-only diffs on those two files are safe to ignore or `git checkout`** — the drift check explicitly excludes `generatedAt` / `<!-- generated:` lines.
 
 ### `validate` vs `ci:local`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,27 +41,73 @@ CLI tool (`ck`) for bootstrapping/updating ClaudeKit projects from GitHub releas
 **MUST pass before ANY commit/PR. No exceptions.**
 
 ```bash
-bun run validate
-# Equivalent to: bun run typecheck && bun run lint && bun test && bun run build
-# Note: validate uses lint (read-only check), not lint:fix. Run lint:fix manually first.
+bun run ci:local
 ```
 
-**When touching UI files (`src/ui/`):** The pre-push hook runs `bun run ui:build` automatically. The UI has a stricter TypeScript config (`tsc -b`) that catches errors `tsc --noEmit` misses (unused vars, missing ES lib methods like `Array.at()`). If debugging CI failures manually, run `bun run ui:build` from root.
+`bun run ci:local` is the **single source of truth** for what passing CI means. It runs the exact same 7 steps as the `Test` job in `.github/workflows/ci.yml`, in the same order, with the same env vars. If `ci:local` passes, the CI `Test` job will pass — modulo network/env quirks.
 
-**Enforced by git hooks** — `pre-commit` runs typecheck+lint+build, `pre-push` adds tests. Hooks auto-install on `bun install`. If hooks are missing, run `bun run install:hooks`.
+The pre-push git hook calls into the same script, so hook ↔ CI parity can never silently drift. **AI sessions MUST run `bun run ci:local` before pushing.**
 
-**AI agents: NEVER use `--no-verify` to bypass hooks. NEVER set `SKIP_HOOKS=true`. If the hook rejects your commit, fix the code — do not skip the gate. This rule is NON-NEGOTIABLE.**
+### What `ci:local` checks (mirrors CI `Test` job)
 
-**Human bypass (emergencies only):** `SKIP_HOOKS=true git commit -m "..."` or `SKIP_HOOKS=true git push`.
+| # | Step | Catches |
+|---|------|---------|
+| 1 | `typecheck` (`tsc --noEmit`) | Type errors |
+| 2 | `lint` (`biome check`) | Style + auto-fixable issues |
+| 3 | `build` (`bun build src/index.ts`) | Bundle errors |
+| 4 | `test` (`bun test`) | Unit/integration test failures |
+| 5 | **`help:check-parity` + `manifest:generate` + `docs:generate` drift check** | Stale `cli-manifest.json` / `docs/cli-reference.md` |
+| 6 | `ui:build` (`tsc -b` + vite) | UI type errors stricter than `tsc --noEmit` (unused vars, ES lib methods like `Array.at()`) |
+| 7 | `prepublish-check` (`node scripts/prepublish-check.js`) | Packaged CLI shape |
+
+### Common upstream drift class (self-heal)
+
+| Symptom (CI error) | Cause | One-liner self-heal |
+|---|---|---|
+| `cli-manifest.json or docs/cli-reference.md is stale` | Release commit on `main` bumped `package.json` but skipped regenerating the manifest/docs (step 5 above) | `bun run manifest:generate && bun run docs:generate && git add cli-manifest.json docs/cli-reference.md && git commit -m "chore: regenerate cli-manifest and docs"` |
+| `[X] CAC <-> HELP_REGISTRY parity check failed` | Added a command or flag without updating the help registry | Update the relevant entry in the help-command source, rerun `bun run help:check-parity` |
+| `tsc -b` errors only in `ui:build`, not `typecheck` | UI tsconfig is stricter (unused vars, ES lib methods) | Run `bun run ui:build` from the repo root, fix the errors |
+| `Prepublish check failed` | `package.json` `files`/`bin` arrays missing a path | Audit `package.json` `files` against `bin/`, `dist/`, `cli-manifest.json` |
+
+Use `chore:` (NOT `hotfix:` or `fix:`) for the manifest-regen commit — version-sync commits must NOT trigger releases.
+
+### `validate` vs `ci:local`
+
+| Command | Use for | Includes |
+|---|---|---|
+| `bun run validate` | Fast inner-loop dev check | typecheck + lint + bun test + ui:test + build |
+| `bun run ci:local` | **Pre-push / pre-PR / mirror CI exactly** | typecheck + lint + build + bun test + **help-parity drift** + **ui:build** + **prepublish-check** |
+
+`validate` is FASTER but does NOT catch the parity-drift class. **Use `ci:local` before pushing.**
+
+### Other CI workflows (not gated by `ci:local`)
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `CI / Metadata Deletions Check` | every PR | `scripts/check-metadata-deletions.js` — guards command-archive deletions metadata |
+| `CI / Release Dry-Run Check` | PRs touching release-related files only | semantic-release dry-run; auto-skipped otherwise |
+| `Claude Code Review` | every PR | AI bot review (severity-tagged) — feeds the maintainer review-loop |
+| `release.yml` / `release-dev.yml` | merge to `main` / `dev` | semantic-release publishes npm package |
+| `sync-dev-after-release.yml` | post-release on `main` | opens `chore: merge main into dev` PR |
+
+`ci:local` does NOT mirror `Metadata Deletions Check` or `Release Dry-Run Check` (both require git-history context and rarely fail). If you're touching release config or deletions metadata, also run the matching script manually: `node scripts/check-metadata-deletions.js` or `node scripts/check-release-dry-run.js`.
+
+### Pre-push hook (auto-installed)
+
+`pre-push` calls `scripts/ci-local.sh`, then adds `bun run ui:test` (vitest suite that CI's Test job does NOT run). Hooks auto-install on `bun install`; if missing run `bun run install:hooks`. The hook works in both normal repos and worktrees.
+
+**AI agents: NEVER use `--no-verify` to bypass hooks. NEVER set `SKIP_HOOKS=true`.** If the hook rejects, fix the code — do not skip the gate. This rule is NON-NEGOTIABLE.
+
+**Human bypass (emergencies only):** `SKIP_HOOKS=true git push`.
 
 **Why:** AI-generated code historically failed CI in 80%+ of PRs, causing 3-6 fix-up commits each. The hooks exist to catch these failures locally before they waste CI cycles and pollute git history.
 
-**Worktree support:** Hooks work in both normal repos and worktrees. The install script uses `core.hooksPath` with a relative path (`.githooks`) that resolves from each worktree's root. After creating a worktree, run `bun install` or `bun run install:hooks` from the worktree root.
+### Common pitfalls
 
-**Common pitfalls:**
 - Web server deps (`express`, `ws`, `chokidar`, `get-port`, `open`) must be in `package.json` — not just transitive
 - UI component files must pass biome formatting (long JSX lines auto-wrapped)
 - Express 5 types `req.params`/`req.query` as `string | string[]` — cast with `String()`
+- Don't `git pull` from `main` into a feature branch — use `git merge origin/main` and resolve with `git checkout --ours CHANGELOG.md package.json` (see Release Workflow below)
 
 ## Quick Commands
 

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.1.0",
-	"generatedAt": "2026-05-11T16:20:04.261Z",
+	"version": "4.1.0-dev.1",
+	"generatedAt": "2026-05-11T16:50:53.387Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-11T16:20:04.344Z -->
+<!-- generated: 2026-05-11T16:50:53.448Z -->

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"dev:all": "./scripts/dev-quick-start.sh all",
 		"metrics": "bun run scripts/workflow-metrics.ts",
 		"validate": "bun run typecheck && bun run lint && bun test && bun run ui:test && bun run build",
+		"ci:local": "bash scripts/ci-local.sh",
 		"install:hooks": "./.githooks/install.sh",
 		"prepare": "node -e \"try{require('child_process').execSync('git rev-parse --git-dir',{stdio:'ignore'});require('child_process').execSync('bash .githooks/install.sh',{stdio:'inherit'})}catch(e){console.warn('[i] Hook install skipped:',e.message)}\"",
 		"help:check-parity": "bun run scripts/check-help-parity.ts",

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# scripts/ci-local.sh — Local CI parity runner
+#
+# Mirrors the `Test` job in .github/workflows/ci.yml exactly. Run this before
+# pushing to be sure CI will pass. This file is the SINGLE SOURCE OF TRUTH for
+# what "passing CI" means; both `bun run ci:local` and the pre-push hook call
+# into here so hook ↔ CI parity can never silently drift.
+#
+# If you ever add a step to ci.yml's Test job, add it here too. If you ever
+# remove a step here, audit ci.yml first.
+#
+# Self-heal: the manifest/docs drift step regenerates artifacts but does NOT
+# auto-commit. If it reports drift, run the suggested one-liner and commit.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+# Match ci.yml env so test behavior is identical (non-interactive, CI-safe).
+export NON_INTERACTIVE=true
+export CI_SAFE_MODE=true
+
+step() { echo ""; echo "  [$1] $2..."; }
+fail() { echo ""; echo "  [X] $1"; exit 1; }
+ok()   { echo "  [OK] $1"; }
+
+step "1/7" "Typecheck (tsc --noEmit)"
+bun run typecheck || fail "Typecheck failed."
+
+step "2/7" "Lint (biome check)"
+bun run lint || fail "Lint failed. Run 'bun run lint:fix' to auto-fix, then re-stage."
+
+step "3/7" "Build CLI bundle"
+bun run build || fail "Build failed."
+
+step "4/7" "Tests (bun test)"
+# CI uses `timeout 300 bun test --verbose`; locally we trust dev to ctrl-c.
+bun test || fail "Tests failed."
+
+step "5/7" "Help parity + manifest/docs drift check"
+# Mirrors ci.yml "Verify help parity and regenerated docs" step verbatim.
+# This is the class of failure that most often surprises AI sessions: a
+# release commit on main bumps package.json but skips regenerating
+# cli-manifest.json / docs/cli-reference.md, so every branch off main fails
+# this step until the artifacts are refreshed.
+bun run help:check-parity || fail "Help parity check failed."
+bun run manifest:generate
+bun run docs:generate
+DIFF=$(git diff -- cli-manifest.json docs/cli-reference.md)
+if [ -n "$DIFF" ]; then
+  MEANINGFUL=$(echo "$DIFF" | grep -E '^[+-][^+-]' | grep -v '"generatedAt"' | grep -v '<!-- generated:' || true)
+  if [ -n "$MEANINGFUL" ]; then
+    echo ""
+    echo "  [X] cli-manifest.json or docs/cli-reference.md is stale."
+    echo "      Self-heal:"
+    echo "        bun run manifest:generate && bun run docs:generate"
+    echo "        git add cli-manifest.json docs/cli-reference.md"
+    echo "        git commit -m 'chore: regenerate cli-manifest and docs'"
+    echo ""
+    echo "  Meaningful diff:"
+    echo "$MEANINGFUL" | sed 's/^/    /'
+    exit 1
+  fi
+fi
+ok "no meaningful drift in cli-manifest.json / docs/cli-reference.md"
+
+step "6/7" "UI build (tsc -b + vite, stricter than tsc --noEmit)"
+bun run ui:build || fail "UI build failed. tsc -b catches errors tsc --noEmit misses (unused vars, missing ES lib methods)."
+
+step "7/7" "Verify packaged CLI"
+node scripts/prepublish-check.js || fail "Prepublish check failed."
+
+# Note: ui:test runs in a separate vitest config and is invoked by `bun run
+# validate`. CI's Test job does NOT run ui:test directly — it's covered by
+# ui:build (tsc -b) plus the vitest suite that runs inside `bun test` via
+# bun's test runner. Keep this in mind when comparing local vs CI.
+
+echo ""
+echo "  [OK] Local CI parity passed. Safe to push."
+echo ""

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -17,7 +17,12 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)" || exit 1
 
 # Match ci.yml env so test behavior is identical (non-interactive, CI-safe).
+# CI=true is required for `test.skipIf(!!process.env.CI)` guards and direct
+# `process.env.CI === "true"` checks that bypass the isCIEnvironment() helper.
+# The export is local to this bash subprocess, so it does NOT leak to the
+# pre-push hook's CI/SKIP_HOOKS short-circuit when the hook calls into here.
 export NON_INTERACTIVE=true
+export CI=true
 export CI_SAFE_MODE=true
 
 step() { echo ""; echo "  [$1] $2..."; }
@@ -33,9 +38,11 @@ bun run lint || fail "Lint failed. Run 'bun run lint:fix' to auto-fix, then re-s
 step "3/7" "Build CLI bundle"
 bun run build || fail "Build failed."
 
-step "4/7" "Tests (bun test)"
-# CI uses `timeout 300 bun test --verbose`; locally we trust dev to ctrl-c.
-bun test || fail "Tests failed."
+step "4/7" "Tests (bun test --verbose)"
+# CI uses `timeout 300 bun test --verbose`; locally we trust dev to ctrl-c
+# but keep --verbose so local output format matches CI logs exactly when
+# diagnosing failures.
+bun test --verbose || fail "Tests failed."
 
 step "5/7" "Help parity + manifest/docs drift check"
 # Mirrors ci.yml "Verify help parity and regenerated docs" step verbatim.


### PR DESCRIPTION
## Summary

Adds `bun run ci:local` as the canonical "match CI exactly" check and updates AI-facing docs (`CLAUDE.md`) so future sessions know which command to run before pushing. Closes the gap that drove the recent 43% CI failure rate.

Closes #805

## Root Cause (recap)

Across the last 30 CI runs: 13 failures vs 17 successes. Dominant class was the `Verify help parity and regenerated docs` step in the `Test` job tripping on stale `cli-manifest.json` after release commits. `bun run validate` does NOT cover that step, so AI sessions kept pushing red CI.

## What Changed

| File | Change |
|------|--------|
| `scripts/ci-local.sh` | New. Single source of truth mirroring CI Test job's 7 steps in order with matching env (`NON_INTERACTIVE=true`, `CI_SAFE_MODE=true`). Prints a copy-paste self-heal one-liner if the manifest/docs drift check fails. |
| `package.json` | Adds `"ci:local": "bash scripts/ci-local.sh"` |
| `.githooks/pre-push` | Now delegates to `scripts/ci-local.sh` (full CI parity) then runs `bun run ui:test` as a local-only safety net (CI does not run `ui:test`). Hook ↔ CI parity can no longer drift. |
| `CLAUDE.md` | Rewrites the "CRITICAL: Quality Gate" section. Adds tables for: each CI Test job step + what it catches, parity-drift class + self-heal one-liners, `validate` vs `ci:local`, other CI workflows (Metadata Deletions, Release Dry-Run, Claude Code Review), pre-push hook behavior. |
| `cli-manifest.json` / `docs/cli-reference.md` | Regenerated for `4.1.0-dev.1` (self-heal applied via the new drift check). |

## How AI sessions should use it

Before pushing any branch:
```bash
bun run ci:local
```

If the drift check fails:
```bash
bun run manifest:generate && bun run docs:generate
git add cli-manifest.json docs/cli-reference.md
git commit -m "chore: regenerate cli-manifest and docs"
```

Note: use `chore:` (NOT `hotfix:` or `fix:`) for the regen commit — version-sync commits must NOT trigger releases.

## Validation

- [x] `bun run ci:local` passes locally end-to-end (typecheck + lint + build + 4718 tests + drift check + ui:build + prepublish-check)
- [x] Pre-push hook tested via `bash scripts/ci-local.sh` (Phase 1) + `bun run ui:test` (Phase 2)
- [x] Self-heal one-liner verified: drift check correctly reported `4.1.0` vs `4.1.0-dev.1`, regen + commit cleared it

## Non-goals

- No changes to CI workflows themselves (we want local to match CI, not the reverse)
- No changes to release/semantic-release config
- `ci:local` does NOT include `ui:test` because CI's `Test` job doesn't run it; `ui:test` stays in the pre-push hook as a local-only safety net
