### PR TITLE
fix: prune legacy prompt hooks after init

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.1-dev.9",
-	"generatedAt": "2026-05-21T00:57:46.294Z",
+	"version": "4.3.1-dev.10",
+	"generatedAt": "2026-05-21T01:22:36.402Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/__tests__/commands/init/init-command-self-heal.test.ts
+++ b/src/__tests__/commands/init/init-command-self-heal.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { repairLegacyHookPromptsAfterInit } from "@/commands/init/init-command.js";
+import type { InitContext } from "@/commands/init/types.js";
+
+const originalCwd = process.cwd();
+const originalCkTestHome = process.env.CK_TEST_HOME;
+
+function makeLegacyPromptSettings() {
+	return {
+		hooks: {
+			PreToolUse: [
+				{
+					matcher: "Write",
+					hooks: [
+						{
+							type: "prompt",
+							prompt:
+								"Legacy descriptive-name hook: Use kebab-case for all filenames, including Python .py files.",
+						},
+					],
+				},
+			],
+		},
+	};
+}
+
+describe("init self-heal", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "ck-init-self-heal-"));
+		process.env.CK_TEST_HOME = join(tempDir, "home");
+		await mkdir(join(process.env.CK_TEST_HOME, ".claude"), { recursive: true });
+	});
+
+	afterEach(async () => {
+		process.chdir(originalCwd);
+		if (originalCkTestHome === undefined) {
+			process.env.CK_TEST_HOME = undefined;
+		} else {
+			process.env.CK_TEST_HOME = originalCkTestHome;
+		}
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	test("global init prunes legacy prompt hooks from the current project settings", async () => {
+		const projectDir = join(tempDir, "project");
+		const projectClaudeDir = join(projectDir, ".claude");
+		await mkdir(projectClaudeDir, { recursive: true });
+		await writeFile(
+			join(projectClaudeDir, "settings.json"),
+			JSON.stringify(makeLegacyPromptSettings(), null, 2),
+		);
+
+		process.chdir(projectDir);
+
+		await repairLegacyHookPromptsAfterInit({
+			resolvedDir: process.env.CK_TEST_HOME,
+			options: { global: true },
+		} as unknown as InitContext);
+
+		const settings = JSON.parse(await readFile(join(projectClaudeDir, "settings.json"), "utf8"));
+		expect(JSON.stringify(settings)).not.toContain("kebab-case");
+		expect(settings.hooks).toBeUndefined();
+	});
+});

--- a/src/commands/init/init-command.ts
+++ b/src/commands/init/init-command.ts
@@ -4,7 +4,10 @@
  */
 
 import { GitHubClient } from "@/domains/github/github-client.js";
-import { repairMissingHookFileReferences } from "@/domains/health-checks/checkers/hook-health-checker.js";
+import {
+	repairLegacyHookPrompts,
+	repairMissingHookFileReferences,
+} from "@/domains/health-checks/checkers/hook-health-checker.js";
 import { maybeShowConfigUpdateNotification } from "@/domains/sync/index.js";
 import { PromptsManager } from "@/domains/ui/prompts.js";
 import { logger } from "@/shared/logger.js";
@@ -159,6 +162,24 @@ async function repairMissingHookFileReferencesAfterInit(ctx: InitContext): Promi
 	}
 }
 
+export async function repairLegacyHookPromptsAfterInit(ctx: InitContext): Promise<void> {
+	if (!ctx.resolvedDir) return;
+
+	const projectDir = ctx.options.global ? process.cwd() : ctx.resolvedDir;
+	try {
+		const repaired = await repairLegacyHookPrompts(projectDir);
+		if (repaired > 0) {
+			logger.info(`Pruned ${repaired} legacy hook prompt(s)`);
+		}
+	} catch (error) {
+		logger.debug(
+			`Legacy hook prompt repair skipped after init: ${
+				error instanceof Error ? error.message : "unknown"
+			}`,
+		);
+	}
+}
+
 /**
  * Internal init command implementation
  * Runs all phases in sequence, passing context through each
@@ -262,6 +283,7 @@ async function executeInit(options: UpdateCommandOptions, prompts: PromptsManage
 	}
 
 	if (!isSyncMode) {
+		await repairLegacyHookPromptsAfterInit(ctx);
 		await repairMissingHookFileReferencesAfterInit(ctx);
 	}
 

--- a/src/domains/installation/merger/zombie-wirings-pruner.ts
+++ b/src/domains/installation/merger/zombie-wirings-pruner.ts
@@ -125,11 +125,17 @@ export function isLegacyDescriptiveNamePrompt(entry: {
 	const prompt = entry.prompt;
 	if (entry.type !== "prompt" || typeof prompt !== "string") return false;
 
-	return (
+	const lowerPrompt = prompt.toLowerCase();
+	const isOriginalLegacyPrompt =
 		prompt.includes("Use kebab-case file naming") &&
 		prompt.includes("self-documenting") &&
-		prompt.includes("Grep, Glob, Search")
-	);
+		prompt.includes("Grep, Glob, Search");
+	const isDescriptiveNameKebabPrompt =
+		lowerPrompt.includes("descriptive-name") &&
+		lowerPrompt.includes("kebab-case") &&
+		(lowerPrompt.includes("file") || lowerPrompt.includes("filename"));
+
+	return isOriginalLegacyPrompt || isDescriptiveNameKebabPrompt;
 }
 
 /**


### PR DESCRIPTION
## Summary
- prune stale legacy descriptive-name prompt hooks after `ck init`
- catch shorter legacy prompts that mention `descriptive-name` + `kebab-case` filename guidance
- add regression coverage for project-local stale prompt hook self-heal

## Why
Older `ck update --dev -y` processes can install the new CLI and invoke `ck init -g`, but they cannot run the newer post-update repair logic themselves. This makes `ck init` the deterministic self-heal point for stale project/global prompt hooks.

## Test plan
- bun run typecheck
- bun run lint
- bun run build
- focused init self-heal tests
- full local pre-push parity: 4883 pass, 57 skip, 0 fail; UI build; UI Vitest 150 pass; packaged CLI verification

Docs impact: none
Action: no update needed — internal doctor/update/init self-heal only; no new user-facing command or flag.