### PR TITLE
feat(install): surface hook command self-heal in install logs and docs

### DIFF
--- a/__tests__/domains/installation/merger/settings-processor.test.ts
+++ b/__tests__/domains/installation/merger/settings-processor.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SettingsProcessor } from "@/domains/installation/merger/settings-processor.js";
+import { logger } from "@/shared/logger.js";
 
 const HOME_VAR = "$HOME";
 const PROJECT_VAR = "$CLAUDE_PROJECT_DIR";
@@ -1552,6 +1553,144 @@ describe("SettingsProcessor", () => {
 			expect(result.hooks.Stop[0].hooks[0].command).toBe(
 				'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-state.cjs',
 			);
+		});
+	});
+
+	describe("hook command self-heal logging", () => {
+		const REPAIR_RE = /Repaired (\d+) hook command path\(s\) to canonical quoted format/;
+
+		it("emits a count-bearing log when fresh install repairs paths", async () => {
+			const sourceSettings = {
+				hooks: {
+					UserPromptSubmit: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command:
+										"bash .claude/hooks/node-hook-runner.sh .claude/hooks/dev-rules-reminder.cjs",
+								},
+							],
+						},
+					],
+				},
+			};
+			const sourceFile = join(sourceDir, "settings.json");
+			await writeFile(sourceFile, JSON.stringify(sourceSettings), "utf-8");
+
+			const destFile = join(destDir, "settings.json");
+			const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
+
+			try {
+				const processor = new SettingsProcessor();
+				processor.setGlobalFlag(true);
+				processor.setProjectDir(destDir);
+				await processor.processSettingsJson(sourceFile, destFile);
+
+				const repairCalls = infoSpy.mock.calls.filter((call) => String(call[0]).match(REPAIR_RE));
+				expect(repairCalls.length).toBeGreaterThan(0);
+				const match = String(repairCalls[0]?.[0]).match(REPAIR_RE);
+				expect(match).not.toBeNull();
+				// Count must be >= 1 — exact count depends on whether normalize sweeps run first
+				expect(Number.parseInt(match?.[1] ?? "0", 10)).toBeGreaterThan(0);
+			} finally {
+				infoSpy.mockRestore();
+			}
+		});
+
+		it("does NOT emit the repair log when commands are already canonical", async () => {
+			const sourceSettings = {
+				hooks: {
+					UserPromptSubmit: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command:
+										'bash "$HOME/.claude/hooks/node-hook-runner.sh" "$HOME/.claude/hooks/dev-rules-reminder.cjs"',
+								},
+							],
+						},
+					],
+				},
+			};
+			const sourceFile = join(sourceDir, "settings.json");
+			await writeFile(sourceFile, JSON.stringify(sourceSettings), "utf-8");
+
+			const destFile = join(destDir, "settings.json");
+			const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
+
+			try {
+				const processor = new SettingsProcessor();
+				processor.setGlobalFlag(true);
+				processor.setProjectDir(destDir);
+				await processor.processSettingsJson(sourceFile, destFile);
+
+				const repairCalls = infoSpy.mock.calls.filter((call) => String(call[0]).match(REPAIR_RE));
+				expect(repairCalls.length).toBe(0);
+			} finally {
+				infoSpy.mockRestore();
+			}
+		});
+
+		it("emits the repair log when selective merge fixes a pre-existing unquoted command", async () => {
+			// Destination has an unquoted hook runner command (the Bean-bug shape)
+			const destSettings = {
+				hooks: {
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command:
+										"bash $HOME/.claude/hooks/node-hook-runner.sh $HOME/.claude/hooks/session-init.cjs",
+								},
+							],
+						},
+					],
+				},
+			};
+			const destFile = join(destDir, "settings.json");
+			await writeFile(destFile, JSON.stringify(destSettings), "utf-8");
+
+			// Source with same hook in fresh format — triggers selective merge path
+			const sourceSettings = {
+				hooks: {
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: "bash .claude/hooks/node-hook-runner.sh .claude/hooks/session-init.cjs",
+								},
+							],
+						},
+					],
+				},
+			};
+			const sourceFile = join(sourceDir, "settings.json");
+			await writeFile(sourceFile, JSON.stringify(sourceSettings), "utf-8");
+
+			const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
+
+			try {
+				const processor = new SettingsProcessor();
+				processor.setGlobalFlag(true);
+				processor.setProjectDir(destDir);
+				await processor.processSettingsJson(sourceFile, destFile);
+
+				const repairCalls = infoSpy.mock.calls.filter((call) => String(call[0]).match(REPAIR_RE));
+				expect(repairCalls.length).toBeGreaterThan(0);
+
+				// Verify the merged file ends up canonical
+				const result = JSON.parse(await readFile(destFile, "utf-8"));
+				const cmd = result.hooks.SessionStart[0].hooks[0].command;
+				expect(cmd).toBe(
+					'bash "$HOME/.claude/hooks/node-hook-runner.sh" "$HOME/.claude/hooks/session-init.cjs"',
+				);
+			} finally {
+				infoSpy.mockRestore();
+			}
 		});
 	});
 });

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -558,6 +558,19 @@ installation/
 - Facade exports `setMultiKitContext()` method
 - Wires multi-kit context through to CopyExecutor
 
+**Hook command self-heal contract:**
+
+`ck init`, `ck install`, and `ck doctor --fix` all canonicalize hook command paths in user `settings.json` to the quoted form
+`bash "$HOME/.claude/hooks/node-hook-runner.sh" "$HOME/.claude/hooks/<script>.cjs"`. This protects Windows Git Bash users whose
+`$HOME` contains a space (e.g. `/c/Users/Tran Family`) — unquoted, the shell word-splits the path and bash emits
+`syntax error near unexpected token '('` because it tries to execute the first split fragment as a script.
+
+- Logic: `src/shared/command-normalizer.ts → repairClaudeHookCommandPath`
+- Doctor surface: `src/domains/health-checks/checkers/hook-health-checker.ts → checkHookCommandPaths` (id `hook-command-paths`)
+- Install rewrite: `src/domains/installation/merger/settings-processor.ts → fixHookCommandPaths` — emits `logger.info("Repaired N hook command path(s)...")` per call site when N > 0
+- Recognized inputs per arg: bare relative `.claude/...`, `$HOME` / `${HOME}` / `$CLAUDE_PROJECT_DIR` / `${CLAUDE_PROJECT_DIR}`, `%USERPROFILE%` / `%CLAUDE_PROJECT_DIR%`, `~/`, raw absolute (remapped to `$HOME` when under home)
+- `ck doctor` (without `--fix`) reports findings as fail; `ck doctor --fix` rewrites them
+
 #### skills/ - Skills Management
 Facades: customization-scanner, detector, migrator. Submodules: customization (comparison, hashing, scanning), detection (config, dependency, script), migrator (executor, validator).
 

--- a/src/domains/installation/merger/settings-processor.ts
+++ b/src/domains/installation/merger/settings-processor.ts
@@ -131,7 +131,7 @@ export class SettingsProcessor {
 					const parsedSettings = JSON.parse(transformedSource) as SettingsJson;
 
 					// Fix broken hook path formats before writing
-					this.fixHookCommandPaths(parsedSettings);
+					this.logHookCommandRepair(this.fixHookCommandPaths(parsedSettings));
 
 					await SettingsMerger.writeSettingsFile(destFile, parsedSettings);
 
@@ -249,10 +249,7 @@ export class SettingsProcessor {
 		}
 
 		// Fix broken hook path formats (tilde, variable-only quoting, unquoted)
-		const pathsFixed = this.fixHookCommandPaths(mergeResult.merged);
-		if (pathsFixed) {
-			logger.info("Fixed hook command paths to canonical quoted format");
-		}
+		this.logHookCommandRepair(this.fixHookCommandPaths(mergeResult.merged));
 
 		// Prune hooks referencing files listed in metadata.json deletions
 		const hooksPruned = this.pruneDeletedHooks(mergeResult.merged);
@@ -469,7 +466,7 @@ export class SettingsProcessor {
 			const content = await readFile(destFile, "utf-8");
 			if (!content.trim()) return null;
 			const parsedSettings = JSON.parse(content) as SettingsJson;
-			this.fixHookCommandPaths(parsedSettings);
+			this.logHookCommandRepair(this.fixHookCommandPaths(parsedSettings));
 			return parsedSettings;
 		} catch {
 			return null;
@@ -538,8 +535,19 @@ export class SettingsProcessor {
 	 *
 	 * This runs AFTER merge so it catches both source (new) and destination (existing) hooks.
 	 */
-	private fixHookCommandPaths(settings: SettingsJson): boolean {
-		let fixed = false;
+	/**
+	 * Emit a one-line log when hook command paths were canonicalized. Centralizes the
+	 * message so all callers describe the self-heal identically.
+	 */
+	private logHookCommandRepair(count: number): void {
+		if (count <= 0) return;
+		logger.info(
+			`Repaired ${count} hook command path(s) to canonical quoted format (protects against shells word-splitting on usernames with spaces)`,
+		);
+	}
+
+	private fixHookCommandPaths(settings: SettingsJson): number {
+		let fixed = 0;
 
 		// Fix hooks
 		if (settings.hooks) {
@@ -549,7 +557,7 @@ export class SettingsProcessor {
 						const result = this.fixSingleCommandPath(entry.command);
 						if (result !== entry.command) {
 							entry.command = result;
-							fixed = true;
+							fixed++;
 						}
 					}
 					if ("hooks" in entry && entry.hooks) {
@@ -558,7 +566,7 @@ export class SettingsProcessor {
 								const result = this.fixSingleCommandPath(hook.command);
 								if (result !== hook.command) {
 									hook.command = result;
-									fixed = true;
+									fixed++;
 								}
 							}
 						}
@@ -573,7 +581,7 @@ export class SettingsProcessor {
 			const result = this.fixSingleCommandPath(statusLine.command);
 			if (result !== statusLine.command) {
 				statusLine.command = result;
-				fixed = true;
+				fixed++;
 			}
 		}
 
@@ -665,10 +673,11 @@ export class SettingsProcessor {
 		}
 
 		const pathsFixed = this.fixHookCommandPaths(settings);
-		if (!pathsFixed) {
+		if (pathsFixed === 0) {
 			return false;
 		}
 
+		this.logHookCommandRepair(pathsFixed);
 		await SettingsMerger.writeSettingsFile(filePath, settings);
 		return true;
 	}

--- a/src/domains/installation/merger/settings-processor.ts
+++ b/src/domains/installation/merger/settings-processor.ts
@@ -131,7 +131,7 @@ export class SettingsProcessor {
 					const parsedSettings = JSON.parse(transformedSource) as SettingsJson;
 
 					// Fix broken hook path formats before writing
-					this.logHookCommandRepair(this.fixHookCommandPaths(parsedSettings));
+					this.logHookCommandRepair(this.fixHookCommandPaths(parsedSettings), "fresh install");
 
 					await SettingsMerger.writeSettingsFile(destFile, parsedSettings);
 
@@ -249,7 +249,7 @@ export class SettingsProcessor {
 		}
 
 		// Fix broken hook path formats (tilde, variable-only quoting, unquoted)
-		this.logHookCommandRepair(this.fixHookCommandPaths(mergeResult.merged));
+		this.logHookCommandRepair(this.fixHookCommandPaths(mergeResult.merged), "merged settings");
 
 		// Prune hooks referencing files listed in metadata.json deletions
 		const hooksPruned = this.pruneDeletedHooks(mergeResult.merged);
@@ -466,7 +466,10 @@ export class SettingsProcessor {
 			const content = await readFile(destFile, "utf-8");
 			if (!content.trim()) return null;
 			const parsedSettings = JSON.parse(content) as SettingsJson;
-			this.logHookCommandRepair(this.fixHookCommandPaths(parsedSettings));
+			this.logHookCommandRepair(
+				this.fixHookCommandPaths(parsedSettings),
+				"existing global settings",
+			);
 			return parsedSettings;
 		} catch {
 			return null;
@@ -523,6 +526,19 @@ export class SettingsProcessor {
 	}
 
 	/**
+	 * Emit a one-line log when hook command paths were canonicalized. Centralizes the
+	 * message so all callers describe the self-heal identically. `context` optionally
+	 * disambiguates simultaneous repair passes (e.g. "during merge" vs. a specific file).
+	 */
+	private logHookCommandRepair(count: number, context?: string): void {
+		if (count <= 0) return;
+		const suffix = context ? ` (${context})` : "";
+		logger.info(
+			`Repaired ${count} hook command path(s) to canonical quoted format${suffix} — protects against shells word-splitting on usernames with spaces`,
+		);
+	}
+
+	/**
 	 * Fix hook command path formats in settings after merge.
 	 * Repairs all known broken formats to the canonical scope-aware form.
 	 *
@@ -535,17 +551,6 @@ export class SettingsProcessor {
 	 *
 	 * This runs AFTER merge so it catches both source (new) and destination (existing) hooks.
 	 */
-	/**
-	 * Emit a one-line log when hook command paths were canonicalized. Centralizes the
-	 * message so all callers describe the self-heal identically.
-	 */
-	private logHookCommandRepair(count: number): void {
-		if (count <= 0) return;
-		logger.info(
-			`Repaired ${count} hook command path(s) to canonical quoted format (protects against shells word-splitting on usernames with spaces)`,
-		);
-	}
-
 	private fixHookCommandPaths(settings: SettingsJson): number {
 		let fixed = 0;
 
@@ -677,7 +682,7 @@ export class SettingsProcessor {
 			return false;
 		}
 
-		this.logHookCommandRepair(pathsFixed);
+		this.logHookCommandRepair(pathsFixed, filePath);
 		await SettingsMerger.writeSettingsFile(filePath, settings);
 		return true;
 	}
@@ -688,9 +693,7 @@ export class SettingsProcessor {
 			return;
 		}
 
-		if (await this.repairSettingsFile(settingsLocalPath)) {
-			logger.info(`Repaired stale .claude command paths in ${settingsLocalPath}`);
-		}
+		await this.repairSettingsFile(settingsLocalPath);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Make the bash-hook-runner path canonicalization (introduced by db7d7e9) visible: every install path that rewrites a user's `settings.json` now logs `Repaired N hook command path(s) to canonical quoted format (protects against shells word-splitting on usernames with spaces)`.
- Refactors `fixHookCommandPaths` to return a count (was boolean) and centralizes the log via a private `logHookCommandRepair` helper so all 4 install entry points (overwrite, selective merge, normalize-pre-merge, sibling-local repair) describe the self-heal identically.
- Adds a "Hook command self-heal contract" section to `docs/codebase-summary.md` documenting the accepted input forms, canonical output, doctor surface, and why the rewrite exists (Windows Git Bash word-splits unquoted `$HOME` when the username contains a space).

## Root Cause / Why

The hotfix in db7d7e9 silently rewrote user hook commands in 3 of 4 install paths. Users had no way to know `ck init` modified their `settings.json`. Three of those paths logged nothing; the fourth logged a one-liner without a count. This makes a mutating side-effect observable.

## Changes

| File | Change |
|------|--------|
| `src/domains/installation/merger/settings-processor.ts` | `fixHookCommandPaths` now returns `number`. New private `logHookCommandRepair(count)` helper emits one info line when count > 0. All 4 call sites use the helper. |
| `docs/codebase-summary.md` | New "Hook command self-heal contract" block under the installation/merger section. |
| `__tests__/domains/installation/merger/settings-processor.test.ts` | New `describe("hook command self-heal logging")` block: 3 tests covering log-emitted on repair, no-log when canonical, log on selective-merge repair. |

## Test plan

- [x] `bun test __tests__/domains/installation/merger/settings-processor.test.ts` — 52 pass / 0 fail
- [x] `bun test` (full suite) — 4737 pass / 55 skip / 0 fail
- [x] `bun run lint` — clean after `bun run format`
- [x] Reviewed by code-reviewer agent: APPROVED, no blockers