### PR TITLE
fix: remove invalid Windows librsvg remediation

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.2.3-dev.1",
-	"generatedAt": "2026-05-13T02:39:25.559Z",
+	"version": "4.2.3-dev.2",
+	"generatedAt": "2026-05-13T14:39:07.008Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-13T02:39:25.629Z -->
+<!-- generated: 2026-05-13T14:39:07.088Z -->

--- a/src/services/package-installer/install-error-handler.ts
+++ b/src/services/package-installer/install-error-handler.ts
@@ -22,11 +22,15 @@ export interface InstallErrorSummary {
 const WINDOWS_SYSTEM_PACKAGES = {
 	ffmpeg: "Gyan.FFmpeg",
 	imagemagick: "ImageMagick.ImageMagick",
-	librsvg: "GNOME.librsvg",
-	"rsvg-convert": "GNOME.librsvg",
 } as const;
-type SystemToolKey = keyof typeof WINDOWS_SYSTEM_PACKAGES;
-const SYSTEM_TOOL_KEYS = Object.keys(WINDOWS_SYSTEM_PACKAGES) as SystemToolKey[];
+const SYSTEM_TOOL_KEYS = ["ffmpeg", "imagemagick", "librsvg", "rsvg-convert"] as const;
+type SystemToolKey = (typeof SYSTEM_TOOL_KEYS)[number];
+type WindowsWingetToolKey = keyof typeof WINDOWS_SYSTEM_PACKAGES;
+
+const WINDOWS_RSVG_COMMANDS = [
+	"choco install rsvg-convert -y  # run from elevated PowerShell",
+	"pacman -S mingw-w64-x86_64-librsvg  # MSYS2 alternative",
+] as const;
 
 /**
  * Parse "name: reason" strings safely, handling multiple colons
@@ -67,23 +71,48 @@ function isWindowsSummary(summary: InstallErrorSummary): boolean {
 	);
 }
 
-function getSystemPackageCommand(
-	summary: InstallErrorSummary,
-	systemFailures: string[],
-): string | undefined {
-	if (isWindowsSummary(summary)) {
-		const packageIds = new Set<string>();
-		for (const failure of systemFailures) {
-			const key = getSystemToolKey(failure);
-			if (key) packageIds.add(WINDOWS_SYSTEM_PACKAGES[key]);
+function isWindowsWingetToolKey(key: SystemToolKey): key is WindowsWingetToolKey {
+	return key in WINDOWS_SYSTEM_PACKAGES;
+}
+
+function getWindowsSystemPackageCommands(systemFailures: string[]): string[] {
+	const packageIds = new Set<string>();
+	let needsRsvg = false;
+
+	for (const failure of systemFailures) {
+		const key = getSystemToolKey(failure);
+		if (!key) continue;
+
+		if (isWindowsWingetToolKey(key)) {
+			packageIds.add(WINDOWS_SYSTEM_PACKAGES[key]);
+		} else {
+			needsRsvg = true;
 		}
-		if (packageIds.size > 0) {
-			return `winget install ${Array.from(packageIds).join(" ")}`;
-		}
-		return summary.remediation.winget_packages;
 	}
 
-	return summary.remediation.sudo_packages || undefined;
+	const commands: string[] = [];
+	if (packageIds.size > 0) {
+		commands.push(`winget install ${Array.from(packageIds).join(" ")}`);
+	}
+	if (needsRsvg) {
+		commands.push(...WINDOWS_RSVG_COMMANDS);
+	}
+	return commands;
+}
+
+function getSystemPackageCommands(
+	summary: InstallErrorSummary,
+	systemFailures: string[],
+): string[] {
+	if (isWindowsSummary(summary)) {
+		const commands = getWindowsSystemPackageCommands(systemFailures);
+		if (commands.length > 0) {
+			return commands;
+		}
+		return summary.remediation.winget_packages ? [summary.remediation.winget_packages] : [];
+	}
+
+	return summary.remediation.sudo_packages ? [summary.remediation.sudo_packages] : [];
 }
 
 /**
@@ -114,7 +143,7 @@ export function displayInstallErrors(skillsDir: string): void {
 	try {
 		const systemOptionalFailures = summary.optional_failures.filter(isSystemToolFailure);
 		const pythonOptionalFailures = summary.optional_failures.filter((f) => !isSystemToolFailure(f));
-		const systemPackageCommand = getSystemPackageCommand(summary, [
+		const systemPackageCommands = getSystemPackageCommands(summary, [
 			...systemOptionalFailures,
 			...summary.skipped,
 		]);
@@ -168,9 +197,14 @@ export function displayInstallErrors(skillsDir: string): void {
 			logger.info("");
 		}
 
-		if ((summary.skipped.length > 0 || systemOptionalFailures.length > 0) && systemPackageCommand) {
+		if (
+			(summary.skipped.length > 0 || systemOptionalFailures.length > 0) &&
+			systemPackageCommands.length > 0
+		) {
 			logger.info("Install system packages:");
-			logger.info(`  ${systemPackageCommand}`);
+			for (const command of systemPackageCommands) {
+				logger.info(`  ${command}`);
+			}
 			logger.info("");
 		}
 

--- a/tests/utils/install-error-handler.test.ts
+++ b/tests/utils/install-error-handler.test.ts
@@ -137,7 +137,7 @@ describe("install-error-handler", () => {
 			expect(loggerInfoSpy).toHaveBeenCalledWith("  sudo apt-get install -y ffmpeg");
 		});
 
-		it("should show winget remediation for Windows system tool failures without pip retry", () => {
+		it("should show Windows system tool remediation without nonexistent librsvg winget command", () => {
 			const pipRetry =
 				'.\\.claude\\skills\\.venv\\Scripts\\Activate.ps1; python -m pip install "<package>"';
 			const summary: InstallErrorSummary = {
@@ -161,7 +161,17 @@ describe("install-error-handler", () => {
 			displayInstallErrors(testDir);
 
 			expect(loggerInfoSpy).toHaveBeenCalledWith("Install system packages:");
-			expect(loggerInfoSpy).toHaveBeenCalledWith("  winget install Gyan.FFmpeg GNOME.librsvg");
+			expect(loggerInfoSpy).toHaveBeenCalledWith("  winget install Gyan.FFmpeg");
+			expect(loggerInfoSpy).toHaveBeenCalledWith(
+				"  choco install rsvg-convert -y  # run from elevated PowerShell",
+			);
+			expect(loggerInfoSpy).toHaveBeenCalledWith(
+				"  pacman -S mingw-w64-x86_64-librsvg  # MSYS2 alternative",
+			);
+			const loggedInfo: string[] = loggerInfoSpy.mock.calls.map((call: unknown[]) =>
+				String(call[0]),
+			);
+			expect(loggedInfo.some((line) => line.includes("GNOME.librsvg"))).toBe(false);
 			expect(loggerInfoSpy).not.toHaveBeenCalledWith("Then retry failed packages manually:");
 			expect(loggerInfoSpy).not.toHaveBeenCalledWith(`  ${pipRetry}`);
 		});


### PR DESCRIPTION
## Summary
- Stop mapping librsvg/rsvg-convert failures to the nonexistent GNOME.librsvg winget package.
- Split system-tool remediation from pip remediation so Windows rsvg failures print Chocolatey/MSYS2 commands only.
- Refresh generated CLI manifest/reference files for the current dev version.
- Add regression coverage that prevents GNOME.librsvg from returning in install error output.

## Validation
- bun test tests/utils/install-error-handler.test.ts
- bunx biome check src/services/package-installer/install-error-handler.ts tests/utils/install-error-handler.test.ts
- bun run typecheck
- bun run build
- bun run ci:local
- pre-push hook: full local CI parity + UI vitest

Closes #821
Related: claudekit/claudekit-engineer#756