### PR TITLE
fix: self-heal missing hook dependencies on update

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.1-dev.6",
-	"generatedAt": "2026-05-20T20:38:54.075Z",
+	"version": "4.3.1-dev.7",
+	"generatedAt": "2026-05-20T21:14:42.914Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/__tests__/commands/update-cli-auto-init.test.ts
+++ b/src/__tests__/commands/update-cli-auto-init.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PromptKitUpdateDeps } from "@/commands/update-cli.js";
@@ -215,6 +215,23 @@ describe("promptKitUpdate auto-init behavior", () => {
 		await promptKitUpdate(false, true, deps);
 		expect(execCount()).toBe(0);
 		expect(spawnCount()).toBe(0);
+	});
+
+	test("reinstalls latest kit when installed hooks have missing dependencies (--yes mode)", async () => {
+		const hooksDir = join(tempDir, "hooks");
+		await mkdir(hooksDir, { recursive: true });
+		await writeFile(
+			join(hooksDir, "usage-context-awareness.cjs"),
+			"const quota = require('./usage-quota-cache-refresh.cjs');\nconsole.log(quota);\n",
+		);
+
+		const { deps, execCount, spawnCount, capturedExecCmd } = makeDeps();
+		deps.getLatestReleaseTagFn = async () => "v1.0.0";
+		await promptKitUpdate(false, true, deps);
+		expect(execCount()).toBe(1);
+		expect(spawnCount()).toBe(0);
+		expect(capturedExecCmd()).toContain("--yes");
+		expect(capturedExecCmd()).toContain("--kit engineer");
 	});
 
 	test("interactive mode passes --beta when installed version is prerelease", async () => {

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
@@ -13,7 +13,19 @@ import {
 	checkHookSyntax,
 	checkPythonVenv,
 	repairMissingHookFileReferences,
+	resolveDoctorCkExecutable,
 } from "@/domains/health-checks/checkers/hook-health-checker.js";
+
+describe("resolveDoctorCkExecutable", () => {
+	test("uses the npm cmd shim on Windows", () => {
+		expect(resolveDoctorCkExecutable("win32")).toBe("ck.cmd");
+	});
+
+	test("uses ck directly on POSIX platforms", () => {
+		expect(resolveDoctorCkExecutable("darwin")).toBe("ck");
+		expect(resolveDoctorCkExecutable("linux")).toBe("ck");
+	});
+});
 
 describe("checkHookSyntax", () => {
 	let tempDir: string;

--- a/src/commands/portable/__tests__/migrated-hooks-cleanup.test.ts
+++ b/src/commands/portable/__tests__/migrated-hooks-cleanup.test.ts
@@ -27,10 +27,12 @@ describe("cleanupMigratedHooksForProviders", () => {
 		const hooksDir = join(testDir, ".codex", "hooks");
 		const hookPath = join(hooksDir, "session-init.cjs");
 		const contextHookPath = join(hooksDir, "usage-context-awareness.cjs");
+		const usageQuotaHookPath = join(hooksDir, "usage-quota-cache-refresh.cjs");
 		const safeHookPath = join(hooksDir, "privacy-block.cjs");
 		await mkdir(hooksDir, { recursive: true });
 		await writeFile(hookPath, "// migrated hook");
 		await writeFile(contextHookPath, "// migrated hook");
+		await writeFile(usageQuotaHookPath, "// current default hook");
 		await writeFile(safeHookPath, "// safe hook");
 		await writeFile(
 			join(testDir, ".codex", "hooks.json"),
@@ -42,6 +44,7 @@ describe("cleanupMigratedHooksForProviders", () => {
 								hooks: [
 									{ type: "command", command: `node "${hookPath}"` },
 									{ type: "command", command: `node "${contextHookPath}"` },
+									{ type: "command", command: `node "${usageQuotaHookPath}"` },
 									{ type: "command", command: `node "${safeHookPath}"` },
 									{ type: "command", command: "echo user-owned" },
 								],
@@ -63,10 +66,12 @@ describe("cleanupMigratedHooksForProviders", () => {
 		expect(results[0]?.filesRemoved).toBe(2);
 		expect(existsSync(hookPath)).toBe(false);
 		expect(existsSync(contextHookPath)).toBe(false);
+		expect(existsSync(usageQuotaHookPath)).toBe(true);
 		expect(existsSync(safeHookPath)).toBe(true);
 
 		const hooksJson = JSON.parse(await readFile(join(testDir, ".codex", "hooks.json"), "utf8"));
 		expect(hooksJson.hooks.SessionStart[0].hooks).toEqual([
+			{ type: "command", command: `node "${usageQuotaHookPath}"` },
 			{ type: "command", command: `node "${safeHookPath}"` },
 			{ type: "command", command: "echo user-owned" },
 		]);
@@ -76,10 +81,12 @@ describe("cleanupMigratedHooksForProviders", () => {
 		const hooksDir = join(testDir, ".claude", "hooks");
 		const runnerPath = join(hooksDir, "node-hook-runner.sh");
 		const hookPath = join(hooksDir, "session-init.cjs");
+		const usageQuotaHookPath = join(hooksDir, "usage-quota-cache-refresh.cjs");
 		const safeHookPath = join(hooksDir, "privacy-block.cjs");
 		await mkdir(hooksDir, { recursive: true });
 		await writeFile(runnerPath, "#!/bin/sh\n");
 		await writeFile(hookPath, "// migrated hook");
+		await writeFile(usageQuotaHookPath, "// current default hook");
 		await writeFile(safeHookPath, "// safe hook");
 		await writeFile(
 			join(testDir, ".claude", "settings.json"),
@@ -96,6 +103,10 @@ describe("cleanupMigratedHooksForProviders", () => {
 										type: "command",
 										command:
 											"bash .claude/hooks/node-hook-runner.sh .claude/hooks/session-init.cjs",
+									},
+									{
+										type: "command",
+										command: "node .claude/hooks/usage-quota-cache-refresh.cjs",
 									},
 								],
 							},
@@ -125,11 +136,14 @@ describe("cleanupMigratedHooksForProviders", () => {
 
 		expect(results[0]?.hooksPruned).toBe(1);
 		expect(existsSync(hookPath)).toBe(false);
+		expect(existsSync(usageQuotaHookPath)).toBe(true);
 		expect(existsSync(safeHookPath)).toBe(true);
 		expect(existsSync(runnerPath)).toBe(true);
 
 		const settings = JSON.parse(await readFile(join(testDir, ".claude", "settings.json"), "utf8"));
-		expect(settings.hooks.SessionStart).toBeUndefined();
+		expect(settings.hooks.SessionStart[0].hooks).toEqual([
+			{ type: "command", command: "node .claude/hooks/usage-quota-cache-refresh.cjs" },
+		]);
 		expect(settings.hooks.PreToolUse[0].hooks[0].command).toContain("privacy-block.cjs");
 		expect(settings.statusLine.command).toContain("node-hook-runner.sh");
 	});

--- a/src/commands/portable/generated-context-hooks.ts
+++ b/src/commands/portable/generated-context-hooks.ts
@@ -9,7 +9,6 @@ const GENERATED_CONTEXT_HOOK_FILENAMES = new Set([
 	"subagent-init.cjs",
 	"team-context-inject.cjs",
 	"usage-context-awareness.cjs",
-	"usage-quota-cache-refresh.cjs",
 ]);
 
 // Keep this list in sync with claudekit-engineer metadata deletions and default hook settings.

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -6,6 +6,9 @@
  */
 
 import { exec, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { builtinModules } from "node:module";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { CkConfigManager } from "@/domains/config/ck-config-manager.js";
@@ -34,6 +37,7 @@ const execAsync = promisify(exec);
 
 // Only allow alphanumeric chars and hyphens in provider names (defense-in-depth against injection)
 const SAFE_PROVIDER_NAME = /^[a-z0-9-]+$/;
+const HOOK_DEPENDENCY_EXTENSIONS = [".js", ".cjs", ".mjs", ".json"];
 
 // ─── Kit selection ────────────────────────────────────────────────────────────
 
@@ -208,6 +212,39 @@ export interface PromptKitUpdateDeps {
 	loadFullConfigFn?: PromptKitUpdateConfigLoader;
 	confirmFn?: PromptKitUpdateConfirmFn;
 	isCancelFn?: PromptKitUpdateCancelFn;
+	findMissingHookDependenciesFn?: (claudeDir: string) => Promise<string[]>;
+}
+
+async function findMissingHookDependencies(claudeDir: string): Promise<string[]> {
+	const hooksDir = join(claudeDir, "hooks");
+	if (!existsSync(hooksDir)) return [];
+
+	const files = await readdir(hooksDir);
+	const cjsFiles = files.filter((file) => file.endsWith(".cjs"));
+	const missing: string[] = [];
+	const nodeBuiltins = new Set([
+		...builtinModules,
+		...builtinModules.map((name) => `node:${name}`),
+	]);
+
+	for (const file of cjsFiles) {
+		const content = await readFile(join(hooksDir, file), "utf8");
+		const requireRegex = /require\(['"]([^'"]+)['"]\)/g;
+		for (let match = requireRegex.exec(content); match; match = requireRegex.exec(content)) {
+			const depPath = match[1];
+			if (!depPath || nodeBuiltins.has(depPath) || !depPath.startsWith(".")) continue;
+			const resolvedPath = join(hooksDir, depPath);
+			const exists =
+				existsSync(resolvedPath) ||
+				HOOK_DEPENDENCY_EXTENSIONS.some((ext) => existsSync(resolvedPath + ext)) ||
+				existsSync(join(resolvedPath, "index.js")) ||
+				existsSync(join(resolvedPath, "index.cjs")) ||
+				existsSync(join(resolvedPath, "index.mjs"));
+			if (!exists) missing.push(`${file}: ${depPath}`);
+		}
+	}
+
+	return missing;
 }
 
 /**
@@ -227,6 +264,8 @@ export async function promptKitUpdate(
 		const confirmFn = deps?.confirmFn ?? confirm;
 		const isCancelFn = deps?.isCancelFn ?? isCancel;
 		const getSetupFn = deps?.getSetupFn ?? getClaudeKitSetup;
+		const findMissingHookDepsFn =
+			deps?.findMissingHookDependenciesFn ?? findMissingHookDependencies;
 		const setup = await getSetupFn();
 		const hasLocal = !!setup.project.metadata;
 		const hasGlobal = !!setup.global.metadata;
@@ -263,12 +302,28 @@ export async function promptKitUpdate(
 			const getTagFn = deps?.getLatestReleaseTagFn ?? fetchLatestReleaseTag;
 			const latestTag = await getTagFn(selection.kit, beta || isBetaInstalled);
 			if (latestTag && versionsMatch(kitVersion, latestTag)) {
-				logger.success(
-					`Already at latest version (${selection.kit}@${kitVersion}), skipping reinstall`,
-				);
 				alreadyAtLatest = true;
 			} else if (latestTag) {
 				logger.info(`Kit update available: ${kitVersion} -> ${latestTag}`);
+			}
+		}
+
+		if (alreadyAtLatest) {
+			try {
+				const claudeDir = selection.isGlobal ? setup.global.path : setup.project.path;
+				const missingHookDeps = claudeDir ? await findMissingHookDepsFn(claudeDir) : [];
+				if (missingHookDeps.length > 0) {
+					logger.warning(
+						`Detected ${missingHookDeps.length} missing hook dependency(ies); reinstalling kit content`,
+					);
+					alreadyAtLatest = false;
+				}
+			} catch (error) {
+				logger.verbose(
+					`Hook dependency self-heal check skipped: ${
+						error instanceof Error ? error.message : "unknown"
+					}`,
+				);
 			}
 		}
 
@@ -281,7 +336,12 @@ export async function promptKitUpdate(
 			// Non-fatal — fall back to manual prompt
 		}
 
-		if (alreadyAtLatest && !autoInit) return;
+		if (alreadyAtLatest && !autoInit) {
+			logger.success(
+				`Already at latest version (${selection.kit}@${kitVersion}), skipping reinstall`,
+			);
+			return;
+		}
 
 		// Prompt user unless --yes, autoInit, or already at latest
 		if (!yes && !autoInit) {

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -15,6 +15,12 @@ const HOOK_CHECK_TIMEOUT_MS = 5000;
 const PYTHON_CHECK_TIMEOUT_MS = 3000;
 const MAX_LOG_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
 
+export function resolveDoctorCkExecutable(
+	platformName: NodeJS.Platform = process.platform,
+): string {
+	return platformName === "win32" ? "ck.cmd" : "ck";
+}
+
 export interface ClaudeSettingsFile {
 	path: string;
 	label: string;
@@ -1348,7 +1354,7 @@ export async function checkHookLogs(projectDir: string): Promise<CheckResult> {
 export async function checkCliVersion(): Promise<CheckResult> {
 	try {
 		// Try to get installed version from ck -V command
-		const versionResult = spawnSync("ck", ["-V"], {
+		const versionResult = spawnSync(resolveDoctorCkExecutable(), ["-V"], {
 			timeout: HOOK_CHECK_TIMEOUT_MS,
 			encoding: "utf-8",
 		});


### PR DESCRIPTION
## Summary
- preserve usage-quota-cache-refresh.cjs during generated-context hook cleanup
- force kit reinstall during ck update --yes when installed hook files have missing relative require() dependencies
- use ck.cmd for ck doctor CLI version checks on Windows so stale Bun ck.exe does not shadow npm installs
- regenerate cli-manifest.json for 4.3.1-dev.7

## Validation
- bun run typecheck
- bun run lint
- bun run build
- bun test
- pre-push local CI parity, packaged CLI smoke, and UI vitest suite

Docs impact: none
Action: no docs site update needed — internal update/self-heal and doctor resolution behavior only.