### PR TITLE
fix: restore portable registry home resolution

### DIFF
--- a/src/commands/portable/__tests__/portable-registry.test.ts
+++ b/src/commands/portable/__tests__/portable-registry.test.ts
@@ -5,8 +5,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
  */
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { homedir, tmpdir } from "node:os";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import {
 	type PortableRegistryV3,
@@ -525,38 +525,6 @@ describe("empty registry initialization", () => {
 		expect(loaded.installations).toEqual([]);
 		expect(loaded.lastReconciled).toBeUndefined();
 		expect(loaded.appliedManifestVersion).toBeUndefined();
-	});
-
-	test("uses CK_TEST_HOME for registry isolation", async () => {
-		const originalCkTestHome = process.env.CK_TEST_HOME;
-		const testHome = await mkdtemp(join(tmpdir(), "ck-portable-registry-home-"));
-
-		try {
-			process.env.CK_TEST_HOME = testHome;
-
-			await addPortableInstallation(
-				"isolated",
-				"skill",
-				"cursor",
-				false,
-				".cursor/skills/isolated",
-				".claude/skills/isolated",
-			);
-
-			const isolatedRegistryPath = join(testHome, ".claudekit", "portable-registry.json");
-			expect(existsSync(isolatedRegistryPath)).toBe(true);
-
-			const loaded = await readPortableRegistry();
-			expect(loaded.installations).toHaveLength(1);
-			expect(loaded.installations[0]?.item).toBe("isolated");
-		} finally {
-			if (originalCkTestHome === undefined) {
-				Reflect.deleteProperty(process.env, "CK_TEST_HOME");
-			} else {
-				process.env.CK_TEST_HOME = originalCkTestHome;
-			}
-			await rm(testHome, { recursive: true, force: true });
-		}
 	});
 });
 

--- a/src/commands/portable/portable-registry.ts
+++ b/src/commands/portable/portable-registry.ts
@@ -15,7 +15,7 @@ import { UNKNOWN_CHECKSUM, normalizeChecksum } from "./reconcile-types.js";
 import type { PortableType, ProviderType } from "./types.js";
 
 function getPortableRegistryPaths() {
-	const home = process.env.CK_TEST_HOME || homedir();
+	const home = homedir();
 	const claudekitDir = join(home, ".claudekit");
 	return {
 		registryPath: join(claudekitDir, "portable-registry.json"),


### PR DESCRIPTION
## Summary
- restore portable registry path resolution to the real user home directory
- remove the CK_TEST_HOME registry-isolation test added in the prior CI unblock attempt
- keep the serial Bun test workflow change already merged on dev

## Why
The dev release job was still failing after PR #858 because the temporary CK_TEST_HOME override changed portable registry runtime behavior and interfered with existing process-wide test assumptions. This follow-up reverts only that runtime/test change so the release workflow can use the serial test command already on dev.

## Validation
- bun test --max-concurrency=1 --verbose src/commands/portable/__tests__/portable-registry.test.ts
- bun run lint
- bun run typecheck
- bun run build
- bun test --max-concurrency=1 --verbose
- git diff --check
- pre-push local CI parity suite

## Docs impact
None. CI/test stabilization only; no user-facing CLI or docs behavior change.