### PR TITLE
test: guard Windows global kit path

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.1.1-dev.1",
-	"generatedAt": "2026-05-11T16:50:53.387Z",
+	"version": "4.1.1-dev.2",
+	"generatedAt": "2026-05-12T14:24:55.192Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-11T16:50:53.448Z -->
+<!-- generated: 2026-05-12T14:24:55.283Z -->

--- a/tests/utils/path-resolver.test.ts
+++ b/tests/utils/path-resolver.test.ts
@@ -208,16 +208,19 @@ describe("PathResolver", () => {
 			expect(globalKitDir).toBe(join(homedir(), ".claude"));
 		});
 
-		it("should return consistent path regardless of environment variables", () => {
-			// Test that it doesn't depend on APPDATA or other env vars
+		it("should return consistent path regardless of Windows app data environment variables", () => {
 			const originalAppData = process.env.APPDATA;
-			process.env.APPDATA = undefined;
+			const originalLocalAppData = process.env.LOCALAPPDATA;
+			process.env.APPDATA = "C:\\Users\\admin\\AppData\\Roaming";
+			process.env.LOCALAPPDATA = "C:\\Users\\admin\\AppData\\Local";
 
-			const globalKitDir = PathResolver.getGlobalKitDir();
-			expect(globalKitDir).toBe(join(homedir(), ".claude"));
-
-			// Restore
-			process.env.APPDATA = originalAppData;
+			try {
+				const globalKitDir = PathResolver.getGlobalKitDir();
+				expect(globalKitDir).toBe(join(homedir(), ".claude"));
+			} finally {
+				process.env.APPDATA = originalAppData;
+				process.env.LOCALAPPDATA = originalLocalAppData;
+			}
 		});
 
 		it("should respect CLAUDE_CONFIG_DIR when set", () => {


### PR DESCRIPTION
## Summary
- Add explicit regression coverage that `APPDATA` and `LOCALAPPDATA` do not affect global kit path resolution.
- Keep global kit installs anchored to the user Claude directory (`~/.claude`, `%USERPROFILE%\.claude\` on Windows).

Closes #808

## Root Cause
CLI behavior already resolved global installs to the user Claude directory. The docs drifted to `%LOCALAPPDATA%\.claude\`, and the path resolver test did not explicitly guard `LOCALAPPDATA`.

## Changes
| File | Change |
|---|---|
| `tests/utils/path-resolver.test.ts` | Covers both `APPDATA` and `LOCALAPPDATA` env vars when resolving the global kit directory. |

## Test plan
- [x] `bun test tests/utils/path-resolver.test.ts`
- [x] `bun run ci:local`
- [x] pre-push quality gate, including UI vitest extra suite

## Docs
- Paired docs PR: claudekit/claudekit-docs#161