### PR TITLE
hotfix: avoid duplicate skill inventory at home

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.2.1",
-	"generatedAt": "2026-05-12T17:15:51.954Z",
+	"version": "4.2.2",
+	"generatedAt": "2026-05-12T19:18:05.735Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-12T17:15:52.017Z -->
+<!-- generated: 2026-05-12T19:18:05.819Z -->

--- a/src/__tests__/domains/health-checks/checkers/skill-budget-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/skill-budget-checker.test.ts
@@ -223,6 +223,20 @@ describe("checkSkillBudget", () => {
 		expect(inventory.autoFixable).toBe(false);
 	});
 
+	test("does not warn on duplicates when home project scope aliases global scope", async () => {
+		await writeSkill(join(tempDir, ".claude", "skills"), "cook", {
+			userInvocable: true,
+		});
+
+		const results = await checkSkillBudget(createGlobalEngineerSetup(), tempDir);
+		const inventory = resultById(results, "ck-skill-inventory");
+		const descriptionInventory = resultById(results, "ck-skill-description-inventory");
+
+		expect(inventory.status).toBe("pass");
+		expect(inventory.message).toContain("No duplicate");
+		expect(descriptionInventory.message).toContain("1 active project/global skills");
+	});
+
 	test("passes when project skills omit user-invocable because Claude Code defaults to user visibility", async () => {
 		await writeSkill(join(projectDir, ".claude", "skills"), "cook", {});
 
@@ -359,6 +373,25 @@ function createEngineerSetup(): ClaudeKitSetup {
 				description: "Engineer kit",
 			},
 			components: { agents: 0, commands: 0, rules: 0, skills: 1 },
+		},
+	};
+}
+
+function createGlobalEngineerSetup(): ClaudeKitSetup {
+	return {
+		global: {
+			path: "",
+			metadata: {
+				name: "claudekit-engineer",
+				version: "1.0.0",
+				description: "Engineer kit",
+			},
+			components: { agents: 0, commands: 0, rules: 0, skills: 1 },
+		},
+		project: {
+			path: "",
+			metadata: null,
+			components: { agents: 0, commands: 0, rules: 0, skills: 0 },
 		},
 	};
 }

--- a/src/commands/skills/__tests__/installed-skills-inventory.test.ts
+++ b/src/commands/skills/__tests__/installed-skills-inventory.test.ts
@@ -46,6 +46,20 @@ describe("getActiveClaudeSkillInstallations", () => {
 		expect(installed.every((entry) => entry.skill === "agent-browser")).toBe(true);
 		expect(installed.every((entry) => entry.duplicateAcrossScopes)).toBe(true);
 	});
+
+	test("does not double-count global skills when project dir is home", async () => {
+		const homeDir = join(testRoot, "home");
+		const homeGlobalDir = join(homeDir, ".claude");
+		await writeSkill(join(homeGlobalDir, "skills"), "cook");
+
+		const installed = await getActiveClaudeSkillInstallations({
+			projectDir: homeDir,
+			globalDir: homeGlobalDir,
+		});
+
+		expect(installed.map((entry) => `${entry.skill}:${entry.scope}`)).toEqual(["cook:global"]);
+		expect(installed.every((entry) => !entry.duplicateAcrossScopes)).toBe(true);
+	});
 });
 
 async function writeSkill(skillsDir: string, dirName: string, frontmatterName = dirName) {

--- a/src/commands/skills/installed-skills-inventory.ts
+++ b/src/commands/skills/installed-skills-inventory.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { scanSkills } from "@/domains/health-checks/checkers/skill-budget-scanner.js";
 import { PathResolver } from "@/shared/path-resolver.js";
 
@@ -25,9 +25,11 @@ export async function getActiveClaudeSkillInstallations(
 	options: ActiveClaudeSkillInventoryOptions = {},
 ): Promise<ActiveClaudeSkillInstallation[]> {
 	const projectDir = options.projectDir ?? process.cwd();
-	const globalDir = options.globalDir ?? PathResolver.getGlobalKitDir();
+	const globalDir = resolve(options.globalDir ?? PathResolver.getGlobalKitDir());
+	const projectClaudeDir = resolve(projectDir, ".claude");
+	const projectScopeAliasesGlobal = projectClaudeDir === globalDir;
 	const [projectSkills, globalSkills] = await Promise.all([
-		scanSkills(join(projectDir, ".claude", "skills")),
+		projectScopeAliasesGlobal ? Promise.resolve([]) : scanSkills(join(projectClaudeDir, "skills")),
 		scanSkills(join(globalDir, "skills")),
 	]);
 	const projectIds = new Set(projectSkills.map((skill) => skill.id));

--- a/src/domains/health-checks/checkers/skill-budget-checker.ts
+++ b/src/domains/health-checks/checkers/skill-budget-checker.ts
@@ -24,13 +24,14 @@ export async function checkSkillBudget(
 	projectDir: string,
 ): Promise<CheckResult[]> {
 	const projectClaudeDir = resolve(projectDir, ".claude");
-	const globalClaudeDir = PathResolver.getGlobalKitDir();
+	const globalClaudeDir = resolve(PathResolver.getGlobalKitDir());
+	const projectScopeAliasesGlobal = projectClaudeDir === globalClaudeDir;
 	const [projectSkills, globalSkills] = await Promise.all([
-		scanSkills(join(projectClaudeDir, "skills")),
+		projectScopeAliasesGlobal ? Promise.resolve([]) : scanSkills(join(projectClaudeDir, "skills")),
 		scanSkills(join(globalClaudeDir, "skills")),
 	]);
 
-	if (!isEngineerLikeProject(setup, projectSkills)) return [];
+	if (!isEngineerLikeProject(setup, [...projectSkills, ...globalSkills])) return [];
 
 	const settingsPath = join(projectClaudeDir, "settings.json");
 	const settings = await readProjectSettings(settingsPath);
@@ -61,6 +62,9 @@ function isEngineerLikeProject(setup: ClaudeKitSetup, projectSkills: SkillMeta[]
 		setup.project.metadata?.name,
 		setup.project.metadata?.description,
 		setup.project.metadata?.repository?.url,
+		setup.global.metadata?.name,
+		setup.global.metadata?.description,
+		setup.global.metadata?.repository?.url,
 	]
 		.filter(Boolean)
 		.join(" ")


### PR DESCRIPTION
## Summary
- suppress project skill scanning when the current project `.claude` resolves to the same directory as the global Claude config
- keep global Engineer installs eligible for Doctor skill-budget checks while avoiding duplicate project/global inventory warnings at `$HOME`
- add regressions for Doctor skill inventory and `ck skills --list --installed`
- include generated CLI manifest/reference alignment for v4.2.2 so the hotfix branch passes local parity from `main`

Closes #815

## Validation
- `bun test src/commands/skills/__tests__/installed-skills-inventory.test.ts src/__tests__/domains/health-checks/checkers/skill-budget-checker.test.ts`
- fake-home repro: Doctor duplicate status passes; installed skills count is single-scope global entries instead of double-counted project+global entries
- `bun run ci:local`
- pre-push quality gate, including UI vitest suite

Docs impact: none
Action: no update needed -- CLI behavior restored; no docs surface changed.