### PR TITLE
fix: self-heal hooks during npm postinstall

### DIFF
--- a/bin/postinstall-hook-restore.cjs
+++ b/bin/postinstall-hook-restore.cjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const MAX_SETTINGS_BYTES = 5 * 1024 * 1024;
+const SAFE_KIT_NAMES = new Set(["engineer", "marketing"]);
+
+function getHomeDir() {
+	return process.env.CK_TEST_HOME || os.homedir();
+}
+
+function readJsonFile(filePath) {
+	try {
+		if (!filePath || !fs.existsSync(filePath)) return null;
+		const stat = fs.statSync(filePath);
+		if (!stat.isFile() || stat.size > MAX_SETTINGS_BYTES) return null;
+		return JSON.parse(fs.readFileSync(filePath, "utf8").replace(/^\uFEFF/, ""));
+	} catch {
+		return null;
+	}
+}
+
+function normalizeCommand(command) {
+	if (!command) return "";
+	let normalized = String(command).replace(/"/g, "");
+	normalized = normalized.replace(/~\//g, "$HOME/");
+	normalized = normalized.replace(/\$\{HOME\}/g, "$HOME");
+	normalized = normalized.replace(/\$CLAUDE_PROJECT_DIR/g, "$HOME");
+	normalized = normalized.replace(/%USERPROFILE%/g, "$HOME");
+	normalized = normalized.replace(/%CLAUDE_PROJECT_DIR%/g, "$HOME");
+	normalized = normalized.replace(/(^|\s)(?:\.\/)?\.claude\//g, "$1$HOME/.claude/");
+	normalized = normalized.replace(/\\/g, "/");
+	return normalized.replace(/\s+/g, " ").trim();
+}
+
+function collectHookCommands(settings) {
+	const commands = new Set();
+	for (const entries of Object.values(settings?.hooks || {})) {
+		if (!Array.isArray(entries)) continue;
+		for (const entry of entries) {
+			if (typeof entry?.command === "string") commands.add(normalizeCommand(entry.command));
+			if (!Array.isArray(entry?.hooks)) continue;
+			for (const hook of entry.hooks) {
+				if (typeof hook?.command === "string") commands.add(normalizeCommand(hook.command));
+			}
+		}
+	}
+	return commands;
+}
+
+function extractCkHookName(command) {
+	if (!String(command || "").trim().startsWith("node ")) return null;
+	const normalized = String(command).replace(/\\/g, "/");
+	const match = normalized.match(/\/hooks\/([^/"'\s]+)\.(?:cjs|mjs|js)(?:["'\s]|$)/);
+	return match?.[1] || null;
+}
+
+function installedHookCommands(config) {
+	return Object.values(config?.kits || {}).flatMap((entry) =>
+		Array.isArray(entry?.installedSettings?.hooks) ? entry.installedSettings.hooks : [],
+	);
+}
+
+function countMissingCkHookRegistrations(claudeDir) {
+	const settings = readJsonFile(path.join(claudeDir, "settings.json"));
+	const config = readJsonFile(path.join(claudeDir, ".ck.json"));
+	if (!settings || !config) return 0;
+
+	const existingCommands = collectHookCommands(settings);
+	const disabledHooks = new Set(
+		Object.entries(config.hooks || {})
+			.filter(([, enabled]) => enabled === false)
+			.map(([name]) => name),
+	);
+
+	let missing = 0;
+	for (const command of installedHookCommands(config)) {
+		const hookName = extractCkHookName(command);
+		if (hookName && disabledHooks.has(hookName)) continue;
+		if (!existingCommands.has(normalizeCommand(command))) missing++;
+	}
+	return missing;
+}
+
+function normalizeKitName(name) {
+	const normalized = String(name || "").toLowerCase();
+	if (normalized.includes("engineer")) return "engineer";
+	if (normalized.includes("marketing")) return "marketing";
+	return SAFE_KIT_NAMES.has(normalized) ? normalized : null;
+}
+
+function getInstalledKit(claudeDir) {
+	const metadata = readJsonFile(path.join(claudeDir, "metadata.json"));
+	const metadataKit = normalizeKitName(Object.keys(metadata?.kits || {})[0] || metadata?.name);
+	if (metadataKit) {
+		const kitVersion = metadata?.kits?.[metadataKit]?.version || metadata?.version || "";
+		return { kit: metadataKit, isBeta: String(kitVersion).includes("beta") };
+	}
+
+	const config = readJsonFile(path.join(claudeDir, ".ck.json"));
+	const configKit = normalizeKitName(Object.keys(config?.kits || {})[0]);
+	return configKit ? { kit: configKit, isBeta: false } : null;
+}
+
+function collectCandidateClaudeDirs(settingsFiles) {
+	const dirs = new Set();
+	for (const settingsFile of settingsFiles) dirs.add(path.dirname(settingsFile));
+	return [...dirs];
+}
+
+function resolveCkEntrypoint() {
+	return process.env.CK_POSTINSTALL_CK_BIN || path.join(__dirname, "ck.js");
+}
+
+function restoreMissingHookRegistrations(settingsFiles) {
+	if (process.env.CK_POSTINSTALL_SKIP_RESTORE_CK_HOOKS === "1") return 0;
+
+	let restored = 0;
+	for (const claudeDir of collectCandidateClaudeDirs(settingsFiles)) {
+		const missing = countMissingCkHookRegistrations(claudeDir);
+		if (missing <= 0) continue;
+
+		const installedKit = getInstalledKit(claudeDir);
+		if (!installedKit?.kit) continue;
+
+		const homeDir = getHomeDir();
+		const globalClaudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(homeDir, ".claude");
+		const isGlobal = path.resolve(claudeDir) === path.resolve(globalClaudeDir);
+		const args = [resolveCkEntrypoint(), "init"];
+		if (isGlobal) args.push("-g");
+		args.push("--kit", installedKit.kit, "--yes", "--restore-ck-hooks", "--install-skills");
+		if (installedKit.isBeta) args.push("--beta");
+
+		const result = spawnSync(process.execPath, args, {
+			env: { ...process.env, CK_POSTINSTALL_SKIP_RESTORE_CK_HOOKS: "1" },
+			stdio: process.env.CK_POSTINSTALL_DEBUG === "1" ? "inherit" : "ignore",
+		});
+		if (result.status === 0) restored += missing;
+	}
+
+	return restored;
+}
+
+module.exports = {
+	countMissingCkHookRegistrations,
+	restoreMissingHookRegistrations,
+};

--- a/bin/postinstall-self-heal.cjs
+++ b/bin/postinstall-self-heal.cjs
@@ -4,6 +4,10 @@
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const {
+	countMissingCkHookRegistrations,
+	restoreMissingHookRegistrations,
+} = require("./postinstall-hook-restore.cjs");
 
 const MAX_SETTINGS_BYTES = 5 * 1024 * 1024;
 
@@ -124,12 +128,18 @@ function collectCandidateSettingsFiles() {
 
 function main() {
 	let pruned = 0;
-	for (const filePath of collectCandidateSettingsFiles()) {
+	const settingsFiles = collectCandidateSettingsFiles();
+	for (const filePath of settingsFiles) {
 		pruned += pruneSettingsFile(filePath);
 	}
 
+	const restored = restoreMissingHookRegistrations(settingsFiles);
+
 	if (pruned > 0 && process.env.CK_POSTINSTALL_DEBUG === "1") {
 		console.warn(`[claudekit-cli] Pruned ${pruned} legacy hook prompt(s)`);
+	}
+	if (restored > 0 && process.env.CK_POSTINSTALL_DEBUG === "1") {
+		console.warn(`[claudekit-cli] Restored ${restored} missing hook registration(s)`);
 	}
 }
 
@@ -137,7 +147,9 @@ main();
 
 module.exports = {
 	collectCandidateSettingsFiles,
+	countMissingCkHookRegistrations,
 	isLegacyDescriptiveNamePrompt,
 	pruneHooks,
 	pruneSettingsFile,
+	restoreMissingHookRegistrations,
 };

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.1-dev.17",
-	"generatedAt": "2026-05-27T11:58:34.546Z",
+	"version": "4.3.1-dev.18",
+	"generatedAt": "2026-05-27T12:39:16.162Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	},
 	"files": [
 		"bin/ck.js",
+		"bin/postinstall-hook-restore.cjs",
 		"bin/postinstall-self-heal.cjs",
 		"dist/index.js",
 		"dist/ui/",

--- a/src/__tests__/scripts/postinstall-self-heal.test.ts
+++ b/src/__tests__/scripts/postinstall-self-heal.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -62,5 +62,93 @@ describe("postinstall self-heal", () => {
 		const ccsSettings = JSON.parse(await readFile(ccsSettingsPath, "utf8"));
 		expect(projectSettings.hooks).toBeUndefined();
 		expect(ccsSettings.hooks).toBeUndefined();
+	});
+
+	test("restores sparse global CK hook registrations during npm postinstall", async () => {
+		const globalClaudeDir = join(tempDir, ".claude");
+		await mkdir(globalClaudeDir, { recursive: true });
+
+		const settingsPath = join(globalClaudeDir, "settings.json");
+		await writeFile(
+			settingsPath,
+			`\uFEFF${JSON.stringify(
+				{
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: 'node "$HOME/.claude/hooks/simplify-gate.cjs"',
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			)}`,
+		);
+		await writeFile(
+			join(globalClaudeDir, ".ck.json"),
+			JSON.stringify(
+				{
+					hooks: {},
+					kits: {
+						"ClaudeKit Engineer": {
+							installedSettings: {
+								hooks: [
+									"node $HOME/.claude/hooks/simplify-gate.cjs",
+									"node $HOME/.claude/hooks/session-state.cjs",
+								],
+							},
+						},
+					},
+				},
+				null,
+				2,
+			),
+		);
+		await writeFile(
+			join(globalClaudeDir, "metadata.json"),
+			JSON.stringify({
+				scope: "global",
+				kits: { engineer: { version: "v2.19.2-beta.1" } },
+			}),
+		);
+
+		const stubPath = join(tempDir, "ck-stub.cjs");
+		const stubOutputPath = join(tempDir, "ck-stub-output.json");
+		await writeFile(
+			stubPath,
+			`#!/usr/bin/env node
+const fs = require("node:fs");
+fs.writeFileSync(process.env.CK_POSTINSTALL_STUB_OUTPUT, JSON.stringify(process.argv.slice(2)));
+`,
+		);
+		await chmod(stubPath, 0o755);
+
+		execFileSync(process.execPath, [scriptPath], {
+			env: {
+				...process.env,
+				CK_POSTINSTALL_CK_BIN: stubPath,
+				CK_POSTINSTALL_STUB_OUTPUT: stubOutputPath,
+				CK_TEST_HOME: tempDir,
+			},
+			stdio: "pipe",
+		});
+
+		const args = JSON.parse(await readFile(stubOutputPath, "utf8"));
+		expect(args).toEqual([
+			"init",
+			"-g",
+			"--kit",
+			"engineer",
+			"--yes",
+			"--restore-ck-hooks",
+			"--install-skills",
+			"--beta",
+		]);
 	});
 });

--- a/src/commands/portable/__tests__/portable-registry.test.ts
+++ b/src/commands/portable/__tests__/portable-registry.test.ts
@@ -37,9 +37,16 @@ function getMigrationLockPath(): string {
 	return join(getRegistryDir(), ".migration.lock");
 }
 
+function pinTestHome(): void {
+	if (!testHome) {
+		throw new Error("testHome is not initialized");
+	}
+	process.env.CK_TEST_HOME = testHome;
+}
+
 beforeEach(async () => {
 	testHome = await mkdtemp(join(tmpdir(), "ck-portable-registry-"));
-	process.env.CK_TEST_HOME = testHome;
+	pinTestHome();
 	await mkdir(getRegistryDir(), { recursive: true });
 });
 
@@ -665,8 +672,10 @@ describe("removeInstallationsByFilter (stale entry cleanup)", () => {
 
 describe("addPortableInstallation (path alignment for cursor/windsurf)", () => {
 	test("records cursor skill at .cursor/skills/<name> path", async () => {
+		pinTestHome();
 		await writePortableRegistry({ version: "3.0", installations: [] });
 
+		pinTestHome();
 		await addPortableInstallation(
 			"scout",
 			"skill",
@@ -676,6 +685,7 @@ describe("addPortableInstallation (path alignment for cursor/windsurf)", () => {
 			".claude/skills/scout",
 		);
 
+		pinTestHome();
 		const loaded = await readPortableRegistry();
 		const entry = loaded.installations.find((i) => i.item === "scout");
 		expect(entry).toBeDefined();
@@ -685,8 +695,10 @@ describe("addPortableInstallation (path alignment for cursor/windsurf)", () => {
 	});
 
 	test("records windsurf skill at .windsurf/skills/<name> path (project scope)", async () => {
+		pinTestHome();
 		await writePortableRegistry({ version: "3.0", installations: [] });
 
+		pinTestHome();
 		await addPortableInstallation(
 			"debug",
 			"skill",
@@ -696,6 +708,7 @@ describe("addPortableInstallation (path alignment for cursor/windsurf)", () => {
 			".claude/skills/debug",
 		);
 
+		pinTestHome();
 		const loaded = await readPortableRegistry();
 		const entry = loaded.installations.find((i) => i.item === "debug");
 		expect(entry).toBeDefined();
@@ -705,9 +718,11 @@ describe("addPortableInstallation (path alignment for cursor/windsurf)", () => {
 	});
 
 	test("records windsurf skill at ~/.codeium/windsurf/skills/<name> path (global scope)", async () => {
+		pinTestHome();
 		await writePortableRegistry({ version: "3.0", installations: [] });
 
 		const globalPath = join(homedir(), ".codeium", "windsurf", "skills", "debug");
+		pinTestHome();
 		await addPortableInstallation(
 			"debug",
 			"skill",
@@ -717,6 +732,7 @@ describe("addPortableInstallation (path alignment for cursor/windsurf)", () => {
 			".claude/skills/debug",
 		);
 
+		pinTestHome();
 		const loaded = await readPortableRegistry();
 		const entry = loaded.installations.find((i) => i.item === "debug" && i.global === true);
 		expect(entry).toBeDefined();


### PR DESCRIPTION
## Summary
- add npm postinstall repair for sparse CK-owned hook registrations
- restore missing global/local hook registrations by running `ck init --restore-ck-hooks` from the newly installed package
- cover sparse global settings in postinstall tests and harden portable-registry test home isolation

## Validation
- `bun test src/__tests__/scripts/postinstall-self-heal.test.ts src/__tests__/commands/update-cli-auto-init.test.ts --max-concurrency=1 --verbose`
- `bun test src/commands/portable/__tests__/portable-registry.test.ts --max-concurrency=1 --verbose`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run verify:package`
- pre-push local CI parity gate passed
- GitHub CI passed
- Windows global tarball E2E on `i9-bootcamp`: stable global install -> sparse global settings -> global tarball install restored 15 hook commands and accepted bare `ship`

## Docs impact
none — update-time self-heal only, no user-facing command syntax changes.