### PR TITLE
test: reset ConfigManager static cache before each config test

### DIFF
--- a/tests/utils/config.test.ts
+++ b/tests/utils/config.test.ts
@@ -14,6 +14,14 @@ describe("ConfigManager", () => {
 	let testPaths: TestPaths;
 
 	beforeEach(async () => {
+		// Reset ConfigManager's static cache BEFORE each test, not only after.
+		// The cache is a process-global static and Bun shares it across test
+		// files, so a sibling test that loads a real config (when CK_TEST_HOME
+		// is unset) can leak its value into the first test here — which has no
+		// preceding afterEach to clear it. Mirrors the afterEach reset.
+		(ConfigManager as any).config = null;
+		ConfigManager.setGlobalFlag(false);
+
 		// Setup isolated test paths - PathResolver will use these
 		testPaths = setupTestPaths();
 	});


### PR DESCRIPTION
<!--
STAGED PR BODY — ConfigManager test isolation.
Target: mrgoonie/claudekit-cli | base: dev | head: darraghh1:fix/configmanager-test-static-cache-isolation
-->

## Summary

`tests/utils/config.test.ts` → **`ConfigManager > load > should return default config when no config file exists`** fails in the full `bun test` run (passes in isolation) on machines that have a real `~/.claudekit/config.json`. CI stays green because clean runners have no such file.

## Root cause

`ConfigManager.config` is a process-global `static` cache, and `load()` returns it immediately when set (`config-manager.ts:54`). Bun runs all test files in one process, so that static is shared across files. A sibling test loads the real config (at a moment when `CK_TEST_HOME` is unset) and leaves the cache populated. `config.test.ts` clears the cache only in `afterEach`, so its **first** test — which has no preceding `afterEach` — inherits the leaked value.

Instrumented capture of the failure:

```
received:     {"defaults":{"kit":"engineer","dir":"~/Projects"}}   # the real user config
CK_TEST_HOME: <valid, empty temp dir>
configFile:   <temp>/.claudekit/config.json   exists: false        # file absent → value came from the static cache
```

On a clean CI runner there is no real config, so the leaked cache equals the default `{ defaults: {} }` and the test passes — which is why this never surfaced in CI.

## Fix

Clear the static cache (and global flag) in `beforeEach` too, mirroring the existing `afterEach`:

```ts
beforeEach(async () => {
  (ConfigManager as any).config = null;
  ConfigManager.setGlobalFlag(false);
  testPaths = setupTestPaths();
});
```

One test file touched; no production code changes.

## Testing

- [x] Full `bun test` — **0 fail** (was deterministically failing); confirmed across 3 runs
- [x] `config.test.ts` alone — 18 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` (biome) — clean

> **CI note:** the "Verify help parity" step may show red from a pre-existing `dev` manifest drift (`cli-manifest.json` is `4.4.0-dev.1` while `package.json` is `4.4.0-dev.2`) — unrelated to this one-file test change.
