### PR TITLE
test: properly unset CK_TEST_HOME in test-paths cleanup

### DIFF
--- a/tests/helpers/test-paths.ts
+++ b/tests/helpers/test-paths.ts
@@ -43,7 +43,7 @@ export function setupTestPaths(): TestPaths {
 		} catch (_error) {
 			// Ignore cleanup errors
 		}
-		process.env.CK_TEST_HOME = undefined;
+		Reflect.deleteProperty(process.env, "CK_TEST_HOME");
 	};
 
 	return {


### PR DESCRIPTION
<!--
STAGED PR BODY — test-paths CK_TEST_HOME cleanup.
Target: mrgoonie/claudekit-cli | base: dev | head: darraghh1:fix/test-paths-cktesthome-delete
-->

## Summary

`setupTestPaths().cleanup()` in `tests/helpers/test-paths.ts` never actually unsets `CK_TEST_HOME`.

```ts
process.env.CK_TEST_HOME = undefined;   // ← Node coerces to the STRING "undefined"
```

Assigning `undefined` to a `process.env` value stores the literal string `"undefined"` — the variable is not removed. So after any test's cleanup, `PathResolver.getTestHomeDir()` returns `"undefined"` (truthy), and config/cache paths resolve under a bogus **relative** `undefined/.claudekit/...` directory instead of restoring the real production location. `isTestMode()` (`CK_TEST_HOME !== undefined`) also stays `true` forever.

## Fix

Use `Reflect.deleteProperty` to truly remove the variable — the same idiom the other test files already use (`hook-log-routes.test.ts`, `hook-log-reader.test.ts`, `action-executor.test.ts`, `plans-registry.test.ts`):

```ts
Reflect.deleteProperty(process.env, "CK_TEST_HOME");
```

`delete process.env.CK_TEST_HOME` would also work semantically but trips biome's `lint/performance/noDelete` rule (and its autofix rewrites it straight back to `= undefined`, reintroducing the bug). `Reflect.deleteProperty` is lint-clean and matches the existing convention.

## Testing

- [x] Full `bun test` — no new failures vs. the dev baseline (diffed failure sets; confirmed across 3 runs)
- [x] `bun run lint` (biome) — clean (the `delete` form fails `noDelete`; this form passes)
- [x] `bun run typecheck` — clean

> **CI note:** the "Verify help parity" step may show red from a pre-existing `dev` manifest drift (`cli-manifest.json` `4.4.0-dev.1` vs `package.json` `4.4.0-dev.2`), unrelated to this one-line change. The single `ConfigManager` suite failure that exists on the `dev` base is addressed separately in the companion PR.
