### PR TITLE
fix(scripts): preserve generated timestamps when content unchanged

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.1",
-	"generatedAt": "2026-05-14T14:21:22.593Z",
+	"version": "4.3.1-dev.1",
+	"generatedAt": "2026-05-14T17:20:57.866Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/scripts/generate-cli-manifest.ts
+++ b/scripts/generate-cli-manifest.ts
@@ -11,7 +11,7 @@
  */
 
 import { execSync } from "node:child_process";
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import _pkg from "../package.json" with { type: "json" };
 import { HELP_REGISTRY } from "../src/domains/help/help-commands.js";
@@ -51,6 +51,21 @@ if (import.meta.main) {
 	const outputPath = join(repoRoot, "cli-manifest.json");
 
 	const manifest = generateManifest();
+
+	// Reuse existing timestamp when nothing else changed — avoids churn on every
+	// `manifest:generate` run (a common source of "2 files modified" noise after
+	// running `ci:local` or the pre-push hook).
+	try {
+		const existing = JSON.parse(await readFile(outputPath, "utf-8")) as CliManifest;
+		const { generatedAt: _prev, ...existingRest } = existing;
+		const { generatedAt: _curr, ...newRest } = manifest;
+		if (JSON.stringify(existingRest) === JSON.stringify(newRest)) {
+			manifest.generatedAt = existing.generatedAt;
+		}
+	} catch {
+		// First-time generation or unreadable previous file — keep fresh timestamp.
+	}
+
 	// Use tab indent to match project biome formatter settings
 	const content = `${JSON.stringify(manifest, null, "\t")}\n`;
 

--- a/scripts/generate-cli-reference.ts
+++ b/scripts/generate-cli-reference.ts
@@ -13,7 +13,7 @@
  * Output: docs/cli-reference.md
  */
 
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { HELP_REGISTRY } from "../src/domains/help/help-commands.js";
 import type { CommandHelp, OptionGroup } from "../src/domains/help/help-types.js";
@@ -151,11 +151,31 @@ export function generateReference(): string {
 // CLI entrypoint
 // ---------------------------------------------------------------------------
 
+// Matches the timestamp footer this script emits, e.g.
+//   <!-- generated: 2026-05-14T14:39:42.781Z -->
+const TIMESTAMP_FOOTER_RE = /<!-- generated: [^>]+-->/;
+
 if (import.meta.main) {
 	const repoRoot = new URL("..", import.meta.url).pathname;
 	const outputPath = join(repoRoot, "docs", "cli-reference.md");
 
-	const content = generateReference();
+	let content = generateReference();
+
+	// Reuse the existing footer timestamp when the rest of the document is
+	// byte-identical — prevents every `docs:generate` run from dirtying the file.
+	try {
+		const existing = await readFile(outputPath, "utf-8");
+		const existingStripped = existing.replace(TIMESTAMP_FOOTER_RE, "");
+		const newStripped = content.replace(TIMESTAMP_FOOTER_RE, "");
+		if (existingStripped === newStripped) {
+			const existingFooter = existing.match(TIMESTAMP_FOOTER_RE)?.[0];
+			if (existingFooter) {
+				content = content.replace(TIMESTAMP_FOOTER_RE, existingFooter);
+			}
+		}
+	} catch {
+		// First-time generation or unreadable previous file — keep fresh timestamp.
+	}
 
 	await writeFile(outputPath, content, "utf-8");
 	console.log(`[OK] Generated: ${outputPath}`);


### PR DESCRIPTION
## Summary

- `manifest:generate` and `docs:generate` now only bump `generatedAt` / `<!-- generated -->` when the rest of the content actually changed.
- Eliminates the persistent "2 files modified" noise after every `ci:local` / pre-push run.

Closes #831

## Root Cause

Both scripts unconditionally called `new Date().toISOString()` on every run:
- `scripts/generate-cli-manifest.ts:43`
- `scripts/generate-cli-reference.ts:144`

CI already excluded these lines from drift checks (`.github/workflows/ci.yml:70`) and `CLAUDE.md` told humans to `git checkout` them — clear signal the bumping was pure noise.

## Approach

Read the existing output, compare the rest of the content byte-for-byte, reuse the previous timestamp when nothing else changed. Schema (`generatedAt: string`) and tests (`tests/scripts/cli-manifest.test.ts`) are unaffected — the field stays populated; only its value stabilizes.

## What changed

| File | Change |
|------|--------|
| `scripts/generate-cli-manifest.ts` | Read existing `cli-manifest.json`, reuse `generatedAt` when `{ version, commands }` are identical |
| `scripts/generate-cli-reference.ts` | Read existing `docs/cli-reference.md`, reuse footer when body (sans footer) is identical |
| `cli-manifest.json` | Regenerated for current `4.3.1-dev.1` version (separate `chore:` commit, the documented dev-pre-release self-heal) |

## Test plan

- [x] `bun run ci:local` passes
- [x] Running `manifest:generate && docs:generate` twice in a row produces zero diff on the second run
- [x] First run after a real content change still bumps the timestamp
- [x] Schema test (`tests/scripts/cli-manifest.test.ts`) still asserts ISO 8601 `generatedAt`
