### PR TITLE
fix: restore hooks with legacy metadata

### DIFF
--- a/bin/postinstall-hook-restore.cjs
+++ b/bin/postinstall-hook-restore.cjs
@@ -8,6 +8,13 @@ const { spawnSync } = require("node:child_process");
 
 const MAX_SETTINGS_BYTES = 5 * 1024 * 1024;
 const SAFE_KIT_NAMES = new Set(["engineer", "marketing"]);
+const COMPLETE_HOOK_SENTINELS = new Set(["session-init", "session-state", "subagent-init"]);
+const LEGACY_SPARSE_HOOK_SENTINELS = new Set([
+	"descriptive-name",
+	"privacy-block",
+	"scout-block",
+	"simplify-gate",
+]);
 
 function getHomeDir() {
 	return process.env.CK_TEST_HOME || os.homedir();
@@ -65,6 +72,35 @@ function installedHookCommands(config) {
 	);
 }
 
+function hasInstalledKit(config) {
+	return Object.keys(config?.kits || {}).some((kitName) => normalizeKitName(kitName));
+}
+
+function hasLegacySparseCkHooks(settings, config) {
+	if (!hasInstalledKit(config)) return false;
+
+	const hookNames = new Set();
+	for (const command of collectHookCommands(settings)) {
+		const hookName = extractCkHookName(command);
+		if (hookName) hookNames.add(hookName);
+	}
+
+	const hasKnownSparseHook = [...LEGACY_SPARSE_HOOK_SENTINELS].some((hookName) =>
+		hookNames.has(hookName),
+	);
+	if (!hasKnownSparseHook) return false;
+
+	const disabledHooks = new Set(
+		Object.entries(config?.hooks || {})
+			.filter(([, enabled]) => enabled === false)
+			.map(([name]) => name),
+	);
+
+	return [...COMPLETE_HOOK_SENTINELS].some(
+		(hookName) => !disabledHooks.has(hookName) && !hookNames.has(hookName),
+	);
+}
+
 function countMissingCkHookRegistrations(claudeDir) {
 	const settings = readJsonFile(path.join(claudeDir, "settings.json"));
 	const config = readJsonFile(path.join(claudeDir, ".ck.json"));
@@ -83,6 +119,11 @@ function countMissingCkHookRegistrations(claudeDir) {
 		if (hookName && disabledHooks.has(hookName)) continue;
 		if (!existingCommands.has(normalizeCommand(command))) missing++;
 	}
+
+	if (missing === 0 && installedHookCommands(config).length === 0) {
+		return hasLegacySparseCkHooks(settings, config) ? 1 : 0;
+	}
+
 	return missing;
 }
 

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.1-dev.18",
-	"generatedAt": "2026-05-27T12:39:16.162Z",
+	"version": "4.3.1-dev.19",
+	"generatedAt": "2026-05-27T13:27:14.698Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/__tests__/scripts/postinstall-self-heal.test.ts
+++ b/src/__tests__/scripts/postinstall-self-heal.test.ts
@@ -151,4 +151,104 @@ fs.writeFileSync(process.env.CK_POSTINSTALL_STUB_OUTPUT, JSON.stringify(process.
 			"--beta",
 		]);
 	});
+
+	test("restores sparse global CK hooks when legacy metadata has no hook snapshot", async () => {
+		const globalClaudeDir = join(tempDir, ".claude");
+		await mkdir(globalClaudeDir, { recursive: true });
+
+		await writeFile(
+			join(globalClaudeDir, "settings.json"),
+			JSON.stringify(
+				{
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: 'node "$HOME/.claude/hooks/simplify-gate.cjs"',
+									},
+								],
+							},
+						],
+						PreToolUse: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: 'node "$HOME/.claude/hooks/descriptive-name.cjs"',
+									},
+									{
+										type: "command",
+										command: 'node "$HOME/.claude/hooks/privacy-block.cjs"',
+									},
+									{
+										type: "command",
+										command: 'node "$HOME/.claude/hooks/scout-block.cjs"',
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+		await writeFile(
+			join(globalClaudeDir, ".ck.json"),
+			JSON.stringify(
+				{
+					hooks: {},
+					kits: {
+						"ClaudeKit Engineer": {
+							version: "v2.19.2-beta.1",
+						},
+					},
+				},
+				null,
+				2,
+			),
+		);
+		await writeFile(
+			join(globalClaudeDir, "metadata.json"),
+			JSON.stringify({
+				scope: "global",
+				kits: { engineer: { version: "v2.19.2-beta.1" } },
+			}),
+		);
+
+		const stubPath = join(tempDir, "ck-stub.cjs");
+		const stubOutputPath = join(tempDir, "ck-stub-output.json");
+		await writeFile(
+			stubPath,
+			`#!/usr/bin/env node
+const fs = require("node:fs");
+fs.writeFileSync(process.env.CK_POSTINSTALL_STUB_OUTPUT, JSON.stringify(process.argv.slice(2)));
+`,
+		);
+		await chmod(stubPath, 0o755);
+
+		execFileSync(process.execPath, [scriptPath], {
+			env: {
+				...process.env,
+				CK_POSTINSTALL_CK_BIN: stubPath,
+				CK_POSTINSTALL_STUB_OUTPUT: stubOutputPath,
+				CK_TEST_HOME: tempDir,
+			},
+			stdio: "pipe",
+		});
+
+		const args = JSON.parse(await readFile(stubOutputPath, "utf8"));
+		expect(args).toEqual([
+			"init",
+			"-g",
+			"--kit",
+			"engineer",
+			"--yes",
+			"--restore-ck-hooks",
+			"--install-skills",
+			"--beta",
+		]);
+	});
 });

--- a/src/commands/portable/__tests__/portable-registry.test.ts
+++ b/src/commands/portable/__tests__/portable-registry.test.ts
@@ -37,6 +37,10 @@ function getMigrationLockPath(): string {
 	return join(getRegistryDir(), ".migration.lock");
 }
 
+async function readTestPortableRegistry(): Promise<PortableRegistryV3> {
+	return JSON.parse(await readFile(getRegistryPath(), "utf-8")) as PortableRegistryV3;
+}
+
 function pinTestHome(): void {
 	if (!testHome) {
 		throw new Error("testHome is not initialized");
@@ -686,7 +690,7 @@ describe("addPortableInstallation (path alignment for cursor/windsurf)", () => {
 		);
 
 		pinTestHome();
-		const loaded = await readPortableRegistry();
+		const loaded = await readTestPortableRegistry();
 		const entry = loaded.installations.find((i) => i.item === "scout");
 		expect(entry).toBeDefined();
 		expect(entry?.path).toBe(".cursor/skills/scout");
@@ -709,7 +713,7 @@ describe("addPortableInstallation (path alignment for cursor/windsurf)", () => {
 		);
 
 		pinTestHome();
-		const loaded = await readPortableRegistry();
+		const loaded = await readTestPortableRegistry();
 		const entry = loaded.installations.find((i) => i.item === "debug");
 		expect(entry).toBeDefined();
 		expect(entry?.path).toBe(".windsurf/skills/debug");
@@ -733,7 +737,7 @@ describe("addPortableInstallation (path alignment for cursor/windsurf)", () => {
 		);
 
 		pinTestHome();
-		const loaded = await readPortableRegistry();
+		const loaded = await readTestPortableRegistry();
 		const entry = loaded.installations.find((i) => i.item === "debug" && i.global === true);
 		expect(entry).toBeDefined();
 		expect(entry?.path).toBe(globalPath);


### PR DESCRIPTION
## Summary
- Restore CK hook registrations during npm postinstall even when legacy `.ck.json` metadata has no stored hook snapshot.
- Detect sparse CK-owned global hook sets from known hook commands and re-run `ck init --restore-ck-hooks` for the installed kit.
- Refresh the CLI manifest for the current dev package version.

## Validation
- `bun test src/__tests__/scripts/postinstall-self-heal.test.ts --max-concurrency=1 --verbose`
- `bun run typecheck`
- `bun run lint`
- Pre-push gate: typecheck, lint, build, 4914 backend tests, manifest/docs drift check, UI build, packaged CLI verification, 153 UI tests

## Docs impact
None. Update-time self-heal only; no user-facing command syntax changes.
