### PR TITLE
hotfix: quote bash hook runner paths

### DIFF
--- a/__tests__/domains/installation/merger/settings-processor.test.ts
+++ b/__tests__/domains/installation/merger/settings-processor.test.ts
@@ -1082,6 +1082,40 @@ describe("SettingsProcessor", () => {
 			expect(cmd).toBe('node "$HOME/.claude/hooks/session-init.cjs" compact');
 		});
 
+		it("should quote bash node-hook-runner paths for global install", async () => {
+			const sourceSettings = {
+				hooks: {
+					UserPromptSubmit: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command:
+										"bash .claude/hooks/node-hook-runner.sh .claude/hooks/dev-rules-reminder.cjs",
+								},
+							],
+						},
+					],
+				},
+			};
+			const sourceFile = join(sourceDir, "settings.json");
+			await writeFile(sourceFile, JSON.stringify(sourceSettings), "utf-8");
+
+			const destFile = join(destDir, "settings.json");
+
+			const processor = new SettingsProcessor();
+			processor.setGlobalFlag(true);
+			processor.setProjectDir(destDir);
+			await processor.processSettingsJson(sourceFile, destFile);
+
+			const result = JSON.parse(await readFile(destFile, "utf-8"));
+			const cmd = result.hooks.UserPromptSubmit[0].hooks[0].command;
+
+			expect(cmd).toBe(
+				'bash "$HOME/.claude/hooks/node-hook-runner.sh" "$HOME/.claude/hooks/dev-rules-reminder.cjs"',
+			);
+		});
+
 		it("should keep .claude outside the quoted project dir for local install", async () => {
 			const sourceSettings = {
 				hooks: {
@@ -1102,6 +1136,39 @@ describe("SettingsProcessor", () => {
 			const cmd = result.hooks.SessionStart[0].command;
 
 			expect(cmd).toBe('node "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-init.cjs');
+		});
+
+		it("should keep .claude outside the quoted project dir for local bash runner hooks", async () => {
+			const sourceSettings = {
+				hooks: {
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: "bash .claude/hooks/node-hook-runner.sh .claude/hooks/session-init.cjs",
+								},
+							],
+						},
+					],
+				},
+			};
+			const sourceFile = join(sourceDir, "settings.json");
+			await writeFile(sourceFile, JSON.stringify(sourceSettings), "utf-8");
+
+			const destFile = join(destDir, "settings.json");
+
+			const processor = new SettingsProcessor();
+			processor.setGlobalFlag(false);
+			processor.setProjectDir(destDir);
+			await processor.processSettingsJson(sourceFile, destFile);
+
+			const result = JSON.parse(await readFile(destFile, "utf-8"));
+			const cmd = result.hooks.SessionStart[0].hooks[0].command;
+
+			expect(cmd).toBe(
+				'bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/node-hook-runner.sh "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-init.cjs',
+			);
 		});
 	});
 
@@ -1212,6 +1279,56 @@ describe("SettingsProcessor", () => {
 
 			// Must have quotes around the full path
 			expect(cmd).toMatch(/^node\s+"[^"]+\.claude\/[^"]+"/);
+		});
+
+		it("should self-heal unquoted bash node-hook-runner paths already present in destination", async () => {
+			const destSettings = {
+				hooks: {
+					UserPromptSubmit: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command:
+										"bash $HOME/.claude/hooks/node-hook-runner.sh $HOME/.claude/hooks/dev-rules-reminder.cjs",
+								},
+							],
+						},
+					],
+				},
+			};
+			const destFile = join(destDir, "settings.json");
+			await writeFile(destFile, JSON.stringify(destSettings), "utf-8");
+
+			const sourceSettings = {
+				hooks: {
+					UserPromptSubmit: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command:
+										"bash .claude/hooks/node-hook-runner.sh .claude/hooks/dev-rules-reminder.cjs",
+								},
+							],
+						},
+					],
+				},
+			};
+			const sourceFile = join(sourceDir, "settings.json");
+			await writeFile(sourceFile, JSON.stringify(sourceSettings), "utf-8");
+
+			const processor = new SettingsProcessor();
+			processor.setGlobalFlag(true);
+			processor.setProjectDir(destDir);
+			await processor.processSettingsJson(sourceFile, destFile);
+
+			const result = JSON.parse(await readFile(destFile, "utf-8"));
+			const cmd = result.hooks.UserPromptSubmit[0].hooks[0].command;
+
+			expect(cmd).toBe(
+				'bash "$HOME/.claude/hooks/node-hook-runner.sh" "$HOME/.claude/hooks/dev-rules-reminder.cjs"',
+			);
 		});
 
 		it("should fix nested hooks with matcher", async () => {

--- a/__tests__/domains/installation/merger/settings-processor.test.ts
+++ b/__tests__/domains/installation/merger/settings-processor.test.ts
@@ -1331,6 +1331,55 @@ describe("SettingsProcessor", () => {
 			);
 		});
 
+		it("should self-heal unquoted local bash node-hook-runner paths already present in destination", async () => {
+			const destSettings = {
+				hooks: {
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command:
+										"bash $CLAUDE_PROJECT_DIR/.claude/hooks/node-hook-runner.sh $CLAUDE_PROJECT_DIR/.claude/hooks/session-init.cjs",
+								},
+							],
+						},
+					],
+				},
+			};
+			const destFile = join(destDir, "settings.json");
+			await writeFile(destFile, JSON.stringify(destSettings), "utf-8");
+
+			const sourceSettings = {
+				hooks: {
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: "bash .claude/hooks/node-hook-runner.sh .claude/hooks/session-init.cjs",
+								},
+							],
+						},
+					],
+				},
+			};
+			const sourceFile = join(sourceDir, "settings.json");
+			await writeFile(sourceFile, JSON.stringify(sourceSettings), "utf-8");
+
+			const processor = new SettingsProcessor();
+			processor.setGlobalFlag(false);
+			processor.setProjectDir(destDir);
+			await processor.processSettingsJson(sourceFile, destFile);
+
+			const result = JSON.parse(await readFile(destFile, "utf-8"));
+			const cmd = result.hooks.SessionStart[0].hooks[0].command;
+
+			expect(cmd).toBe(
+				'bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/node-hook-runner.sh "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-init.cjs',
+			);
+		});
+
 		it("should fix nested hooks with matcher", async () => {
 			const destSettings = {
 				hooks: {

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.2.0",
-	"generatedAt": "2026-05-12T16:21:09.272Z",
+	"version": "4.2.1",
+	"generatedAt": "2026-05-12T17:15:51.954Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-12T15:00:19.312Z -->
+<!-- generated: 2026-05-12T17:15:52.017Z -->

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker-corpus.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker-corpus.test.ts
@@ -4,7 +4,7 @@
  * Exhaustive corpus tests proving every known stale hook command path shape
  * converges in a single `ck doctor --fix` pass (issue #776).
  *
- * Each test row: input command → repairClaudeNodeCommandPath → assert:
+ * Each test row: input command → hook command repair → assert:
  *   - no FixerDidNotConvergeError
  *   - post-fix re-detection finds 0 stale entries
  *   - canonical form matches expected pattern
@@ -29,7 +29,10 @@ import {
 	checkHookCommandPaths,
 	findStaleHookCommandsInFile,
 } from "@/domains/health-checks/checkers/hook-health-checker.js";
-import { repairClaudeNodeCommandPath } from "@/shared/command-normalizer.js";
+import {
+	repairClaudeHookCommandPath,
+	repairClaudeNodeCommandPath,
+} from "@/shared/command-normalizer.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -111,7 +114,7 @@ async function assertProjectCommandConverges(
 
 /**
  * Test that a stale command in a global settings file (root="$HOME") converges
- * after `repairClaudeNodeCommandPath` is applied via the detect→fix→detect cycle.
+ * after hook command repair is applied via the detect→fix→detect cycle.
  *
  * Note: We cannot use `checkHookCommandPaths` for global settings in tests because
  * `CK_TEST_HOME` changes `PathResolver.getGlobalKitDir()` to a temp path, which
@@ -158,13 +161,13 @@ async function assertGlobalCommandConverges(
 					hooks?: Array<{ command?: string }>;
 				}>) {
 					if (typeof entry.command === "string") {
-						const r = repairClaudeNodeCommandPath(entry.command, sf.root);
+						const r = repairClaudeHookCommandPath(entry.command, sf.root);
 						if (r.changed) entry.command = r.command;
 					}
 					if (Array.isArray(entry.hooks)) {
 						for (const h of entry.hooks) {
 							if (typeof h.command === "string") {
-								const r = repairClaudeNodeCommandPath(h.command, sf.root);
+								const r = repairClaudeHookCommandPath(h.command, sf.root);
 								if (r.changed) h.command = r.command;
 							}
 						}
@@ -720,6 +723,14 @@ describe("hook-health-checker corpus: nested matcher hook entries", () => {
 			},
 			fixture: settingsFile,
 		});
+	});
+
+	test("converges: unquoted global bash node-hook-runner commands", async () => {
+		await assertGlobalCommandConverges(
+			ctx,
+			"bash $HOME/.claude/hooks/node-hook-runner.sh $HOME/.claude/hooks/dev-rules-reminder.cjs",
+			/^bash "\$HOME\/\.claude\/hooks\/node-hook-runner\.sh" "\$HOME\/\.claude\/hooks\/dev-rules-reminder\.cjs"$/,
+		);
 	});
 });
 

--- a/src/__tests__/shared/command-normalizer.test.ts
+++ b/src/__tests__/shared/command-normalizer.test.ts
@@ -58,6 +58,15 @@ describe("normalizeCommand", () => {
 		expect(result.issue).toBe("invalid-format");
 		expect(result.command).toBe('node "$CLAUDE_PROJECT_DIR"/.claude/hooks/scout-block.cjs');
 	});
+
+	it("normalizes quoted and unquoted bash runner commands to the same comparison key", () => {
+		const quoted =
+			'bash "$HOME/.claude/hooks/node-hook-runner.sh" "$HOME/.claude/hooks/dev-rules-reminder.cjs"';
+		const unquoted =
+			"bash $HOME/.claude/hooks/node-hook-runner.sh $HOME/.claude/hooks/dev-rules-reminder.cjs";
+
+		expect(normalizeCommand(quoted)).toBe(normalizeCommand(unquoted));
+	});
 });
 
 describe("repairClaudeHookCommandPath — node hook runner", () => {
@@ -91,6 +100,16 @@ describe("repairClaudeHookCommandPath — node hook runner", () => {
 		const command =
 			'bash "$HOME/.claude/hooks/node-hook-runner.sh" "$HOME/.claude/hooks/session-init.cjs"';
 		const result = repairClaudeHookCommandPath(command, "$HOME");
+
+		expect(result.changed).toBe(false);
+		expect(result.issue).toBeNull();
+		expect(result.command).toBe(command);
+	});
+
+	it("is idempotent for already quoted local runner commands", () => {
+		const command =
+			'bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/node-hook-runner.sh "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-init.cjs';
+		const result = repairClaudeHookCommandPath(command, "$CLAUDE_PROJECT_DIR");
 
 		expect(result.changed).toBe(false);
 		expect(result.issue).toBeNull();

--- a/src/__tests__/shared/command-normalizer.test.ts
+++ b/src/__tests__/shared/command-normalizer.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { normalizeCommand, repairClaudeNodeCommandPath } from "@/shared/command-normalizer.js";
+import {
+	normalizeCommand,
+	repairClaudeHookCommandPath,
+	repairClaudeNodeCommandPath,
+} from "@/shared/command-normalizer.js";
 
 describe("normalizeCommand", () => {
 	const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
@@ -53,6 +57,53 @@ describe("normalizeCommand", () => {
 		expect(result.changed).toBe(true);
 		expect(result.issue).toBe("invalid-format");
 		expect(result.command).toBe('node "$CLAUDE_PROJECT_DIR"/.claude/hooks/scout-block.cjs');
+	});
+});
+
+describe("repairClaudeHookCommandPath — node hook runner", () => {
+	it("quotes global bash runner paths so $HOME with spaces survives shell parsing", () => {
+		const result = repairClaudeHookCommandPath(
+			"bash $HOME/.claude/hooks/node-hook-runner.sh $HOME/.claude/hooks/dev-rules-reminder.cjs",
+			"$HOME",
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.issue).toBe("invalid-format");
+		expect(result.command).toBe(
+			'bash "$HOME/.claude/hooks/node-hook-runner.sh" "$HOME/.claude/hooks/dev-rules-reminder.cjs"',
+		);
+	});
+
+	it("rewrites relative bash runner commands to the local project form", () => {
+		const result = repairClaudeHookCommandPath(
+			"bash .claude/hooks/node-hook-runner.sh .claude/hooks/session-init.cjs",
+			"$CLAUDE_PROJECT_DIR",
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.issue).toBe("invalid-format");
+		expect(result.command).toBe(
+			'bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/node-hook-runner.sh "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-init.cjs',
+		);
+	});
+
+	it("is idempotent for already quoted global runner commands", () => {
+		const command =
+			'bash "$HOME/.claude/hooks/node-hook-runner.sh" "$HOME/.claude/hooks/session-init.cjs"';
+		const result = repairClaudeHookCommandPath(command, "$HOME");
+
+		expect(result.changed).toBe(false);
+		expect(result.issue).toBeNull();
+		expect(result.command).toBe(command);
+	});
+
+	it("leaves unrelated bash commands untouched", () => {
+		const command = "bash .claude/hooks/scout-block.cjs";
+		const result = repairClaudeHookCommandPath(command, "$CLAUDE_PROJECT_DIR");
+
+		expect(result.changed).toBe(false);
+		expect(result.issue).toBeNull();
+		expect(result.command).toBe(command);
 	});
 });
 

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -5,7 +5,7 @@ import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { type SettingsJson, SettingsMerger } from "@/domains/config/settings-merger.js";
 import { CLAUDEKIT_CLI_NPM_PACKAGE_NAME } from "@/shared/claudekit-constants.js";
-import { repairClaudeNodeCommandPath } from "@/shared/command-normalizer.js";
+import { repairClaudeHookCommandPath } from "@/shared/command-normalizer.js";
 import { logger } from "@/shared/logger.js";
 import { PathResolver } from "@/shared/path-resolver.js";
 import type { CheckResult } from "../types.js";
@@ -128,7 +128,13 @@ function getClaudeSettingsFiles(projectDir: string): ClaudeSettingsFile[] {
 function isAlreadyCanonical(cmd: string): boolean {
 	return (
 		/^node\s+"\$HOME\/\.claude\/[^"]+"/.test(cmd) ||
-		/^node\s+"\$CLAUDE_PROJECT_DIR"\/\.claude\/\S+/.test(cmd)
+		/^node\s+"\$CLAUDE_PROJECT_DIR"\/\.claude\/\S+/.test(cmd) ||
+		/^bash\s+"\$HOME\/\.claude\/hooks\/node-hook-runner\.sh"\s+"\$HOME\/\.claude\/[^"]+"/.test(
+			cmd,
+		) ||
+		/^bash\s+"\$CLAUDE_PROJECT_DIR"\/\.claude\/hooks\/node-hook-runner\.sh\s+"\$CLAUDE_PROJECT_DIR"\/\.claude\/\S+/.test(
+			cmd,
+		)
 	);
 }
 
@@ -146,7 +152,7 @@ function collectHookCommandFindings(
 			if ("command" in entry && typeof entry.command === "string") {
 				// Skip commands already in any canonical form — cross-scope references are valid.
 				if (isAlreadyCanonical(entry.command)) continue;
-				const repair = repairClaudeNodeCommandPath(entry.command, settingsFile.root);
+				const repair = repairClaudeHookCommandPath(entry.command, settingsFile.root);
 				if (repair.changed && repair.issue) {
 					findings.push({
 						path: settingsFile.path,
@@ -171,7 +177,7 @@ function collectHookCommandFindings(
 				// Skip commands already in any canonical form — cross-scope references are valid.
 				if (isAlreadyCanonical(hook.command)) continue;
 
-				const repair = repairClaudeNodeCommandPath(hook.command, settingsFile.root);
+				const repair = repairClaudeHookCommandPath(hook.command, settingsFile.root);
 				if (!repair.changed || !repair.issue) {
 					continue;
 				}

--- a/src/domains/installation/merger/settings-processor.ts
+++ b/src/domains/installation/merger/settings-processor.ts
@@ -505,6 +505,8 @@ export class SettingsProcessor {
 		// The .replace(/"/g, '\\"') is needed here because this regex operates on raw JSON text,
 		// so quotes must be escaped. fixSingleCommandPath does NOT apply this escape because it
 		// works on parsed command strings (post-JSON-decode).
+		// Bash node-hook-runner commands are parsed commands, not raw node invocations, so
+		// fixHookCommandPaths repairs them after JSON parsing.
 		transformed = transformed.replace(
 			/(node\s+)(?:\.\/)?(\.claude\/[^\s"\\]+)([^"\\]*)/g,
 			(_match, nodePrefix: string, relativePath: string, suffix: string) => {

--- a/src/domains/installation/merger/settings-processor.ts
+++ b/src/domains/installation/merger/settings-processor.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { InstalledSettingsTracker } from "@/domains/config/installed-settings-tracker.js";
 import { type SettingsJson, SettingsMerger } from "@/domains/config/settings-merger.js";
-import { normalizeCommand, repairClaudeNodeCommandPath } from "@/shared/command-normalizer.js";
+import { normalizeCommand, repairClaudeHookCommandPath } from "@/shared/command-normalizer.js";
 import { logger } from "@/shared/logger.js";
 import { PathResolver } from "@/shared/path-resolver.js";
 import type { InstalledSettings } from "@/types";
@@ -583,7 +583,7 @@ export class SettingsProcessor {
 	 * Only processes paths containing .claude/ — leaves other commands untouched.
 	 */
 	private fixSingleCommandPath(cmd: string): string {
-		return repairClaudeNodeCommandPath(cmd, this.getClaudeCommandRoot()).command;
+		return repairClaudeHookCommandPath(cmd, this.getClaudeCommandRoot()).command;
 	}
 
 	private formatCommandPath(

--- a/src/shared/command-normalizer.ts
+++ b/src/shared/command-normalizer.ts
@@ -10,6 +10,11 @@ export interface ClaudeNodeCommandRepairResult {
 	issue: ClaudeNodeCommandIssue | null;
 }
 
+interface ClaudePathArg {
+	root: string;
+	relativePath: string;
+}
+
 function escapeRegex(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -34,6 +39,56 @@ function formatCanonicalClaudeCommand(
 	return normalizedRoot === "$CLAUDE_PROJECT_DIR"
 		? `${nodePrefix}"${normalizedRoot}"/${normalizedRelativePath}${suffix}`
 		: `${nodePrefix}"${normalizedRoot}/${normalizedRelativePath}"${suffix}`;
+}
+
+function resolveClaudePathArg(arg: string, root: string): ClaudePathArg | null {
+	const normalizedArg = arg.replace(/\\/g, "/");
+
+	const bareRelativeMatch = normalizedArg.match(/^(?:\.\/)?(\.claude\/.+)$/);
+	if (bareRelativeMatch) {
+		return { root, relativePath: bareRelativeMatch[1] };
+	}
+
+	const variableMatch = normalizedArg.match(
+		/^(?:\$HOME|\$\{HOME\}|\$CLAUDE_PROJECT_DIR|\$\{CLAUDE_PROJECT_DIR\}|%USERPROFILE%|%CLAUDE_PROJECT_DIR%)\/(\.claude\/.+)$/,
+	);
+	if (variableMatch) {
+		return { root, relativePath: variableMatch[1] };
+	}
+
+	const tildeMatch = normalizedArg.match(/^~\/(\.claude\/.+)$/);
+	if (tildeMatch) {
+		return { root, relativePath: tildeMatch[1] };
+	}
+
+	const absoluteMatch = normalizedArg.match(/^((?:[A-Za-z]:\/|\/).*?\/\.claude\/.+)$/);
+	if (absoluteMatch) {
+		const absolutePath = absoluteMatch[1];
+		const dotClaudeIdx = absolutePath.indexOf("/.claude/");
+		if (dotClaudeIdx === -1) {
+			return null;
+		}
+
+		const isWin = process.platform === "win32";
+		const cmp = (s: string) => (isWin ? s.toLowerCase() : s);
+		const globalRoots = [
+			`${homedir().replace(/\\/g, "/").replace(/\/+$/, "")}/.claude/`,
+			`${PathResolver.getGlobalKitDir().replace(/\\/g, "/").replace(/\/+$/, "")}/`,
+		];
+		const isUnderGlobal = globalRoots.some((g) => cmp(absolutePath).startsWith(cmp(g)));
+		const resolvedRoot = isUnderGlobal ? "$HOME" : root;
+
+		return {
+			root: resolvedRoot,
+			relativePath: absolutePath.slice(dotClaudeIdx + 1),
+		};
+	}
+
+	return null;
+}
+
+function formatCanonicalClaudeArg(pathArg: ClaudePathArg): string {
+	return formatCanonicalClaudeCommand("", pathArg.root, pathArg.relativePath);
 }
 
 /**
@@ -156,6 +211,68 @@ export function repairClaudeNodeCommandPath(
 	}
 
 	return { command: cmd, changed: false, issue: null };
+}
+
+function repairClaudeHookRunnerCommandPath(
+	cmd: string | null | undefined,
+	root: string,
+): ClaudeNodeCommandRepairResult {
+	if (!cmd) {
+		return { command: cmd ?? "", changed: false, issue: null };
+	}
+
+	const runnerMatch = cmd.match(
+		/^(\s*bash\s+)(?:"([^"]+)"|([^\s"]+))\s+(?:"([^"]+)"|([^\s"]+))(.*)$/,
+	);
+	if (!runnerMatch) {
+		return { command: cmd, changed: false, issue: null };
+	}
+
+	const [, bashPrefix, quotedRunner, unquotedRunner, quotedTarget, unquotedTarget, suffix] =
+		runnerMatch;
+	const runnerArg = quotedRunner ?? unquotedRunner;
+	const targetArg = quotedTarget ?? unquotedTarget;
+
+	const runnerPath = resolveClaudePathArg(runnerArg, root);
+	if (
+		!runnerPath ||
+		runnerPath.relativePath.replace(/\\/g, "/") !== ".claude/hooks/node-hook-runner.sh"
+	) {
+		return { command: cmd, changed: false, issue: null };
+	}
+
+	const targetPath = resolveClaudePathArg(targetArg, root);
+	if (!targetPath) {
+		return { command: cmd, changed: false, issue: null };
+	}
+
+	const command = `${bashPrefix}${formatCanonicalClaudeArg(runnerPath)} ${formatCanonicalClaudeArg(
+		targetPath,
+	)}${suffix}`;
+
+	return {
+		command,
+		changed: command !== cmd,
+		issue: command !== cmd ? "invalid-format" : null,
+	};
+}
+
+/**
+ * Canonicalize Claude hook commands into scope-aware, quoted path forms.
+ *
+ * Handles both legacy direct `node .claude/...` hooks and the current
+ * `bash .claude/hooks/node-hook-runner.sh .claude/...` runner form.
+ */
+export function repairClaudeHookCommandPath(
+	cmd: string | null | undefined,
+	root: string,
+): ClaudeNodeCommandRepairResult {
+	const nodeRepair = repairClaudeNodeCommandPath(cmd, root);
+	if (nodeRepair.changed || nodeRepair.issue || isNodeClaudeCommand(cmd)) {
+		return nodeRepair;
+	}
+
+	return repairClaudeHookRunnerCommandPath(cmd, root);
 }
 
 /**


### PR DESCRIPTION
## Summary

- quote `.claude/hooks/node-hook-runner.sh` bash runner arguments during command repair
- apply the repair from fresh install, reinstall/self-heal, and doctor hook command checks
- add regression coverage for global/local runner commands and existing broken `$HOME/.claude/...` settings
- regenerate CLI manifest/reference for the current stable version

Closes #813

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun test`
- `bun test src/__tests__/shared/command-normalizer.test.ts`
- `bun test __tests__/domains/installation/merger/settings-processor.test.ts`
- `bun test src/__tests__/domains/health-checks/checkers/hook-health-checker-corpus.test.ts`
- pre-commit quality gate
- pre-push local CI parity gate, including full tests, packaged CLI verification, and UI Vitest suite
- Windows Git Bash proof on `ssh i9-bootcamp`: unquoted `$HOME` path with a space fails, quoted runner command exits 0

## Docs Impact

Internal installer/doctor behavior only. Repo-generated CLI manifest/reference refreshed because the pre-push gate found version drift from 4.2.0 to 4.2.1.