### PR TITLE
fix(migrate): handle symlinked skills target without clobbering source

### DIFF
--- a/src/commands/migrate/__tests__/skill-directory-installer.test.ts
+++ b/src/commands/migrate/__tests__/skill-directory-installer.test.ts
@@ -1,13 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
-import {
-	existsSync,
-	mkdirSync,
-	readFileSync,
-	readlinkSync,
-	rmSync,
-	symlinkSync,
-	writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SkillInfo } from "../../skills/types.js";
@@ -224,7 +216,6 @@ describe("installSkillDirectories", () => {
 		// Skip if symlinking is unavailable (e.g. Windows without dev mode)
 		try {
 			symlinkSync(sourceDir, symlinkedSkills, "dir");
-			readlinkSync(symlinkedSkills);
 		} catch {
 			return;
 		}

--- a/src/commands/migrate/__tests__/skill-directory-installer.test.ts
+++ b/src/commands/migrate/__tests__/skill-directory-installer.test.ts
@@ -1,5 +1,13 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	readlinkSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SkillInfo } from "../../skills/types.js";
@@ -203,6 +211,45 @@ describe("installSkillDirectories", () => {
 			join(customPath, "my-skill"),
 			expect.any(String),
 		);
+	});
+
+	// Regression: #817 — symlinked target basePath must not clobber the source.
+	// Setup: user has ~/.agents/skills -> ~/.claude/skills (single source of truth).
+	// Before the fix, resolve()-only comparison would proceed with rename+copy and
+	// destroy the source directory entry, producing cascading ENOENT failures.
+	it("skips all skills cleanly when basePath is symlinked to the source root", async () => {
+		const symlinkRoot = join(testDir, "symlink-base");
+		mkdirSync(symlinkRoot, { recursive: true });
+		const symlinkedSkills = join(symlinkRoot, "skills");
+		// Skip if symlinking is unavailable (e.g. Windows without dev mode)
+		try {
+			symlinkSync(sourceDir, symlinkedSkills, "dir");
+			readlinkSync(symlinkedSkills);
+		} catch {
+			return;
+		}
+
+		const skill = makeSkill("my-skill", join(sourceDir, "my-skill"));
+		const origSkills = patchSkillsPath(symlinkedSkills);
+
+		const sourceContent = readFileSync(join(sourceDir, "my-skill", "SKILL.md"), "utf-8");
+
+		const results = await installSkillDirectories([skill], ["claude-code"], { global: false });
+
+		originalProviders["claude-code"].skills = origSkills;
+
+		expect(results).toHaveLength(1);
+		expect(results[0].success).toBe(true);
+		expect(results[0].skipped).toBe(true);
+		expect(results[0].skipReason).toContain("symlinked to source");
+		// Source must be intact — the original bug renamed/deleted it
+		expect(existsSync(join(sourceDir, "my-skill", "SKILL.md"))).toBe(true);
+		expect(readFileSync(join(sourceDir, "my-skill", "SKILL.md"), "utf-8")).toBe(sourceContent);
+		// addPortableInstallation must NOT be called — nothing was installed
+		expect(addPortableInstallationMock).not.toHaveBeenCalled();
+
+		rmSync(symlinkedSkills, { force: true });
+		rmSync(symlinkRoot, { recursive: true, force: true });
 	});
 
 	it("windsurf global: installs skill to global path derived from registry", async () => {

--- a/src/commands/migrate/skill-directory-installer.ts
+++ b/src/commands/migrate/skill-directory-installer.ts
@@ -21,7 +21,10 @@ async function canonicalize(path: string): Promise<string> {
 		}
 		try {
 			const canonicalParent = await realpath(parent);
-			return join(canonicalParent, resolve(path).slice(resolve(parent).length + 1) || "");
+			const absPath = resolve(path);
+			const absParent = resolve(parent);
+			const basename = absPath.slice(absParent.length + 1) || "";
+			return join(canonicalParent, basename);
 		} catch {
 			return resolve(path);
 		}
@@ -78,6 +81,12 @@ export async function installSkillDirectories(
 		// resolves to the same canonical path as the source root, per-skill
 		// rename+copy would clobber the source itself. Skip the whole provider
 		// cleanly so the user gets one clear message per skill, not 79 ENOENTs.
+		//
+		// Invariant: all skills in a single batch share the same parent directory
+		// (callers build batches from a single source root per migration run).
+		// We sample skills[0] as a proxy for the batch's source root — this is
+		// an optimisation; the per-skill canonical check below still catches any
+		// mixed-batch outlier safely (just without the single-message UX win).
 		const sourceRoot = skills.length > 0 ? dirname(skills[0].path) : null;
 		const canonicalBase = existsSync(basePath) ? await canonicalize(basePath) : null;
 		const canonicalSourceRoot = sourceRoot ? await canonicalize(sourceRoot) : null;

--- a/src/commands/migrate/skill-directory-installer.ts
+++ b/src/commands/migrate/skill-directory-installer.ts
@@ -1,14 +1,41 @@
 import { existsSync } from "node:fs";
-import { cp, mkdir, rename, rm } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { cp, mkdir, realpath, rename, rm } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
 import { addPortableInstallation } from "../portable/portable-registry.js";
 import { providers } from "../portable/provider-registry.js";
 import type { PortableInstallResult, ProviderType } from "../portable/types.js";
 import type { SkillInfo } from "../skills/types.js";
 
 /**
+ * Resolve a path to its canonical form, following symlinks. Falls back to the
+ * canonical parent + basename when the leaf itself doesn't exist yet so that
+ * not-yet-created paths inside symlinked parents still canonicalise correctly.
+ */
+async function canonicalize(path: string): Promise<string> {
+	try {
+		return await realpath(path);
+	} catch {
+		const parent = dirname(path);
+		if (parent === path) {
+			return resolve(path);
+		}
+		try {
+			const canonicalParent = await realpath(parent);
+			return join(canonicalParent, resolve(path).slice(resolve(parent).length + 1) || "");
+		} catch {
+			return resolve(path);
+		}
+	}
+}
+
+/**
  * Install skill directories preserving full structure (scripts, assets, references/).
  * Warns when overwriting existing skill directories (#406).
+ *
+ * Handles symlinked target directories (#817): if the provider's skills base
+ * path resolves (via realpath) to the same canonical directory as the source
+ * root, every per-skill copy would clobber its own source. Detect once at the
+ * basePath level, emit one clear skip per skill, and avoid destructive rename+copy.
  *
  * Note: Provider path collision warnings (#450) are handled by annotateCollisions()
  * in migration-result-utils.ts after all results are collected — single source of truth.
@@ -47,11 +74,42 @@ export async function installSkillDirectories(
 			continue;
 		}
 
+		// Detect basePath-level symlink loop: if the target skills directory
+		// resolves to the same canonical path as the source root, per-skill
+		// rename+copy would clobber the source itself. Skip the whole provider
+		// cleanly so the user gets one clear message per skill, not 79 ENOENTs.
+		const sourceRoot = skills.length > 0 ? dirname(skills[0].path) : null;
+		const canonicalBase = existsSync(basePath) ? await canonicalize(basePath) : null;
+		const canonicalSourceRoot = sourceRoot ? await canonicalize(sourceRoot) : null;
+		const basePathIsSymlinkedToSource =
+			canonicalBase !== null &&
+			canonicalSourceRoot !== null &&
+			canonicalBase === canonicalSourceRoot &&
+			resolve(basePath) !== resolve(sourceRoot ?? "");
+
+		if (basePathIsSymlinkedToSource) {
+			for (const skill of skills) {
+				results.push({
+					provider,
+					providerDisplayName: config.displayName,
+					success: true,
+					path: join(basePath, skill.name),
+					skipped: true,
+					skipReason: `Skills directory ${basePath} is symlinked to source (${canonicalBase}); already in place`,
+				});
+			}
+			continue;
+		}
+
 		for (const skill of skills) {
 			const targetDir = join(basePath, skill.name);
 
-			// Skip when source and destination are identical (common in Claude Code project scope)
-			if (resolve(skill.path) === resolve(targetDir)) {
+			// Canonical (symlink-aware) comparison — catches per-skill cases where
+			// individual skills happen to point at the same inode regardless of
+			// basePath identity (e.g. Claude Code project scope).
+			const canonicalSource = await canonicalize(skill.path);
+			const canonicalTarget = await canonicalize(targetDir);
+			if (canonicalSource === canonicalTarget) {
 				results.push({
 					provider,
 					providerDisplayName: config.displayName,


### PR DESCRIPTION
## Problem

`ck migrate -a codex` failed with 79 `ENOENT` errors when `~/.agents/skills` is symlinked to `~/.claude/skills` (single-source-of-truth setup). 13 entries also rolled back because the skill rename had already moved the source aside before `cp()` ran.

Closes #817

## Root Cause

`skill-directory-installer.ts` compared source vs target with `path.resolve()`, which normalises strings but does **not** follow symlinks. The two paths looked different, so the same-path early-return was skipped. The code then:

1. `existsSync(targetDir)` → true (symlink resolves)
2. `rename(targetDir, backupDir)` → renamed the **source** file (via symlink) to backup
3. `cp(skill.path, targetDir)` → ENOENT, source had just been moved

Each iteration tore at the source root, producing cascading failures across all 79 skills.

## Fix

- New `canonicalize()` helper uses `fs.realpath()` (with parent-fallback for non-existent leaves) to compare canonical paths
- Detect basePath-level symlink to source root once per provider — emit a single clear skip-reason per skill instead of 79 destructive attempts
- Per-skill canonical check still runs for mixed cases (e.g. Claude Code project scope where only one skill happens to alias)

The non-symlinked path is unchanged: target dir gets `rename` → `cp` → registry update as before.

## What changed

| File | Change |
|------|--------|
| `src/commands/migrate/skill-directory-installer.ts` | `realpath`-based canonical compare; basePath-symlink short-circuit; new `canonicalize()` helper |
| `src/commands/migrate/__tests__/skill-directory-installer.test.ts` | Regression test using a real `symlinkSync` setup that mirrors the user's repro |

## Test plan

- [x] `bun test src/commands/migrate/__tests__/skill-directory-installer.test.ts` → 9 pass (new symlink case included)
- [x] `bun run ci:local` → green (typecheck, lint, build, tests, parity, ui:build, prepublish)
- [x] Asserts source `SKILL.md` is intact after migration (the destructive failure mode)
- [x] Asserts `addPortableInstallation` is **not** called when basePath is symlinked