### PR TITLE
fix: extend cli update install timeout

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.1-dev.19",
-	"generatedAt": "2026-05-27T13:27:14.698Z",
+	"version": "4.3.1-dev.20",
+	"generatedAt": "2026-05-27T13:56:54.428Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/__tests__/commands/update-cli.test.ts
+++ b/src/__tests__/commands/update-cli.test.ts
@@ -6,6 +6,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	CLI_UPDATE_INSTALL_TIMEOUT_MS,
 	type KitSelectionParams,
 	type UpdateCliCommandDeps,
 	buildInitCommand,
@@ -822,10 +823,9 @@ describe("update-cli", () => {
 
 			expect(deps.npmRegistryClient.getDevVersion).toHaveBeenCalledTimes(1);
 			expect(deps.npmRegistryClient.getLatestVersion).not.toHaveBeenCalled();
-			expect(deps.execAsyncFn).toHaveBeenCalledWith(
-				"npm install -g claudekit-cli@3.36.0-dev.37",
-				expect.any(Object),
-			);
+			expect(deps.execAsyncFn).toHaveBeenCalledWith("npm install -g claudekit-cli@3.36.0-dev.37", {
+				timeout: CLI_UPDATE_INSTALL_TIMEOUT_MS,
+			});
 			expect(deps.promptKitUpdateFn).toHaveBeenCalledWith(true, true);
 		});
 

--- a/src/commands/update-cli.ts
+++ b/src/commands/update-cli.ts
@@ -38,6 +38,7 @@ import { compareCliVersions } from "./update/version-comparator.js";
 // All consumers (tests, system-routes.ts, command-registry.ts) import from here.
 
 export { CliUpdateError } from "./update/error.js";
+export { CLI_UPDATE_INSTALL_TIMEOUT_MS } from "./update/package-manager-runner.js";
 // isBetaVersion and parseCliVersionFromOutput live in version-comparator; post-update-handler
 // imports them from there. Exporting from the canonical source avoids duplicate bindings.
 export { isBetaVersion, parseCliVersionFromOutput } from "./update/version-comparator.js";

--- a/src/commands/update/package-manager-runner.ts
+++ b/src/commands/update/package-manager-runner.ts
@@ -15,6 +15,8 @@ export interface RunUpdateDeps {
 	spinnerStop: (msg: string) => void;
 }
 
+export const CLI_UPDATE_INSTALL_TIMEOUT_MS = 600000;
+
 /** Extract stdout string from exec result (handles both string and object forms). */
 export function extractCommandStdout(
 	result: { stdout?: string; stderr?: string } | string,
@@ -37,7 +39,7 @@ export async function runPackageManagerUpdate(
 
 	spinnerStart("Updating CLI...");
 	try {
-		await execAsyncFn(updateCmd, { timeout: 120000 });
+		await execAsyncFn(updateCmd, { timeout: CLI_UPDATE_INSTALL_TIMEOUT_MS });
 		spinnerStop("Update completed");
 	} catch (error) {
 		spinnerStop("Update failed");


### PR DESCRIPTION
## Summary
- Extend the `ck update` package-manager install timeout to 10 minutes.
- Prevent slow Windows global npm installs plus postinstall self-heal from being reported as failed while the install is still completing.
- Refresh `cli-manifest.json` for the current dev package version.

## Validation
- `bun test src/__tests__/commands/update-cli.test.ts`
- `bun run typecheck`
- `bun run lint`
- Pre-push gate: typecheck, lint, build, 4914 backend tests, manifest/docs drift check, UI build, packaged CLI verification, 153 UI tests

## Docs impact
None. Timeout hardening only; no user-facing command syntax changes.
