### PR TITLE
fix: make SQLite driver optional for CLI updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Without a purchased kit and repository access, the CLI will not be able to downl
 
 The ClaudeKit CLI is published on npm at [npmjs.com/package/claudekit-cli](https://www.npmjs.com/package/claudekit-cli).
 
-End-user runtime note: global installs from `npm`, `pnpm`, `yarn`, or `bun` all execute the packaged Node.js CLI. Bun is optional for users and only needed for local ClaudeKit CLI development workflows.
+End-user runtime note: global installs from `npm`, `pnpm`, `yarn`, or `bun` all execute the packaged Node.js CLI. Bun is optional for users and only needed for local ClaudeKit CLI development workflows. Most commands do not require native build tools; `ck content` uses an optional SQLite driver and shows remediation steps if that driver is unavailable.
 
 ### Using npm (Recommended)
 
@@ -406,6 +406,8 @@ ck content start --verbose
 ```
 
 **Features:** 11-phase pipeline (scan → filter → classify → context → create → validate → review → photo → publish → engage → analyze), noise filtering, context caching (24h TTL), content validation, photo generation, 3 review modes (auto/manual/hybrid), quiet hours scheduling, engagement tracking, SQLite database, platform-specific adapters.
+
+**Runtime dependency:** `ck content` uses the optional native SQLite driver `better-sqlite3`. If the driver is unavailable, other CLI commands still work and `ck content` prints reinstall/build-tool guidance.
 
 **Config:** `.ck.json` under `content` key. See [docs/ck-content.md](./docs/ck-content.md) for full configuration reference.
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,6 @@
       "dependencies": {
         "@clack/prompts": "^0.7.0",
         "@octokit/rest": "^22.0.0",
-        "better-sqlite3": "^12.6.2",
         "cac": "^6.7.14",
         "chokidar": "^5.0.0",
         "cli-progress": "^3.12.0",
@@ -53,6 +52,9 @@
         "conventional-changelog-conventionalcommits": "^9.1.0",
         "semantic-release": "^24.2.0",
         "typescript": "^5.7.2",
+      },
+      "optionalDependencies": {
+        "better-sqlite3": "^12.6.2",
       },
     },
   },

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.4.0",
-	"generatedAt": "2026-05-27T18:34:51.414Z",
+	"version": "4.4.0-dev.1",
+	"generatedAt": "2026-05-30T14:15:44.863Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/ck-content.md
+++ b/docs/ck-content.md
@@ -17,6 +17,8 @@
 
 ## Quick Start
 
+`ck content` uses the optional native SQLite driver `better-sqlite3` for local persistence. If that driver is not available in the current CLI install, ClaudeKit keeps other commands usable and `ck content` prints reinstall or Windows build-tool guidance.
+
 ```bash
 # Interactive onboarding setup
 ck content setup

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
 	"dependencies": {
 		"@clack/prompts": "^0.7.0",
 		"@octokit/rest": "^22.0.0",
-		"better-sqlite3": "^12.6.2",
 		"cac": "^6.7.14",
 		"chokidar": "^5.0.0",
 		"cli-progress": "^3.12.0",
@@ -94,6 +93,9 @@
 		"tmp": "^0.2.3",
 		"ws": "^8.19.0",
 		"zod": "^3.23.8"
+	},
+	"optionalDependencies": {
+		"better-sqlite3": "^12.6.2"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",

--- a/src/__tests__/commands/content/sqlite-client.test.ts
+++ b/src/__tests__/commands/content/sqlite-client.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type Database,
+	OptionalSqliteDriverError,
+	createMissingSqliteDriverError,
+	loadBetterSqlite3Driver,
+	resolveBetterSqlite3Constructor,
+} from "@/commands/content/phases/sqlite-client.js";
+
+describe("sqlite-client optional driver loading", () => {
+	it("resolves CommonJS better-sqlite3 constructor exports", () => {
+		const DatabaseStub = class {} as unknown as new (dbPath: string) => Database;
+
+		expect(resolveBetterSqlite3Constructor(DatabaseStub)).toBe(DatabaseStub);
+	});
+
+	it("resolves default-wrapped better-sqlite3 constructor exports", () => {
+		const DatabaseStub = class {} as unknown as new (dbPath: string) => Database;
+
+		expect(resolveBetterSqlite3Constructor({ default: DatabaseStub })).toBe(DatabaseStub);
+	});
+
+	it("throws targeted guidance when the optional driver is missing", () => {
+		const missingModuleError = new Error("Cannot find module 'better-sqlite3'");
+
+		expect(() =>
+			loadBetterSqlite3Driver(() => {
+				throw missingModuleError;
+			}),
+		).toThrow(OptionalSqliteDriverError);
+
+		try {
+			loadBetterSqlite3Driver(() => {
+				throw missingModuleError;
+			});
+		} catch (error) {
+			expect(error).toBeInstanceOf(OptionalSqliteDriverError);
+			const message = error instanceof Error ? error.message : String(error);
+			expect(message).toContain("`ck content` requires the optional native package");
+			expect(message).toContain("npm install -g claudekit-cli --include=optional");
+			expect(message).toContain("Most ClaudeKit CLI commands do not need it");
+			expect(message).toContain("Cannot find module 'better-sqlite3'");
+		}
+	});
+
+	it("formats missing-driver guidance without an Error instance", () => {
+		const error = createMissingSqliteDriverError("missing native package");
+
+		expect(error.message).toContain("`ck content` requires the optional native package");
+		expect(error.message).not.toContain("Original error:");
+	});
+});

--- a/src/__tests__/commands/update-package-manager-runner.test.ts
+++ b/src/__tests__/commands/update-package-manager-runner.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, mock } from "bun:test";
+import { CliUpdateError } from "@/commands/update/error.js";
+import {
+	CLI_UPDATE_INSTALL_TIMEOUT_MS,
+	isNativeDependencyBuildError,
+	runPackageManagerUpdate,
+} from "@/commands/update/package-manager-runner.js";
+
+describe("package-manager-runner native dependency failures", () => {
+	it("detects better-sqlite3 node-gyp failures", () => {
+		const message = [
+			"prebuild-install warn install No prebuilt binaries found",
+			"npm error path C:\\Users\\Admin\\AppData\\Roaming\\npm\\node_modules\\claudekit-cli\\node_modules\\better-sqlite3",
+			"npm error gyp ERR! stack Error: Could not find any Visual Studio installation to use",
+		].join("\n");
+
+		expect(isNativeDependencyBuildError(message)).toBe(true);
+	});
+
+	it("does not classify generic npm failures as native dependency failures", () => {
+		expect(isNativeDependencyBuildError("npm error code E404 package not found")).toBe(false);
+	});
+
+	it("surfaces targeted guidance for native dependency build failures", async () => {
+		const execAsyncFn = mock(async () => {
+			throw new Error(
+				[
+					"prebuild-install warn install No prebuilt binaries found",
+					"npm error path node_modules/claudekit-cli/node_modules/better-sqlite3",
+					"npm error gyp ERR! stack Error: Could not find any Visual Studio installation to use",
+				].join("\n"),
+			);
+		});
+		const spinnerStart = mock(() => {});
+		const spinnerStop = mock(() => {});
+
+		let thrown: unknown;
+		try {
+			await runPackageManagerUpdate("npm.cmd install -g claudekit-cli@4.3.1", "npm", {
+				execAsyncFn,
+				spinnerStart,
+				spinnerStop,
+			});
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeInstanceOf(CliUpdateError);
+		const message = thrown instanceof Error ? thrown.message : String(thrown);
+		expect(message).toContain("native optional dependency");
+		expect(message).toContain("should not require native SQLite");
+		expect(message).toContain("Manual update: npm.cmd install -g claudekit-cli@4.3.1");
+		expect(execAsyncFn).toHaveBeenCalledWith("npm.cmd install -g claudekit-cli@4.3.1", {
+			timeout: CLI_UPDATE_INSTALL_TIMEOUT_MS,
+		});
+		expect(spinnerStop).toHaveBeenCalledWith("Update failed");
+	});
+});

--- a/src/commands/content/phases/sqlite-client.ts
+++ b/src/commands/content/phases/sqlite-client.ts
@@ -1,8 +1,73 @@
-import BetterSqlite3 from "better-sqlite3";
+import { createRequire } from "node:module";
 import type { Database as BetterSqliteDatabase } from "better-sqlite3";
 
 export type Database = BetterSqliteDatabase;
 
+type BetterSqlite3Constructor = new (dbPath: string) => Database;
+type BetterSqlite3Module =
+	| BetterSqlite3Constructor
+	| {
+			default?: BetterSqlite3Constructor;
+	  };
+
+const require = createRequire(import.meta.url);
+let cachedBetterSqlite3: BetterSqlite3Constructor | null = null;
+
+export class OptionalSqliteDriverError extends Error {
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, options);
+		this.name = "OptionalSqliteDriverError";
+	}
+}
+
+export function createMissingSqliteDriverError(cause: unknown): OptionalSqliteDriverError {
+	const detail =
+		cause instanceof Error && cause.message ? `\n\nOriginal error: ${cause.message}` : "";
+	return new OptionalSqliteDriverError(
+		[
+			"`ck content` requires the optional native package `better-sqlite3`, but it is not available in this CLI install.",
+			"Most ClaudeKit CLI commands do not need it and should continue to work.",
+			"",
+			"To use `ck content`, reinstall the CLI with optional dependencies for your active Node.js runtime:",
+			"  npm install -g claudekit-cli --include=optional",
+			"",
+			"If npm attempts a source build on Windows, install Visual Studio Build Tools with the Desktop development with C++ workload.",
+		].join("\n") + detail,
+		{ cause },
+	);
+}
+
+export function resolveBetterSqlite3Constructor(
+	sqliteModule: BetterSqlite3Module,
+): BetterSqlite3Constructor {
+	if (typeof sqliteModule === "function") {
+		return sqliteModule;
+	}
+
+	if (sqliteModule.default && typeof sqliteModule.default === "function") {
+		return sqliteModule.default;
+	}
+
+	throw new OptionalSqliteDriverError(
+		"`better-sqlite3` loaded, but did not expose a database constructor.",
+	);
+}
+
+export function loadBetterSqlite3Driver(
+	loadModule: () => BetterSqlite3Module = () => require("better-sqlite3") as BetterSqlite3Module,
+): BetterSqlite3Constructor {
+	try {
+		return resolveBetterSqlite3Constructor(loadModule());
+	} catch (error) {
+		if (error instanceof OptionalSqliteDriverError) {
+			throw error;
+		}
+		throw createMissingSqliteDriverError(error);
+	}
+}
+
 export function openDatabase(dbPath: string): Database {
+	const BetterSqlite3 = cachedBetterSqlite3 ?? loadBetterSqlite3Driver();
+	cachedBetterSqlite3 = BetterSqlite3;
 	return new BetterSqlite3(dbPath);
 }

--- a/src/commands/update/package-manager-runner.ts
+++ b/src/commands/update/package-manager-runner.ts
@@ -26,6 +26,20 @@ export function extractCommandStdout(
 	return "";
 }
 
+export function isNativeDependencyBuildError(errorMessage: string): boolean {
+	const normalized = errorMessage.toLowerCase();
+	return (
+		(normalized.includes("better-sqlite3") ||
+			normalized.includes("prebuild-install") ||
+			normalized.includes("node-gyp")) &&
+		(normalized.includes("no prebuilt binaries found") ||
+			normalized.includes("could not find any visual studio installation") ||
+			normalized.includes("visual studio build tools") ||
+			normalized.includes("desktop development with c++") ||
+			normalized.includes("node-gyp rebuild"))
+	);
+}
+
 /**
  * Execute the package manager update command.
  * Throws CliUpdateError with platform-appropriate guidance on permission or generic failures.
@@ -60,6 +74,19 @@ export async function runPackageManagerUpdate(
 				? `Run your terminal as Administrator and retry: ${updateCmd}`
 				: `sudo ${updateCmd}`;
 			throw new CliUpdateError(`Permission denied. Try: ${elevationHint}${permHint}`);
+		}
+
+		if (isNativeDependencyBuildError(errorMessage)) {
+			throw new CliUpdateError(
+				[
+					"Update failed while installing a native optional dependency.",
+					"ClaudeKit CLI should not require native SQLite for normal install/update commands.",
+					"",
+					`Manual update: ${redactCommandForLog(updateCmd)}`,
+					"",
+					"If this persists, retry after updating ClaudeKit CLI to a version where `better-sqlite3` is optional, or install Visual Studio Build Tools with the Desktop development with C++ workload for `ck content` support.",
+				].join("\n"),
+			);
 		}
 
 		logger.error(`Update failed: ${errorMessage}`);


### PR DESCRIPTION
Closes #869

## Problem

Windows users can hit a failed `ck update` when npm tries to build `better-sqlite3` and no matching prebuilt binary is available for the active Node runtime. That blocks the whole CLI update even though most CLI commands do not need SQLite.

## Changes

- Move `better-sqlite3` to `optionalDependencies` so native SQLite does not gate CLI install/update.
- Lazy-load the SQLite driver only when `ck content` actually opens the content database.
- Add targeted remediation when the optional driver is missing or when update output shows a native SQLite build failure.
- Update CLI source docs for install/update/content behavior.

## Validation

- `bun test src/__tests__/commands/content/sqlite-client.test.ts src/__tests__/commands/update-package-manager-runner.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run ci:local`
- Temporarily removed `node_modules/better-sqlite3` and verified `node dist/index.js --version` plus `node dist/index.js content --help` still work.
- Packed the CLI tarball, installed it into a temp npm prefix with `--omit=optional`, and verified `--version` plus `content --help` still work from the installed package.

## Docs Impact

Docs impact: minor
Action: updated CLI source docs; claudekit-docs `dev` has matching install/update/content notes.

## Risk

`ck content` still needs the optional SQLite driver for database operations. When the driver is absent, it now fails at the content DB boundary with explicit remediation instead of breaking unrelated CLI install/update flows.
