### PR TITLE
test: isolate portable registry home in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,10 @@ jobs:
           env | grep -E '^(CI|NODE|BUN|NON_INTERACTIVE)' | sort
           echo ""
           echo "Running tests with timeout..."
-          timeout 300 bun test --verbose || {
+          timeout 300 bun test --max-concurrency=1 --verbose || {
             echo "[X] Tests failed or timed out"
             echo "Last 50 lines of test output:"
-            bun test --verbose 2>&1 | tail -50 || true
+            bun test --max-concurrency=1 --verbose 2>&1 | tail -50 || true
             exit 1
           }
         env:

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -74,7 +74,7 @@ jobs:
         run: bun run lint
 
       - name: Run tests
-        run: bun test --verbose
+        run: bun test --max-concurrency=1 --verbose
         env:
           NON_INTERACTIVE: "true"
           CI: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         run: bun run lint
 
       - name: Run tests
-        run: bun test
+        run: bun test --max-concurrency=1
 
       - name: Build dist bundle
         run: bun run build

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -38,12 +38,12 @@ bun run lint || fail "Lint failed. Run 'bun run lint:fix' to auto-fix, then re-s
 step "3/7" "Build CLI bundle"
 bun run build || fail "Build failed."
 
-step "4/7" "Tests (bun test --verbose)"
-# CI uses `timeout 300 bun test --verbose`; locally we trust dev
+step "4/7" "Tests (bun test --max-concurrency=1 --verbose)"
+# CI uses `timeout 300 bun test --max-concurrency=1 --verbose`; locally we trust dev
 # to ctrl-c but keep --verbose so local output format matches CI logs exactly when
 # diagnosing failures. Keep max concurrency at 1 because several legacy tests use
 # process-wide Bun module mocks for portable registry helpers.
-bun test --verbose || fail "Tests failed."
+bun test --max-concurrency=1 --verbose || fail "Tests failed."
 
 step "5/7" "Help parity + manifest/docs drift check"
 # Mirrors ci.yml "Verify help parity and regenerated docs" step verbatim.

--- a/src/commands/portable/__tests__/portable-registry.test.ts
+++ b/src/commands/portable/__tests__/portable-registry.test.ts
@@ -5,8 +5,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
  */
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	type PortableRegistryV3,
@@ -525,6 +525,38 @@ describe("empty registry initialization", () => {
 		expect(loaded.installations).toEqual([]);
 		expect(loaded.lastReconciled).toBeUndefined();
 		expect(loaded.appliedManifestVersion).toBeUndefined();
+	});
+
+	test("uses CK_TEST_HOME for registry isolation", async () => {
+		const originalCkTestHome = process.env.CK_TEST_HOME;
+		const testHome = await mkdtemp(join(tmpdir(), "ck-portable-registry-home-"));
+
+		try {
+			process.env.CK_TEST_HOME = testHome;
+
+			await addPortableInstallation(
+				"isolated",
+				"skill",
+				"cursor",
+				false,
+				".cursor/skills/isolated",
+				".claude/skills/isolated",
+			);
+
+			const isolatedRegistryPath = join(testHome, ".claudekit", "portable-registry.json");
+			expect(existsSync(isolatedRegistryPath)).toBe(true);
+
+			const loaded = await readPortableRegistry();
+			expect(loaded.installations).toHaveLength(1);
+			expect(loaded.installations[0]?.item).toBe("isolated");
+		} finally {
+			if (originalCkTestHome === undefined) {
+				Reflect.deleteProperty(process.env, "CK_TEST_HOME");
+			} else {
+				process.env.CK_TEST_HOME = originalCkTestHome;
+			}
+			await rm(testHome, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/src/commands/portable/portable-registry.ts
+++ b/src/commands/portable/portable-registry.ts
@@ -15,7 +15,7 @@ import { UNKNOWN_CHECKSUM, normalizeChecksum } from "./reconcile-types.js";
 import type { PortableType, ProviderType } from "./types.js";
 
 function getPortableRegistryPaths() {
-	const home = homedir();
+	const home = process.env.CK_TEST_HOME || homedir();
 	const claudekitDir = join(home, ".claudekit");
 	return {
 		registryPath: join(claudekitDir, "portable-registry.json"),


### PR DESCRIPTION
## Summary
- make portable registry paths honor `CK_TEST_HOME`
- add regression coverage so registry writes stay inside the isolated test home
- unblocks the dev release workflow, which was failing on real-home portable registry state during release tests

## Validation
- `bun test --verbose src/commands/portable/__tests__/portable-registry.test.ts`
- `bun run typecheck`
- `bun run lint`
- pre-push quality gate

## Docs impact
None. Test/runtime path isolation only; no user-facing workflow or docs behavior changes.
