### PR TITLE
fix: allow in-boundary symlinks in portable installer path validation

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.0",
-	"generatedAt": "2026-05-13T17:02:51.252Z",
+	"version": "4.3.1",
+	"generatedAt": "2026-05-14T14:21:22.593Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1067,4 +1067,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-13T17:02:51.341Z -->
+<!-- generated: 2026-05-14T14:21:22.659Z -->

--- a/src/commands/portable/__tests__/portable-installer.test.ts
+++ b/src/commands/portable/__tests__/portable-installer.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { computeContentChecksum } from "../checksum-utils.js";
 import { convertItem } from "../converters/index.js";
@@ -477,11 +477,12 @@ describe("nested command flattening", () => {
 		}
 	});
 
-	test("rejects symlinked Codex command skill target", async () => {
+	test("rejects symlinked Codex command skill target that escapes cwd", async () => {
 		const tempDir = await mkdtemp(join(process.cwd(), ".tmp-portable-codex-symlink-"));
+		const outsideDir = await mkdtemp(join(tmpdir(), "portable-codex-escape-"));
 		const commandTargetPath = join(tempDir, ".agents", "skills");
 		const sourcePath = join(tempDir, "local.md");
-		const outsidePath = join(tempDir, "outside-skill.md");
+		const outsidePath = join(outsideDir, "outside-skill.md");
 		const skillDir = join(commandTargetPath, "source-command-local");
 		const skillPath = join(skillDir, "SKILL.md");
 		const pathConfig = getPathConfig("codex", "commands");
@@ -516,13 +517,15 @@ describe("nested command flattening", () => {
 		} finally {
 			pathConfig.projectPath = originalProjectPath;
 			await rm(tempDir, { recursive: true, force: true });
+			await rm(outsideDir, { recursive: true, force: true });
 		}
 	});
 
-	test("rejects symlinked parent directory for Codex command skills", async () => {
+	test("rejects symlinked parent directory that escapes cwd", async () => {
 		const tempDir = await mkdtemp(join(process.cwd(), ".tmp-portable-codex-parent-symlink-"));
+		const outsideDir = await mkdtemp(join(tmpdir(), "portable-codex-parent-escape-"));
 		const agentsLinkPath = join(tempDir, ".agents");
-		const outsideAgentsPath = join(tempDir, "outside-agents");
+		const outsideAgentsPath = join(outsideDir, "outside-agents");
 		const commandTargetPath = join(agentsLinkPath, "skills");
 		const sourcePath = join(tempDir, "local.md");
 		const pathConfig = getPathConfig("codex", "commands");
@@ -555,6 +558,52 @@ describe("nested command flattening", () => {
 			expect(
 				existsSync(join(outsideAgentsPath, "skills", "source-command-local", "SKILL.md")),
 			).toBe(false);
+		} finally {
+			pathConfig.projectPath = originalProjectPath;
+			await rm(tempDir, { recursive: true, force: true });
+			await rm(outsideDir, { recursive: true, force: true });
+		}
+	});
+
+	test("accepts in-boundary symlinked parent directory (dotfile managers)", async () => {
+		// Simulates stow/chezmoi/yadm setups where e.g. ~/.config is a symlink
+		// to ~/dotfiles/.config — both inside the boundary. The install must
+		// succeed and write to the resolved real path.
+		const tempDir = await mkdtemp(join(process.cwd(), ".tmp-portable-codex-inboundary-symlink-"));
+		const realAgentsPath = join(tempDir, "dotfiles", "agents");
+		const agentsLinkPath = join(tempDir, "project", ".agents");
+		const commandTargetPath = join(agentsLinkPath, "skills");
+		const sourcePath = join(tempDir, "local.md");
+		const pathConfig = getPathConfig("codex", "commands");
+		const originalProjectPath = pathConfig.projectPath;
+
+		try {
+			await mkdir(realAgentsPath, { recursive: true });
+			await mkdir(join(tempDir, "project"), { recursive: true });
+			await writeFile(sourcePath, "---\nname: Local\n---\n# Local command\n", "utf-8");
+			await symlink(realAgentsPath, agentsLinkPath, "dir");
+			pathConfig.projectPath = commandTargetPath;
+
+			const results = await installPortableItems(
+				[
+					makePortableItem({
+						type: "command",
+						name: "local",
+						sourcePath,
+						frontmatter: { name: "Local" },
+						body: "# Local command\n",
+					}),
+				],
+				["codex"],
+				"command",
+				{ global: false },
+			);
+
+			expect(results).toHaveLength(1);
+			expect(results[0].success).toBe(true);
+			expect(existsSync(join(realAgentsPath, "skills", "source-command-local", "SKILL.md"))).toBe(
+				true,
+			);
 		} finally {
 			pathConfig.projectPath = originalProjectPath;
 			await rm(tempDir, { recursive: true, force: true });

--- a/src/commands/portable/__tests__/portable-installer.test.ts
+++ b/src/commands/portable/__tests__/portable-installer.test.ts
@@ -610,6 +610,44 @@ describe("nested command flattening", () => {
 		}
 	});
 
+	test("rejects circular symlink (ELOOP) with a clear error", async () => {
+		const tempDir = await mkdtemp(join(process.cwd(), ".tmp-portable-codex-eloop-"));
+		const agentsLinkPath = join(tempDir, ".agents");
+		const commandTargetPath = join(agentsLinkPath, "skills");
+		const sourcePath = join(tempDir, "local.md");
+		const pathConfig = getPathConfig("codex", "commands");
+		const originalProjectPath = pathConfig.projectPath;
+
+		try {
+			await writeFile(sourcePath, "---\nname: Local\n---\n# Local command\n", "utf-8");
+			// Circular: .agents -> .agents (self-loop via realpath chain)
+			await symlink(agentsLinkPath, agentsLinkPath, "dir");
+			pathConfig.projectPath = commandTargetPath;
+
+			const results = await installPortableItems(
+				[
+					makePortableItem({
+						type: "command",
+						name: "local",
+						sourcePath,
+						frontmatter: { name: "Local" },
+						body: "# Local command\n",
+					}),
+				],
+				["codex"],
+				"command",
+				{ global: false },
+			);
+
+			expect(results).toHaveLength(1);
+			expect(results[0].success).toBe(false);
+			expect(results[0].error).toContain("circular symlink");
+		} finally {
+			pathConfig.projectPath = originalProjectPath;
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	test("skips later Codex commands that convert to an existing batch target", async () => {
 		addPortableInstallationMock.mockClear();
 		const tempDir = await mkdtemp(join(process.cwd(), ".tmp-portable-codex-collision-"));

--- a/src/commands/portable/portable-installer.ts
+++ b/src/commands/portable/portable-installer.ts
@@ -3,7 +3,7 @@
  * Handles all write strategies: per-file, merge-single, yaml-merge, json-merge
  */
 import { existsSync } from "node:fs";
-import { lstat, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, realpath, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import lockfile from "proper-lockfile";
@@ -145,23 +145,41 @@ async function validateNoSymlinkComponents(
 		return `Unsafe path: target escapes ${resolvedBoundary}`;
 	}
 
+	// Walk segments to find the deepest existing ancestor, then resolve symlinks
+	// via realpath. A symlinked segment is safe as long as its resolved real path
+	// stays within the boundary — this allows in-home dotfile managers (stow,
+	// chezmoi, yadm) while still blocking symlinks that escape $HOME / cwd.
 	const segments = relative(resolvedBoundary, resolvedTarget)
 		.split(/[\\/]+/)
 		.filter(Boolean);
 	let cursor = resolvedBoundary;
+	let deepestExisting = resolvedBoundary;
 	for (const segment of segments) {
 		cursor = join(cursor, segment);
 		try {
-			const stats = await lstat(cursor);
-			if (stats.isSymbolicLink()) {
-				return `Unsafe path: target path contains symlink (${cursor})`;
-			}
+			await lstat(cursor);
+			deepestExisting = cursor;
 		} catch (error) {
 			if (isErrnoCode(error, "ENOENT")) {
 				break;
 			}
 			throw error;
 		}
+	}
+
+	let realDeepest: string;
+	try {
+		realDeepest = await realpath(deepestExisting);
+	} catch (error) {
+		if (isErrnoCode(error, "ENOENT")) {
+			return null;
+		}
+		throw error;
+	}
+
+	const realBoundary = await realpath(resolvedBoundary).catch(() => resolvedBoundary);
+	if (!isPathWithinBoundary(realDeepest, realBoundary)) {
+		return `Unsafe path: target path contains symlink that escapes ${realBoundary} (${deepestExisting} -> ${realDeepest})`;
 	}
 
 	return null;

--- a/src/commands/portable/portable-installer.ts
+++ b/src/commands/portable/portable-installer.ts
@@ -163,6 +163,9 @@ async function validateNoSymlinkComponents(
 			if (isErrnoCode(error, "ENOENT")) {
 				break;
 			}
+			if (isErrnoCode(error, "ELOOP")) {
+				return `Unsafe path: circular symlink detected at ${cursor}`;
+			}
 			throw error;
 		}
 	}
@@ -174,10 +177,26 @@ async function validateNoSymlinkComponents(
 		if (isErrnoCode(error, "ENOENT")) {
 			return null;
 		}
+		if (isErrnoCode(error, "ELOOP")) {
+			return `Unsafe path: circular symlink detected at ${deepestExisting}`;
+		}
 		throw error;
 	}
 
-	const realBoundary = await realpath(resolvedBoundary).catch(() => resolvedBoundary);
+	let realBoundary: string;
+	try {
+		realBoundary = await realpath(resolvedBoundary);
+	} catch (error) {
+		// Boundary should always exist ($HOME or process.cwd()), so only swallow ENOENT
+		// from rare race conditions. ELOOP on the boundary itself is unsafe.
+		if (isErrnoCode(error, "ENOENT")) {
+			realBoundary = resolvedBoundary;
+		} else if (isErrnoCode(error, "ELOOP")) {
+			return `Unsafe path: circular symlink detected at boundary ${resolvedBoundary}`;
+		} else {
+			throw error;
+		}
+	}
 	if (!isPathWithinBoundary(realDeepest, realBoundary)) {
 		return `Unsafe path: target path contains symlink that escapes ${realBoundary} (${deepestExisting} -> ${realDeepest})`;
 	}


### PR DESCRIPTION
## Summary

- Stop rejecting every symlink in the install path; only reject symlinks whose resolved real path escapes the boundary.
- Unblocks `ck migrate` for users who manage `~/.config` via stow, chezmoi, yadm or similar dotfile tooling.
- Discord report: 13/13 Opencode subagents failing with `Unsafe path: target path contains symlink (/Users/<user>/.config/...)`.
- Handle `ELOOP` (circular symlinks) with a clear error instead of leaking the cryptic libc message.

Closes #829

## Root Cause

`src/commands/portable/portable-installer.ts` -> `validateNoSymlinkComponents` walked every path segment from the boundary (`$HOME` for global, `process.cwd()` for project) to the target and rejected any segment that was a symlink — even when the symlink resolved back inside the same boundary. The intended threat model is "writes escaping the boundary"; the implementation rejected all symlinks regardless of destination.

## Fix

- Walk segments only to locate the deepest existing ancestor, then call `fs.realpath()` on it.
- Compare that real path against `realpath(boundary)` via the existing `isPathWithinBoundary` helper.
- In-boundary symlinks pass; boundary-escaping symlinks still return `Unsafe path: target path contains symlink that escapes <boundary>`.
- `ENOENT` paths (deeper not-yet-created leaves) keep the previous lenient behaviour.
- `ELOOP` from circular symlinks returns `Unsafe path: circular symlink detected at <path>` (handled in both segment-walk and realpath, including at the boundary itself).
- Boundary `realpath()` catch narrowed: only swallow `ENOENT` (rare race), all other errors propagate.

## Note on test changes

The two pre-existing "escape" tests were actually testing **in-boundary** rejection: `outsidePath = join(tempDir, "outside-skill.md")` is inside `tempDir`, which is inside `process.cwd()`. Those tests were asserting the buggy behaviour this PR fixes. They are retargeted to `os.tmpdir()` (genuinely outside `process.cwd()` on macOS/Linux) so they still validate the actual escape threat model. This is an implicit test-correctness fix riding alongside the production fix.

## Changes

| File | Change |
|------|--------|
| `src/commands/portable/portable-installer.ts` | Replace per-segment `lstat` rejection with deepest-existing-ancestor `realpath` boundary check; handle `ELOOP` explicitly; narrow boundary catch |
| `src/commands/portable/__tests__/portable-installer.test.ts` | Retarget two escape tests to `os.tmpdir()` (real cwd escape); add positive test mirroring stow/chezmoi case; add ELOOP regression test |
| `cli-manifest.json`, `docs/cli-reference.md` | Self-heal version drift (regen-only, committed as `chore:`) |

## Test plan

- [x] `bun test src/commands/portable/__tests__/portable-installer.test.ts` — 37/37 pass (positive in-boundary test + ELOOP regression)
- [x] `bun run ci:local` — all 7 gates pass (4799 tests, 0 fail)
- [ ] Manual: `ln -s ~/dotfiles/.config ~/.config && ck migrate` succeeds

## Security note

The boundary check is unchanged: writes that escape `\$HOME` (global) or `process.cwd()` (project) are still blocked. The change narrows the symlink rejection to its actual threat model — a hostile symlink redirecting writes outside the user's home — and stops false-positiving on common dotfile manager setups.