### PR TITLE
fix: prune generated context hooks during migration

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.2.3-dev.2",
-	"generatedAt": "2026-05-13T14:39:07.008Z",
+	"version": "4.2.3-dev.3",
+	"generatedAt": "2026-05-13T15:26:41.748Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-13T14:39:07.088Z -->
+<!-- generated: 2026-05-13T15:26:41.834Z -->

--- a/src/__tests__/commands/update-cli-migrate-step.test.ts
+++ b/src/__tests__/commands/update-cli-migrate-step.test.ts
@@ -22,6 +22,7 @@ const loadFullConfigMock = mock(
 );
 
 const execCalls: string[] = [];
+const cleanupCalls: Array<{ providers: string[]; global: boolean }> = [];
 
 function makeDeps(): PromptMigrateUpdateDeps {
 	return {
@@ -44,12 +45,17 @@ function makeDeps(): PromptMigrateUpdateDeps {
 			execCalls.push(command);
 			return { stdout: "", stderr: "" };
 		},
+		cleanupMigratedHooksFn: async (providers, options) => {
+			cleanupCalls.push({ providers, global: options.global });
+			return [];
+		},
 	};
 }
 
 describe("promptMigrateUpdate (step 3 of update pipeline)", () => {
 	beforeEach(() => {
 		execCalls.length = 0;
+		cleanupCalls.length = 0;
 		detectInstalledProvidersMock.mockReset();
 		detectInstalledProvidersMock.mockResolvedValue([]);
 		getProviderConfigMock.mockReset();
@@ -102,6 +108,9 @@ describe("promptMigrateUpdate (step 3 of update pipeline)", () => {
 			config: { updatePipeline: { autoMigrateAfterUpdate: true, migrateProviders: "auto" } },
 		});
 		await promptMigrateUpdate(makeDeps());
+		expect(cleanupCalls).toEqual([
+			{ providers: ["claude-code", "codex", "gemini-cli"], global: false },
+		]);
 		expect(execCalls).toEqual(["ck migrate --agent codex --agent gemini-cli --yes"]);
 	});
 
@@ -141,6 +150,7 @@ describe("promptMigrateUpdate (step 3 of update pipeline)", () => {
 			},
 		});
 		await promptMigrateUpdate(deps);
+		expect(cleanupCalls).toEqual([{ providers: ["codex"], global: true }]);
 		expect(execCalls).toEqual(["ck migrate -g --agent codex --yes"]);
 	});
 

--- a/src/__tests__/domains/web-server/routes/migration-routes.test.ts
+++ b/src/__tests__/domains/web-server/routes/migration-routes.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import express, { type Express } from "express";
@@ -114,11 +114,13 @@ const removePortableInstallationMock = mock(
 		_options?: { path?: string },
 	): Promise<unknown> => undefined,
 );
+const removeInstallationsByFilterMock = mock(async () => []);
 mock.module("@/commands/portable/portable-registry.js", () => ({
 	...actualPortableRegistry,
 	readPortableRegistry: readPortableRegistryMock,
 	addPortableInstallation: addPortableInstallationMock,
 	removePortableInstallation: removePortableInstallationMock,
+	removeInstallationsByFilter: removeInstallationsByFilterMock,
 }));
 
 const { registerMigrationRoutes } = await import("@/domains/web-server/routes/migration-routes.js");
@@ -225,6 +227,8 @@ describe.serial("migration reconcile route", () => {
 		addPortableInstallationMock.mockResolvedValue(undefined);
 		removePortableInstallationMock.mockReset();
 		removePortableInstallationMock.mockResolvedValue(undefined);
+		removeInstallationsByFilterMock.mockReset();
+		removeInstallationsByFilterMock.mockResolvedValue([]);
 	});
 
 	afterEach(async () => {
@@ -344,6 +348,81 @@ describe.serial("migration reconcile route", () => {
 			counts: { installed: number; skipped: number; failed: number };
 		};
 		expect(body.counts.skipped).toBeGreaterThanOrEqual(1);
+	});
+
+	test("plan execution prunes generated-context hook artifacts before installing", async () => {
+		const originalCwd = process.cwd();
+		try {
+			process.chdir(ctx.testHome);
+			const hooksDir = join(ctx.testHome, ".codex", "hooks");
+			const generatedHookPath = join(hooksDir, "session-init.cjs");
+			const safeHookPath = join(hooksDir, "privacy-block.cjs");
+			await mkdir(hooksDir, { recursive: true });
+			await writeFile(generatedHookPath, "// generated context hook");
+			await writeFile(safeHookPath, "// safe hook");
+			await writeFile(
+				join(ctx.testHome, ".codex", "hooks.json"),
+				JSON.stringify(
+					{
+						hooks: {
+							SessionStart: [
+								{
+									hooks: [{ type: "command", command: `node "${generatedHookPath}"` }],
+								},
+							],
+							PreToolUse: [
+								{
+									hooks: [{ type: "command", command: `node "${safeHookPath}"` }],
+								},
+							],
+						},
+					},
+					null,
+					2,
+				),
+			);
+
+			const plan = {
+				actions: [],
+				summary: { install: 0, update: 0, skip: 0, conflict: 0, delete: 0 },
+				hasConflicts: false,
+				meta: {
+					include: {
+						agents: false,
+						commands: false,
+						skills: false,
+						config: false,
+						rules: false,
+						hooks: true,
+					},
+					providers: ["codex"],
+				},
+			};
+
+			const res = await fetch(`${ctx.baseUrl}/api/migrate/execute`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ plan, resolutions: {} }),
+			});
+
+			expect(res.status).toBe(200);
+			const body = (await res.json()) as {
+				warnings: string[];
+				counts: { installed: number; skipped: number; failed: number };
+			};
+			expect(body.warnings).toContain("Disabled 2 generated-context hook artifact(s) for codex");
+			expect(body.counts).toEqual({ installed: 0, skipped: 0, failed: 0 });
+			expect(existsSync(generatedHookPath)).toBe(false);
+			expect(existsSync(safeHookPath)).toBe(true);
+
+			const hooksJson = JSON.parse(
+				await readFile(join(ctx.testHome, ".codex", "hooks.json"), "utf8"),
+			);
+			expect(hooksJson.hooks.SessionStart).toBeUndefined();
+			expect(hooksJson.hooks.PreToolUse[0].hooks[0].command).toContain("privacy-block.cjs");
+		} finally {
+			process.chdir(originalCwd);
+		}
 	});
 
 	test("backfills stale registry checksums for skip actions during plan execution", async () => {

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -1,6 +1,7 @@
 /**
- * Migrate command — one-shot migration of all agents, commands, skills, config,
- * rules, and hooks to target providers. Thin orchestration layer over portable infrastructure.
+ * Migrate command — one-shot migration of all agents, commands, skills,
+ * config, rules, and hooks to target providers. Thin orchestration layer over
+ * portable infrastructure.
  */
 import { existsSync } from "node:fs";
 import { readFile, rm, unlink } from "node:fs/promises";
@@ -34,6 +35,10 @@ import { resolveConflict } from "../portable/conflict-resolver.js";
 import { convertItem } from "../portable/converters/index.js";
 import { generateDiff } from "../portable/diff-display.js";
 import { migrateHooksSettings } from "../portable/hooks-settings-merger.js";
+import {
+	cleanupMigratedHooksForProviders,
+	isGeneratedContextHookName,
+} from "../portable/migrated-hooks-cleanup.js";
 import { setTaxonomyOverrides } from "../portable/model-taxonomy.js";
 import {
 	OpenCodeAuthRequiredError,
@@ -169,6 +174,28 @@ export function renderBanners(banners: ReconcileBanner[]): void {
 			for (const line of lines) {
 				console.log(line);
 			}
+		}
+	}
+}
+
+function logHookCleanupResults(
+	results: Awaited<ReturnType<typeof cleanupMigratedHooksForProviders>>,
+): void {
+	const cleaned = results.filter(
+		(result) =>
+			result.hooksPruned > 0 || result.filesRemoved > 0 || result.registryEntriesRemoved > 0,
+	);
+	if (cleaned.length > 0) {
+		const count = cleaned.reduce(
+			(total, result) =>
+				total + result.hooksPruned + result.filesRemoved + result.registryEntriesRemoved,
+			0,
+		);
+		p.log.info(pc.dim(`[migrate] Disabled generated-context hooks (${count} cleanup action(s))`));
+	}
+	for (const result of results) {
+		for (const warning of result.warnings) {
+			p.log.warn(warning);
 		}
 	}
 }
@@ -508,12 +535,21 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			: null;
 		// rulesSourcePath is non-null when scope.rules is true (same guard)
 		const ruleItems = rulesSourcePath ? await discoverRules(rulesSourcePath) : [];
-		const { items: hookItems, skippedShellHooks } = hooksSource
+		const { items: discoveredHookItems, skippedShellHooks } = hooksSource
 			? await discoverHooks(hooksSource)
 			: { items: [], skippedShellHooks: [] };
+		const disabledGeneratedHooks = discoveredHookItems.filter((item) =>
+			isGeneratedContextHookName(item.name),
+		);
+		const hookItems = discoveredHookItems.filter((item) => !isGeneratedContextHookName(item.name));
 		if (skippedShellHooks.length > 0) {
 			logger.warning(
 				`[migrate] Skipping ${skippedShellHooks.length} shell hook(s) not supported for migration (node-runnable only): ${skippedShellHooks.join(", ")}`,
+			);
+		}
+		if (disabledGeneratedHooks.length > 0) {
+			logger.warning(
+				`[migrate] Disabling ${disabledGeneratedHooks.length} generated-context hook(s): ${disabledGeneratedHooks.map((item) => item.name).join(", ")}`,
 			);
 		}
 
@@ -527,20 +563,8 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			ruleItems.length > 0 ||
 			hookItems.length > 0;
 
-		if (!hasItems) {
-			p.log.error("Nothing to migrate.");
-			p.log.info(
-				pc.dim(
-					"Check .claude/agents/, .claude/commands/, .claude/skills/, .claude/rules/, .claude/hooks/, and CLAUDE.md (project or ~/.claude/)",
-				),
-			);
-			p.outro(pc.red("Nothing to migrate"));
-			return;
-		}
-
 		// Phase 2: Select providers
 		const detectedProviders = await detectInstalledProviders();
-		let selectedProviders: ProviderType[];
 
 		// Build the full set of providers that support at least one portable type
 		const allSupportedProviders = Array.from(
@@ -553,6 +577,19 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 				...getProvidersSupporting("hooks"),
 			]),
 		);
+
+		if (!hasItems && !options.agent?.length && !options.all && !options.yes) {
+			p.log.error("Nothing to migrate.");
+			p.log.info(
+				pc.dim(
+					"Check .claude/agents/, .claude/commands/, .claude/skills/, .claude/rules/, .claude/hooks/, and CLAUDE.md (project or ~/.claude/)",
+				),
+			);
+			p.outro(pc.red("Nothing to migrate"));
+			return;
+		}
+
+		let selectedProviders: ProviderType[];
 
 		if (options.agent && options.agent.length > 0) {
 			// Validate provider names
@@ -650,6 +687,17 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			}
 			requestedGlobal = scopeChoice as boolean;
 			installGlobally = requestedGlobal;
+		}
+
+		const cleanupResults = await cleanupMigratedHooksForProviders(selectedProviders, {
+			global: installGlobally,
+		});
+		logHookCleanupResults(cleanupResults);
+
+		if (!hasItems) {
+			p.log.info("No migratable items found after generated-context hooks were disabled.");
+			p.outro(pc.green("Hook cleanup complete"));
+			return;
 		}
 
 		const sourceCounts: PortableSourceCounts = {

--- a/src/commands/portable/__tests__/migrated-hooks-cleanup.test.ts
+++ b/src/commands/portable/__tests__/migrated-hooks-cleanup.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cleanupMigratedHooksForProviders } from "../migrated-hooks-cleanup.js";
+
+describe("cleanupMigratedHooksForProviders", () => {
+	let testDir: string;
+	let originalCwd: string;
+
+	beforeEach(async () => {
+		originalCwd = process.cwd();
+		testDir = await mkdtemp(join(tmpdir(), "ck-migrated-hooks-cleanup-"));
+		process.chdir(testDir);
+	});
+
+	afterEach(async () => {
+		process.chdir(originalCwd);
+		await rm(testDir, { recursive: true, force: true });
+	});
+
+	it("removes migrated Codex generated-context hooks while preserving other hooks", async () => {
+		const hooksDir = join(testDir, ".codex", "hooks");
+		const hookPath = join(hooksDir, "session-init.cjs");
+		const contextHookPath = join(hooksDir, "usage-context-awareness.cjs");
+		const safeHookPath = join(hooksDir, "privacy-block.cjs");
+		await mkdir(hooksDir, { recursive: true });
+		await writeFile(hookPath, "// migrated hook");
+		await writeFile(contextHookPath, "// migrated hook");
+		await writeFile(safeHookPath, "// safe hook");
+		await writeFile(
+			join(testDir, ".codex", "hooks.json"),
+			JSON.stringify(
+				{
+					hooks: {
+						SessionStart: [
+							{
+								hooks: [
+									{ type: "command", command: `node "${hookPath}"` },
+									{ type: "command", command: `node "${contextHookPath}"` },
+									{ type: "command", command: `node "${safeHookPath}"` },
+									{ type: "command", command: "echo user-owned" },
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const results = await cleanupMigratedHooksForProviders(["codex"], {
+			global: false,
+			pruneRegistry: false,
+		});
+
+		expect(results[0]?.hooksPruned).toBe(2);
+		expect(results[0]?.filesRemoved).toBe(2);
+		expect(existsSync(hookPath)).toBe(false);
+		expect(existsSync(contextHookPath)).toBe(false);
+		expect(existsSync(safeHookPath)).toBe(true);
+
+		const hooksJson = JSON.parse(await readFile(join(testDir, ".codex", "hooks.json"), "utf8"));
+		expect(hooksJson.hooks.SessionStart[0].hooks).toEqual([
+			{ type: "command", command: `node "${safeHookPath}"` },
+			{ type: "command", command: "echo user-owned" },
+		]);
+	});
+
+	it("prunes Claude Code hook registrations without deleting the statusline runner", async () => {
+		const hooksDir = join(testDir, ".claude", "hooks");
+		const runnerPath = join(hooksDir, "node-hook-runner.sh");
+		const hookPath = join(hooksDir, "session-init.cjs");
+		const safeHookPath = join(hooksDir, "privacy-block.cjs");
+		await mkdir(hooksDir, { recursive: true });
+		await writeFile(runnerPath, "#!/bin/sh\n");
+		await writeFile(hookPath, "// migrated hook");
+		await writeFile(safeHookPath, "// safe hook");
+		await writeFile(
+			join(testDir, ".claude", "settings.json"),
+			JSON.stringify(
+				{
+					statusLine: {
+						command: "bash .claude/hooks/node-hook-runner.sh .claude/statusline.cjs",
+					},
+					hooks: {
+						SessionStart: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command:
+											"bash .claude/hooks/node-hook-runner.sh .claude/hooks/session-init.cjs",
+									},
+								],
+							},
+						],
+						PreToolUse: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command:
+											"bash .claude/hooks/node-hook-runner.sh .claude/hooks/privacy-block.cjs",
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const results = await cleanupMigratedHooksForProviders(["claude-code"], {
+			global: false,
+			pruneRegistry: false,
+		});
+
+		expect(results[0]?.hooksPruned).toBe(1);
+		expect(existsSync(hookPath)).toBe(false);
+		expect(existsSync(safeHookPath)).toBe(true);
+		expect(existsSync(runnerPath)).toBe(true);
+
+		const settings = JSON.parse(await readFile(join(testDir, ".claude", "settings.json"), "utf8"));
+		expect(settings.hooks.SessionStart).toBeUndefined();
+		expect(settings.hooks.PreToolUse[0].hooks[0].command).toContain("privacy-block.cjs");
+		expect(settings.statusLine.command).toContain("node-hook-runner.sh");
+	});
+});

--- a/src/commands/portable/__tests__/migrated-hooks-cleanup.test.ts
+++ b/src/commands/portable/__tests__/migrated-hooks-cleanup.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { cleanupMigratedHooksForProviders } from "../migrated-hooks-cleanup.js";
+import { readPortableRegistry, writePortableRegistry } from "../portable-registry.js";
+
+const registryPath = join(homedir(), ".claudekit", "portable-registry.json");
 
 describe("cleanupMigratedHooksForProviders", () => {
 	let testDir: string;
@@ -129,5 +132,63 @@ describe("cleanupMigratedHooksForProviders", () => {
 		expect(settings.hooks.SessionStart).toBeUndefined();
 		expect(settings.hooks.PreToolUse[0].hooks[0].command).toContain("privacy-block.cjs");
 		expect(settings.statusLine.command).toContain("node-hook-runner.sh");
+	});
+
+	it("prunes generated-context hook entries from the portable registry", async () => {
+		const registryBackup = existsSync(registryPath) ? await readFile(registryPath, "utf8") : null;
+		try {
+			await rm(registryPath, { force: true });
+			const hooksDir = join(testDir, ".codex", "hooks");
+			const generatedHookPath = join(hooksDir, "session-init.cjs");
+			const safeHookPath = join(hooksDir, "privacy-block.cjs");
+			await mkdir(hooksDir, { recursive: true });
+			await writeFile(generatedHookPath, "// generated hook");
+			await writeFile(safeHookPath, "// safe hook");
+			await writePortableRegistry({
+				version: "3.0",
+				installations: [
+					{
+						item: "session-init",
+						type: "hooks",
+						provider: "codex",
+						global: false,
+						path: generatedHookPath,
+						installedAt: "2026-05-13T00:00:00.000Z",
+						sourcePath: generatedHookPath,
+						sourceChecksum: "unknown",
+						targetChecksum: "unknown",
+						installSource: "kit",
+					},
+					{
+						item: "privacy-block",
+						type: "hooks",
+						provider: "codex",
+						global: false,
+						path: safeHookPath,
+						installedAt: "2026-05-13T00:00:00.000Z",
+						sourcePath: safeHookPath,
+						sourceChecksum: "unknown",
+						targetChecksum: "unknown",
+						installSource: "kit",
+					},
+				],
+			});
+
+			const results = await cleanupMigratedHooksForProviders(["codex"], { global: false });
+
+			expect(results[0]?.registryEntriesRemoved).toBe(1);
+			expect(results[0]?.filesRemoved).toBe(1);
+			expect(existsSync(generatedHookPath)).toBe(false);
+			expect(existsSync(safeHookPath)).toBe(true);
+
+			const registry = await readPortableRegistry();
+			expect(registry.installations.map((entry) => entry.item)).toEqual(["privacy-block"]);
+		} finally {
+			if (registryBackup === null) {
+				await rm(registryPath, { force: true });
+			} else {
+				await writeFile(registryPath, registryBackup, "utf8");
+			}
+		}
 	});
 });

--- a/src/commands/portable/generated-context-hooks.ts
+++ b/src/commands/portable/generated-context-hooks.ts
@@ -12,6 +12,7 @@ const GENERATED_CONTEXT_HOOK_FILENAMES = new Set([
 	"usage-quota-cache-refresh.cjs",
 ]);
 
+// Keep this list in sync with claudekit-engineer metadata deletions and default hook settings.
 export function isGeneratedContextHookName(name: string): boolean {
 	const normalized = basename(name.replace(/\\/g, "/"));
 	return Array.from(GENERATED_CONTEXT_HOOK_FILENAMES).some(
@@ -19,6 +20,9 @@ export function isGeneratedContextHookName(name: string): boolean {
 	);
 }
 
+// Settings entries usually contain full commands, sometimes through wrappers; substring
+// matching intentionally catches those broader references while the basename classifier
+// above handles discovered item names and registry paths.
 export function referencesGeneratedContextHook(value: string): boolean {
 	const normalized = value.replace(/\\/g, "/");
 	return Array.from(GENERATED_CONTEXT_HOOK_FILENAMES).some((name) => normalized.includes(name));

--- a/src/commands/portable/generated-context-hooks.ts
+++ b/src/commands/portable/generated-context-hooks.ts
@@ -1,0 +1,25 @@
+import { basename } from "node:path";
+
+const GENERATED_CONTEXT_HOOK_FILENAMES = new Set([
+	"cook-after-plan-reminder.cjs",
+	"dev-rules-reminder.cjs",
+	"plan-format-kanban.cjs",
+	"session-init.cjs",
+	"session-state.cjs",
+	"subagent-init.cjs",
+	"team-context-inject.cjs",
+	"usage-context-awareness.cjs",
+	"usage-quota-cache-refresh.cjs",
+]);
+
+export function isGeneratedContextHookName(name: string): boolean {
+	const normalized = basename(name.replace(/\\/g, "/"));
+	return Array.from(GENERATED_CONTEXT_HOOK_FILENAMES).some(
+		(hookName) => normalized === hookName || normalized.endsWith(`-${hookName}`),
+	);
+}
+
+export function referencesGeneratedContextHook(value: string): boolean {
+	const normalized = value.replace(/\\/g, "/");
+	return Array.from(GENERATED_CONTEXT_HOOK_FILENAMES).some((name) => normalized.includes(name));
+}

--- a/src/commands/portable/migrated-hook-settings-cleanup.ts
+++ b/src/commands/portable/migrated-hook-settings-cleanup.ts
@@ -1,0 +1,137 @@
+import { existsSync } from "node:fs";
+import { readFile, rename, rm, unlink, writeFile } from "node:fs/promises";
+import { basename, isAbsolute, relative, resolve } from "node:path";
+import { logger } from "../../shared/logger.js";
+import {
+	isGeneratedContextHookName,
+	referencesGeneratedContextHook,
+} from "./generated-context-hooks.js";
+
+type HookEntry = { command?: unknown; [key: string]: unknown };
+type HookGroup = { hooks?: unknown; [key: string]: unknown };
+type HooksSection = Record<string, HookGroup[]>;
+
+export async function pruneSettingsHooks(
+	settingsPath: string,
+	hooksDir: string,
+): Promise<{ hooksPruned: number; filesToRemove: Set<string>; warnings: string[] }> {
+	const filesToRemove = new Set<string>();
+	const warnings: string[] = [];
+	if (!existsSync(settingsPath)) return { hooksPruned: 0, filesToRemove, warnings };
+
+	let parsed: Record<string, unknown>;
+	try {
+		parsed = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+	} catch (error) {
+		warnings.push(
+			`Could not parse ${settingsPath}; hook cleanup skipped (${error instanceof Error ? error.message : String(error)})`,
+		);
+		return { hooksPruned: 0, filesToRemove, warnings };
+	}
+
+	if (!parsed.hooks || typeof parsed.hooks !== "object" || Array.isArray(parsed.hooks)) {
+		return { hooksPruned: 0, filesToRemove, warnings };
+	}
+
+	const sourceHooks = parsed.hooks as HooksSection;
+	const nextHooks: HooksSection = {};
+	let hooksPruned = 0;
+
+	for (const [event, groups] of Object.entries(sourceHooks)) {
+		if (!Array.isArray(groups)) continue;
+		const nextGroups: HookGroup[] = [];
+		for (const group of groups) {
+			const hooks = Array.isArray(group?.hooks) ? (group.hooks as HookEntry[]) : [];
+			const kept = hooks.filter((entry) => {
+				const command = typeof entry.command === "string" ? entry.command : "";
+				if (!shouldPruneCommand(command, hooksDir)) return true;
+				hooksPruned += 1;
+				for (const filePath of hookFilesFromCommand(command, hooksDir)) {
+					filesToRemove.add(filePath);
+				}
+				return false;
+			});
+			if (kept.length > 0) nextGroups.push({ ...group, hooks: kept });
+		}
+		if (nextGroups.length > 0) nextHooks[event] = nextGroups;
+	}
+
+	if (hooksPruned === 0) return { hooksPruned, filesToRemove, warnings };
+
+	if (Object.keys(nextHooks).length > 0) parsed.hooks = nextHooks;
+	else {
+		parsed = Object.fromEntries(Object.entries(parsed).filter(([key]) => key !== "hooks"));
+	}
+
+	if (Object.keys(parsed).length === 0) await rm(settingsPath, { force: true });
+	else await atomicWrite(settingsPath, JSON.stringify(parsed, null, 2));
+
+	return { hooksPruned, filesToRemove, warnings };
+}
+
+export async function removeHookFiles(paths: Set<string>, hooksDir: string): Promise<number> {
+	let removed = 0;
+	for (const filePath of paths) {
+		if (!isPathWithin(filePath, hooksDir)) continue;
+		try {
+			if (existsSync(filePath)) {
+				await rm(filePath, { force: true, recursive: true });
+				removed += 1;
+			}
+		} catch (error) {
+			logger.verbose(`Failed to remove migrated hook file ${filePath}: ${String(error)}`);
+		}
+	}
+	return removed;
+}
+
+function shouldPruneCommand(command: string, hooksDir: string): boolean {
+	const normalized = command.replace(/\\/g, "/");
+	if (!referencesHooksDir(normalized, hooksDir) && !normalized.includes("/.claude/hooks/")) {
+		return false;
+	}
+	return referencesGeneratedContextHook(normalized);
+}
+
+function hookFilesFromCommand(command: string, hooksDir: string): string[] {
+	const files = new Set<string>();
+	for (const ref of command.match(/(?:^|[\s"'(])([^"'\s()]+(?:\.cjs|\.mjs|\.js|\.ts|\.sh))/g) ??
+		[]) {
+		const cleaned = ref.trim().replace(/^["']|["']$/g, "");
+		const name = basename(cleaned);
+		if (!name || !isGeneratedContextHookName(name)) continue;
+		if (isAbsolute(cleaned) && isPathWithin(cleaned, hooksDir)) files.add(resolve(cleaned));
+		else if (referencesHooksDir(cleaned, hooksDir) || cleaned.includes(".claude/hooks/")) {
+			files.add(resolve(hooksDir, name));
+		}
+	}
+	return Array.from(files);
+}
+
+function referencesHooksDir(command: string, hooksDir: string): boolean {
+	const normalizedDir = hooksDir.replace(/\\/g, "/");
+	const normalized = command.replace(/\\/g, "/");
+	return (
+		normalized.includes(normalizedDir) ||
+		normalized.includes(".claude/hooks/") ||
+		normalized.includes(".codex/hooks/") ||
+		normalized.includes(".gemini/hooks/") ||
+		normalized.includes(".factory/hooks/")
+	);
+}
+
+function isPathWithin(filePath: string, parentDir: string): boolean {
+	const rel = relative(resolve(parentDir), resolve(filePath));
+	return rel === "" || (!!rel && !rel.startsWith("..") && !isAbsolute(rel));
+}
+
+async function atomicWrite(filePath: string, content: string): Promise<void> {
+	const tempPath = `${filePath}.ck-tmp`;
+	try {
+		await writeFile(tempPath, `${content}\n`, "utf8");
+		await rename(tempPath, filePath);
+	} catch (error) {
+		await unlink(tempPath).catch(() => undefined);
+		throw error;
+	}
+}

--- a/src/commands/portable/migrated-hook-settings-cleanup.ts
+++ b/src/commands/portable/migrated-hook-settings-cleanup.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { readFile, rename, rm, unlink, writeFile } from "node:fs/promises";
 import { basename, isAbsolute, relative, resolve } from "node:path";
 import { logger } from "../../shared/logger.js";
@@ -87,9 +87,7 @@ export async function removeHookFiles(paths: Set<string>, hooksDir: string): Pro
 
 function shouldPruneCommand(command: string, hooksDir: string): boolean {
 	const normalized = command.replace(/\\/g, "/");
-	if (!referencesHooksDir(normalized, hooksDir) && !normalized.includes("/.claude/hooks/")) {
-		return false;
-	}
+	if (!referencesHooksDir(normalized, hooksDir)) return false;
 	return referencesGeneratedContextHook(normalized);
 }
 
@@ -121,8 +119,16 @@ function referencesHooksDir(command: string, hooksDir: string): boolean {
 }
 
 function isPathWithin(filePath: string, parentDir: string): boolean {
-	const rel = relative(resolve(parentDir), resolve(filePath));
+	const rel = relative(resolvePathForContainment(parentDir), resolvePathForContainment(filePath));
 	return rel === "" || (!!rel && !rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function resolvePathForContainment(pathValue: string): string {
+	try {
+		return realpathSync.native(pathValue);
+	} catch {
+		return resolve(pathValue);
+	}
 }
 
 async function atomicWrite(filePath: string, content: string): Promise<void> {

--- a/src/commands/portable/migrated-hooks-cleanup.ts
+++ b/src/commands/portable/migrated-hooks-cleanup.ts
@@ -1,0 +1,103 @@
+import { isAbsolute, resolve } from "node:path";
+import { isGeneratedContextHookName } from "./generated-context-hooks.js";
+import { pruneSettingsHooks, removeHookFiles } from "./migrated-hook-settings-cleanup.js";
+import { removeInstallationsByFilter } from "./portable-registry.js";
+import { providers } from "./provider-registry.js";
+import type { ProviderType } from "./types.js";
+
+export interface MigratedHookCleanupResult {
+	provider: ProviderType;
+	global: boolean;
+	settingsPath: string | null;
+	hooksPruned: number;
+	filesRemoved: number;
+	registryEntriesRemoved: number;
+	warnings: string[];
+}
+
+export interface MigratedHookCleanupOptions {
+	global: boolean;
+	pruneRegistry?: boolean;
+}
+
+export { isGeneratedContextHookName } from "./generated-context-hooks.js";
+
+export async function cleanupMigratedHooksForProviders(
+	providerIds: string[],
+	options: MigratedHookCleanupOptions,
+): Promise<MigratedHookCleanupResult[]> {
+	const uniqueProviders = Array.from(new Set(providerIds));
+	const results: MigratedHookCleanupResult[] = [];
+
+	for (const providerId of uniqueProviders) {
+		if (!(providerId in providers)) continue;
+		const provider = providerId as ProviderType;
+		const config = providers[provider];
+		if (!config.hooks && !config.settingsJsonPath) continue;
+
+		results.push(await cleanupMigratedHooksForProvider(provider, options));
+	}
+
+	return results;
+}
+
+async function cleanupMigratedHooksForProvider(
+	provider: ProviderType,
+	options: MigratedHookCleanupOptions,
+): Promise<MigratedHookCleanupResult> {
+	const config = providers[provider];
+	const hooksDir = resolveProviderPath(
+		options.global ? config.hooks?.globalPath : config.hooks?.projectPath,
+	);
+	const settingsPath = resolveProviderPath(
+		options.global ? config.settingsJsonPath?.globalPath : config.settingsJsonPath?.projectPath,
+	);
+	const warnings: string[] = [];
+	const filesToRemove = new Set<string>();
+	let hooksPruned = 0;
+
+	if (settingsPath && hooksDir) {
+		const pruned = await pruneSettingsHooks(settingsPath, hooksDir);
+		hooksPruned = pruned.hooksPruned;
+		for (const filePath of pruned.filesToRemove) filesToRemove.add(filePath);
+		warnings.push(...pruned.warnings);
+	}
+
+	let registryEntriesRemoved = 0;
+	if (options.pruneRegistry !== false) {
+		try {
+			const removed = await removeInstallationsByFilter(
+				(entry) =>
+					entry.type === "hooks" &&
+					entry.provider === provider &&
+					entry.global === options.global &&
+					(isGeneratedContextHookName(entry.item) ||
+						isGeneratedContextHookName(entry.path) ||
+						isGeneratedContextHookName(entry.sourcePath)),
+			);
+			registryEntriesRemoved = removed.length;
+			for (const entry of removed) filesToRemove.add(entry.path);
+		} catch (error) {
+			warnings.push(
+				`Registry cleanup failed for ${provider}: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
+
+	const filesRemoved = hooksDir ? await removeHookFiles(filesToRemove, hooksDir) : 0;
+
+	return {
+		provider,
+		global: options.global,
+		settingsPath: settingsPath ?? null,
+		hooksPruned,
+		filesRemoved,
+		registryEntriesRemoved,
+		warnings,
+	};
+}
+
+function resolveProviderPath(pathValue: string | null | undefined): string | null {
+	if (!pathValue) return null;
+	return isAbsolute(pathValue) ? pathValue : resolve(process.cwd(), pathValue);
+}

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -381,6 +381,12 @@ export interface PromptMigrateUpdateDeps {
 	getSetupFn?: (projectDir?: string) => Promise<PromptKitUpdateSetup>;
 	loadFullConfigFn?: PromptKitUpdateConfigLoader;
 	execAsyncFn?: ExecAsyncFn;
+	cleanupMigratedHooksFn?: (
+		providers: string[],
+		options: { global: boolean },
+	) => Promise<
+		Array<{ hooksPruned: number; filesRemoved: number; registryEntriesRemoved: number }>
+	>;
 }
 
 /**
@@ -406,8 +412,45 @@ export async function promptMigrateUpdate(deps?: PromptMigrateUpdateDeps): Promi
 
 		if (!detectFn || !getConfigFn) return;
 
-		// Detect installed providers (excludes claude-code — it's the source, not a target)
+		// Detect installed providers. Claude Code is not an auto-migration target,
+		// but it can still contain generated-context hook registrations that need
+		// self-healing after a CLI update.
 		const allProviders = await detectFn();
+		if (allProviders.length === 0) {
+			logger.verbose("No migration providers detected, skipping migrate step");
+			return;
+		}
+
+		// Auto-detect global vs local install before cleanup/migration.
+		let isGlobal = false;
+		try {
+			const setup = await getSetupFn();
+			isGlobal = !!setup.global.metadata && !setup.project.metadata;
+		} catch {
+			// Non-fatal — default to local
+		}
+
+		try {
+			const cleanupFn =
+				deps?.cleanupMigratedHooksFn ??
+				(await import("@/commands/portable/migrated-hooks-cleanup.js"))
+					.cleanupMigratedHooksForProviders;
+			const cleanupProviders = allProviders.filter((p) => SAFE_PROVIDER_NAME.test(p));
+			const cleanupResults = await cleanupFn(cleanupProviders, { global: isGlobal });
+			const cleanupCount = cleanupResults.reduce(
+				(total, result) =>
+					total + result.hooksPruned + result.filesRemoved + result.registryEntriesRemoved,
+				0,
+			);
+			if (cleanupCount > 0) {
+				logger.info(`Cleaned up ${cleanupCount} generated-context hook artifact(s)`);
+			}
+		} catch (error) {
+			logger.verbose(
+				`Migrated hook cleanup skipped: ${error instanceof Error ? error.message : "unknown"}`,
+			);
+		}
+
 		const targets = allProviders.filter((p) => p !== "claude-code");
 		if (targets.length === 0) {
 			logger.verbose("No migration targets detected, skipping migrate step");
@@ -451,15 +494,6 @@ export async function promptMigrateUpdate(deps?: PromptMigrateUpdateDeps): Promi
 			logger.warning("Some provider names contain invalid characters and were skipped");
 		}
 		if (safeProviders.length === 0) return;
-
-		// Auto-detect global vs local install
-		let isGlobal = false;
-		try {
-			const setup = await getSetupFn();
-			isGlobal = !!setup.global.metadata && !setup.project.metadata;
-		} catch {
-			// Non-fatal — default to local
-		}
 
 		const providerNames = safeProviders.map((p) => getConfigFn(p).displayName).join(", ");
 

--- a/src/domains/web-server/routes/migration-routes.ts
+++ b/src/domains/web-server/routes/migration-routes.ts
@@ -68,6 +68,7 @@ import type {
 } from "@/commands/portable/types.js";
 import { ProviderType } from "@/commands/portable/types.js";
 import { discoverSkills, getSkillSourcePath } from "@/commands/skills/skills-discovery.js";
+import { logger } from "@/shared/logger.js";
 import type { Express, Request, Response } from "express";
 import { z } from "zod";
 import {
@@ -644,6 +645,44 @@ function getProvidersFromPlan(plan: z.infer<typeof RECONCILE_PLAN_SCHEMA>): Prov
 	return providersFromActions;
 }
 
+function getProviderScopesFromPlan(
+	plan: z.infer<typeof RECONCILE_PLAN_SCHEMA>,
+): Map<ProviderTypeValue, Set<boolean>> {
+	const providerScopes = new Map<ProviderTypeValue, Set<boolean>>();
+	for (const action of plan.actions) {
+		const provider = action.provider as ProviderTypeValue;
+		const scopes = providerScopes.get(provider) ?? new Set<boolean>();
+		scopes.add(action.global);
+		providerScopes.set(provider, scopes);
+	}
+	return providerScopes;
+}
+
+async function cleanupGeneratedContextHookArtifacts(
+	providerIds: ProviderTypeValue[],
+	providerScopes: Map<ProviderTypeValue, Set<boolean>>,
+	warnings: string[],
+): Promise<void> {
+	for (const provider of providerIds) {
+		const scopes = providerScopes.get(provider) ?? new Set<boolean>([false]);
+		for (const scope of scopes) {
+			const cleanupResults = await cleanupMigratedHooksForProviders([provider], {
+				global: scope,
+			});
+			for (const result of cleanupResults) {
+				const cleanupCount =
+					result.hooksPruned + result.filesRemoved + result.registryEntriesRemoved;
+				if (cleanupCount > 0) {
+					warnings.push(
+						`Disabled ${cleanupCount} generated-context hook artifact(s) for ${provider}`,
+					);
+				}
+				warnings.push(...result.warnings);
+			}
+		}
+	}
+}
+
 function getConfigSourceFromPlan(plan: z.infer<typeof RECONCILE_PLAN_SCHEMA>): string | undefined {
 	const meta = getPlanMeta(plan);
 	if (typeof meta?.source !== "string") {
@@ -936,7 +975,7 @@ async function discoverMigrationItems(
 					}
 					const disabledItems = items.filter((item) => isGeneratedContextHookName(item.name));
 					if (disabledItems.length > 0) {
-						console.warn(
+						logger.warning(
 							`[migrate] Disabling ${disabledItems.length} generated-context hook(s): ${disabledItems.map((item) => item.name).join(", ")}`,
 						);
 					}
@@ -1609,6 +1648,9 @@ export function registerMigrationRoutes(app: Express): void {
 				const allResults: PortableInstallResult[] = [];
 				const warnings: string[] = [];
 				const hookRegistrationResults: PortableInstallResult[] = [];
+				const allPlanProviders = getProvidersFromPlan(plan);
+				const providerScopes = getProviderScopesFromPlan(plan);
+				await cleanupGeneratedContextHookArtifacts(allPlanProviders, providerScopes, warnings);
 				const successfulHookFiles = new Map<string, { files: string[]; global: boolean }>();
 				// Absolute paths of installed hook files per provider — needed for Codex wrapper generation.
 				const successfulHookAbsPaths = new Map<string, string[]>();
@@ -1759,33 +1801,6 @@ export function registerMigrationRoutes(app: Express): void {
 						warnings,
 						hookRegistrationResults,
 					);
-				}
-
-				const allPlanProviders = getProvidersFromPlan(plan);
-				const providerScopes = new Map<ProviderTypeValue, Set<boolean>>();
-				for (const action of plan.actions) {
-					const provider = action.provider as ProviderTypeValue;
-					const scopes = providerScopes.get(provider) ?? new Set<boolean>();
-					scopes.add(action.global);
-					providerScopes.set(provider, scopes);
-				}
-				for (const provider of allPlanProviders) {
-					const scopes = providerScopes.get(provider) ?? new Set<boolean>([false]);
-					for (const scope of scopes) {
-						const cleanupResults = await cleanupMigratedHooksForProviders([provider], {
-							global: scope,
-						});
-						for (const result of cleanupResults) {
-							const cleanupCount =
-								result.hooksPruned + result.filesRemoved + result.registryEntriesRemoved;
-							if (cleanupCount > 0) {
-								warnings.push(
-									`Disabled ${cleanupCount} generated-context hook artifact(s) for ${provider}`,
-								);
-							}
-							warnings.push(...result.warnings);
-						}
-					}
 				}
 
 				// Handle skills fallback (directory-based, may not be in reconcile actions).

--- a/src/domains/web-server/routes/migration-routes.ts
+++ b/src/domains/web-server/routes/migration-routes.ts
@@ -27,6 +27,10 @@ import {
 	resolveSourceOrigin,
 } from "@/commands/portable/config-discovery.js";
 import { migrateHooksSettings } from "@/commands/portable/hooks-settings-merger.js";
+import {
+	cleanupMigratedHooksForProviders,
+	isGeneratedContextHookName,
+} from "@/commands/portable/migrated-hooks-cleanup.js";
 import { installPortableItems } from "@/commands/portable/portable-installer.js";
 import { loadPortableManifest } from "@/commands/portable/portable-manifest.js";
 import {
@@ -930,7 +934,13 @@ async function discoverMigrationItems(
 							`[migrate] Skipping ${skippedShellHooks.length} shell hook(s) not supported for migration (node-runnable only): ${skippedShellHooks.join(", ")}`,
 						);
 					}
-					return items;
+					const disabledItems = items.filter((item) => isGeneratedContextHookName(item.name));
+					if (disabledItems.length > 0) {
+						console.warn(
+							`[migrate] Disabling ${disabledItems.length} generated-context hook(s): ${disabledItems.map((item) => item.name).join(", ")}`,
+						);
+					}
+					return items.filter((item) => !isGeneratedContextHookName(item.name));
 				})
 			: Promise.resolve([]),
 	]);
@@ -1752,6 +1762,31 @@ export function registerMigrationRoutes(app: Express): void {
 				}
 
 				const allPlanProviders = getProvidersFromPlan(plan);
+				const providerScopes = new Map<ProviderTypeValue, Set<boolean>>();
+				for (const action of plan.actions) {
+					const provider = action.provider as ProviderTypeValue;
+					const scopes = providerScopes.get(provider) ?? new Set<boolean>();
+					scopes.add(action.global);
+					providerScopes.set(provider, scopes);
+				}
+				for (const provider of allPlanProviders) {
+					const scopes = providerScopes.get(provider) ?? new Set<boolean>([false]);
+					for (const scope of scopes) {
+						const cleanupResults = await cleanupMigratedHooksForProviders([provider], {
+							global: scope,
+						});
+						for (const result of cleanupResults) {
+							const cleanupCount =
+								result.hooksPruned + result.filesRemoved + result.registryEntriesRemoved;
+							if (cleanupCount > 0) {
+								warnings.push(
+									`Disabled ${cleanupCount} generated-context hook artifact(s) for ${provider}`,
+								);
+							}
+							warnings.push(...result.warnings);
+						}
+					}
+				}
 
 				// Handle skills fallback (directory-based, may not be in reconcile actions).
 				// In install mode, the plan is authoritative — skip the fallback entirely


### PR DESCRIPTION
## Summary
- keep hook migration enabled, but filter ClaudeKit generated/session-context hooks out of migration discovery
- add idempotent cleanup for migrated provider settings, hook files, and portable registry entries
- run cleanup during `ck update`, CLI migration, and dashboard migration execution so already-migrated users self-heal on the next update/migrate
- preserve active hooks such as privacy-block, scout-block, descriptive-name, simplify-gate, and statusline behavior

Closes #823.
Paired Engineer default-install PR: claudekit/claudekit-engineer#760.

## Validation
- `bun test src/commands/portable/__tests__/migrated-hooks-cleanup.test.ts src/__tests__/commands/update-cli-migrate-step.test.ts src/__tests__/domains/web-server/routes/migration-routes.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run ci:local`
- pre-push quality gate including UI vitest suite
