### PR TITLE
fix: migrate legacy statusline runner

### DIFF
--- a/__tests__/domains/installation/merger/settings-processor.test.ts
+++ b/__tests__/domains/installation/merger/settings-processor.test.ts
@@ -1475,6 +1475,79 @@ describe("SettingsProcessor", () => {
 			expect(result.statusLine.command).not.toMatch(/"[^"]*"\/\.claude/);
 		});
 
+		it("should migrate legacy statusLine runner when node-hook-runner is deleted", async () => {
+			const destSettings = {
+				statusLine: {
+					type: "command",
+					command: 'bash "$HOME/.claude/hooks/node-hook-runner.sh" "$HOME/.claude/statusline.cjs"',
+				},
+			};
+			const destFile = join(destDir, "settings.json");
+			await writeFile(destFile, JSON.stringify(destSettings), "utf-8");
+
+			const sourceSettings = {
+				statusLine: {
+					type: "command",
+					command: 'node ".claude/statusline.cjs"',
+				},
+			};
+			const sourceFile = join(sourceDir, "settings.json");
+			await writeFile(sourceFile, JSON.stringify(sourceSettings), "utf-8");
+
+			const processor = new SettingsProcessor();
+			processor.setGlobalFlag(true);
+			processor.setProjectDir(destDir);
+			processor.setDeletions(["hooks/node-hook-runner.sh"]);
+			await processor.processSettingsJson(sourceFile, destFile);
+
+			const result = JSON.parse(await readFile(destFile, "utf-8"));
+
+			expect(result.statusLine.command).toBe('node "$HOME/.claude/statusline.cjs"');
+			expect(result.statusLine.command).not.toContain("node-hook-runner.sh");
+		});
+
+		it("should preserve customized statusLine runner commands", async () => {
+			const customCommands = [
+				'CK_THEME=dark bash "$HOME/.claude/hooks/node-hook-runner.sh" "$HOME/.claude/statusline.cjs"',
+				'echo "$HOME/.claude/hooks/node-hook-runner.sh" && node "$HOME/.claude/statusline.cjs"',
+			];
+
+			for (const [index, customCommand] of customCommands.entries()) {
+				const caseSourceDir = join(sourceDir, `custom-statusline-${index}`);
+				const caseDestDir = join(destDir, `custom-statusline-${index}`);
+				await mkdir(caseSourceDir, { recursive: true });
+				await mkdir(caseDestDir, { recursive: true });
+
+				const destSettings = {
+					statusLine: {
+						type: "command",
+						command: customCommand,
+					},
+				};
+				const destFile = join(caseDestDir, "settings.json");
+				await writeFile(destFile, JSON.stringify(destSettings), "utf-8");
+
+				const sourceSettings = {
+					statusLine: {
+						type: "command",
+						command: 'node ".claude/statusline.cjs"',
+					},
+				};
+				const sourceFile = join(caseSourceDir, "settings.json");
+				await writeFile(sourceFile, JSON.stringify(sourceSettings), "utf-8");
+
+				const processor = new SettingsProcessor();
+				processor.setGlobalFlag(true);
+				processor.setProjectDir(caseDestDir);
+				processor.setDeletions(["hooks/node-hook-runner.sh"]);
+				await processor.processSettingsJson(sourceFile, destFile);
+
+				const result = JSON.parse(await readFile(destFile, "utf-8"));
+
+				expect(result.statusLine.command).toBe(customCommand);
+			}
+		});
+
 		it("should preserve variable-only quoting for local-install hooks", async () => {
 			const destSettings = {
 				hooks: {

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.3.1-dev.20",
-	"generatedAt": "2026-05-27T13:56:54.428Z",
+	"version": "4.4.0",
+	"generatedAt": "2026-05-27T18:34:51.414Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/domains/installation/merger/settings-processor.ts
+++ b/src/domains/installation/merger/settings-processor.ts
@@ -280,6 +280,10 @@ export class SettingsProcessor {
 			await this.tracker.saveInstalledSettings(installedSettings);
 		}
 
+		if (this.migrateLegacyStatusLineRunner(mergeResult.merged, sourceSettings)) {
+			logger.info("Migrated legacy statusLine runner command to current ClaudeKit statusline");
+		}
+
 		// Fix broken hook path formats (tilde, variable-only quoting, unquoted)
 		this.logHookCommandRepair(this.fixHookCommandPaths(mergeResult.merged), "merged settings");
 
@@ -559,6 +563,56 @@ export class SettingsProcessor {
 		}
 
 		return pruned;
+	}
+
+	/**
+	 * Older kits ran statusLine through hooks/node-hook-runner.sh. Once that runner was
+	 * deleted, a selective merge could preserve a statusLine command pointing at a
+	 * missing file because statusLine is not part of hook-array pruning. Only replace
+	 * this known CK-owned legacy form; arbitrary user statusLine commands stay intact.
+	 */
+	private migrateLegacyStatusLineRunner(
+		settings: SettingsJson,
+		sourceSettings: SettingsJson,
+	): boolean {
+		const statusLine = settings.statusLine as { command?: unknown } | undefined;
+		const sourceStatusLine = sourceSettings.statusLine as { command?: unknown } | undefined;
+
+		if (
+			!statusLine ||
+			typeof statusLine.command !== "string" ||
+			!sourceStatusLine ||
+			typeof sourceStatusLine.command !== "string"
+		) {
+			return false;
+		}
+		if (!this.deletionPatterns.includes("hooks/node-hook-runner.sh")) {
+			return false;
+		}
+		if (!this.isLegacyStatusLineRunnerCommand(statusLine.command)) {
+			return false;
+		}
+		if (this.isLegacyStatusLineRunnerCommand(sourceStatusLine.command)) {
+			return false;
+		}
+
+		settings.statusLine = structuredClone(sourceSettings.statusLine);
+		return true;
+	}
+
+	private isLegacyStatusLineRunnerCommand(command: string): boolean {
+		const match = command.match(
+			/^\s*bash\s+(?:"([^"]+)"|'([^']+)'|([^\s"']+))\s+(?:"([^"]+)"|'([^']+)'|([^\s"']+))\s*$/,
+		);
+		if (!match) return false;
+
+		const runnerArg = match[1] ?? match[2] ?? match[3];
+		const targetArg = match[4] ?? match[5] ?? match[6];
+
+		return (
+			this.extractHookRelativePath(runnerArg) === "hooks/node-hook-runner.sh" &&
+			this.extractHookRelativePath(targetArg) === "statusline.cjs"
+		);
 	}
 
 	/**


### PR DESCRIPTION
Closes #867

## Summary
- migrate the known legacy statusLine `bash node-hook-runner.sh statusline.cjs` command when metadata deletes the runner
- keep custom/env-prefixed/compound statusLine commands untouched
- cover the migration and preservation cases in SettingsProcessor tests
- regenerate the CLI manifest required by the push gate

## Validation
- bun test __tests__/domains/installation/merger/settings-processor.test.ts
- bun run lint
- bun run typecheck
- bun run build
- git diff --check
- bun test
- pre-push gate: typecheck, lint, build, bun test --max-concurrency=1 --verbose, help parity, manifest/docs drift check, UI build, packaged CLI verification, UI vitest

## Docs impact
Docs impact: none
Action: no update needed — internal update self-heal; no user-facing command/config docs changed
