### PR TITLE
hotfix: show active Claude skills in installed list

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.1.1-dev.4",
-	"generatedAt": "2026-05-12T15:00:17.908Z",
+	"version": "4.2.0",
+	"generatedAt": "2026-05-12T16:21:09.272Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/__tests__/domains/health-checks/checkers/skill-budget-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/skill-budget-checker.test.ts
@@ -219,6 +219,7 @@ describe("checkSkillBudget", () => {
 
 		expect(inventory.status).toBe("warn");
 		expect(inventory.message).toContain("duplicate");
+		expect(inventory.suggestion).toContain("ck skills --list --installed");
 		expect(inventory.autoFixable).toBe(false);
 	});
 

--- a/src/commands/skills/__tests__/installed-skills-inventory.test.ts
+++ b/src/commands/skills/__tests__/installed-skills-inventory.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getActiveClaudeSkillInstallations } from "../installed-skills-inventory.js";
+
+describe("getActiveClaudeSkillInstallations", () => {
+	let testRoot: string;
+	let projectDir: string;
+	let globalDir: string;
+
+	beforeEach(async () => {
+		testRoot = join(
+			tmpdir(),
+			`ck-installed-skills-inventory-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		projectDir = join(testRoot, "project");
+		globalDir = join(testRoot, "home", ".claude");
+	});
+
+	afterEach(async () => {
+		await rm(testRoot, { recursive: true, force: true });
+	});
+
+	test("lists active Claude Code skills from project and global scopes", async () => {
+		await writeSkill(join(projectDir, ".claude", "skills"), "cook");
+		await writeSkill(join(globalDir, "skills"), "ask");
+
+		const installed = await getActiveClaudeSkillInstallations({ projectDir, globalDir });
+
+		expect(installed.map((entry) => `${entry.skill}:${entry.scope}`)).toEqual([
+			"ask:global",
+			"cook:project",
+		]);
+		expect(installed.every((entry) => !entry.duplicateAcrossScopes)).toBe(true);
+	});
+
+	test("marks duplicate project/global skill ids", async () => {
+		await writeSkill(join(projectDir, ".claude", "skills"), "agent-browser", "ck:agent-browser");
+		await writeSkill(join(globalDir, "skills"), "agent-browser", "ck:agent-browser");
+
+		const installed = await getActiveClaudeSkillInstallations({ projectDir, globalDir });
+
+		expect(installed).toHaveLength(2);
+		expect(installed.map((entry) => entry.scope).sort()).toEqual(["global", "project"]);
+		expect(installed.every((entry) => entry.skill === "agent-browser")).toBe(true);
+		expect(installed.every((entry) => entry.duplicateAcrossScopes)).toBe(true);
+	});
+});
+
+async function writeSkill(skillsDir: string, dirName: string, frontmatterName = dirName) {
+	const skillDir = join(skillsDir, dirName);
+	await mkdir(skillDir, { recursive: true });
+	await writeFile(
+		join(skillDir, "SKILL.md"),
+		["---", `name: ${frontmatterName}`, "description: Test skill", "---", "", "Body"].join("\n"),
+	);
+}

--- a/src/commands/skills/installed-skills-inventory.ts
+++ b/src/commands/skills/installed-skills-inventory.ts
@@ -1,0 +1,53 @@
+import { join } from "node:path";
+import { scanSkills } from "@/domains/health-checks/checkers/skill-budget-scanner.js";
+import { PathResolver } from "@/shared/path-resolver.js";
+
+export type ClaudeSkillScope = "project" | "global";
+
+export interface ActiveClaudeSkillInstallation {
+	skill: string;
+	scope: ClaudeSkillScope;
+	path: string;
+	duplicateAcrossScopes: boolean;
+}
+
+export interface ActiveClaudeSkillInventoryOptions {
+	projectDir?: string;
+	globalDir?: string;
+}
+
+const SCOPE_SORT_ORDER: Record<ClaudeSkillScope, number> = {
+	project: 0,
+	global: 1,
+};
+
+export async function getActiveClaudeSkillInstallations(
+	options: ActiveClaudeSkillInventoryOptions = {},
+): Promise<ActiveClaudeSkillInstallation[]> {
+	const projectDir = options.projectDir ?? process.cwd();
+	const globalDir = options.globalDir ?? PathResolver.getGlobalKitDir();
+	const [projectSkills, globalSkills] = await Promise.all([
+		scanSkills(join(projectDir, ".claude", "skills")),
+		scanSkills(join(globalDir, "skills")),
+	]);
+	const projectIds = new Set(projectSkills.map((skill) => skill.id));
+	const globalIds = new Set(globalSkills.map((skill) => skill.id));
+
+	return [
+		...projectSkills.map((skill) => ({
+			skill: skill.id,
+			scope: "project" as const,
+			path: skill.file,
+			duplicateAcrossScopes: globalIds.has(skill.id),
+		})),
+		...globalSkills.map((skill) => ({
+			skill: skill.id,
+			scope: "global" as const,
+			path: skill.file,
+			duplicateAcrossScopes: projectIds.has(skill.id),
+		})),
+	].sort(
+		(a, b) =>
+			a.skill.localeCompare(b.skill) || SCOPE_SORT_ORDER[a.scope] - SCOPE_SORT_ORDER[b.scope],
+	);
+}

--- a/src/commands/skills/skills-command.ts
+++ b/src/commands/skills/skills-command.ts
@@ -13,6 +13,7 @@ import {
 import { searchSkills } from "../../domains/skills/skill-search-index.js";
 import { logger } from "../../shared/logger.js";
 import { agents } from "./agents.js";
+import { getActiveClaudeSkillInstallations } from "./installed-skills-inventory.js";
 import { discoverSkills, findSkillByName, getSkillSourcePath } from "./skills-discovery.js";
 import { getInstallPreview, installSkillToAgents } from "./skills-installer.js";
 import { readRegistry, syncRegistry } from "./skills-registry.js";
@@ -214,37 +215,72 @@ async function detectInstalledAgents(): Promise<AgentType[]> {
  */
 async function listSkills(showInstalled: boolean): Promise<void> {
 	if (showInstalled) {
-		// Show installed skills from registry
-		const installations = await getInstalledSkills();
-		if (installations.length === 0) {
-			p.log.warn("No skills installed via ck skills.");
+		const [installations, activeClaudeSkills] = await Promise.all([
+			getInstalledSkills(),
+			getActiveClaudeSkillInstallations(),
+		]);
+
+		if (installations.length === 0 && activeClaudeSkills.length === 0) {
+			p.log.warn("No installed skills found.");
 			return;
 		}
 
 		console.log();
-		p.log.step(pc.bold("Installed Skills"));
-		console.log();
+		if (activeClaudeSkills.length > 0) {
+			p.log.step(pc.bold("Active Claude Code Skills"));
+			console.log();
 
-		// Group by skill name
-		const bySkill = new Map<string, typeof installations>();
-		for (const inst of installations) {
-			const list = bySkill.get(inst.skill) || [];
-			list.push(inst);
-			bySkill.set(inst.skill, list);
-		}
-
-		for (const [skill, installs] of bySkill) {
-			console.log(`  ${pc.cyan(skill)}`);
-			for (const inst of installs) {
-				const scope = inst.global ? "global" : "project";
-				console.log(`    ${pc.dim("→")} ${inst.agent} (${scope}): ${pc.dim(inst.path)}`);
+			const bySkill = new Map<string, typeof activeClaudeSkills>();
+			for (const inst of activeClaudeSkills) {
+				const list = bySkill.get(inst.skill) || [];
+				list.push(inst);
+				bySkill.set(inst.skill, list);
 			}
+
+			for (const [skill, installs] of bySkill) {
+				const duplicate = installs.some((inst) => inst.duplicateAcrossScopes)
+					? ` ${pc.yellow("(project/global duplicate)")}`
+					: "";
+				console.log(`  ${pc.cyan(skill)}${duplicate}`);
+				for (const inst of installs) {
+					console.log(`    ${pc.dim("→")} ${inst.scope}: ${pc.dim(inst.path)}`);
+				}
+			}
+
+			console.log();
+			console.log(
+				pc.dim(`  ${activeClaudeSkills.length} active Claude Code skill installation(s)`),
+			);
+			console.log();
 		}
 
-		console.log();
-		console.log(
-			pc.dim(`  ${installations.length} installation(s) across ${bySkill.size} skill(s)`),
-		);
+		if (installations.length > 0) {
+			p.log.step(pc.bold("Registry-managed Agent Skills"));
+			console.log();
+
+			const bySkill = new Map<string, typeof installations>();
+			for (const inst of installations) {
+				const list = bySkill.get(inst.skill) || [];
+				list.push(inst);
+				bySkill.set(inst.skill, list);
+			}
+
+			for (const [skill, installs] of bySkill) {
+				console.log(`  ${pc.cyan(skill)}`);
+				for (const inst of installs) {
+					const scope = inst.global ? "global" : "project";
+					console.log(`    ${pc.dim("→")} ${inst.agent} (${scope}): ${pc.dim(inst.path)}`);
+				}
+			}
+
+			console.log();
+			console.log(
+				pc.dim(
+					`  ${installations.length} registry-managed installation(s) across ${bySkill.size} skill(s)`,
+				),
+			);
+		}
+
 		console.log();
 		return;
 	}

--- a/src/domains/health-checks/checkers/skill-budget-checker.ts
+++ b/src/domains/health-checks/checkers/skill-budget-checker.ts
@@ -171,7 +171,7 @@ function buildDuplicateInventoryCheck(
 		"Skill Inventory",
 		`${duplicates.length} duplicate project/global skill(s)`,
 		duplicates,
-		"Keep one installation scope per skill; inspect with: ck skills list --installed",
+		"Keep one installation scope per skill; inspect with: ck skills --list --installed",
 	);
 }
 


### PR DESCRIPTION
## Summary
- include active Claude Code project/global skills in `ck skills --list --installed`
- mark project/global duplicates and show both `SKILL.md` locations
- update Doctor's duplicate-skill suggestion to the supported flag syntax
- align `cli-manifest.json` with released package version `4.2.0` so CI drift check passes on `main`

Closes #811

## Validation
- `bun test src/commands/skills/__tests__/installed-skills-inventory.test.ts src/__tests__/domains/health-checks/checkers/skill-budget-checker.test.ts src/commands/skills/__tests__/skills-uninstaller.test.ts src/commands/skills/__tests__/skills-discovery.test.ts`
- temp repro: `ck skills --list --installed` now prints active project/global duplicates with both paths
- `bun run ci:local`
- pre-push quality gate, including UI vitest suite

## Docs impact
Docs impact: none
Action: no update needed — existing docs already describe `--installed` as showing installed skills with locations; this restores that behavior.