### PR TITLE
fix(update): avoid shell spawn for kit init handoff

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "4.1.0-dev.1",
+	"version": "4.1.1-dev.1",
 	"generatedAt": "2026-05-11T16:50:53.387Z",
 	"commands": {
 		"agents": {

--- a/src/__tests__/commands/update-cli.test.ts
+++ b/src/__tests__/commands/update-cli.test.ts
@@ -14,6 +14,7 @@ import {
 	readMetadataFile,
 	redactCommandForLog,
 	resolveCkExecutable,
+	resolveCkInitSpawnCommand,
 	selectKitForUpdate,
 	shouldRunCkExecutableInShell,
 	updateCliCommand,
@@ -116,13 +117,39 @@ describe("update-cli", () => {
 	});
 
 	describe("shouldRunCkExecutableInShell", () => {
-		it("uses shell mode for Windows cmd shims", () => {
-			expect(shouldRunCkExecutableInShell("win32")).toBe(true);
+		it("does not use shell mode for Windows cmd shims", () => {
+			expect(shouldRunCkExecutableInShell("win32")).toBe(false);
 		});
 
 		it("does not use shell mode on POSIX platforms", () => {
 			expect(shouldRunCkExecutableInShell("darwin")).toBe(false);
 			expect(shouldRunCkExecutableInShell("linux")).toBe(false);
+		});
+	});
+
+	describe("resolveCkInitSpawnCommand", () => {
+		it("relaunches the current CLI entrypoint through the active runtime", () => {
+			const result = resolveCkInitSpawnCommand(["init", "-g", "--install-skills"], {
+				execPath: "/usr/local/bin/node",
+				argv: ["/usr/local/bin/node", "/opt/claudekit/bin/ck.js"],
+			});
+
+			expect(result).toEqual({
+				command: "/usr/local/bin/node",
+				args: ["/opt/claudekit/bin/ck.js", "init", "-g", "--install-skills"],
+			});
+		});
+
+		it("falls back to the platform shim when the entrypoint is unavailable", () => {
+			const result = resolveCkInitSpawnCommand(["init"], {
+				argv: ["/usr/local/bin/node"],
+				platformName: "win32",
+			});
+
+			expect(result).toEqual({
+				command: "ck.cmd",
+				args: ["init"],
+			});
 		});
 	});
 

--- a/src/commands/update-cli.ts
+++ b/src/commands/update-cli.ts
@@ -46,6 +46,7 @@ export {
 	fetchLatestReleaseTag,
 	promptKitUpdate,
 	promptMigrateUpdate,
+	resolveCkInitSpawnCommand,
 	readMetadataFile,
 	resolveCkExecutable,
 	selectKitForUpdate,

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -134,7 +134,40 @@ export function resolveCkExecutable(platformName: NodeJS.Platform = process.plat
 export function shouldRunCkExecutableInShell(
 	platformName: NodeJS.Platform = process.platform,
 ): boolean {
-	return platformName === "win32";
+	void platformName;
+	return false;
+}
+
+export interface CkInitSpawnCommand {
+	command: string;
+	args: string[];
+}
+
+export interface CkInitSpawnCommandOptions {
+	execPath?: string;
+	argv?: string[];
+	platformName?: NodeJS.Platform;
+}
+
+export function resolveCkInitSpawnCommand(
+	initArgs: string[],
+	options: CkInitSpawnCommandOptions = {},
+): CkInitSpawnCommand {
+	const execPath = options.execPath ?? process.execPath;
+	const argv = options.argv ?? process.argv;
+	const currentEntrypoint = argv[1];
+
+	if (currentEntrypoint) {
+		return {
+			command: execPath,
+			args: [currentEntrypoint, ...initArgs],
+		};
+	}
+
+	return {
+		command: resolveCkExecutable(options.platformName),
+		args: initArgs,
+	};
 }
 
 // ─── Latest release tag fetcher ───────────────────────────────────────────────
@@ -317,10 +350,8 @@ export async function promptKitUpdate(
 				deps?.spawnInitFn ??
 				((spawnArgs: string[]) =>
 					new Promise<number>((resolve) => {
-						const child = spawn(resolveCkExecutable(), spawnArgs, {
-							stdio: "inherit",
-							shell: shouldRunCkExecutableInShell(),
-						});
+						const initCommand = resolveCkInitSpawnCommand(spawnArgs);
+						const child = spawn(initCommand.command, initCommand.args, { stdio: "inherit" });
 						child.on("close", (code) => resolve(code ?? 1));
 						child.on("error", (err) => {
 							logger.verbose(`Failed to spawn ck init: ${err.message}`);


### PR DESCRIPTION
## Summary
- relaunch interactive `ck init` handoffs through the current Node runtime and CLI entrypoint instead of spawning the `ck` shim with shell mode
- keep Windows/POSIX command resolution covered with tests while removing the Node DEP0190 warning path
- sync generated CLI manifest version with package version so local CI drift checks stay green

## Diagnosis
The reported `No kit access found` path still maps to GitHub private-repo access: 404s for both kit repos mean the current GitHub identity/token cannot see the private kit repositories. The repo configuration points to the expected `claudekit/claudekit-engineer` and `claudekit/claudekit-marketing` repositories, and maintainer auth can view both.

The deprecation warning is a real CLI-side issue in the interactive update handoff: `ck update` spawned `ck init` using `shell` mode with an args array on Windows-compatible paths, which Node 24 warns about via DEP0190.

## Test plan
- `bun test src/__tests__/commands/update-cli.test.ts src/__tests__/commands/update-cli-auto-init.test.ts src/__tests__/commands/update-cli.windows-integration.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run ci:local`
- pre-push hook: full local CI parity + extra UI vitest suite

## Docs impact
Docs impact: none
Action: no update needed — internal update handoff fix; no CLI syntax/user-facing docs changed
