### PR TITLE
fix: accept rules-bundled Claude guidance

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.1-dev.13",
-	"generatedAt": "2026-05-22T04:30:23.505Z",
+	"version": "4.3.1-dev.14",
+	"generatedAt": "2026-05-23T19:46:42.841Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/domains/installation/extraction/extraction-validator.ts
+++ b/src/domains/installation/extraction/extraction-validator.ts
@@ -7,6 +7,15 @@ import { join } from "node:path";
 import { logger } from "@/shared/logger.js";
 import { ExtractionError } from "@/types";
 
+async function pathExists(path: string): Promise<boolean> {
+	try {
+		await access(path, constants.F_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 /**
  * Validate extraction results
  * @param extractDir - Directory to validate
@@ -23,17 +32,31 @@ export async function validateExtraction(extractDir: string): Promise<void> {
 		}
 
 		// Verify critical paths exist
-		const criticalPaths = [".claude", "CLAUDE.md"];
+		const criticalPaths = [".claude"];
 		const missingPaths: string[] = [];
 
 		for (const path of criticalPaths) {
-			try {
-				await access(join(extractDir, path), constants.F_OK);
+			if (await pathExists(join(extractDir, path))) {
 				logger.debug(`Found: ${path}`);
-			} catch {
-				logger.warning(`Expected path not found: ${path}`);
-				missingPaths.push(path);
+				continue;
 			}
+
+			logger.warning(`Expected path not found: ${path}`);
+			missingPaths.push(path);
+		}
+
+		const guidancePaths = ["CLAUDE.md", ".claude/CLAUDE.md", ".claude/rules/CLAUDE.md"];
+		let guidancePath: string | null = null;
+		for (const path of guidancePaths) {
+			if (await pathExists(join(extractDir, path))) {
+				guidancePath = path;
+				break;
+			}
+		}
+		if (guidancePath) {
+			logger.debug(`Found: ${guidancePath}`);
+		} else {
+			logger.debug("No CLAUDE.md guidance file found in extracted kit");
 		}
 
 		// Warn if critical paths are missing but don't fail validation

--- a/tests/lib/download.test.ts
+++ b/tests/lib/download.test.ts
@@ -86,6 +86,15 @@ describe("DownloadManager", () => {
 			await manager.validateExtraction(validDir);
 		});
 
+		test("should pass validation when CLAUDE.md is bundled as a rule", async () => {
+			const validDir = join(testDir, "valid-rules-guidance");
+			await mkdir(join(validDir, ".claude", "rules"), { recursive: true });
+			await writeFile(join(validDir, ".claude", "rules", "CLAUDE.md"), "# Test");
+
+			// Should not throw
+			await manager.validateExtraction(validDir);
+		});
+
 		test("should warn but not fail for directory with files but missing critical paths", async () => {
 			const partialDir = join(testDir, "partial");
 			await mkdir(partialDir, { recursive: true });


### PR DESCRIPTION
## Summary
- accept .claude/rules/CLAUDE.md as valid engineer kit guidance during archive extraction validation
- add regression coverage for rules-bundled Claude guidance
- refresh cli-manifest.json after the pre-push hook detected generated manifest drift

## Validation
- bun test tests/lib/download.test.ts
- npm run typecheck --if-present
- npm run lint --if-present
- npm run build --if-present
- pre-push hook: local CI parity, packaged CLI verification, UI vitest suite