### PR TITLE
fix: self-heal missing hook runner references

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.2.3-dev.3",
-	"generatedAt": "2026-05-13T15:26:41.748Z",
+	"version": "4.3.0",
+	"generatedAt": "2026-05-13T17:02:51.252Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-13T15:26:41.834Z -->
+<!-- generated: 2026-05-13T17:02:51.341Z -->

--- a/src/__tests__/commands/update-cli-migrate-step.test.ts
+++ b/src/__tests__/commands/update-cli-migrate-step.test.ts
@@ -23,6 +23,7 @@ const loadFullConfigMock = mock(
 
 const execCalls: string[] = [];
 const cleanupCalls: Array<{ providers: string[]; global: boolean }> = [];
+const repairCalls: string[] = [];
 
 function makeDeps(): PromptMigrateUpdateDeps {
 	return {
@@ -49,6 +50,10 @@ function makeDeps(): PromptMigrateUpdateDeps {
 			cleanupCalls.push({ providers, global: options.global });
 			return [];
 		},
+		repairHookFileReferencesFn: async (projectDir) => {
+			repairCalls.push(projectDir);
+			return 0;
+		},
 	};
 }
 
@@ -56,6 +61,7 @@ describe("promptMigrateUpdate (step 3 of update pipeline)", () => {
 	beforeEach(() => {
 		execCalls.length = 0;
 		cleanupCalls.length = 0;
+		repairCalls.length = 0;
 		detectInstalledProvidersMock.mockReset();
 		detectInstalledProvidersMock.mockResolvedValue([]);
 		getProviderConfigMock.mockReset();
@@ -82,6 +88,7 @@ describe("promptMigrateUpdate (step 3 of update pipeline)", () => {
 	test("skips when autoMigrateAfterUpdate is not configured", async () => {
 		detectInstalledProvidersMock.mockResolvedValue(["claude-code", "codex"]);
 		await promptMigrateUpdate(makeDeps());
+		expect(repairCalls).toEqual([process.cwd()]);
 		expect(execCalls).toEqual([]);
 	});
 
@@ -90,7 +97,40 @@ describe("promptMigrateUpdate (step 3 of update pipeline)", () => {
 			config: { updatePipeline: { autoMigrateAfterUpdate: true } },
 		});
 		await promptMigrateUpdate(makeDeps());
+		expect(repairCalls).toEqual([process.cwd()]);
 		expect(execCalls).toEqual([]);
+	});
+
+	test("logs hook file reference repairs even when no providers are detected", async () => {
+		const deps = makeDeps();
+		deps.repairHookFileReferencesFn = async (projectDir) => {
+			repairCalls.push(projectDir);
+			return 2;
+		};
+
+		await promptMigrateUpdate(deps);
+
+		expect(repairCalls).toEqual([process.cwd()]);
+		expect(logger.info).toHaveBeenCalledWith("Repaired 2 missing hook file reference(s)");
+		expect(execCalls).toEqual([]);
+	});
+
+	test("continues migration step when hook file reference repair fails", async () => {
+		detectInstalledProvidersMock.mockResolvedValue(["codex"]);
+		loadFullConfigMock.mockResolvedValue({
+			config: { updatePipeline: { autoMigrateAfterUpdate: true } },
+		});
+		const deps = makeDeps();
+		deps.repairHookFileReferencesFn = async () => {
+			throw new Error("repair failed");
+		};
+
+		await promptMigrateUpdate(deps);
+
+		expect(logger.verbose).toHaveBeenCalledWith(
+			expect.stringContaining("Hook file reference repair skipped: repair failed"),
+		);
+		expect(execCalls).toEqual(["ck migrate --agent codex --yes"]);
 	});
 
 	test("skips when only claude-code is detected", async () => {

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
@@ -850,6 +850,118 @@ describe("checkHookFileReferences", () => {
 		expect(result.status).toBe("pass");
 	});
 
+	test("returns pass when bash runner and target hook both exist", async () => {
+		await mkdir(join(projectDir, ".claude", "hooks"), { recursive: true });
+		await writeFile(join(projectDir, ".claude", "hooks", "node-hook-runner.sh"), "#!/bin/sh\n");
+		await writeFile(join(projectDir, ".claude", "hooks", "privacy-block.cjs"), "process.exit(0);");
+		await writeFile(
+			join(projectDir, ".claude", "settings.json"),
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Bash",
+							hooks: [
+								{
+									type: "command",
+									command: "bash .claude/hooks/node-hook-runner.sh .claude/hooks/privacy-block.cjs",
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookFileReferences(projectDir);
+		expect(result.status).toBe("pass");
+	});
+
+	test("detects and prunes bash runner command when runner file is missing", async () => {
+		await mkdir(join(projectDir, ".claude", "hooks"), { recursive: true });
+		await writeFile(join(projectDir, ".claude", "hooks", "privacy-block.cjs"), "process.exit(0);");
+		const settingsPath = join(projectDir, ".claude", "settings.json");
+		await writeFile(
+			settingsPath,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Bash",
+							hooks: [
+								{
+									type: "command",
+									command: "bash .claude/hooks/node-hook-runner.sh .claude/hooks/privacy-block.cjs",
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookFileReferences(projectDir);
+		expect(result.status).toBe("fail");
+		expect(result.details).toContain("node-hook-runner.sh");
+
+		const fixResult = await result.fix?.execute();
+		expect(fixResult?.success).toBe(true);
+
+		const updated = JSON.parse(await readFile(settingsPath, "utf-8"));
+		expect(updated.hooks).toBeUndefined();
+	});
+
+	test("detects bash runner command when target hook file is missing", async () => {
+		await mkdir(join(projectDir, ".claude", "hooks"), { recursive: true });
+		await writeFile(join(projectDir, ".claude", "hooks", "node-hook-runner.sh"), "#!/bin/sh\n");
+		await writeFile(
+			join(projectDir, ".claude", "settings.json"),
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: "bash .claude/hooks/node-hook-runner.sh .claude/hooks/privacy-block.cjs",
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkHookFileReferences(projectDir);
+		expect(result.status).toBe("fail");
+		expect(result.details).toContain("privacy-block.cjs");
+	});
+
+	test("detects and prunes stale statusLine runner command", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		const settingsPath = join(projectDir, ".claude", "settings.json");
+		await writeFile(
+			settingsPath,
+			JSON.stringify({
+				statusLine: {
+					command: "bash .claude/hooks/node-hook-runner.sh .claude/statusline.cjs",
+				},
+				otherField: "preserved",
+			}),
+		);
+
+		const result = await checkHookFileReferences(projectDir);
+		expect(result.status).toBe("fail");
+		expect(result.details).toContain("node-hook-runner.sh");
+
+		const fixResult = await result.fix?.execute();
+		expect(fixResult?.success).toBe(true);
+
+		const updated = JSON.parse(await readFile(settingsPath, "utf-8"));
+		expect(updated.statusLine).toBeUndefined();
+		expect(updated.otherField).toBe("preserved");
+	});
+
 	test("returns fail when settings reference a missing hook file", async () => {
 		await mkdir(join(projectDir, ".claude"), { recursive: true });
 		await writeFile(

--- a/src/commands/update-cli.ts
+++ b/src/commands/update-cli.ts
@@ -46,6 +46,7 @@ export {
 	fetchLatestReleaseTag,
 	promptKitUpdate,
 	promptMigrateUpdate,
+	repairMissingHookFileReferences,
 	resolveCkInitSpawnCommand,
 	readMetadataFile,
 	resolveCkExecutable,

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -381,12 +381,31 @@ export interface PromptMigrateUpdateDeps {
 	getSetupFn?: (projectDir?: string) => Promise<PromptKitUpdateSetup>;
 	loadFullConfigFn?: PromptKitUpdateConfigLoader;
 	execAsyncFn?: ExecAsyncFn;
+	repairHookFileReferencesFn?: (projectDir: string) => Promise<number>;
 	cleanupMigratedHooksFn?: (
 		providers: string[],
 		options: { global: boolean },
 	) => Promise<
 		Array<{ hooksPruned: number; filesRemoved: number; registryEntriesRemoved: number }>
 	>;
+}
+
+export async function repairMissingHookFileReferences(projectDir = process.cwd()): Promise<number> {
+	const { checkHookFileReferences } = await import(
+		"@/domains/health-checks/checkers/hook-health-checker.js"
+	);
+	const result = await checkHookFileReferences(projectDir);
+	if (result.status !== "fail" || !result.fix) {
+		return 0;
+	}
+
+	const fixResult = await result.fix.execute();
+	if (!fixResult.success) {
+		throw new Error(fixResult.message);
+	}
+
+	const match = fixResult.message.match(/Pruned\s+(\d+)/);
+	return match?.[1] ? Number.parseInt(match[1], 10) : 0;
 }
 
 /**
@@ -396,6 +415,18 @@ export interface PromptMigrateUpdateDeps {
  */
 export async function promptMigrateUpdate(deps?: PromptMigrateUpdateDeps): Promise<void> {
 	try {
+		try {
+			const repairFn = deps?.repairHookFileReferencesFn ?? repairMissingHookFileReferences;
+			const repaired = await repairFn(process.cwd());
+			if (repaired > 0) {
+				logger.info(`Repaired ${repaired} missing hook file reference(s)`);
+			}
+		} catch (error) {
+			logger.verbose(
+				`Hook file reference repair skipped: ${error instanceof Error ? error.message : "unknown"}`,
+			);
+		}
+
 		const providerRegistry =
 			deps?.detectInstalledProvidersFn && deps?.getProviderConfigFn
 				? null

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -733,19 +733,39 @@ interface MissingHookReference {
 	resolvedPath: string;
 }
 
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /**
- * Extract a `.cjs` hook script path from a `node`-style hook command.
- * Returns null if the command is not a node-executed `.claude` hook.
+ * Extract Claude hook file references from commands managed by ClaudeKit.
+ *
+ * Handles legacy direct node hooks and the current bash runner form:
+ * - `node .claude/hooks/foo.cjs`
+ * - `bash .claude/hooks/node-hook-runner.sh .claude/hooks/foo.cjs`
  */
-function extractHookScriptPath(cmd: string | null | undefined): string | null {
-	if (!cmd) return null;
-	// Strip all double-quotes: the .cjs anchor terminates the capture before any trailing
-	// args, so extra quotes in arg values won't corrupt the extracted path.
-	const stripped = cmd.replace(/"/g, "");
-	// Match: node <path-ending-in-.cjs> (followed by whitespace or end)
-	const match = stripped.match(/\bnode\s+(\S*?\.claude[/\\]\S+?\.cjs)(?:\s|$)/);
-	if (!match) return null;
-	return match[1];
+function extractHookReferencePaths(cmd: string | null | undefined): string[] {
+	if (!cmd) return [];
+
+	const normalized = cmd.replace(/["']/g, "").replace(/\\/g, "/");
+	const isNodeHook = /^\s*node\s+/.test(normalized) && normalized.includes(".claude/");
+	const isRunnerHook =
+		/^\s*bash\s+/.test(normalized) && normalized.includes(".claude/hooks/node-hook-runner.sh");
+
+	if (!isNodeHook && !isRunnerHook) return [];
+
+	const extensionPattern = HOOK_EXTENSIONS.map((ext) => escapeRegex(ext)).join("|");
+	const candidatePattern = new RegExp(
+		`(?:^|\\s)(\\S*?\\.claude/\\S+?(?:${extensionPattern}))(?=\\s|$)`,
+		"g",
+	);
+	const paths: string[] = [];
+	for (const match of normalized.matchAll(candidatePattern)) {
+		if (!match[1]) continue;
+		paths.push(match[1]);
+	}
+
+	return Array.from(new Set(paths));
 }
 
 /**
@@ -772,8 +792,6 @@ function collectMissingHookReferences(
 	settingsFile: ClaudeSettingsFile,
 	projectDir: string,
 ): MissingHookReference[] {
-	if (!settings.hooks) return [];
-
 	const findings: MissingHookReference[] = [];
 	const seen = new Set<string>();
 
@@ -783,23 +801,30 @@ function collectMissingHookReferences(
 		matcher: string | undefined,
 	) => {
 		if (!command) return;
-		const scriptPath = extractHookScriptPath(command);
-		if (!scriptPath) return;
-		const resolvedPath = resolveHookScriptPath(scriptPath, projectDir);
-		if (existsSync(resolvedPath)) return;
-		const key = `${settingsFile.path}::${eventName}::${matcher ?? ""}::${scriptPath}`;
-		if (seen.has(key)) return;
-		seen.add(key);
-		findings.push({
-			path: settingsFile.path,
-			label: settingsFile.label,
-			eventName,
-			matcher,
-			command,
-			scriptPath,
-			resolvedPath,
-		});
+		for (const scriptPath of extractHookReferencePaths(command)) {
+			const resolvedPath = resolveHookScriptPath(scriptPath, projectDir);
+			if (existsSync(resolvedPath)) continue;
+			const key = `${settingsFile.path}::${eventName}::${matcher ?? ""}::${scriptPath}`;
+			if (seen.has(key)) continue;
+			seen.add(key);
+			findings.push({
+				path: settingsFile.path,
+				label: settingsFile.label,
+				eventName,
+				matcher,
+				command,
+				scriptPath,
+				resolvedPath,
+			});
+		}
 	};
+
+	const statusLine = settings.statusLine as { command?: unknown } | undefined;
+	if (typeof statusLine?.command === "string") {
+		consider("statusLine", statusLine.command, undefined);
+	}
+
+	if (!settings.hooks) return findings;
 
 	for (const [eventName, entries] of Object.entries(settings.hooks)) {
 		for (const entry of entries) {
@@ -823,60 +848,71 @@ async function pruneMissingHookReferencesInSettingsFile(
 	projectDir: string,
 ): Promise<number> {
 	const settings = await SettingsMerger.readSettingsFile(settingsFile.path);
-	if (!settings?.hooks) return 0;
+	if (!settings) return 0;
 
 	let pruned = 0;
 
 	const hookFileMissing = (command: string | undefined): boolean => {
 		if (!command) return false;
-		const scriptPath = extractHookScriptPath(command);
-		if (!scriptPath) return false;
-		return !existsSync(resolveHookScriptPath(scriptPath, projectDir));
+		const scriptPaths = extractHookReferencePaths(command);
+		if (scriptPaths.length === 0) return false;
+		return scriptPaths.some(
+			(scriptPath) => !existsSync(resolveHookScriptPath(scriptPath, projectDir)),
+		);
 	};
 
-	const hooksRecord = settings.hooks as Record<string, unknown[]>;
-	for (const [eventName, entries] of Object.entries(hooksRecord)) {
-		const filteredEntries: unknown[] = [];
-		for (const entry of entries) {
-			const e = entry as { command?: string; hooks?: Array<{ command?: string }> };
-			// Flat command entry
-			if (typeof e.command === "string") {
-				if (hookFileMissing(e.command)) {
-					pruned++;
-					continue;
-				}
-				filteredEntries.push(entry);
-				continue;
-			}
-
-			// Matcher entry with nested hooks[]
-			if (Array.isArray(e.hooks)) {
-				const keptHooks = e.hooks.filter((h) => {
-					if (hookFileMissing(h.command)) {
-						pruned++;
-						return false;
-					}
-					return true;
-				});
-				if (keptHooks.length === 0) {
-					continue;
-				}
-				filteredEntries.push({ ...e, hooks: keptHooks });
-				continue;
-			}
-
-			filteredEntries.push(entry);
-		}
-		if (filteredEntries.length === 0) {
-			delete hooksRecord[eventName];
-		} else {
-			hooksRecord[eventName] = filteredEntries;
-		}
+	const statusLine = settings.statusLine as { command?: unknown } | undefined;
+	if (typeof statusLine?.command === "string" && hookFileMissing(statusLine.command)) {
+		// biome-ignore lint/performance/noDelete: settings cleanup should remove the stale key
+		delete (settings as Record<string, unknown>).statusLine;
+		pruned++;
 	}
 
-	if (Object.keys(hooksRecord).length === 0) {
-		// biome-ignore lint/performance/noDelete: clearer semantics than = undefined for key removal
-		delete (settings as Record<string, unknown>).hooks;
+	if (settings.hooks) {
+		const hooksRecord = settings.hooks as Record<string, unknown[]>;
+		for (const [eventName, entries] of Object.entries(hooksRecord)) {
+			const filteredEntries: unknown[] = [];
+			for (const entry of entries) {
+				const e = entry as { command?: string; hooks?: Array<{ command?: string }> };
+				// Flat command entry
+				if (typeof e.command === "string") {
+					if (hookFileMissing(e.command)) {
+						pruned++;
+						continue;
+					}
+					filteredEntries.push(entry);
+					continue;
+				}
+
+				// Matcher entry with nested hooks[]
+				if (Array.isArray(e.hooks)) {
+					const keptHooks = e.hooks.filter((h) => {
+						if (hookFileMissing(h.command)) {
+							pruned++;
+							return false;
+						}
+						return true;
+					});
+					if (keptHooks.length === 0) {
+						continue;
+					}
+					filteredEntries.push({ ...e, hooks: keptHooks });
+					continue;
+				}
+
+				filteredEntries.push(entry);
+			}
+			if (filteredEntries.length === 0) {
+				delete hooksRecord[eventName];
+			} else {
+				hooksRecord[eventName] = filteredEntries;
+			}
+		}
+
+		if (Object.keys(hooksRecord).length === 0) {
+			// biome-ignore lint/performance/noDelete: clearer semantics than = undefined for key removal
+			delete (settings as Record<string, unknown>).hooks;
+		}
 	}
 
 	if (pruned > 0) {


### PR DESCRIPTION
Closes #826

## Summary
- detect missing Claude Code bash runner hook references in hook health checks
- prune stale hook and statusLine entries when node-hook-runner.sh or target hook files are missing
- run the same repair during ck update before provider migration detection so existing installs self-heal

## Validation
- bun run typecheck
- bun run lint
- bun run build
- bun test
- pre-push local CI parity gate
