### PR TITLE
fix: self-heal missing hook registrations during update

### DIFF
--- a/src/__tests__/commands/update-cli-auto-init.test.ts
+++ b/src/__tests__/commands/update-cli-auto-init.test.ts
@@ -234,6 +234,51 @@ describe("promptKitUpdate auto-init behavior", () => {
 		expect(capturedExecCmd()).toContain("--kit engineer");
 	});
 
+	test("reinstalls local kit when latest project settings have broken hook registrations (--yes mode)", async () => {
+		const projectDir = join(tempDir, "project");
+		const localClaudeDir = join(projectDir, ".claude");
+		await mkdir(localClaudeDir, { recursive: true });
+		await writeMetadata(localClaudeDir);
+
+		const { deps, execCount, spawnCount, capturedExecCmd } = makeDeps();
+		deps.getLatestReleaseTagFn = async () => "v1.0.0";
+		deps.getSetupFn = async () => ({
+			global: {
+				path: tempDir,
+				metadata: {
+					version: "1.0.0",
+					name: "ClaudeKit",
+					description: "test install",
+					kits: { engineer: { version: "1.0.0" } },
+				},
+				components: { commands: 0, hooks: 0, skills: 0, workflows: 0, settings: 0 },
+			},
+			project: {
+				path: localClaudeDir,
+				metadata: {
+					version: "1.0.0",
+					name: "ClaudeKit",
+					description: "test project install",
+					kits: { engineer: { version: "1.0.0" } },
+				},
+				components: { commands: 0, hooks: 0, skills: 0, workflows: 0, settings: 0 },
+			},
+		});
+		deps.countMissingHookFileReferencesFn = async (checkedProjectDir) => {
+			expect(checkedProjectDir).toBe(projectDir);
+			return 1;
+		};
+
+		await promptKitUpdate(false, true, deps);
+
+		expect(execCount()).toBe(1);
+		expect(spawnCount()).toBe(0);
+		expect(capturedExecCmd()).toContain("ck init");
+		expect(capturedExecCmd()).not.toContain("-g");
+		expect(capturedExecCmd()).toContain("--yes");
+		expect(capturedExecCmd()).toContain("--kit engineer");
+	});
+
 	test("interactive mode passes --beta when installed version is prerelease", async () => {
 		await writeMetadata(tempDir, "2.15.1-beta.3");
 		const { deps, capturedSpawnArgs } = makeDeps();

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
@@ -13,6 +13,7 @@ import {
 	checkHookSyntax,
 	checkLegacyHookPrompts,
 	checkPythonVenv,
+	countMissingHookFileReferences,
 	parseDoctorCliVersionOutput,
 	repairMissingHookFileReferences,
 	resolveDoctorCkExecutable,
@@ -1158,6 +1159,31 @@ describe("checkHookFileReferences", () => {
 		const updated = JSON.parse(await readFile(settingsPath, "utf-8"));
 		expect(updated.statusLine).toBeUndefined();
 		expect(updated.hooks).toBeUndefined();
+	});
+
+	test("shared count helper detects stale hook references without mutating settings", async () => {
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		const settingsPath = join(projectDir, ".claude", "settings.json");
+		const settings = {
+			hooks: {
+				Stop: [
+					{
+						hooks: [
+							{
+								type: "command",
+								command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-state.cjs',
+							},
+						],
+					},
+				],
+			},
+		};
+		await writeFile(settingsPath, JSON.stringify(settings));
+
+		const missingReferences = await countMissingHookFileReferences(projectDir);
+
+		expect(missingReferences).toBe(1);
+		expect(JSON.parse(await readFile(settingsPath, "utf-8"))).toEqual(settings);
 	});
 
 	test("returns fail when settings reference a missing hook file", async () => {

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -9,10 +9,11 @@ import { exec, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { builtinModules } from "node:module";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { CkConfigManager } from "@/domains/config/ck-config-manager.js";
 import {
+	countMissingHookFileReferences,
 	repairLegacyHookPrompts,
 	repairMissingHookFileReferences,
 } from "@/domains/health-checks/checkers/hook-health-checker.js";
@@ -216,6 +217,7 @@ export interface PromptKitUpdateDeps {
 	confirmFn?: PromptKitUpdateConfirmFn;
 	isCancelFn?: PromptKitUpdateCancelFn;
 	findMissingHookDependenciesFn?: (claudeDir: string) => Promise<string[]>;
+	countMissingHookFileReferencesFn?: (projectDir: string) => Promise<number>;
 }
 
 async function findMissingHookDependencies(claudeDir: string): Promise<string[]> {
@@ -279,14 +281,14 @@ export async function promptKitUpdate(
 		const localKits = localMetadata ? getInstalledKits(localMetadata) : [];
 		const globalKits = globalMetadata ? getInstalledKits(globalMetadata) : [];
 
-		const selection = selectKitForUpdate({ hasLocal, hasGlobal, localKits, globalKits });
+		let selection = selectKitForUpdate({ hasLocal, hasGlobal, localKits, globalKits });
 
 		if (!selection) {
 			logger.verbose("No ClaudeKit installations detected, skipping kit update prompt");
 			return;
 		}
 
-		const kitVersion = selection.kit
+		let kitVersion = selection.kit
 			? selection.isGlobal
 				? globalMetadata?.kits?.[selection.kit]?.version
 				: localMetadata?.kits?.[selection.kit]?.version
@@ -324,6 +326,40 @@ export async function promptKitUpdate(
 			} catch (error) {
 				logger.verbose(
 					`Hook dependency self-heal check skipped: ${
+						error instanceof Error ? error.message : "unknown"
+					}`,
+				);
+			}
+		}
+
+		if (alreadyAtLatest) {
+			try {
+				const countMissingHookRefsFn =
+					deps?.countMissingHookFileReferencesFn ?? countMissingHookFileReferences;
+				const projectDir = setup.project.path ? dirname(setup.project.path) : process.cwd();
+				const missingHookRefs = await countMissingHookRefsFn(projectDir);
+				if (missingHookRefs > 0) {
+					logger.warning(
+						`Detected ${missingHookRefs} broken hook registration(s); reinstalling kit content`,
+					);
+					alreadyAtLatest = false;
+
+					// A project-local settings.json that points at missing project hooks must be
+					// repaired by a local ck init, even when a global kit also exists.
+					if (setup.project.path && selection.isGlobal) {
+						selection = {
+							isGlobal: false,
+							kit: localKits[0] || selection.kit,
+							promptMessage: `Update local project ClaudeKit content${
+								localKits[0] || selection.kit ? ` (${localKits[0] || selection.kit})` : ""
+							}?`,
+						};
+						kitVersion = selection.kit ? localMetadata?.kits?.[selection.kit]?.version : undefined;
+					}
+				}
+			} catch (error) {
+				logger.verbose(
+					`Hook registration self-heal check skipped: ${
 						error instanceof Error ? error.message : "unknown"
 					}`,
 				);

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -1231,6 +1231,17 @@ export async function checkHookFileReferences(projectDir: string): Promise<Check
 	};
 }
 
+export async function countMissingHookFileReferences(projectDir = process.cwd()): Promise<number> {
+	const settingsFiles = getClaudeSettingsFiles(projectDir);
+	let count = 0;
+	for (const settingsFile of settingsFiles) {
+		const settings = await SettingsMerger.readSettingsFile(settingsFile.path);
+		if (!settings) continue;
+		count += collectMissingHookReferences(settings, settingsFile, projectDir).length;
+	}
+	return count;
+}
+
 export async function repairMissingHookFileReferences(projectDir = process.cwd()): Promise<number> {
 	const result = await checkHookFileReferences(projectDir);
 	if (result.status !== "fail" || !result.fix) {


### PR DESCRIPTION
Closes #854

## Summary
- Add a non-mutating missing hook registration counter for Claude settings files.
- Make `ck update -y` reinstall kit content when the installed kit is already latest but settings point at missing hook files.
- Force local project reinstall for broken project hooks even when a global install is also present.

## Validation
- `bun test src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts src/__tests__/commands/update-cli-auto-init.test.ts`
- `bun run typecheck`
- `bun run ci:local`
- Pre-push hook: `ci:local` + UI vitest suite

## Docs
Docs impact: none. No command surface, setup flow, or user documentation changes; this is update self-heal behavior.