### PR TITLE
fix: self-heal hook references after init

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.1-dev.5",
-	"generatedAt": "2026-05-20T20:22:57.440Z",
+	"version": "4.3.1-dev.6",
+	"generatedAt": "2026-05-20T20:38:54.075Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
@@ -12,6 +12,7 @@ import {
 	checkHookRuntime,
 	checkHookSyntax,
 	checkPythonVenv,
+	repairMissingHookFileReferences,
 } from "@/domains/health-checks/checkers/hook-health-checker.js";
 
 describe("checkHookSyntax", () => {
@@ -960,6 +961,38 @@ describe("checkHookFileReferences", () => {
 		const updated = JSON.parse(await readFile(settingsPath, "utf-8"));
 		expect(updated.statusLine).toBeUndefined();
 		expect(updated.otherField).toBe("preserved");
+	});
+
+	test("shared repair helper prunes stale hook references and returns count", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		const settingsPath = join(projectDir, ".claude", "settings.json");
+		await writeFile(
+			settingsPath,
+			JSON.stringify({
+				statusLine: {
+					command: "bash .claude/hooks/node-hook-runner.sh .claude/statusline.cjs",
+				},
+				hooks: {
+					Stop: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-state.cjs',
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+
+		const repaired = await repairMissingHookFileReferences(projectDir);
+
+		expect(repaired).toBe(2);
+		const updated = JSON.parse(await readFile(settingsPath, "utf-8"));
+		expect(updated.statusLine).toBeUndefined();
+		expect(updated.hooks).toBeUndefined();
 	});
 
 	test("returns fail when settings reference a missing hook file", async () => {

--- a/src/commands/init/init-command.ts
+++ b/src/commands/init/init-command.ts
@@ -4,6 +4,7 @@
  */
 
 import { GitHubClient } from "@/domains/github/github-client.js";
+import { repairMissingHookFileReferences } from "@/domains/health-checks/checkers/hook-health-checker.js";
 import { maybeShowConfigUpdateNotification } from "@/domains/sync/index.js";
 import { PromptsManager } from "@/domains/ui/prompts.js";
 import { logger } from "@/shared/logger.js";
@@ -140,6 +141,24 @@ function createInitContext(rawOptions: UpdateCommandOptions, prompts: PromptsMan
 	};
 }
 
+async function repairMissingHookFileReferencesAfterInit(ctx: InitContext): Promise<void> {
+	if (!ctx.resolvedDir) return;
+
+	const projectDir = ctx.options.global ? process.cwd() : ctx.resolvedDir;
+	try {
+		const repaired = await repairMissingHookFileReferences(projectDir);
+		if (repaired > 0) {
+			logger.info(`Repaired ${repaired} missing hook file reference(s)`);
+		}
+	} catch (error) {
+		logger.debug(
+			`Hook file reference repair skipped after init: ${
+				error instanceof Error ? error.message : "unknown"
+			}`,
+		);
+	}
+}
+
 /**
  * Internal init command implementation
  * Runs all phases in sequence, passing context through each
@@ -240,6 +259,10 @@ async function executeInit(options: UpdateCommandOptions, prompts: PromptsManage
 		logger.success(
 			`\nInstalled ${installedKits.length} kits: ${installedKits.map((k) => AVAILABLE_KITS[k].name).join(", ")}`,
 		);
+	}
+
+	if (!isSyncMode) {
+		await repairMissingHookFileReferencesAfterInit(ctx);
 	}
 
 	// Success outro (only for normal mode - sync has its own outro)

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -9,6 +9,7 @@ import { exec, spawn } from "node:child_process";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { CkConfigManager } from "@/domains/config/ck-config-manager.js";
+import { repairMissingHookFileReferences } from "@/domains/health-checks/checkers/hook-health-checker.js";
 import { getInstalledKits } from "@/domains/migration/metadata-migration.js";
 import { versionsMatch } from "@/domains/versioning/checking/version-utils.js";
 import { getClaudeKitSetup } from "@/services/file-operations/claudekit-scanner.js";
@@ -390,23 +391,7 @@ export interface PromptMigrateUpdateDeps {
 	>;
 }
 
-export async function repairMissingHookFileReferences(projectDir = process.cwd()): Promise<number> {
-	const { checkHookFileReferences } = await import(
-		"@/domains/health-checks/checkers/hook-health-checker.js"
-	);
-	const result = await checkHookFileReferences(projectDir);
-	if (result.status !== "fail" || !result.fix) {
-		return 0;
-	}
-
-	const fixResult = await result.fix.execute();
-	if (!fixResult.success) {
-		throw new Error(fixResult.message);
-	}
-
-	const match = fixResult.message.match(/Pruned\s+(\d+)/);
-	return match?.[1] ? Number.parseInt(match[1], 10) : 0;
-}
+export { repairMissingHookFileReferences };
 
 /**
  * Step 3 of the update pipeline: independently check and run migration.

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -1005,6 +1005,21 @@ export async function checkHookFileReferences(projectDir: string): Promise<Check
 	};
 }
 
+export async function repairMissingHookFileReferences(projectDir = process.cwd()): Promise<number> {
+	const result = await checkHookFileReferences(projectDir);
+	if (result.status !== "fail" || !result.fix) {
+		return 0;
+	}
+
+	const fixResult = await result.fix.execute();
+	if (!fixResult.success) {
+		throw new Error(fixResult.message);
+	}
+
+	const match = fixResult.message.match(/Pruned\s+(\d+)/);
+	return match?.[1] ? Number.parseInt(match[1], 10) : 0;
+}
+
 /**
  * Check hook configuration validity
  */


### PR DESCRIPTION
## Summary
- run missing hook reference self-heal at the end of `ck init`
- move the hook self-heal helper into the hook health checker so update and init share the same repair path
- keep the repair best-effort/non-fatal and cover the shared helper with regression coverage

## Why
Older `ck update --dev -y` processes keep running the old in-memory update handler after installing the new CLI, but they invoke `ck init` through the newly installed binary in the same run. Running the repair in init closes that first-update self-heal gap for stale `node-hook-runner.sh` settings.

## Tests
- bun test src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts src/__tests__/commands/update-cli-migrate-step.test.ts
- bun run typecheck
- bun run lint
- bun run build
- pre-push local CI parity

Closes #842