### PR TITLE
fix(install): use native unzip on Linux to avoid yauzl hang

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.1-dev.14",
-	"generatedAt": "2026-05-23T19:46:42.841Z",
+	"version": "4.3.1-dev.15",
+	"generatedAt": "2026-05-26T10:12:02.861Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/domains/installation/extraction/native-zip-commands.ts
+++ b/src/domains/installation/extraction/native-zip-commands.ts
@@ -11,7 +11,7 @@ export function getNativeZipCommands(
 	destDir: string,
 	platformName: NodeJS.Platform = process.platform,
 ): NativeZipCommand[] {
-	if (platformName === "darwin") {
+	if (platformName === "darwin" || platformName === "linux") {
 		return [
 			{
 				label: "native unzip",

--- a/src/domains/installation/extraction/zip-extractor.ts
+++ b/src/domains/installation/extraction/zip-extractor.ts
@@ -26,7 +26,7 @@ interface ExtractZipOptions {
 }
 
 /**
- * ZIP archive extractor with native OS fallback on macOS and Windows
+ * ZIP archive extractor with native OS fallback on macOS, Linux, and Windows
  */
 export class ZipExtractor {
 	/**
@@ -81,7 +81,11 @@ export class ZipExtractor {
 		await mkdir(tempExtractDir, { recursive: true });
 
 		try {
-			// Native tools avoid long JS extraction stalls on macOS and Windows.
+			// Native tools avoid long JS extraction stalls on macOS, Linux, and Windows.
+			// On Linux, the bundled extract-zip path hangs under Node >= 24.16.0 due to
+			// yauzl@2.10.0's fd-slicer destroy() colliding with Node's stream lifecycle
+			// (see thejoshwolfe/yauzl#169, fixed in yauzl@3.3.1; nodejs/node#63487).
+			// Shelling out to /usr/bin/unzip side-steps the broken JS path entirely.
 			const nativeSuccess = await this.tryNativeExtraction(archivePath, tempExtractDir);
 
 			if (!nativeSuccess) {

--- a/tests/lib/download.test.ts
+++ b/tests/lib/download.test.ts
@@ -324,8 +324,12 @@ describe("Installation utilities", () => {
 			expect(commands[0]?.args).toEqual(["-o", "-q", "/tmp/kit.zip", "-d", "/tmp/out"]);
 		});
 
-		test("does not use platform native commands on Linux", () => {
-			expect(getNativeZipCommands("/tmp/kit.zip", "/tmp/out", "linux")).toEqual([]);
+		test("uses native unzip on Linux", () => {
+			const commands = getNativeZipCommands("/tmp/kit.zip", "/tmp/out", "linux");
+
+			expect(commands).toHaveLength(1);
+			expect(commands[0]?.command).toBe("unzip");
+			expect(commands[0]?.args).toEqual(["-o", "-q", "/tmp/kit.zip", "-d", "/tmp/out"]);
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- route Linux ZIP extraction through the system `unzip` binary first, matching the existing macOS path; only fall back to the JS `extract-zip` library if `unzip` is missing
- update the Linux extraction test to assert the native command shape (was: asserts empty list)
- refresh `cli-manifest.json` after the pre-push hook detected generated manifest drift

## Why
`ck new` hangs indefinitely at *"Extracting files... this may take a while"* on Linux when the bundled JS extractor is used under Node >= `24.16.0`.

Root cause is a Node stream-lifecycle change that exposes a long-standing bug in `yauzl@2.10.0`'s vendored `fd-slicer`: its custom `destroy()` collides with Node's native readable-stream destroy, and the deflate read stream stops emitting `data`/`end` partway through a sufficiently-large entry. The outer Promise never settles - the spinner spins forever.

`extract-zip@2.0.1` is unmaintained (5 years stale) and still pins `yauzl@^2.10.0`. The upstream fix landed in `yauzl@3.3.1` but is not reachable through `extract-zip`.

Shelling out to `/usr/bin/unzip` on Linux side-steps the broken JS path entirely - the same approach already used on macOS - and replaces a >2-minute hang with ~300 ms native extraction.

References:
- nodejs/node#63487 - Node `24.16.0` regression report (multiple independent repros)
- thejoshwolfe/yauzl#169 - fd-slicer `destroy()` collision (root cause)
- thejoshwolfe/yauzl#170 / yauzl@3.3.1 - upstream fix (unreachable via `extract-zip`)
- max-mapper/extract-zip#154 - `extract-zip` unmaintained, no fix coming

## Test plan
- `bun test tests/lib/download.test.ts` - 37 pass, 0 fail (includes new Linux native-unzip assertion)
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- end-to-end repro: `ck new` on WSL2 + Node `24.16.0` - pre-fix hangs >2 min on `claudekit-engineer.zip` (1882 entries), post-fix completes in ~300 ms via native `unzip`

Docs impact: none
Action: no update needed - internal extraction fallback behavior only; no new user-facing command or flag.