### PR TITLE
fix: prune legacy descriptive-name prompt hook

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.1-dev.3",
-	"generatedAt": "2026-05-20T15:44:40.485Z",
+	"version": "4.3.1-dev.4",
+	"generatedAt": "2026-05-20T19:56:25.678Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/__tests__/domains/installation/merger/zombie-wirings-pruner.test.ts
+++ b/src/__tests__/domains/installation/merger/zombie-wirings-pruner.test.ts
@@ -112,6 +112,70 @@ function buildFixtureSettings(): SettingsJson {
 // Tests
 // ---------------------------------------------------------------------------
 describe("pruneZombieEngineerWirings", () => {
+	it("prunes legacy descriptive-name prompt hook that conflicts with language conventions", () => {
+		const settings = {
+			hooks: {
+				PreToolUse: [
+					{
+						matcher: "Write",
+						hooks: [
+							{
+								type: "prompt",
+								prompt:
+									"Use kebab-case file naming with a long descriptive name to ensure this file name is self-documenting, so that when LLM is using tools (Grep, Glob, Search) to list files, it can guess what the file does right away without reading the file.",
+							},
+							{
+								type: "command",
+								command: `node "${join(testHookDir, "simplify-gate.cjs")}"`,
+								_origin: "engineer",
+							},
+						],
+					},
+				],
+			},
+		} as unknown as SettingsJson;
+
+		const { pruned, settings: result } = pruneZombieEngineerWirings(settings, testHookDir);
+
+		expect(pruned).toContain("legacy-descriptive-name-prompt");
+		const remainingHooks = (result.hooks?.PreToolUse?.flatMap((group) =>
+			"hooks" in group ? (group.hooks ?? []) : [group],
+		) ?? []) as Array<{ command?: string; type?: string }>;
+		expect(remainingHooks.some((hook) => hook.type === "prompt")).toBe(false);
+		expect(remainingHooks.some((hook) => hook.command?.includes("simplify-gate.cjs"))).toBe(true);
+	});
+
+	it("preserves unrelated user prompt hooks", () => {
+		const settings = {
+			hooks: {
+				PreToolUse: [
+					{
+						matcher: "Write",
+						hooks: [
+							{
+								type: "prompt",
+								prompt: "Before writing files, check that generated docs include a support footer.",
+							},
+							{
+								type: "command",
+								command: `node "${join(testHookDir, "simplify-gate.cjs")}"`,
+								_origin: "engineer",
+							},
+						],
+					},
+				],
+			},
+		} as unknown as SettingsJson;
+
+		const { pruned, settings: result } = pruneZombieEngineerWirings(settings, testHookDir);
+
+		expect(pruned).not.toContain("legacy-descriptive-name-prompt");
+		const remainingHooks = (result.hooks?.PreToolUse?.flatMap((group) =>
+			"hooks" in group ? (group.hooks ?? []) : [group],
+		) ?? []) as Array<{ type?: string }>;
+		expect(remainingHooks.some((hook) => hook.type === "prompt")).toBe(true);
+	});
+
 	it("keeps A (engineer, exists), prunes B (engineer, missing skill-dedup.cjs)", () => {
 		const settings = buildFixtureSettings();
 		const { pruned } = pruneZombieEngineerWirings(settings, testHookDir);
@@ -575,12 +639,17 @@ describe("settings-processor integration — zombie wirings pruned post-merge", 
 			await writeFile(sourceFile, JSON.stringify(sourceSettings, null, 2), "utf8");
 
 			// Pre-populate destination with zombie wirings (v2.18.x shape)
-			const zombieSettings: SettingsJson = {
+			const zombieSettings = {
 				hooks: {
 					PreToolUse: [
 						{
 							matcher: "Bash",
 							hooks: [
+								{
+									type: "prompt",
+									prompt:
+										"Use kebab-case file naming with a long descriptive name to ensure this file name is self-documenting, so that when LLM is using tools (Grep, Glob, Search) to list files, it can guess what the file does right away without reading the file.",
+								},
 								{
 									type: "command",
 									command: `node "${join(testHookDir, "simplify-gate.cjs")}"`,
@@ -606,7 +675,7 @@ describe("settings-processor integration — zombie wirings pruned post-merge", 
 						},
 					],
 				},
-			};
+			} as unknown as SettingsJson;
 			const destFile = pathJoin(destDir, "settings.json");
 			await writeFile(destFile, JSON.stringify(zombieSettings, null, 2), "utf8");
 
@@ -629,8 +698,16 @@ describe("settings-processor integration — zombie wirings pruned post-merge", 
 					(g) => g.hooks?.map((h) => h.command) ?? [],
 				),
 			);
+			const allPromptHooks = Object.values(result.hooks ?? {}).flatMap((groups) =>
+				(groups as Array<{ hooks?: Array<{ prompt?: string; type?: string }> }>).flatMap(
+					(g) => g.hooks?.filter((h) => h.type === "prompt") ?? [],
+				),
+			);
 			expect(allCommands.some((c) => c.includes("skill-dedup.cjs"))).toBe(false);
 			expect(allCommands.some((c) => c.includes("node-hook-runner.sh"))).toBe(false);
+			expect(allPromptHooks.some((h) => h.prompt?.includes("Use kebab-case file naming"))).toBe(
+				false,
+			);
 			// simplify-gate.cjs should still be present
 			expect(allCommands.some((c) => c.includes("simplify-gate.cjs"))).toBe(true);
 		} finally {

--- a/src/domains/installation/merger/zombie-wirings-pruner.ts
+++ b/src/domains/installation/merger/zombie-wirings-pruner.ts
@@ -11,6 +11,9 @@
  *
  * Conservative by design: entries without `_origin: "engineer"` are NEVER pruned,
  * even if the referenced file is missing. This preserves user-added wirings.
+ * Exception: known legacy ClaudeKit prompt hooks with the old hard-coded
+ * descriptive-name text are pruned because they conflict with the current
+ * language-aware command hook and cannot self-heal via missing-file checks.
  */
 import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
@@ -97,6 +100,11 @@ export function pruneZombieEngineerWirings(settings: SettingsJson, hookDir: stri
  * Side-effect: pushes the basename to `pruned` list when pruning.
  */
 function shouldPruneEntry(entry: HookEntry, hookDir: string, pruned: string[]): boolean {
+	if (isLegacyDescriptiveNamePrompt(entry)) {
+		pruned.push("legacy-descriptive-name-prompt");
+		return true;
+	}
+
 	// Conservative: only prune entries explicitly tagged as engineer-origin
 	if (entry._origin !== "engineer") return false;
 
@@ -108,6 +116,17 @@ function shouldPruneEntry(entry: HookEntry, hookDir: string, pruned: string[]): 
 	// File missing and engineer-tagged — prune
 	pruned.push(basename(filePath));
 	return true;
+}
+
+function isLegacyDescriptiveNamePrompt(entry: HookEntry): boolean {
+	const prompt = (entry as HookEntry & { prompt?: unknown }).prompt;
+	if (entry.type !== "prompt" || typeof prompt !== "string") return false;
+
+	return (
+		prompt.includes("Use kebab-case file naming") &&
+		prompt.includes("self-documenting") &&
+		prompt.includes("Grep, Glob, Search")
+	);
 }
 
 /**

--- a/src/schemas/ck-config.schema.json
+++ b/src/schemas/ck-config.schema.json
@@ -457,7 +457,7 @@
 				"descriptive-name": {
 					"type": "boolean",
 					"default": true,
-					"description": "PreToolUse hook - enforces kebab-case descriptive file naming for scripts"
+					"description": "PreToolUse hook - injects language-aware descriptive file naming guidance"
 				},
 				"dev-rules-reminder": {
 					"type": "boolean",

--- a/src/ui/src/services/configFieldDocs.ts
+++ b/src/ui/src/services/configFieldDocs.ts
@@ -476,13 +476,13 @@ export const CONFIG_FIELD_DOCS: Record<string, FieldDoc> = {
 		type: "boolean",
 		default: "true",
 		description:
-			"Injects descriptive naming context so agents generate meaningful, self-documenting file and variable names.",
+			"Injects language-aware naming context so agents generate meaningful, self-documenting file names.",
 		descriptionVi:
-			"Tiêm ngữ cảnh đặt tên mô tả để agent tạo tên tệp và biến có ý nghĩa, tự tài liệu hóa.",
+			"Tiêm ngữ cảnh đặt tên theo ngôn ngữ để agent tạo tên tệp có ý nghĩa, tự tài liệu hóa.",
 		effect:
-			"When enabled, reminds the agent to use long, descriptive kebab-case names for files and clear variable naming conventions.",
+			"When enabled, reminds the agent to prefer descriptive names while respecting language conventions such as snake_case for Python, Go, and Rust.",
 		effectVi:
-			"Khi bật, nhắc nhở agent sử dụng tên kebab-case dài, mô tả cho tệp và quy ước đặt tên biến rõ ràng.",
+			"Khi bật, nhắc agent ưu tiên tên mô tả nhưng vẫn theo quy ước ngôn ngữ như snake_case cho Python, Go và Rust.",
 		example: '{\n  "hooks": {\n    "descriptive-name": false\n  }\n}',
 	},
 	"hooks.dev-rules-reminder": {


### PR DESCRIPTION
## Summary
- prune the known legacy prompt-based descriptive-name hook during settings merge cleanup
- preserve unrelated user prompt hooks and existing command hook behavior
- update config schema/UI copy to describe the hook as language-aware guidance
- regenerate cli-manifest for the current dev version

## Root Cause
Current engineer installs use the `descriptive-name.cjs` command hook, but older Claude settings can still contain a prompt-based `PreToolUse` Write hook with hard-coded kebab-case guidance. The CLI merge path preserved that prompt because it was neither an engineer-origin command entry nor a missing-file zombie, so users kept seeing stale naming rejections for Python-style `snake_case` files.

## Validation
- `bun test src/__tests__/domains/installation/merger/zombie-wirings-pruner.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- pre-push local CI parity: 4825 pass, 59 skip, 0 fail
- UI Vitest: 150 pass

Closes #838