### PR TITLE
fix: repair doctor version and post-heal reporting

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.1-dev.7",
-	"generatedAt": "2026-05-20T21:14:42.914Z",
+	"version": "4.3.1-dev.8",
+	"generatedAt": "2026-05-20T21:36:09.363Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
@@ -12,6 +12,7 @@ import {
 	checkHookRuntime,
 	checkHookSyntax,
 	checkPythonVenv,
+	parseDoctorCliVersionOutput,
 	repairMissingHookFileReferences,
 	resolveDoctorCkExecutable,
 } from "@/domains/health-checks/checkers/hook-health-checker.js";
@@ -24,6 +25,26 @@ describe("resolveDoctorCkExecutable", () => {
 	test("uses ck directly on POSIX platforms", () => {
 		expect(resolveDoctorCkExecutable("darwin")).toBe("ck");
 		expect(resolveDoctorCkExecutable("linux")).toBe("ck");
+	});
+});
+
+describe("parseDoctorCliVersionOutput", () => {
+	test("extracts the version from current ck -V output", () => {
+		expect(
+			parseDoctorCliVersionOutput(
+				"CLI Version: 4.3.1-dev.8\nGlobal Kit Version: engineer@v2.19.1-beta.9\n",
+			),
+		).toBe("4.3.1-dev.8");
+	});
+
+	test("extracts bare semantic version output", () => {
+		expect(parseDoctorCliVersionOutput("v4.3.1\n")).toBe("4.3.1");
+		expect(parseDoctorCliVersionOutput("4.3.1-dev.8\n")).toBe("4.3.1-dev.8");
+	});
+
+	test("returns null for unrecognized output", () => {
+		expect(parseDoctorCliVersionOutput("Global Kit Version: engineer@v2.19.1-beta.9")).toBeNull();
+		expect(parseDoctorCliVersionOutput("")).toBeNull();
 	});
 });
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -39,21 +39,7 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<void> 
 		intro("ClaudeKit Health Check");
 	}
 
-	// Create and configure runner
-	const runner = new CheckRunner(runnerOptions);
-
-	// Register checkers
-	runner.registerChecker(new SystemChecker());
-	runner.registerChecker(new ClaudekitChecker());
-	runner.registerChecker(new AuthChecker());
-	runner.registerChecker(new PlatformChecker());
-	runner.registerChecker(new NetworkChecker());
-	// Always-on layered GitHub reachability probe (DNS → TCP → TLS → Auth)
-	// TODO(#766-followup): The auth layer overlaps with AuthChecker.checkRepositoryAccess
-	// — both call repos.get for the engineer kit. Consider deprecating AuthChecker's
-	// repo-access call in favour of this layered version, or making the reachability
-	// checker skip the auth layer when AuthChecker is also registered.
-	runner.registerChecker(new GitHubReachabilityChecker());
+	const runner = createDoctorRunner(runnerOptions);
 
 	// Run all checks
 	const summary = await runner.run();
@@ -80,9 +66,7 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<void> 
 		return;
 	}
 
-	// Display interactive results (pass verbose flag for enhanced output)
 	const renderer = new DoctorUIRenderer({ verbose: runnerOptions.verbose });
-	renderer.renderResults(summary);
 
 	// Handle --fix flag
 	if (fix) {
@@ -91,15 +75,31 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<void> 
 			const healSummary = await healer.healAll(summary.checks);
 			renderer.renderHealingSummary(healSummary);
 
-			if (healSummary.failed === 0 && healSummary.succeeded > 0) {
-				outro("All fixable issues resolved!");
-				return;
+			const finalSummary =
+				healSummary.succeeded > 0 ? await createDoctorRunner(runnerOptions).run() : summary;
+			renderer.renderResults(finalSummary);
+
+			if (checkOnly && finalSummary.failed > 0) {
+				process.exitCode = 1;
 			}
+
+			if (healSummary.failed > 0) {
+				process.exitCode = 1;
+				outro(`${healSummary.failed} auto-fix attempt(s) failed`);
+			} else if (finalSummary.failed === 0) {
+				outro(healSummary.succeeded > 0 ? "All fixable issues resolved!" : "All checks passed!");
+			} else {
+				outro(`${finalSummary.failed} issue(s) remain after auto-heal`);
+			}
+			return;
 		} catch (error) {
 			logger.error(`Auto-fix failed: ${error instanceof Error ? error.message : "Unknown error"}`);
 			process.exitCode = 1;
 		}
 	}
+
+	// Display interactive results (pass verbose flag for enhanced output)
+	renderer.renderResults(summary);
 
 	// Handle --check-only mode exit code
 	if (checkOnly && summary.failed > 0) {
@@ -130,4 +130,17 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<void> 
 	} else {
 		outro(`${summary.failed} issue(s) found`);
 	}
+}
+
+function createDoctorRunner(options: CheckRunnerOptions): CheckRunner {
+	const runner = new CheckRunner(options);
+	runner.registerChecker(new SystemChecker());
+	runner.registerChecker(new ClaudekitChecker());
+	runner.registerChecker(new AuthChecker());
+	runner.registerChecker(new PlatformChecker());
+	runner.registerChecker(new NetworkChecker());
+	// Always-on layered GitHub reachability probe (DNS -> TCP -> TLS -> Auth)
+	// TODO(#766-followup): The auth layer overlaps with AuthChecker.checkRepositoryAccess.
+	runner.registerChecker(new GitHubReachabilityChecker());
+	return runner;
 }

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -21,6 +21,20 @@ export function resolveDoctorCkExecutable(
 	return platformName === "win32" ? "ck.cmd" : "ck";
 }
 
+export function parseDoctorCliVersionOutput(output: string): string | null {
+	if (!output.trim()) {
+		return null;
+	}
+
+	const labeledMatch = output.match(/CLI Version:\s*v?(\d+\.\d+\.\d+(?:-[^\s]+)?)/);
+	if (labeledMatch?.[1]) {
+		return labeledMatch[1];
+	}
+
+	const bareMatch = output.trim().match(/^v?(\d+\.\d+\.\d+(?:-[^\s]+)?)/);
+	return bareMatch?.[1] ?? null;
+}
+
 export interface ClaudeSettingsFile {
 	path: string;
 	label: string;
@@ -1359,12 +1373,12 @@ export async function checkCliVersion(): Promise<CheckResult> {
 			encoding: "utf-8",
 		});
 
-		let installedVersion = "unknown";
+		let installedVersion: string | null = null;
 		if (versionResult.status === 0 && versionResult.stdout) {
-			installedVersion = versionResult.stdout.trim();
+			installedVersion = parseDoctorCliVersionOutput(versionResult.stdout);
 		}
 
-		if (installedVersion === "unknown") {
+		if (!installedVersion) {
 			return {
 				id: "cli-version",
 				name: "CLI Version",

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { doctorCommand } from "@/commands/doctor.js";
 import { getClaudeKitSetup } from "@/services/file-operations/claudekit-scanner.js";
@@ -58,6 +58,7 @@ describe("Doctor Command", () => {
 	});
 
 	afterEach(async () => {
+		process.exitCode = 0;
 		// Cleanup test directory
 		if (testDir) {
 			await rm(testDir, { recursive: true, force: true });
@@ -235,6 +236,73 @@ describe("Doctor Command", () => {
 				}
 			}
 		}, 30000); // 30 second timeout
+
+		test("fix mode re-runs checks and renders the post-fix state", async () => {
+			for (let i = 0; i < 20; i++) {
+				const skillDir = join(mockClaudeDir, "skills", `budget-skill-${i}`);
+				await mkdir(skillDir, { recursive: true });
+				await writeFile(
+					join(skillDir, "SKILL.md"),
+					[
+						"---",
+						`name: ck:budget-skill-${i}`,
+						`description: Short description ${i}`,
+						"---",
+						"",
+						`# Budget Skill ${i}`,
+					].join("\n"),
+					"utf8",
+				);
+			}
+
+			const originalCwd = process.cwd();
+			const originalCI = process.env.CI;
+			const originalNodeEnv = process.env.NODE_ENV;
+			const originalCkTestHome = process.env.CK_TEST_HOME;
+			const originalConsoleLog = console.log;
+			const output: string[] = [];
+			console.log = (...args: unknown[]) => {
+				output.push(args.map(String).join(" "));
+			};
+			process.env.CI = "true";
+			process.env.NODE_ENV = "test";
+			process.env.CK_TEST_HOME = testDir;
+			process.exitCode = 0;
+
+			try {
+				process.chdir(testDir);
+
+				await doctorCommand({ fix: true });
+
+				const rendered = output.join("\n");
+				expect(rendered).toContain("AUTO-HEAL RESULTS");
+				expect(rendered).toContain("Project defaults configured");
+				expect(rendered).not.toContain("Needs skillListingBudgetFraction");
+
+				const settings = JSON.parse(await readFile(join(mockClaudeDir, "settings.json"), "utf8"));
+				expect(settings.skillListingBudgetFraction).toBeGreaterThanOrEqual(0.03);
+				expect(settings.skillListingMaxDescChars).toBe(512);
+			} finally {
+				console.log = originalConsoleLog;
+				process.chdir(originalCwd);
+				process.exitCode = 0;
+				if (originalCI === undefined) {
+					process.env.CI = undefined;
+				} else {
+					process.env.CI = originalCI;
+				}
+				if (originalNodeEnv === undefined) {
+					process.env.NODE_ENV = undefined;
+				} else {
+					process.env.NODE_ENV = originalNodeEnv;
+				}
+				if (originalCkTestHome === undefined) {
+					process.env.CK_TEST_HOME = undefined;
+				} else {
+					process.env.CK_TEST_HOME = originalCkTestHome;
+				}
+			}
+		}, 30000);
 	});
 
 	describe("Component counting logic", () => {


### PR DESCRIPTION
## Summary
- parse multiline `ck -V` output in doctor so CLI version checks understand current dev output
- re-run doctor checks after successful `ck doctor --fix` and render the post-heal state
- add regression coverage for skill budget auto-heal output

## Validation
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun test`
- pre-push local CI parity, including UI build and UI Vitest: 150 passed

Docs impact: none
Action: no update needed — internal doctor diagnostics/reporting behavior only