### PR TITLE
fix: prune legacy hook prompts during health checks

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.1-dev.8",
-	"generatedAt": "2026-05-20T21:36:09.363Z",
+	"version": "4.3.1-dev.9",
+	"generatedAt": "2026-05-21T00:57:46.294Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/__tests__/commands/update-cli-migrate-step.test.ts
+++ b/src/__tests__/commands/update-cli-migrate-step.test.ts
@@ -24,6 +24,7 @@ const loadFullConfigMock = mock(
 const execCalls: string[] = [];
 const cleanupCalls: Array<{ providers: string[]; global: boolean }> = [];
 const repairCalls: string[] = [];
+const legacyRepairCalls: string[] = [];
 const orderedCalls: string[] = [];
 
 function makeDeps(): PromptMigrateUpdateDeps {
@@ -58,6 +59,11 @@ function makeDeps(): PromptMigrateUpdateDeps {
 			repairCalls.push(projectDir);
 			return 0;
 		},
+		repairLegacyHookPromptsFn: async (projectDir) => {
+			orderedCalls.push("legacy");
+			legacyRepairCalls.push(projectDir);
+			return 0;
+		},
 	};
 }
 
@@ -66,6 +72,7 @@ describe("promptMigrateUpdate (step 3 of update pipeline)", () => {
 		execCalls.length = 0;
 		cleanupCalls.length = 0;
 		repairCalls.length = 0;
+		legacyRepairCalls.length = 0;
 		orderedCalls.length = 0;
 		detectInstalledProvidersMock.mockReset();
 		detectInstalledProvidersMock.mockResolvedValue([]);
@@ -93,6 +100,7 @@ describe("promptMigrateUpdate (step 3 of update pipeline)", () => {
 	test("skips when autoMigrateAfterUpdate is not configured", async () => {
 		detectInstalledProvidersMock.mockResolvedValue(["claude-code", "codex"]);
 		await promptMigrateUpdate(makeDeps());
+		expect(legacyRepairCalls).toEqual([process.cwd(), process.cwd()]);
 		expect(repairCalls).toEqual([process.cwd(), process.cwd()]);
 		expect(execCalls).toEqual([]);
 	});
@@ -102,7 +110,23 @@ describe("promptMigrateUpdate (step 3 of update pipeline)", () => {
 			config: { updatePipeline: { autoMigrateAfterUpdate: true } },
 		});
 		await promptMigrateUpdate(makeDeps());
+		expect(legacyRepairCalls).toEqual([process.cwd()]);
 		expect(repairCalls).toEqual([process.cwd()]);
+		expect(execCalls).toEqual([]);
+	});
+
+	test("logs legacy hook prompt repairs even when no providers are detected", async () => {
+		const deps = makeDeps();
+		deps.repairLegacyHookPromptsFn = async (projectDir) => {
+			orderedCalls.push("legacy");
+			legacyRepairCalls.push(projectDir);
+			return 2;
+		};
+
+		await promptMigrateUpdate(deps);
+
+		expect(legacyRepairCalls).toEqual([process.cwd()]);
+		expect(logger.info).toHaveBeenCalledWith("Pruned 2 legacy hook prompt(s)");
 		expect(execCalls).toEqual([]);
 	});
 
@@ -157,7 +181,8 @@ describe("promptMigrateUpdate (step 3 of update pipeline)", () => {
 
 		await promptMigrateUpdate(deps);
 
-		expect(orderedCalls).toEqual(["repair", "cleanup", "repair"]);
+		expect(orderedCalls).toEqual(["legacy", "repair", "cleanup", "legacy", "repair"]);
+		expect(legacyRepairCalls).toEqual([process.cwd(), process.cwd()]);
 		expect(repairCalls).toEqual([process.cwd(), process.cwd()]);
 		expect(cleanupCalls).toEqual([{ providers: ["claude-code"], global: false }]);
 		expect(logger.info).toHaveBeenCalledWith("Cleaned up 2 generated-context hook artifact(s)");

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
@@ -11,6 +11,7 @@ import {
 	checkHookLogs,
 	checkHookRuntime,
 	checkHookSyntax,
+	checkLegacyHookPrompts,
 	checkPythonVenv,
 	parseDoctorCliVersionOutput,
 	repairMissingHookFileReferences,
@@ -622,6 +623,118 @@ describe("checkHookCommandPaths", () => {
 		expect(repaired.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
 			'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-state.cjs',
 		);
+	});
+});
+
+describe("checkLegacyHookPrompts", () => {
+	let tempDir: string;
+	let projectDir: string;
+	let originalCkTestHome: string | undefined;
+
+	const legacyPrompt =
+		"Use kebab-case file naming with a long descriptive name to ensure this file name is self-documenting, so that when LLM is using tools (Grep, Glob, Search) to list files, it can guess what the file does right away without reading the file.";
+
+	beforeEach(async () => {
+		tempDir = join(
+			tmpdir(),
+			`legacy-hook-prompts-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		projectDir = join(tempDir, "project");
+		await mkdir(projectDir, { recursive: true });
+
+		originalCkTestHome = process.env.CK_TEST_HOME;
+		process.env.CK_TEST_HOME = tempDir;
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+
+		if (originalCkTestHome === undefined) {
+			process.env.CK_TEST_HOME = undefined;
+		} else {
+			process.env.CK_TEST_HOME = originalCkTestHome;
+		}
+	});
+
+	test("detects and prunes legacy descriptive-name prompt hooks from project and global settings", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		await mkdir(join(tempDir, ".claude"), { recursive: true });
+
+		const projectSettingsPath = join(projectDir, ".claude", "settings.json");
+		const globalSettingsPath = join(tempDir, ".claude", "settings.json");
+		await writeFile(
+			projectSettingsPath,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Write",
+							hooks: [
+								{ type: "prompt", prompt: legacyPrompt },
+								{
+									type: "prompt",
+									prompt: "Before writing release notes, include the release channel.",
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+		await writeFile(
+			globalSettingsPath,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Write",
+							hooks: [{ type: "prompt", prompt: legacyPrompt }],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkLegacyHookPrompts(projectDir);
+
+		expect(result.status).toBe("fail");
+		expect(result.message).toBe("2 legacy hook prompt(s)");
+		expect(result.details).toContain("project settings.json");
+		expect(result.details).toContain("global settings.json");
+		expect(result.autoFixable).toBe(true);
+
+		const fixResult = await result.fix?.execute();
+		expect(fixResult?.success).toBe(true);
+		expect(fixResult?.message).toBe("Pruned 2 legacy hook prompt(s)");
+
+		const projectSettings = JSON.parse(await readFile(projectSettingsPath, "utf-8"));
+		expect(projectSettings.hooks.PreToolUse[0].hooks).toHaveLength(1);
+		expect(projectSettings.hooks.PreToolUse[0].hooks[0].prompt).toContain("release channel");
+
+		const globalSettings = JSON.parse(await readFile(globalSettingsPath, "utf-8"));
+		expect(globalSettings.hooks).toBeUndefined();
+	});
+
+	test("passes when settings contain only unrelated prompt hooks", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		await writeFile(
+			join(projectDir, ".claude", "settings.json"),
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Write",
+							hooks: [{ type: "prompt", prompt: "Use project-specific fixture names." }],
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await checkLegacyHookPrompts(projectDir);
+
+		expect(result.status).toBe("pass");
+		expect(result.message).toBe("No legacy hook prompts");
 	});
 });
 

--- a/src/commands/update-cli.ts
+++ b/src/commands/update-cli.ts
@@ -46,6 +46,7 @@ export {
 	fetchLatestReleaseTag,
 	promptKitUpdate,
 	promptMigrateUpdate,
+	repairLegacyHookPrompts,
 	repairMissingHookFileReferences,
 	resolveCkInitSpawnCommand,
 	readMetadataFile,

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -12,7 +12,10 @@ import { builtinModules } from "node:module";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { CkConfigManager } from "@/domains/config/ck-config-manager.js";
-import { repairMissingHookFileReferences } from "@/domains/health-checks/checkers/hook-health-checker.js";
+import {
+	repairLegacyHookPrompts,
+	repairMissingHookFileReferences,
+} from "@/domains/health-checks/checkers/hook-health-checker.js";
 import { getInstalledKits } from "@/domains/migration/metadata-migration.js";
 import { versionsMatch } from "@/domains/versioning/checking/version-utils.js";
 import { getClaudeKitSetup } from "@/services/file-operations/claudekit-scanner.js";
@@ -443,6 +446,7 @@ export interface PromptMigrateUpdateDeps {
 	loadFullConfigFn?: PromptKitUpdateConfigLoader;
 	execAsyncFn?: ExecAsyncFn;
 	repairHookFileReferencesFn?: (projectDir: string) => Promise<number>;
+	repairLegacyHookPromptsFn?: (projectDir: string) => Promise<number>;
 	cleanupMigratedHooksFn?: (
 		providers: string[],
 		options: { global: boolean },
@@ -451,7 +455,7 @@ export interface PromptMigrateUpdateDeps {
 	>;
 }
 
-export { repairMissingHookFileReferences };
+export { repairLegacyHookPrompts, repairMissingHookFileReferences };
 
 /**
  * Step 3 of the update pipeline: independently check and run migration.
@@ -461,6 +465,21 @@ export { repairMissingHookFileReferences };
 export async function promptMigrateUpdate(deps?: PromptMigrateUpdateDeps): Promise<void> {
 	try {
 		const repairFn = deps?.repairHookFileReferencesFn ?? repairMissingHookFileReferences;
+		const repairLegacyPromptsFn = deps?.repairLegacyHookPromptsFn ?? repairLegacyHookPrompts;
+		const repairLegacyHookPromptsSafely = async () => {
+			try {
+				const repaired = await repairLegacyPromptsFn(process.cwd());
+				if (repaired > 0) {
+					logger.info(`Pruned ${repaired} legacy hook prompt(s)`);
+				}
+			} catch (error) {
+				logger.verbose(
+					`Legacy hook prompt repair skipped: ${
+						error instanceof Error ? error.message : "unknown"
+					}`,
+				);
+			}
+		};
 		const repairHookFileReferencesSafely = async () => {
 			try {
 				const repaired = await repairFn(process.cwd());
@@ -474,6 +493,7 @@ export async function promptMigrateUpdate(deps?: PromptMigrateUpdateDeps): Promi
 			}
 		};
 
+		await repairLegacyHookPromptsSafely();
 		await repairHookFileReferencesSafely();
 
 		const providerRegistry =
@@ -531,6 +551,7 @@ export async function promptMigrateUpdate(deps?: PromptMigrateUpdateDeps): Promi
 			);
 		}
 
+		await repairLegacyHookPromptsSafely();
 		await repairHookFileReferencesSafely();
 
 		const targets = allProviders.filter((p) => p !== "claude-code");

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -4,6 +4,7 @@ import { readdir } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { type SettingsJson, SettingsMerger } from "@/domains/config/settings-merger.js";
+import { isLegacyDescriptiveNamePrompt } from "@/domains/installation/merger/zombie-wirings-pruner.js";
 import { CLAUDEKIT_CLI_NPM_PACKAGE_NAME } from "@/shared/claudekit-constants.js";
 import { repairClaudeHookCommandPath } from "@/shared/command-normalizer.js";
 import { logger } from "@/shared/logger.js";
@@ -49,6 +50,12 @@ export interface HookCommandFinding {
 	command: string;
 	expected: string;
 	issue: "raw-relative" | "invalid-format";
+}
+
+interface LegacyHookPromptFinding {
+	label: string;
+	eventName: string;
+	matcher?: string;
 }
 
 /**
@@ -295,6 +302,191 @@ async function repairHookCommandsInSettingsFile(settingsFile: ClaudeSettingsFile
 	}
 
 	return repaired;
+}
+
+function collectLegacyHookPromptFindings(
+	settings: SettingsJson,
+	settingsFile: ClaudeSettingsFile,
+): LegacyHookPromptFinding[] {
+	const findings: LegacyHookPromptFinding[] = [];
+	if (!settings.hooks) return findings;
+
+	for (const [eventName, entries] of Object.entries(settings.hooks)) {
+		for (const entry of entries) {
+			if (isLegacyDescriptiveNamePrompt(entry as { type?: unknown; prompt?: unknown })) {
+				findings.push({
+					label: settingsFile.label,
+					eventName,
+				});
+			}
+
+			if (!("hooks" in entry) || !Array.isArray(entry.hooks)) {
+				continue;
+			}
+
+			const matcher = "matcher" in entry ? entry.matcher : undefined;
+			for (const hook of entry.hooks) {
+				if (!isLegacyDescriptiveNamePrompt(hook)) {
+					continue;
+				}
+				findings.push({
+					label: settingsFile.label,
+					eventName,
+					matcher,
+				});
+			}
+		}
+	}
+
+	return findings;
+}
+
+async function pruneLegacyHookPromptsInSettingsFile(
+	settingsFile: ClaudeSettingsFile,
+): Promise<number> {
+	const settings = await SettingsMerger.readSettingsFile(settingsFile.path);
+	if (!settings?.hooks) return 0;
+
+	let pruned = 0;
+	const hooksRecord = settings.hooks as Record<string, unknown[]>;
+	for (const [eventName, entries] of Object.entries(hooksRecord)) {
+		const filteredEntries: unknown[] = [];
+		for (const entry of entries) {
+			if (isLegacyDescriptiveNamePrompt(entry as { type?: unknown; prompt?: unknown })) {
+				pruned++;
+				continue;
+			}
+
+			const e = entry as { hooks?: unknown[] };
+			if (Array.isArray(e.hooks)) {
+				const keptHooks = e.hooks.filter((hook) => {
+					if (isLegacyDescriptiveNamePrompt(hook as { type?: unknown; prompt?: unknown })) {
+						pruned++;
+						return false;
+					}
+					return true;
+				});
+				if (keptHooks.length === 0) {
+					continue;
+				}
+				filteredEntries.push({ ...e, hooks: keptHooks });
+				continue;
+			}
+
+			filteredEntries.push(entry);
+		}
+
+		if (filteredEntries.length === 0) {
+			delete hooksRecord[eventName];
+		} else {
+			hooksRecord[eventName] = filteredEntries;
+		}
+	}
+
+	if (Object.keys(hooksRecord).length === 0) {
+		// biome-ignore lint/performance/noDelete: settings cleanup should remove empty hooks
+		delete (settings as Record<string, unknown>).hooks;
+	}
+
+	if (pruned > 0) {
+		await SettingsMerger.writeSettingsFile(settingsFile.path, settings);
+	}
+
+	return pruned;
+}
+
+export async function checkLegacyHookPrompts(projectDir: string): Promise<CheckResult> {
+	const settingsFiles = getClaudeSettingsFiles(projectDir);
+
+	if (settingsFiles.length === 0) {
+		return {
+			id: "legacy-hook-prompts",
+			name: "Legacy Hook Prompts",
+			group: "claudekit",
+			priority: "critical",
+			status: "info",
+			message: "No Claude settings files",
+			autoFixable: false,
+		};
+	}
+
+	const findings: LegacyHookPromptFinding[] = [];
+	for (const settingsFile of settingsFiles) {
+		const settings = await SettingsMerger.readSettingsFile(settingsFile.path);
+		if (!settings) continue;
+		findings.push(...collectLegacyHookPromptFindings(settings, settingsFile));
+	}
+
+	if (findings.length === 0) {
+		return {
+			id: "legacy-hook-prompts",
+			name: "Legacy Hook Prompts",
+			group: "claudekit",
+			priority: "critical",
+			status: "pass",
+			message: "No legacy hook prompts",
+			autoFixable: false,
+		};
+	}
+
+	const details = findings
+		.slice(0, 8)
+		.map((finding) => {
+			const matcher = finding.matcher ? ` [${finding.matcher}]` : "";
+			return `${finding.label} :: ${finding.eventName}${matcher} :: legacy descriptive-name prompt`;
+		})
+		.join("\n");
+
+	return {
+		id: "legacy-hook-prompts",
+		name: "Legacy Hook Prompts",
+		group: "claudekit",
+		priority: "critical",
+		status: "fail",
+		message: `${findings.length} legacy hook prompt(s)`,
+		details,
+		suggestion: "Run: ck doctor --fix",
+		autoFixable: true,
+		fix: {
+			id: "fix-legacy-hook-prompts",
+			description: "Prune legacy prompt-only ClaudeKit hook entries",
+			execute: async () => {
+				try {
+					let pruned = 0;
+					for (const settingsFile of settingsFiles) {
+						pruned += await pruneLegacyHookPromptsInSettingsFile(settingsFile);
+					}
+					if (pruned === 0) {
+						return { success: true, message: "No legacy hook prompts needed pruning" };
+					}
+					return {
+						success: true,
+						message: `Pruned ${pruned} legacy hook prompt(s)`,
+					};
+				} catch (error) {
+					return {
+						success: false,
+						message: `Failed to prune legacy hook prompts: ${error}`,
+					};
+				}
+			},
+		},
+	};
+}
+
+export async function repairLegacyHookPrompts(projectDir = process.cwd()): Promise<number> {
+	const result = await checkLegacyHookPrompts(projectDir);
+	if (result.status !== "fail" || !result.fix) {
+		return 0;
+	}
+
+	const fixResult = await result.fix.execute();
+	if (!fixResult.success) {
+		throw new Error(fixResult.message);
+	}
+
+	const match = fixResult.message.match(/Pruned\s+(\d+)/);
+	return match?.[1] ? Number.parseInt(match[1], 10) : 0;
 }
 
 /**

--- a/src/domains/health-checks/checkers/index.ts
+++ b/src/domains/health-checks/checkers/index.ts
@@ -21,6 +21,8 @@ export {
 	checkHookDeps,
 	checkHookRuntime,
 	checkHookCommandPaths,
+	checkLegacyHookPrompts,
+	repairLegacyHookPrompts,
 	checkHookConfig,
 	checkHookFileReferences,
 	checkHookLogs,

--- a/src/domains/health-checks/claudekit-checker.ts
+++ b/src/domains/health-checks/claudekit-checker.ts
@@ -18,6 +18,7 @@ import {
 	checkHookRuntime,
 	checkHookSyntax,
 	checkHooksExist,
+	checkLegacyHookPrompts,
 	checkPathRefsValid,
 	checkProjectConfigCompleteness,
 	checkProjectInstall,
@@ -101,6 +102,8 @@ export class ClaudekitChecker implements Checker {
 		results.push(await checkHookRuntime(this.projectDir));
 		logger.verbose("ClaudekitChecker: Checking hook command paths");
 		results.push(await checkHookCommandPaths(this.projectDir));
+		logger.verbose("ClaudekitChecker: Checking legacy hook prompts");
+		results.push(await checkLegacyHookPrompts(this.projectDir));
 		logger.verbose("ClaudekitChecker: Checking hook file references");
 		results.push(await checkHookFileReferences(this.projectDir));
 		logger.verbose("ClaudekitChecker: Checking hook config");

--- a/src/domains/installation/merger/zombie-wirings-pruner.ts
+++ b/src/domains/installation/merger/zombie-wirings-pruner.ts
@@ -118,8 +118,11 @@ function shouldPruneEntry(entry: HookEntry, hookDir: string, pruned: string[]): 
 	return true;
 }
 
-function isLegacyDescriptiveNamePrompt(entry: HookEntry): boolean {
-	const prompt = (entry as HookEntry & { prompt?: unknown }).prompt;
+export function isLegacyDescriptiveNamePrompt(entry: {
+	type?: unknown;
+	prompt?: unknown;
+}): boolean {
+	const prompt = entry.prompt;
 	if (entry.type !== "prompt" || typeof prompt !== "string") return false;
 
 	return (


### PR DESCRIPTION
## Summary
- detect legacy descriptive-name prompt hooks that force kebab-case globally
- make `ck doctor --fix` prune those stale prompt-only hooks from global and project Claude settings
- run the same repair during `ck update` post-update health repair so affected users self-heal after updating

## Validation
- bun run typecheck
- bun run lint
- bun run build
- bun test src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
- bun test src/__tests__/commands/update-cli-migrate-step.test.ts src/__tests__/commands/update-cli.test.ts
- bun test
- pre-push local CI parity, UI build, UI vitest, packaged CLI verification

Docs impact: none
Action: no update needed — internal doctor/update repair path, no new command or flag
