### PR TITLE
feat(init): self-heal legacy Windows global kit directory

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
 	"version": "4.2.3-dev.1",
-	"generatedAt": "2026-05-13T02:05:09.996Z",
+	"generatedAt": "2026-05-13T02:21:33.897Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.2.1-dev.1",
-	"generatedAt": "2026-05-12T19:32:16.716Z",
+	"version": "4.2.3-dev.1",
+	"generatedAt": "2026-05-13T02:05:09.996Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
 	"version": "4.2.3-dev.1",
-	"generatedAt": "2026-05-13T02:21:33.897Z",
+	"generatedAt": "2026-05-13T02:39:25.559Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-12T19:32:16.804Z -->
+<!-- generated: 2026-05-13T02:05:10.063Z -->

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-13T02:21:33.987Z -->
+<!-- generated: 2026-05-13T02:39:25.629Z -->

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-13T02:05:10.063Z -->
+<!-- generated: 2026-05-13T02:21:33.987Z -->

--- a/src/__tests__/domains/installation/global-kit-legacy-repair.test.ts
+++ b/src/__tests__/domains/installation/global-kit-legacy-repair.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	getLegacyWindowsGlobalKitDirCandidates,
+	repairLegacyWindowsGlobalKitDir,
+} from "@/domains/installation/global-kit-legacy-repair.js";
+import { pathExists } from "fs-extra";
+
+describe("repairLegacyWindowsGlobalKitDir", () => {
+	let testRoot: string;
+	let homeDir: string;
+	let localAppData: string;
+	let appData: string;
+	let targetDir: string;
+
+	beforeEach(async () => {
+		testRoot = join(
+			tmpdir(),
+			`ck-global-kit-repair-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		homeDir = join(testRoot, "Users", "admin");
+		localAppData = join(homeDir, "AppData", "Local");
+		appData = join(homeDir, "AppData", "Roaming");
+		targetDir = join(homeDir, ".claude");
+		await mkdir(localAppData, { recursive: true });
+		await mkdir(appData, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(testRoot, { recursive: true, force: true });
+	});
+
+	test("builds legacy candidates for docs-drift and malformed Windows global paths", () => {
+		expect(
+			getLegacyWindowsGlobalKitDirCandidates(
+				{ LOCALAPPDATA: localAppData, APPDATA: appData },
+				homeDir,
+			),
+		).toEqual([join(localAppData, ".claude"), join(appData, ".claude"), `${homeDir}.claude`]);
+	});
+
+	test("migrates a legacy LOCALAPPDATA .claude kit directory when target is missing", async () => {
+		const legacyDir = join(localAppData, ".claude");
+		await mkdir(legacyDir, { recursive: true });
+		await writeFile(
+			join(legacyDir, "metadata.json"),
+			JSON.stringify({ name: "ClaudeKit Engineer" }),
+		);
+
+		const result = await repairLegacyWindowsGlobalKitDir({
+			targetDir,
+			platform: "win32",
+			homeDir,
+			env: { LOCALAPPDATA: localAppData, APPDATA: appData },
+		});
+
+		expect(result.status).toBe("repaired");
+		expect(result.legacyDir).toBe(legacyDir);
+		expect(await pathExists(join(targetDir, "metadata.json"))).toBe(true);
+		expect(await pathExists(legacyDir)).toBe(false);
+	});
+
+	test("migrates a malformed USERPROFILE.claude kit directory when target is empty", async () => {
+		const legacyDir = `${homeDir}.claude`;
+		await mkdir(legacyDir, { recursive: true });
+		await mkdir(targetDir, { recursive: true });
+		await writeFile(join(legacyDir, "settings.json"), "{}");
+
+		const result = await repairLegacyWindowsGlobalKitDir({
+			targetDir,
+			platform: "win32",
+			homeDir,
+			env: { LOCALAPPDATA: localAppData },
+		});
+
+		expect(result.status).toBe("repaired");
+		expect(result.legacyDir).toBe(legacyDir);
+		expect(await pathExists(join(targetDir, "settings.json"))).toBe(true);
+		expect(await pathExists(legacyDir)).toBe(false);
+	});
+
+	test("does not overwrite an existing real global kit directory", async () => {
+		const legacyDir = join(localAppData, ".claude");
+		await mkdir(legacyDir, { recursive: true });
+		await mkdir(targetDir, { recursive: true });
+		await writeFile(join(legacyDir, "metadata.json"), JSON.stringify({ version: "old" }));
+		await writeFile(join(targetDir, "metadata.json"), JSON.stringify({ version: "current" }));
+
+		const result = await repairLegacyWindowsGlobalKitDir({
+			targetDir,
+			platform: "win32",
+			homeDir,
+			env: { LOCALAPPDATA: localAppData },
+		});
+
+		expect(result.status).toBe("skipped");
+		expect(result.reason).toBe("target-exists");
+		expect(await pathExists(join(legacyDir, "metadata.json"))).toBe(true);
+		expect(await pathExists(join(targetDir, "metadata.json"))).toBe(true);
+	});
+
+	test("ignores empty legacy directories without kit markers", async () => {
+		const legacyDir = join(localAppData, ".claude");
+		await mkdir(legacyDir, { recursive: true });
+
+		const result = await repairLegacyWindowsGlobalKitDir({
+			targetDir,
+			platform: "win32",
+			homeDir,
+			env: { LOCALAPPDATA: localAppData },
+		});
+
+		expect(result.status).toBe("skipped");
+		expect(result.reason).toBe("no-legacy-dir");
+		expect(await pathExists(targetDir)).toBe(false);
+		expect(await pathExists(legacyDir)).toBe(true);
+	});
+
+	test("skips when CLAUDE_CONFIG_DIR selects an explicit custom global target", async () => {
+		const legacyDir = join(localAppData, ".claude");
+		await mkdir(legacyDir, { recursive: true });
+		await writeFile(join(legacyDir, "metadata.json"), "{}");
+
+		const result = await repairLegacyWindowsGlobalKitDir({
+			targetDir,
+			platform: "win32",
+			homeDir,
+			env: { LOCALAPPDATA: localAppData, CLAUDE_CONFIG_DIR: join(homeDir, ".claude-work") },
+		});
+
+		expect(result.status).toBe("skipped");
+		expect(result.reason).toBe("custom-global-dir");
+		expect(await pathExists(legacyDir)).toBe(true);
+	});
+});

--- a/src/__tests__/domains/installation/global-kit-legacy-repair.test.ts
+++ b/src/__tests__/domains/installation/global-kit-legacy-repair.test.ts
@@ -118,6 +118,46 @@ describe("repairLegacyWindowsGlobalKitDir", () => {
 		expect(await pathExists(legacyDir)).toBe(true);
 	});
 
+	test("skips on non-Windows platforms even with kit markers present", async () => {
+		const legacyDir = join(localAppData, ".claude");
+		await mkdir(legacyDir, { recursive: true });
+		await writeFile(join(legacyDir, "metadata.json"), "{}");
+
+		const result = await repairLegacyWindowsGlobalKitDir({
+			targetDir,
+			platform: "linux",
+			homeDir,
+			env: { LOCALAPPDATA: localAppData },
+		});
+
+		expect(result.status).toBe("skipped");
+		expect(result.reason).toBe("not-windows");
+		expect(await pathExists(legacyDir)).toBe(true);
+		expect(await pathExists(targetDir)).toBe(false);
+	});
+
+	test("skips when multiple legacy candidates both contain kit markers (ambiguous)", async () => {
+		const legacyLocal = join(localAppData, ".claude");
+		const legacyRoaming = join(appData, ".claude");
+		await mkdir(legacyLocal, { recursive: true });
+		await mkdir(legacyRoaming, { recursive: true });
+		await writeFile(join(legacyLocal, "metadata.json"), JSON.stringify({ source: "local" }));
+		await writeFile(join(legacyRoaming, "metadata.json"), JSON.stringify({ source: "roaming" }));
+
+		const result = await repairLegacyWindowsGlobalKitDir({
+			targetDir,
+			platform: "win32",
+			homeDir,
+			env: { LOCALAPPDATA: localAppData, APPDATA: appData },
+		});
+
+		expect(result.status).toBe("skipped");
+		expect(result.reason).toBe("ambiguous-legacy-dirs");
+		expect(await pathExists(join(legacyLocal, "metadata.json"))).toBe(true);
+		expect(await pathExists(join(legacyRoaming, "metadata.json"))).toBe(true);
+		expect(await pathExists(targetDir)).toBe(false);
+	});
+
 	test("skips when CLAUDE_CONFIG_DIR selects an explicit custom global target", async () => {
 		const legacyDir = join(localAppData, ".claude");
 		await mkdir(legacyDir, { recursive: true });

--- a/src/commands/init/phases/selection-handler.ts
+++ b/src/commands/init/phases/selection-handler.ts
@@ -10,6 +10,7 @@ import { GitHubClient } from "@/domains/github/github-client.js";
 import { detectAccessibleKits } from "@/domains/github/kit-access-checker.js";
 import { runPreflightChecks } from "@/domains/github/preflight-checker.js";
 import { handleFreshInstallation } from "@/domains/installation/fresh-installer.js";
+import { repairLegacyWindowsGlobalKitDir } from "@/domains/installation/global-kit-legacy-repair.js";
 import { versionsMatch } from "@/domains/versioning/checking/version-utils.js";
 import { readManifest } from "@/services/file-operations/manifest/manifest-reader.js";
 import { logger } from "@/shared/logger.js";
@@ -266,6 +267,22 @@ export async function handleSelection(ctx: InitContext): Promise<InitContext> {
 	}
 
 	const resolvedDir = resolve(targetDir);
+	if (ctx.options.global) {
+		const repairResult = await repairLegacyWindowsGlobalKitDir({ targetDir: resolvedDir });
+		if (repairResult.status === "repaired") {
+			logger.success(
+				`Migrated legacy Windows global kit directory from ${repairResult.legacyDir} to ${resolvedDir}`,
+			);
+		} else if (
+			repairResult.reason === "target-exists" ||
+			repairResult.reason === "ambiguous-legacy-dirs"
+		) {
+			logger.warning(
+				`Detected legacy Windows global kit directory but did not auto-migrate it (${repairResult.reason}).`,
+			);
+			logger.info(`Using global kit directory: ${resolvedDir}`);
+		}
+	}
 	logger.info(`Target directory: ${resolvedDir}`);
 
 	// HOME directory detection: warn if installing to HOME without --global flag

--- a/src/commands/init/phases/selection-handler.ts
+++ b/src/commands/init/phases/selection-handler.ts
@@ -268,19 +268,27 @@ export async function handleSelection(ctx: InitContext): Promise<InitContext> {
 
 	const resolvedDir = resolve(targetDir);
 	if (ctx.options.global) {
-		const repairResult = await repairLegacyWindowsGlobalKitDir({ targetDir: resolvedDir });
-		if (repairResult.status === "repaired") {
-			logger.success(
-				`Migrated legacy Windows global kit directory from ${repairResult.legacyDir} to ${resolvedDir}`,
-			);
-		} else if (
-			repairResult.reason === "target-exists" ||
-			repairResult.reason === "ambiguous-legacy-dirs"
-		) {
+		try {
+			const repairResult = await repairLegacyWindowsGlobalKitDir({ targetDir: resolvedDir });
+			if (repairResult.status === "repaired") {
+				logger.success(
+					`Migrated legacy Windows global kit directory from ${repairResult.legacyDir} to ${resolvedDir}`,
+				);
+			} else if (
+				repairResult.reason === "target-exists" ||
+				repairResult.reason === "ambiguous-legacy-dirs"
+			) {
+				logger.warning(
+					`Detected legacy Windows global kit directory but did not auto-migrate it (${repairResult.reason}).`,
+				);
+				logger.info(`Using global kit directory: ${resolvedDir}`);
+			}
+		} catch (err) {
+			// Repair is opportunistic — never abort the install if it fails
+			// (EACCES on locked dir, ENOTEMPTY on race, etc.)
 			logger.warning(
-				`Detected legacy Windows global kit directory but did not auto-migrate it (${repairResult.reason}).`,
+				`Legacy global kit dir repair failed, continuing: ${err instanceof Error ? err.message : String(err)}`,
 			);
-			logger.info(`Using global kit directory: ${resolvedDir}`);
 		}
 	}
 	logger.info(`Target directory: ${resolvedDir}`);

--- a/src/domains/installation/global-kit-legacy-repair.ts
+++ b/src/domains/installation/global-kit-legacy-repair.ts
@@ -1,0 +1,175 @@
+import { cp, mkdir, readdir, rename, rm, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, normalize, resolve } from "node:path";
+import { pathExists } from "fs-extra";
+
+const LEGACY_KIT_MARKERS = [
+	"metadata.json",
+	".ck.json",
+	"settings.json",
+	"settings.local.json",
+	"agents",
+	"commands",
+	"rules",
+	"hooks",
+	"skills",
+	"CLAUDE.md",
+];
+
+export type LegacyGlobalKitRepairReason =
+	| "not-windows"
+	| "custom-global-dir"
+	| "no-legacy-dir"
+	| "ambiguous-legacy-dirs"
+	| "target-exists"
+	| "repaired";
+
+export interface LegacyGlobalKitRepairResult {
+	status: "repaired" | "skipped";
+	reason: LegacyGlobalKitRepairReason;
+	legacyDir?: string;
+	candidateDirs: string[];
+}
+
+interface LegacyGlobalKitRepairOptions {
+	targetDir: string;
+	env?: NodeJS.ProcessEnv;
+	homeDir?: string;
+	platform?: NodeJS.Platform;
+}
+
+function safeEnvPath(value: string | undefined): string | undefined {
+	if (!value || value.trim() === "" || value.includes("..")) {
+		return undefined;
+	}
+	return value;
+}
+
+function withoutTrailingSeparators(path: string): string {
+	return path.replace(/[\\/]+$/, "");
+}
+
+function uniqueExistingOrder(paths: string[]): string[] {
+	const seen = new Set<string>();
+	const result: string[] = [];
+
+	for (const path of paths) {
+		const normalized = normalize(resolve(path));
+		if (seen.has(normalized)) continue;
+		seen.add(normalized);
+		result.push(path);
+	}
+
+	return result;
+}
+
+export function getLegacyWindowsGlobalKitDirCandidates(
+	env: NodeJS.ProcessEnv = process.env,
+	homeDir = homedir(),
+): string[] {
+	const candidates: string[] = [];
+	const localAppData = safeEnvPath(env.LOCALAPPDATA);
+	const appData = safeEnvPath(env.APPDATA);
+
+	if (localAppData) {
+		candidates.push(join(localAppData, ".claude"));
+	}
+
+	if (appData) {
+		candidates.push(join(appData, ".claude"));
+	}
+
+	if (homeDir) {
+		candidates.push(`${withoutTrailingSeparators(homeDir)}.claude`);
+	}
+
+	return uniqueExistingOrder(candidates);
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+	try {
+		return (await stat(path)).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+async function hasKitMarkers(dir: string): Promise<boolean> {
+	if (!(await isDirectory(dir))) return false;
+
+	for (const marker of LEGACY_KIT_MARKERS) {
+		if (await pathExists(join(dir, marker))) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+async function isEmptyDirectory(dir: string): Promise<boolean> {
+	if (!(await isDirectory(dir))) return false;
+	return (await readdir(dir)).length === 0;
+}
+
+async function moveDirectory(source: string, target: string): Promise<void> {
+	try {
+		await rename(source, target);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "EXDEV") {
+			throw error;
+		}
+
+		await cp(source, target, { recursive: true, errorOnExist: true, force: false });
+		await rm(source, { recursive: true, force: true });
+	}
+}
+
+export async function repairLegacyWindowsGlobalKitDir(
+	options: LegacyGlobalKitRepairOptions,
+): Promise<LegacyGlobalKitRepairResult> {
+	const env = options.env ?? process.env;
+	const os = options.platform ?? process.platform;
+
+	if (os !== "win32") {
+		return { status: "skipped", reason: "not-windows", candidateDirs: [] };
+	}
+
+	if (env.CLAUDE_CONFIG_DIR) {
+		return { status: "skipped", reason: "custom-global-dir", candidateDirs: [] };
+	}
+
+	const targetDir = normalize(resolve(options.targetDir));
+	const candidateDirs = getLegacyWindowsGlobalKitDirCandidates(env, options.homeDir).filter(
+		(candidate) => normalize(resolve(candidate)) !== targetDir,
+	);
+	const legacyDirs: string[] = [];
+
+	for (const candidate of candidateDirs) {
+		if (await hasKitMarkers(candidate)) {
+			legacyDirs.push(candidate);
+		}
+	}
+
+	if (legacyDirs.length === 0) {
+		return { status: "skipped", reason: "no-legacy-dir", candidateDirs };
+	}
+
+	if (legacyDirs.length > 1) {
+		return { status: "skipped", reason: "ambiguous-legacy-dirs", candidateDirs };
+	}
+
+	const [legacyDir] = legacyDirs;
+	const targetExists = await pathExists(targetDir);
+	if (targetExists && !(await isEmptyDirectory(targetDir))) {
+		return { status: "skipped", reason: "target-exists", legacyDir, candidateDirs };
+	}
+
+	if (targetExists) {
+		await rm(targetDir, { recursive: true, force: true });
+	}
+
+	await mkdir(dirname(targetDir), { recursive: true });
+	await moveDirectory(legacyDir, targetDir);
+
+	return { status: "repaired", reason: "repaired", legacyDir, candidateDirs };
+}

--- a/src/domains/installation/global-kit-legacy-repair.ts
+++ b/src/domains/installation/global-kit-legacy-repair.ts
@@ -49,7 +49,7 @@ function withoutTrailingSeparators(path: string): string {
 	return path.replace(/[\\/]+$/, "");
 }
 
-function uniqueExistingOrder(paths: string[]): string[] {
+function uniqueNormalizedPaths(paths: string[]): string[] {
 	const seen = new Set<string>();
 	const result: string[] = [];
 
@@ -80,10 +80,14 @@ export function getLegacyWindowsGlobalKitDirCandidates(
 	}
 
 	if (homeDir) {
+		// Intentionally separator-less: earlier CLI versions concatenated
+		// homedir() with ".claude" instead of using path.join(), producing
+		// e.g. "C:\Users\John.claude". This candidate detects that legacy
+		// layout for migration. Do NOT replace with join(homeDir, ".claude").
 		candidates.push(`${withoutTrailingSeparators(homeDir)}.claude`);
 	}
 
-	return uniqueExistingOrder(candidates);
+	return uniqueNormalizedPaths(candidates);
 }
 
 async function isDirectory(path: string): Promise<boolean> {
@@ -134,7 +138,7 @@ export async function repairLegacyWindowsGlobalKitDir(
 		return { status: "skipped", reason: "not-windows", candidateDirs: [] };
 	}
 
-	if (env.CLAUDE_CONFIG_DIR) {
+	if (safeEnvPath(env.CLAUDE_CONFIG_DIR)) {
 		return { status: "skipped", reason: "custom-global-dir", candidateDirs: [] };
 	}
 


### PR DESCRIPTION
## Summary

When users installed previous CLI versions, the global kit could land in `%LOCALAPPDATA%\.claude` or `%APPDATA%\.claude` instead of the canonical `%USERPROFILE%\.claude`. This PR detects legacy directories during `ck init --global` and migrates them atomically when the canonical target is empty.

## Changes

| File | Change |
|------|--------|
| `src/domains/installation/global-kit-legacy-repair.ts` | New module: detect legacy Windows global kit dirs via marker files, migrate via rename with cross-device `cp+rm` fallback |
| `src/commands/init/phases/selection-handler.ts` | Wire repair into `--global` install path; log success or skip reason |
| `src/__tests__/domains/installation/global-kit-legacy-repair.test.ts` | 6 unit tests covering all skip reasons + happy path |

## Skip safety

The repair is a no-op when:
- Non-Windows platform
- `CLAUDE_CONFIG_DIR` overrides the global dir
- No legacy candidate has kit markers
- Multiple legacy candidates found (ambiguous)
- Canonical target already exists with content

## Paired docs

Paired with [claudekit/claudekit-docs#162](https://github.com/claudekit/claudekit-docs/pull/162) documenting the canonical platform paths.

## Test plan

- [x] Typecheck (`bun run typecheck`)
- [x] Unit tests pass (6 pass, 20 assertions)
- [x] Manifest + cli-reference regenerated