### PR TITLE
fix: self-heal legacy prompt hooks during package update

### DIFF
--- a/bin/postinstall-self-heal.cjs
+++ b/bin/postinstall-self-heal.cjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const MAX_SETTINGS_BYTES = 5 * 1024 * 1024;
+
+function isLegacyDescriptiveNamePrompt(entry) {
+	if (!entry || entry.type !== "prompt" || typeof entry.prompt !== "string") return false;
+
+	const prompt = entry.prompt;
+	const lowerPrompt = prompt.toLowerCase();
+	const isOriginalLegacyPrompt =
+		prompt.includes("Use kebab-case file naming") &&
+		prompt.includes("self-documenting") &&
+		prompt.includes("Grep, Glob, Search");
+	const isDescriptiveNameKebabPrompt =
+		lowerPrompt.includes("descriptive-name") &&
+		lowerPrompt.includes("kebab-case") &&
+		(lowerPrompt.includes("file") || lowerPrompt.includes("filename"));
+
+	return isOriginalLegacyPrompt || isDescriptiveNameKebabPrompt;
+}
+
+function pruneHooks(settings) {
+	if (!settings || typeof settings !== "object" || !settings.hooks) return 0;
+
+	let pruned = 0;
+	for (const [eventName, entries] of Object.entries(settings.hooks)) {
+		if (!Array.isArray(entries)) continue;
+
+		const keptEntries = [];
+		for (const entry of entries) {
+			if (isLegacyDescriptiveNamePrompt(entry)) {
+				pruned++;
+				continue;
+			}
+
+			if (Array.isArray(entry?.hooks)) {
+				const keptHooks = entry.hooks.filter((hook) => {
+					if (isLegacyDescriptiveNamePrompt(hook)) {
+						pruned++;
+						return false;
+					}
+					return true;
+				});
+				if (keptHooks.length > 0) keptEntries.push({ ...entry, hooks: keptHooks });
+				continue;
+			}
+
+			keptEntries.push(entry);
+		}
+
+		if (keptEntries.length === 0) {
+			delete settings.hooks[eventName];
+		} else {
+			settings.hooks[eventName] = keptEntries;
+		}
+	}
+
+	if (Object.keys(settings.hooks).length === 0) settings.hooks = undefined;
+	return pruned;
+}
+
+function pruneSettingsFile(filePath) {
+	try {
+		if (!filePath || !fs.existsSync(filePath)) return 0;
+		const stat = fs.statSync(filePath);
+		if (!stat.isFile() || stat.size > MAX_SETTINGS_BYTES) return 0;
+
+		const settings = JSON.parse(fs.readFileSync(filePath, "utf8"));
+		const pruned = pruneHooks(settings);
+		if (pruned > 0) {
+			fs.writeFileSync(filePath, `${JSON.stringify(settings, null, 2)}\n`);
+		}
+		return pruned;
+	} catch {
+		return 0;
+	}
+}
+
+function getHomeDir() {
+	return process.env.CK_TEST_HOME || os.homedir();
+}
+
+function addIfSettingsFile(files, filePath) {
+	if (!filePath) return;
+	const base = path.basename(filePath);
+	if (
+		base === "settings.json" ||
+		base === "settings.local.json" ||
+		base.endsWith(".settings.json")
+	) {
+		files.add(path.resolve(filePath));
+	}
+}
+
+function collectCandidateSettingsFiles() {
+	const files = new Set();
+	const initCwd = process.env.INIT_CWD;
+	if (initCwd && path.isAbsolute(initCwd)) {
+		addIfSettingsFile(files, path.join(initCwd, ".claude", "settings.json"));
+		addIfSettingsFile(files, path.join(initCwd, ".claude", "settings.local.json"));
+	}
+
+	const homeDir = getHomeDir();
+	const globalClaudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(homeDir, ".claude");
+	addIfSettingsFile(files, path.join(globalClaudeDir, "settings.json"));
+	addIfSettingsFile(files, path.join(globalClaudeDir, "settings.local.json"));
+
+	const ccsDir = process.env.CK_TEST_CCS_DIR || path.join(homeDir, ".ccs");
+	try {
+		for (const dirent of fs.readdirSync(ccsDir, { withFileTypes: true })) {
+			if (dirent.isFile()) addIfSettingsFile(files, path.join(ccsDir, dirent.name));
+		}
+	} catch {
+		// Optional compatibility directory; skip when absent or unreadable.
+	}
+
+	return [...files];
+}
+
+function main() {
+	let pruned = 0;
+	for (const filePath of collectCandidateSettingsFiles()) {
+		pruned += pruneSettingsFile(filePath);
+	}
+
+	if (pruned > 0 && process.env.CK_POSTINSTALL_DEBUG === "1") {
+		console.warn(`[claudekit-cli] Pruned ${pruned} legacy hook prompt(s)`);
+	}
+}
+
+main();
+
+module.exports = {
+	collectCandidateSettingsFiles,
+	isLegacyDescriptiveNamePrompt,
+	pruneHooks,
+	pruneSettingsFile,
+};

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.1-dev.10",
-	"generatedAt": "2026-05-21T01:22:36.402Z",
+	"version": "4.3.1-dev.11",
+	"generatedAt": "2026-05-21T01:38:00.939Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	},
 	"files": [
 		"bin/ck.js",
+		"bin/postinstall-self-heal.cjs",
 		"dist/index.js",
 		"dist/ui/",
 		"cli-manifest.json"
@@ -47,6 +48,7 @@
 		"ci:local": "bash scripts/ci-local.sh",
 		"install:hooks": "./.githooks/install.sh",
 		"prepare": "node -e \"try{require('child_process').execSync('git rev-parse --git-dir',{stdio:'ignore'});require('child_process').execSync('bash .githooks/install.sh',{stdio:'inherit'})}catch(e){console.warn('[i] Hook install skipped:',e.message)}\"",
+		"postinstall": "node bin/postinstall-self-heal.cjs",
 		"help:check-parity": "bun run scripts/check-help-parity.ts",
 		"manifest:generate": "bun run scripts/generate-cli-manifest.ts",
 		"docs:generate": "bun run scripts/generate-cli-reference.ts",

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
@@ -656,12 +656,14 @@ describe("checkLegacyHookPrompts", () => {
 		}
 	});
 
-	test("detects and prunes legacy descriptive-name prompt hooks from project and global settings", async () => {
+	test("detects and prunes legacy descriptive-name prompt hooks from project, global, and .ccs settings", async () => {
 		await mkdir(join(projectDir, ".claude"), { recursive: true });
 		await mkdir(join(tempDir, ".claude"), { recursive: true });
+		await mkdir(join(tempDir, ".ccs"), { recursive: true });
 
 		const projectSettingsPath = join(projectDir, ".claude", "settings.json");
 		const globalSettingsPath = join(tempDir, ".claude", "settings.json");
+		const ccsSettingsPath = join(tempDir, ".ccs", "znguyen.settings.json");
 		await writeFile(
 			projectSettingsPath,
 			JSON.stringify({
@@ -694,18 +696,32 @@ describe("checkLegacyHookPrompts", () => {
 				},
 			}),
 		);
+		await writeFile(
+			ccsSettingsPath,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Write",
+							hooks: [{ type: "prompt", prompt: legacyPrompt }],
+						},
+					],
+				},
+			}),
+		);
 
 		const result = await checkLegacyHookPrompts(projectDir);
 
 		expect(result.status).toBe("fail");
-		expect(result.message).toBe("2 legacy hook prompt(s)");
+		expect(result.message).toBe("3 legacy hook prompt(s)");
 		expect(result.details).toContain("project settings.json");
 		expect(result.details).toContain("global settings.json");
+		expect(result.details).toContain(".ccs/znguyen.settings.json");
 		expect(result.autoFixable).toBe(true);
 
 		const fixResult = await result.fix?.execute();
 		expect(fixResult?.success).toBe(true);
-		expect(fixResult?.message).toBe("Pruned 2 legacy hook prompt(s)");
+		expect(fixResult?.message).toBe("Pruned 3 legacy hook prompt(s)");
 
 		const projectSettings = JSON.parse(await readFile(projectSettingsPath, "utf-8"));
 		expect(projectSettings.hooks.PreToolUse[0].hooks).toHaveLength(1);
@@ -713,6 +729,9 @@ describe("checkLegacyHookPrompts", () => {
 
 		const globalSettings = JSON.parse(await readFile(globalSettingsPath, "utf-8"));
 		expect(globalSettings.hooks).toBeUndefined();
+
+		const ccsSettings = JSON.parse(await readFile(ccsSettingsPath, "utf-8"));
+		expect(ccsSettings.hooks).toBeUndefined();
 	});
 
 	test("passes when settings contain only unrelated prompt hooks", async () => {

--- a/src/__tests__/scripts/postinstall-self-heal.test.ts
+++ b/src/__tests__/scripts/postinstall-self-heal.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const scriptPath = resolve(import.meta.dir, "../../../bin/postinstall-self-heal.cjs");
+
+function makeLegacyPromptSettings() {
+	return {
+		hooks: {
+			PreToolUse: [
+				{
+					matcher: "Write",
+					hooks: [
+						{
+							type: "prompt",
+							prompt:
+								"Legacy descriptive-name hook: Use kebab-case for all filenames, including Python .py files.",
+						},
+					],
+				},
+			],
+		},
+	};
+}
+
+describe("postinstall self-heal", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "ck-postinstall-self-heal-"));
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	test("prunes legacy prompt hooks from invoking project and .ccs profile settings", async () => {
+		const projectDir = join(tempDir, "project");
+		const projectClaudeDir = join(projectDir, ".claude");
+		const ccsDir = join(tempDir, ".ccs");
+		await mkdir(projectClaudeDir, { recursive: true });
+		await mkdir(ccsDir, { recursive: true });
+
+		const projectSettingsPath = join(projectClaudeDir, "settings.json");
+		const ccsSettingsPath = join(ccsDir, "znguyen.settings.json");
+		await writeFile(projectSettingsPath, JSON.stringify(makeLegacyPromptSettings(), null, 2));
+		await writeFile(ccsSettingsPath, JSON.stringify(makeLegacyPromptSettings(), null, 2));
+
+		execFileSync(process.execPath, [scriptPath], {
+			env: {
+				...process.env,
+				INIT_CWD: projectDir,
+				CK_TEST_HOME: tempDir,
+				CK_TEST_CCS_DIR: ccsDir,
+			},
+			stdio: "pipe",
+		});
+
+		const projectSettings = JSON.parse(await readFile(projectSettingsPath, "utf8"));
+		const ccsSettings = JSON.parse(await readFile(ccsSettingsPath, "utf8"));
+		expect(projectSettings.hooks).toBeUndefined();
+		expect(ccsSettings.hooks).toBeUndefined();
+	});
+});

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -109,6 +109,7 @@ function getCanonicalGlobalCommandRoot(): string {
 
 function getClaudeSettingsFiles(projectDir: string): ClaudeSettingsFile[] {
 	const globalClaudeDir = PathResolver.getGlobalKitDir();
+	const ccsSettingsDir = join(process.env.CK_TEST_HOME ?? homedir(), ".ccs");
 	const candidates: ClaudeSettingsFile[] = [
 		{
 			path: resolve(projectDir, ".claude", "settings.json"),
@@ -131,6 +132,19 @@ function getClaudeSettingsFiles(projectDir: string): ClaudeSettingsFile[] {
 			root: getCanonicalGlobalCommandRoot(),
 		},
 	];
+
+	try {
+		for (const dirent of readdirSync(ccsSettingsDir, { withFileTypes: true })) {
+			if (!dirent.isFile() || !dirent.name.endsWith(".settings.json")) continue;
+			candidates.push({
+				path: resolve(ccsSettingsDir, dirent.name),
+				label: `.ccs/${dirent.name}`,
+				root: "$HOME",
+			});
+		}
+	} catch {
+		// Optional compatibility directory; ignore when absent or unreadable.
+	}
 
 	return candidates.filter((candidate) => existsSync(candidate.path));
 }


### PR DESCRIPTION
## Summary
- add a packaged `postinstall` self-heal that prunes legacy descriptive-name prompt hooks from the npm install invoking project via `INIT_CWD`
- include `~/.ccs/*.settings.json` in doctor/init legacy prompt cleanup
- add regression coverage for package lifecycle cleanup and `.ccs` profile settings

## Why
Old updater versions can install the new CLI but skip `ck init` when the Engineer kit is already current, leaving stale prompt hooks active. Running the repair during package installation gives stale updaters a deterministic self-heal path.

## Test plan
- bun test src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts src/__tests__/scripts/postinstall-self-heal.test.ts
- bun run typecheck
- bun run lint
- bun run build
- node scripts/prepublish-check.js
- full local pre-push parity: 4884 pass, 57 skip, 0 fail; UI build; UI Vitest 150 pass; packaged CLI verification

Docs impact: none
Action: no update needed — internal lifecycle/doctor self-heal only; no new user-facing command or flag.