### PR TITLE
ci: build before release tests

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Run linter
         run: bun run lint
 
+      - name: Build CLI bundle before tests
+        run: bun run build
+
       - name: Run tests
         run: bun test --max-concurrency=1 --verbose
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Run linter
         run: bun run lint
 
+      - name: Build CLI bundle before tests
+        run: bun run build
+
       - name: Run tests
         run: bun test --max-concurrency=1
 


### PR DESCRIPTION
## Summary
- Align release workflows with CI by building the CLI bundle before running tests.
- Apply the same generated-bundle state to both dev prerelease and stable release workflows.

## Validation
- Pre-push gate: typecheck, lint, build, backend tests, manifest/docs drift check, UI build, packaged CLI verification, UI tests

## Docs impact
None. CI workflow alignment only; no user-facing command syntax changes.
