### PR TITLE
fix: restore sparse global hook registrations

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.1-dev.16",
-	"generatedAt": "2026-05-27T03:00:13.688Z",
+	"version": "4.3.1-dev.17",
+	"generatedAt": "2026-05-27T11:58:34.546Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/__tests__/commands/update-cli-auto-init.test.ts
+++ b/src/__tests__/commands/update-cli-auto-init.test.ts
@@ -30,6 +30,50 @@ async function writeMetadata(dir: string, version = "1.0.0") {
 	);
 }
 
+async function writeGlobalHookState(
+	dir: string,
+	options: { disabled?: Record<string, boolean>; includeSessionState?: boolean } = {},
+) {
+	const hooks = [{ type: "command", command: 'node "$HOME/.claude/hooks/simplify-gate.cjs"' }];
+	if (options.includeSessionState) {
+		hooks.push({ type: "command", command: 'node "$HOME/.claude/hooks/session-state.cjs"' });
+	}
+
+	await writeFile(
+		join(dir, "settings.json"),
+		JSON.stringify(
+			{
+				hooks: {
+					UserPromptSubmit: [{ hooks }],
+				},
+			},
+			null,
+			2,
+		),
+	);
+	await writeFile(
+		join(dir, ".ck.json"),
+		JSON.stringify(
+			{
+				hooks: options.disabled ?? {},
+				kits: {
+					"ClaudeKit Engineer": {
+						installedSettings: {
+							hooks: [
+								"node $HOME/.claude/hooks/simplify-gate.cjs",
+								"node $HOME/.claude/hooks/session-state.cjs",
+							],
+							mcpServers: [],
+						},
+					},
+				},
+			},
+			null,
+			2,
+		),
+	);
+}
+
 describe("promptKitUpdate auto-init behavior", () => {
 	let tempDir: string;
 
@@ -232,6 +276,34 @@ describe("promptKitUpdate auto-init behavior", () => {
 		expect(spawnCount()).toBe(0);
 		expect(capturedExecCmd()).toContain("--yes");
 		expect(capturedExecCmd()).toContain("--kit engineer");
+	});
+
+	test("restores missing global hook registrations during a kit update (--yes mode)", async () => {
+		await writeGlobalHookState(tempDir, { includeSessionState: false });
+
+		const { deps, execCount, spawnCount, capturedExecCmd } = makeDeps();
+		deps.getLatestReleaseTagFn = async () => "v2.0.0";
+		await promptKitUpdate(false, true, deps);
+
+		expect(execCount()).toBe(1);
+		expect(spawnCount()).toBe(0);
+		expect(capturedExecCmd()).toContain("ck init -g");
+		expect(capturedExecCmd()).toContain("--restore-ck-hooks");
+	});
+
+	test("does not force global hook restore for hooks explicitly disabled in .ck.json", async () => {
+		await writeGlobalHookState(tempDir, {
+			disabled: { "session-state": false },
+			includeSessionState: false,
+		});
+
+		const { deps, execCount, capturedExecCmd } = makeDeps();
+		deps.getLatestReleaseTagFn = async () => "v2.0.0";
+		await promptKitUpdate(false, true, deps);
+
+		expect(execCount()).toBe(1);
+		expect(capturedExecCmd()).toContain("ck init -g");
+		expect(capturedExecCmd()).not.toContain("--restore-ck-hooks");
 	});
 
 	test("reinstalls local kit when latest project settings have broken hook registrations (--yes mode)", async () => {

--- a/src/__tests__/domains/config/merger/hook-origin.test.ts
+++ b/src/__tests__/domains/config/merger/hook-origin.test.ts
@@ -85,6 +85,49 @@ describe("Hook Origin Tracking", () => {
 		expect(result.conflictsDetected.length).toBeGreaterThan(0);
 	});
 
+	it("filters partial duplicates from no-matcher hook groups", () => {
+		const source: SettingsJson = {
+			hooks: {
+				UserPromptSubmit: [
+					{
+						hooks: [
+							{ type: "command", command: 'node "$HOME/.claude/hooks/simplify-gate.cjs"' },
+							{
+								type: "command",
+								command: 'node "$HOME/.claude/hooks/dev-rules-reminder.cjs"',
+							},
+							{
+								type: "command",
+								command: 'node "$HOME/.claude/hooks/usage-quota-cache-refresh.cjs"',
+							},
+						],
+					},
+				],
+			},
+		};
+		const dest: SettingsJson = {
+			hooks: {
+				UserPromptSubmit: [
+					{
+						hooks: [{ type: "command", command: 'node "$HOME/.claude/hooks/simplify-gate.cjs"' }],
+					},
+				],
+			},
+		};
+
+		const result = mergeSettings(source, dest, { sourceKit: "engineer" });
+		const commands =
+			result.merged.hooks?.UserPromptSubmit?.flatMap((entry) =>
+				"hooks" in entry ? (entry.hooks?.map((hook) => hook.command) ?? []) : [],
+			) ?? [];
+
+		expect(commands.filter((command) => command?.includes("simplify-gate.cjs"))).toHaveLength(1);
+		expect(commands.some((command) => command?.includes("dev-rules-reminder.cjs"))).toBe(true);
+		expect(commands.some((command) => command?.includes("usage-quota-cache-refresh.cjs"))).toBe(
+			true,
+		);
+	});
+
 	it("tags hooks with origin when source kit provided", () => {
 		const source: SettingsJson = {
 			hooks: {

--- a/src/commands/portable/__tests__/portable-registry.test.ts
+++ b/src/commands/portable/__tests__/portable-registry.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 /**
  * Tests for portable registry v3.0 migration (Phase 1)
- * Note: These tests use the real ~/.claudekit/ directory
+ * Note: These tests isolate ~/.claudekit/ through CK_TEST_HOME.
  */
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	type PortableRegistryV3,
@@ -18,50 +18,47 @@ import {
 	writePortableRegistry,
 } from "../portable-registry.js";
 
-const REGISTRY_PATH = join(homedir(), ".claudekit", "portable-registry.json");
-const MIGRATION_LOCK_PATH = join(homedir(), ".claudekit", ".migration.lock");
-let backupContent: string | null = null;
-let backupMigrationLockContent: string | null = null;
-let hadMigrationLock = false;
+const originalCkTestHome = process.env.CK_TEST_HOME;
+let testHome: string | null = null;
 let testFilesToRemove: string[] = [];
 
-beforeEach(async () => {
-	// Backup existing registry if present
-	if (existsSync(REGISTRY_PATH)) {
-		backupContent = await readFile(REGISTRY_PATH, "utf-8");
-		await rm(REGISTRY_PATH, { force: true });
+function getRegistryDir(): string {
+	if (!testHome) {
+		throw new Error("testHome is not initialized");
 	}
+	return join(testHome, ".claudekit");
+}
 
-	hadMigrationLock = existsSync(MIGRATION_LOCK_PATH);
-	if (hadMigrationLock) {
-		backupMigrationLockContent = await readFile(MIGRATION_LOCK_PATH, "utf-8");
-		await rm(MIGRATION_LOCK_PATH, { force: true });
-	}
+function getRegistryPath(): string {
+	return join(getRegistryDir(), "portable-registry.json");
+}
+
+function getMigrationLockPath(): string {
+	return join(getRegistryDir(), ".migration.lock");
+}
+
+beforeEach(async () => {
+	testHome = await mkdtemp(join(tmpdir(), "ck-portable-registry-"));
+	process.env.CK_TEST_HOME = testHome;
+	await mkdir(getRegistryDir(), { recursive: true });
 });
 
 afterEach(async () => {
-	// Restore backup or clean up
-	if (backupContent) {
-		await writeFile(REGISTRY_PATH, backupContent, "utf-8");
-		backupContent = null;
-	} else if (existsSync(REGISTRY_PATH)) {
-		await rm(REGISTRY_PATH, { force: true });
-	}
-
-	if (hadMigrationLock) {
-		await mkdir(join(homedir(), ".claudekit"), { recursive: true });
-		await writeFile(MIGRATION_LOCK_PATH, backupMigrationLockContent ?? "", "utf-8");
-	} else if (existsSync(MIGRATION_LOCK_PATH)) {
-		await rm(MIGRATION_LOCK_PATH, { force: true });
-	}
-
 	for (const path of testFilesToRemove) {
 		await rm(path, { force: true });
 	}
 	testFilesToRemove = [];
 
-	hadMigrationLock = false;
-	backupMigrationLockContent = null;
+	if (testHome) {
+		await rm(testHome, { recursive: true, force: true });
+		testHome = null;
+	}
+
+	if (originalCkTestHome === undefined) {
+		Reflect.deleteProperty(process.env, "CK_TEST_HOME");
+	} else {
+		process.env.CK_TEST_HOME = originalCkTestHome;
+	}
 });
 
 describe("PortableRegistryV3 schema validation", () => {
@@ -148,7 +145,7 @@ describe("v2.0 to v3.0 migration", () => {
 			],
 		};
 
-		await writeFile(REGISTRY_PATH, JSON.stringify(v2Registry, null, 2), "utf-8");
+		await writeFile(getRegistryPath(), JSON.stringify(v2Registry, null, 2), "utf-8");
 
 		// Read should auto-migrate to v3.0
 		const loaded = await readPortableRegistry();
@@ -163,7 +160,7 @@ describe("v2.0 to v3.0 migration", () => {
 	});
 
 	test("reads target file for targetChecksum during migration", async () => {
-		const targetPath = join(homedir(), ".claudekit", "test-target-file.md");
+		const targetPath = join(getRegistryDir(), "test-target-file.md");
 		const targetContent = "# Test Agent\n\nContent here";
 		await writeFile(targetPath, targetContent, "utf-8");
 
@@ -183,7 +180,7 @@ describe("v2.0 to v3.0 migration", () => {
 			],
 		};
 
-		await writeFile(REGISTRY_PATH, JSON.stringify(v2Registry, null, 2), "utf-8");
+		await writeFile(getRegistryPath(), JSON.stringify(v2Registry, null, 2), "utf-8");
 
 		// Read and migrate
 		const loaded = await readPortableRegistry();
@@ -213,7 +210,7 @@ describe("v2.0 to v3.0 migration", () => {
 			],
 		};
 
-		await writeFile(REGISTRY_PATH, JSON.stringify(v2Registry, null, 2), "utf-8");
+		await writeFile(getRegistryPath(), JSON.stringify(v2Registry, null, 2), "utf-8");
 		const loaded = await readPortableRegistry();
 
 		const inst = loaded.installations[0];
@@ -261,7 +258,7 @@ describe("v2.0 to v3.0 migration", () => {
 			],
 		};
 
-		await writeFile(REGISTRY_PATH, JSON.stringify(v2Registry, null, 2), "utf-8");
+		await writeFile(getRegistryPath(), JSON.stringify(v2Registry, null, 2), "utf-8");
 		const loaded = await readPortableRegistry();
 
 		expect(loaded.version).toBe("3.0");
@@ -306,7 +303,7 @@ describe("stale v3.0 registry repair", () => {
 			customTopLevel: "preserved",
 		};
 
-		await writeFile(REGISTRY_PATH, JSON.stringify(staleRegistry, null, 2), "utf-8");
+		await writeFile(getRegistryPath(), JSON.stringify(staleRegistry, null, 2), "utf-8");
 
 		const loaded = await readPortableRegistry();
 
@@ -321,7 +318,7 @@ describe("stale v3.0 registry repair", () => {
 		expect(loaded.installations[1].ownedSections).toEqual(["frontmatter"]);
 		expect(loaded.lastReconciled).toBe("2026-05-09T00:00:00.000Z");
 
-		const persistedRaw = JSON.parse(await readFile(REGISTRY_PATH, "utf-8")) as {
+		const persistedRaw = JSON.parse(await readFile(getRegistryPath(), "utf-8")) as {
 			customTopLevel?: string;
 			installations: Array<{
 				sourceChecksum?: string;
@@ -336,9 +333,9 @@ describe("stale v3.0 registry repair", () => {
 	});
 
 	test("computes target checksum from disk while repairing stale v3.0 entries", async () => {
-		const targetPath = join(homedir(), ".claudekit", `test-stale-v3-target-${process.pid}.md`);
+		const targetPath = join(getRegistryDir(), `test-stale-v3-target-${process.pid}.md`);
 		testFilesToRemove.push(targetPath);
-		await mkdir(join(homedir(), ".claudekit"), { recursive: true });
+		await mkdir(getRegistryDir(), { recursive: true });
 		const targetContent = "# Existing target\n\nContent on disk";
 		const expectedChecksum = createHash("sha256").update(targetContent, "utf-8").digest("hex");
 		await writeFile(targetPath, targetContent, "utf-8");
@@ -358,14 +355,14 @@ describe("stale v3.0 registry repair", () => {
 			],
 		};
 
-		await writeFile(REGISTRY_PATH, JSON.stringify(staleRegistry, null, 2), "utf-8");
+		await writeFile(getRegistryPath(), JSON.stringify(staleRegistry, null, 2), "utf-8");
 
 		const loaded = await readPortableRegistry();
 
 		expect(loaded.installations[0].targetChecksum).toBe(expectedChecksum);
 		expect(loaded.installations[0].targetChecksum).toMatch(/^[a-f0-9]{64}$/);
 
-		const persistedRaw = JSON.parse(await readFile(REGISTRY_PATH, "utf-8")) as {
+		const persistedRaw = JSON.parse(await readFile(getRegistryPath(), "utf-8")) as {
 			installations: Array<{ targetChecksum?: string }>;
 		};
 		expect(persistedRaw.installations[0].targetChecksum).toBe(
@@ -389,8 +386,8 @@ describe("stale v3.0 registry repair", () => {
 			],
 		};
 
-		await writeFile(REGISTRY_PATH, JSON.stringify(staleRegistry, null, 2), "utf-8");
-		await writeFile(MIGRATION_LOCK_PATH, String(Date.now()), "utf-8");
+		await writeFile(getRegistryPath(), JSON.stringify(staleRegistry, null, 2), "utf-8");
+		await writeFile(getMigrationLockPath(), String(Date.now()), "utf-8");
 
 		const loaded = await readPortableRegistry();
 
@@ -398,7 +395,7 @@ describe("stale v3.0 registry repair", () => {
 		expect(loaded.installations[0].targetChecksum).toBe("unknown");
 		expect(loaded.installations[0].installSource).toBe("kit");
 
-		const persistedRaw = JSON.parse(await readFile(REGISTRY_PATH, "utf-8")) as {
+		const persistedRaw = JSON.parse(await readFile(getRegistryPath(), "utf-8")) as {
 			installations: Array<{
 				sourceChecksum?: string;
 				targetChecksum?: string;
@@ -429,7 +426,7 @@ describe("stale v3.0 registry repair", () => {
 			],
 		};
 
-		await writeFile(REGISTRY_PATH, JSON.stringify(corruptedRegistry, null, 2), "utf-8");
+		await writeFile(getRegistryPath(), JSON.stringify(corruptedRegistry, null, 2), "utf-8");
 
 		await expect(readPortableRegistry()).rejects.toThrow(
 			"portable-registry.json has unsupported schema/version",
@@ -439,7 +436,7 @@ describe("stale v3.0 registry repair", () => {
 
 describe("invalid registry handling", () => {
 	test("keeps invalid JSON fatal", async () => {
-		await writeFile(REGISTRY_PATH, "{ invalid json", "utf-8");
+		await writeFile(getRegistryPath(), "{ invalid json", "utf-8");
 
 		await expect(readPortableRegistry()).rejects.toThrow(
 			"portable-registry.json is not valid JSON",
@@ -448,7 +445,7 @@ describe("invalid registry handling", () => {
 
 	test("keeps unsupported top-level versions fatal", async () => {
 		await writeFile(
-			REGISTRY_PATH,
+			getRegistryPath(),
 			JSON.stringify({ version: "4.0", installations: [] }, null, 2),
 			"utf-8",
 		);
@@ -476,15 +473,17 @@ describe("migration lock handling", () => {
 			],
 		};
 
-		await writeFile(REGISTRY_PATH, JSON.stringify(v2Registry, null, 2), "utf-8");
-		await writeFile(MIGRATION_LOCK_PATH, "invalid-timestamp", "utf-8");
+		await writeFile(getRegistryPath(), JSON.stringify(v2Registry, null, 2), "utf-8");
+		await writeFile(getMigrationLockPath(), "invalid-timestamp", "utf-8");
 
 		const loaded = await readPortableRegistry();
 		expect(loaded.version).toBe("3.0");
 		expect(loaded.installations).toHaveLength(1);
-		expect(existsSync(MIGRATION_LOCK_PATH)).toBe(true);
+		expect(existsSync(getMigrationLockPath())).toBe(true);
 
-		const persistedRaw = JSON.parse(await readFile(REGISTRY_PATH, "utf-8")) as { version: string };
+		const persistedRaw = JSON.parse(await readFile(getRegistryPath(), "utf-8")) as {
+			version: string;
+		};
 		expect(persistedRaw.version).toBe("2.0");
 	});
 
@@ -504,16 +503,18 @@ describe("migration lock handling", () => {
 			],
 		};
 
-		await writeFile(REGISTRY_PATH, JSON.stringify(v2Registry, null, 2), "utf-8");
-		await writeFile(MIGRATION_LOCK_PATH, String(Date.now() - 120000), "utf-8");
+		await writeFile(getRegistryPath(), JSON.stringify(v2Registry, null, 2), "utf-8");
+		await writeFile(getMigrationLockPath(), String(Date.now() - 120000), "utf-8");
 
 		const loaded = await readPortableRegistry();
 		expect(loaded.version).toBe("3.0");
 		expect(loaded.installations).toHaveLength(1);
 
-		const persistedRaw = JSON.parse(await readFile(REGISTRY_PATH, "utf-8")) as { version: string };
+		const persistedRaw = JSON.parse(await readFile(getRegistryPath(), "utf-8")) as {
+			version: string;
+		};
 		expect(persistedRaw.version).toBe("3.0");
-		expect(existsSync(MIGRATION_LOCK_PATH)).toBe(false);
+		expect(existsSync(getMigrationLockPath())).toBe(false);
 	});
 });
 
@@ -806,7 +807,7 @@ describe("v2.0 schema forward compatibility", () => {
 			],
 		};
 
-		await writeFile(REGISTRY_PATH, JSON.stringify(v3Data, null, 2), "utf-8");
+		await writeFile(getRegistryPath(), JSON.stringify(v3Data, null, 2), "utf-8");
 
 		// Should not throw parse error
 		const loaded = await readPortableRegistry();

--- a/src/commands/portable/portable-registry.ts
+++ b/src/commands/portable/portable-registry.ts
@@ -5,18 +5,17 @@
  */
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import lockfile from "proper-lockfile";
 import { z } from "zod";
 import { logger } from "../../shared/logger.js";
+import { PathResolver } from "../../shared/path-resolver.js";
 import { computeFileChecksum } from "./checksum-utils.js";
 import { UNKNOWN_CHECKSUM, normalizeChecksum } from "./reconcile-types.js";
 import type { PortableType, ProviderType } from "./types.js";
 
 function getPortableRegistryPaths() {
-	const home = homedir();
-	const claudekitDir = join(home, ".claudekit");
+	const claudekitDir = PathResolver.getConfigDir(false);
 	return {
 		registryPath: join(claudekitDir, "portable-registry.json"),
 		registryLockPath: join(claudekitDir, "portable-registry.lock"),

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -20,6 +20,8 @@ import {
 import { getInstalledKits } from "@/domains/migration/metadata-migration.js";
 import { versionsMatch } from "@/domains/versioning/checking/version-utils.js";
 import { getClaudeKitSetup } from "@/services/file-operations/claudekit-scanner.js";
+import { normalizeCommand } from "@/shared/command-normalizer.js";
+import { parseJsonContent } from "@/shared/json-content.js";
 import { logger } from "@/shared/logger.js";
 import { confirm, isCancel, log, spinner } from "@/shared/safe-prompts.js";
 import { AVAILABLE_KITS, type KitType, type Metadata, MetadataSchema } from "@/types";
@@ -42,6 +44,15 @@ const execAsync = promisify(exec);
 // Only allow alphanumeric chars and hyphens in provider names (defense-in-depth against injection)
 const SAFE_PROVIDER_NAME = /^[a-z0-9-]+$/;
 const HOOK_DEPENDENCY_EXTENSIONS = [".js", ".cjs", ".mjs", ".json"];
+
+interface CkSettingsSnapshot {
+	hooks?: Record<string, Array<{ command?: string; hooks?: Array<{ command?: string }> }>>;
+}
+
+interface CkConfigSnapshot {
+	hooks?: Record<string, unknown>;
+	kits?: Record<string, { installedSettings?: { hooks?: string[] } }>;
+}
 
 // ─── Kit selection ────────────────────────────────────────────────────────────
 
@@ -113,6 +124,78 @@ export async function readMetadataFile(claudeDir: string): Promise<Metadata | nu
 		);
 		return null;
 	}
+}
+
+function extractCkHookName(command: string): string | null {
+	if (!command.trim().startsWith("node ")) return null;
+	const normalized = command.replace(/\\/g, "/");
+	const match = normalized.match(/\/hooks\/([^/"'\s]+)\.(?:cjs|mjs|js)(?:["'\s]|$)/);
+	return match?.[1] ?? null;
+}
+
+function collectSettingsHookCommands(settings: CkSettingsSnapshot): Set<string> {
+	const commands = new Set<string>();
+	for (const entries of Object.values(settings.hooks ?? {})) {
+		for (const entry of entries) {
+			if (typeof entry.command === "string") {
+				commands.add(normalizeCommand(entry.command));
+			}
+			for (const hook of entry.hooks ?? []) {
+				if (typeof hook.command === "string") {
+					commands.add(normalizeCommand(hook.command));
+				}
+			}
+		}
+	}
+	return commands;
+}
+
+function getInstalledHookCommands(config: CkConfigSnapshot, kit?: KitType): string[] {
+	const kits = Object.entries(config.kits ?? {});
+	if (kits.length === 0) return [];
+
+	const kitKey = kit?.toLowerCase();
+	const preferred = kitKey
+		? kits.filter(([name]) => {
+				const normalizedName = name.toLowerCase();
+				return normalizedName === kitKey || normalizedName.includes(kitKey);
+			})
+		: [];
+	const candidates = preferred.length > 0 ? preferred : kits;
+
+	return candidates.flatMap(([, entry]) => entry.installedSettings?.hooks ?? []);
+}
+
+/**
+ * Counts CK hook registrations that were previously installed but are absent
+ * from settings.json. Explicit dashboard/.ck.json disables are not counted.
+ */
+export async function countMissingCkHookRegistrations(
+	claudeDir: string,
+	kit?: KitType,
+): Promise<number> {
+	const settingsPath = join(claudeDir, "settings.json");
+	const configPath = join(claudeDir, ".ck.json");
+	if (!existsSync(settingsPath) || !existsSync(configPath)) return 0;
+
+	const settings = parseJsonContent<CkSettingsSnapshot>(await readFile(settingsPath, "utf-8"));
+	const config = parseJsonContent<CkConfigSnapshot>(await readFile(configPath, "utf-8"));
+	const existingCommands = collectSettingsHookCommands(settings);
+	const disabledHooks = new Set(
+		Object.entries(config.hooks ?? {})
+			.filter(([, enabled]) => enabled === false)
+			.map(([name]) => name),
+	);
+
+	let missing = 0;
+	for (const command of getInstalledHookCommands(config, kit)) {
+		const hookName = extractCkHookName(command);
+		if (hookName && disabledHooks.has(hookName)) continue;
+		if (!existingCommands.has(normalizeCommand(command))) {
+			missing++;
+		}
+	}
+	return missing;
 }
 
 // ─── Init command builder ─────────────────────────────────────────────────────
@@ -333,6 +416,48 @@ export async function promptKitUpdate(
 					kit,
 					promptMessage: `Update local project ClaudeKit content${kit ? ` (${kit})` : ""}?`,
 				};
+			}
+		}
+
+		const selectedClaudeDir = selection.isGlobal ? setup.global.path : setup.project.path;
+		if (selectedClaudeDir) {
+			try {
+				const missingHookDeps = await findMissingHookDepsFn(selectedClaudeDir);
+				if (missingHookDeps.length > 0) {
+					logger.warning(
+						`Detected ${missingHookDeps.length} ${
+							selection.isGlobal ? "global" : "local"
+						} missing hook dependency(ies); reinstalling kit content`,
+					);
+					forceKitReinstall = true;
+				}
+			} catch (error) {
+				logger.verbose(
+					`Selected hook dependency self-heal check skipped: ${
+						error instanceof Error ? error.message : "unknown"
+					}`,
+				);
+			}
+
+			try {
+				const missingHookRegistrations = await countMissingCkHookRegistrations(
+					selectedClaudeDir,
+					selection.kit,
+				);
+				if (missingHookRegistrations > 0) {
+					logger.warning(
+						`Detected ${missingHookRegistrations} ${
+							selection.isGlobal ? "global" : "local"
+						} missing hook registration(s); reinstalling kit content`,
+					);
+					forceKitReinstall = true;
+				}
+			} catch (error) {
+				logger.verbose(
+					`Selected hook registration self-heal check skipped: ${
+						error instanceof Error ? error.message : "unknown"
+					}`,
+				);
 			}
 		}
 

--- a/src/domains/config/merger/conflict-resolver.ts
+++ b/src/domains/config/merger/conflict-resolver.ts
@@ -203,21 +203,25 @@ export function mergeHookEntries(
 			// Check if entry should be added:
 			// - If no commands (malformed/empty), add it (can't determine user removal)
 			// - If has commands, check if at least one is new and not user-removed
-			const hasNonRemovedCommands =
-				commands.length === 0 ||
-				commands.some(
-					(cmd) =>
-						!existingCommands.has(normalizeCommand(cmd)) &&
-						!wasCommandInstalled(cmd, installedHooks),
-				);
+			const newCommands = commands.filter(
+				(cmd) =>
+					!existingCommands.has(normalizeCommand(cmd)) && !wasCommandInstalled(cmd, installedHooks),
+			);
+			const hasNonRemovedCommands = commands.length === 0 || newCommands.length > 0;
 
 			if (!isFullyDuplicated && hasNonRemovedCommands) {
-				// Filter out user-removed hooks before adding entry
+				// Filter out duplicate and user-removed hooks before adding entry
 				let filteredEntry = entry;
-				if ("hooks" in entry && entry.hooks && userRemovedCommands.length > 0) {
+				if ("hooks" in entry && entry.hooks && commands.length > 0) {
 					const filteredHooks = entry.hooks.filter(
-						(h) => !h.command || !wasCommandInstalled(h.command, installedHooks),
+						(h) =>
+							!h.command ||
+							(!existingCommands.has(normalizeCommand(h.command)) &&
+								!wasCommandInstalled(h.command, installedHooks)),
 					);
+					if (filteredHooks.length === 0) {
+						continue;
+					}
 					filteredEntry = { ...entry, hooks: filteredHooks };
 				} else if ("command" in entry && wasCommandInstalled(entry.command, installedHooks)) {
 					// Single command entry that was removed - skip entirely
@@ -235,17 +239,13 @@ export function mergeHookEntries(
 					matcherIndex.set(sourceMatcher, merged.length - 1);
 				}
 				// Register new commands and track newly installed
-				for (const cmd of commands) {
+				for (const cmd of newCommands) {
 					const normalizedCmd = normalizeCommand(cmd);
-					if (!existingCommands.has(normalizedCmd) && !wasCommandInstalled(cmd, installedHooks)) {
-						existingCommands.add(normalizedCmd);
-						result.newlyInstalledHooks.push(cmd);
-						// Track in hooksByOrigin
-						if (sourceKit) {
-							trackHookOrigin(result, sourceKit, cmd);
-						}
-					} else if (!existingCommands.has(normalizedCmd)) {
-						existingCommands.add(normalizedCmd);
+					existingCommands.add(normalizedCmd);
+					result.newlyInstalledHooks.push(cmd);
+					// Track in hooksByOrigin
+					if (sourceKit) {
+						trackHookOrigin(result, sourceKit, cmd);
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- detect missing CK-owned hook registrations in the selected global or local install before update-time kit init
- force restore mode when settings are sparse but `.ck.json` shows CK-owned hooks were previously installed
- avoid duplicate no-matcher hook entries when restoring partial hook groups

## Validation
- bun test --max-concurrency=1
- bun run typecheck
- bun run lint
- bun run build
- pre-push gate: typecheck, lint, build, tests, help/manifest drift, UI build, packaged CLI verification, UI Vitest
- real i9-bootcamp global E2E: sparse `C:\Users\kaidu\.claude\settings.json` (4 hooks) -> patched `ck update` restored 15 hooks, kept one `simplify-gate`, and bare `ship` prompt exits 0

Docs impact: none
Action: no update needed — update-time self-heal only, no user-facing command syntax changes.