### PR TITLE
feat(init): preserve ignored skills during updates

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.4.0-dev.1",
-	"generatedAt": "2026-05-30T14:15:44.863Z",
+	"version": "4.4.0-dev.2",
+	"generatedAt": "2026-06-03T00:03:29.156Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -488,7 +488,7 @@ Business logic by domain with facade pattern.
 **config/** - Config management (generator, manager, validator), merger with conflict resolution and diff calculation
 **github/** - GitHub API client (Octokit wrapper), auth (GitHub CLI only), npm registry
 **health-checks/** - Doctor command: 11 parallel checkers (system, auth, GitHub, ClaudeKit, platform, network, etc.) + auto-healer
-**installation/** - Download (streaming), extract (ZIP/TAR with security validation), merge (selective, multi-kit aware), package manager detection
+**installation/** - Download (streaming), extract (ZIP/TAR with security validation), merge (selective, multi-kit aware, preserves ignored/deleted skills), package manager detection
 **skills/** - Detection (config, dependencies, scripts), customization scanning (hashing), migration executor (backup/rollback)
 **ui/** - Interactive prompts (kit/version selection, confirmations), ownership display (3-state model)
 **versioning/** - Version checking (CLI/kit) with caching (7-day TTL), stable-by-default CLI updates, selection UI, beta/prerelease filtering
@@ -552,6 +552,7 @@ installation/
 - `setMultiKitContext(claudeDir, installingKit)`: Enable cross-kit file checking
 - Tracks shared files and skipped count statistics
 - Prevents overwriting newer versions from other kits
+- Preserves skill directories intentionally deleted by the user and records them as per-kit ignored skills; `--force-overwrite` reinstalls them
 - Passes multi-kit context to SelectiveMerger for intelligent decisions
 
 `file-merger.ts` (ENHANCED):
@@ -582,7 +583,7 @@ Facades: version-checker, selector. Submodules: checking (cli/kit checkers, noti
 Cross-domain services with focused submodules.
 
 #### file-operations/ - File System Operations
-Facade: manifest-writer. Ownership-checker. Manifest/ submodule: reader (multi-kit aware, `findFileInInstalledKits()`), tracker, updater. Supports multi-kit + legacy format metadata.
+Facade: manifest-writer. Ownership-checker. Manifest/ submodule: reader (multi-kit aware, `findFileInInstalledKits()`), tracker, updater. Supports multi-kit + legacy format metadata, including per-kit `ignoredSkills` roots for update-time skill opt-outs.
 
 #### package-installer/ - Package Installation (17 files + gemini-mcp/)
 Dependency installer (Node, Python, system). Gemini MCP linker for AI tooling. Process executor for system commands. Detection of installed package managers.

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -270,6 +270,8 @@ ClaudeKit CLI provides a comprehensive solution with:
 - User prompted before migration in interactive mode
 - Backup created before any file movement
 - Customized skills preserved during migration
+- Deleted CK-managed skill directories are preserved as ignored skills on future updates
+- `--force-overwrite` can reinstall previously ignored skills
 - Rollback successful on any error
 - New manifest written after successful migration
 - Non-interactive mode works in CI/CD environments

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -525,3 +525,4 @@ Global Mode (Kit Installation):
 - Future development focuses on maintenance, security updates, minor enhancements
 - No breaking changes anticipated in v1.x releases
 - Modularization improves maintainability and LLM context efficiency
+- 2026-06-02: Kit updates now preserve user-deleted CK-managed skill directories as ignored skills, with `--force-overwrite` as the reinstall path

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -167,7 +167,7 @@ Octokit wrapper for releases and auth (GitHub CLI only). Asset selection: offici
 Parallel checkers for system (Node, npm, Python, git, gh), auth (token scopes, rate limit), GitHub API, ClaudeKit (installs, versions, skills), platform, network. Includes auto-healer for common issues.
 
 ### installation/ - Download, Extract, Merge
-File downloader with streaming. ZIP/TAR extraction with security validation (path traversal, archive bombs, 500MB limit). Selective merger with multi-kit awareness: detects shared files, prevents overwriting newer versions.
+File downloader with streaming. ZIP/TAR extraction with security validation (path traversal, archive bombs, 500MB limit). Selective merger with multi-kit awareness: detects shared files, prevents overwriting newer versions, and preserves user-deleted skill directories as per-kit ignored skills unless `--force-overwrite` is used.
 
 ### skills/ - Skills Management
 Detection (config, dependencies, scripts), customization scanning with hash comparison, migration executor with backup and rollback. agentskills.io integration with metadata version/author support.
@@ -208,7 +208,7 @@ Metadata schemas, release manifest parsing, legacy version migration support.
 ## Services Layer
 
 ### file-operations/ - File System
-Manifest reader/writer with multi-kit support. Manifest tracker for file ownership. Ownership checker.
+Manifest reader/writer with multi-kit support. Manifest tracker for file ownership and ignored skill roots. Ownership checker.
 
 ### package-installer/ - Package Installation
 Dependency installer (Node, Python, system). Gemini MCP linker for AI tooling. Process executor. Package manager detection (npm/yarn/pnpm/bun).

--- a/src/__tests__/domains/installation/merger/copy-executor-deleted-skills.test.ts
+++ b/src/__tests__/domains/installation/merger/copy-executor-deleted-skills.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CopyExecutor } from "@/domains/installation/merger/copy-executor.js";
+import type { Metadata } from "@/types";
+
+const ISO_DATE = "2025-01-01T00:00:00.000Z";
+const CHECKSUM = "a".repeat(64);
+
+describe("CopyExecutor deleted skills", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = join(
+			tmpdir(),
+			`copy-executor-deleted-skills-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		await mkdir(tempDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("preserves a deleted global skill previously tracked by the same kit", async () => {
+		const sourceDir = join(tempDir, "source");
+		const claudeDir = join(tempDir, "dest");
+		await writeSkill(sourceDir, "skills/shopify");
+		await writeMetadata(claudeDir, ["skills/shopify/SKILL.md"]);
+
+		const executor = new CopyExecutor([]);
+		executor.setMultiKitContext(claudeDir, "engineer");
+		await executor.copyFiles(sourceDir, claudeDir);
+
+		expect(existsSync(join(claudeDir, "skills", "shopify", "SKILL.md"))).toBe(false);
+		expect(executor.getIgnoredSkillDirectories()).toEqual(["skills/shopify"]);
+	});
+
+	it("normalizes local .claude skill paths before preserving a deleted skill", async () => {
+		const sourceDir = join(tempDir, "source");
+		const projectDir = join(tempDir, "project");
+		const claudeDir = join(projectDir, ".claude");
+		await writeSkill(sourceDir, ".claude/skills/shopify");
+		await writeMetadata(claudeDir, ["skills/shopify/SKILL.md"]);
+
+		const executor = new CopyExecutor([]);
+		executor.setMultiKitContext(claudeDir, "engineer");
+		await executor.copyFiles(sourceDir, projectDir);
+
+		expect(existsSync(join(claudeDir, "skills", "shopify", "SKILL.md"))).toBe(false);
+		expect(executor.getIgnoredSkillDirectories()).toEqual(["skills/shopify"]);
+	});
+
+	it("installs a new skill when no prior metadata marks it as deleted", async () => {
+		const sourceDir = join(tempDir, "source");
+		const claudeDir = join(tempDir, "dest");
+		await writeSkill(sourceDir, "skills/shopify");
+		await mkdir(claudeDir, { recursive: true });
+
+		const executor = new CopyExecutor([]);
+		executor.setMultiKitContext(claudeDir, "engineer");
+		await executor.copyFiles(sourceDir, claudeDir);
+
+		expect(existsSync(join(claudeDir, "skills", "shopify", "SKILL.md"))).toBe(true);
+		expect(executor.getIgnoredSkillDirectories()).toEqual([]);
+	});
+
+	it("copies missing files when the skill directory still exists", async () => {
+		const sourceDir = join(tempDir, "source");
+		const claudeDir = join(tempDir, "dest");
+		await writeSkill(sourceDir, "skills/shopify");
+		await writeFile(join(sourceDir, "skills", "shopify", "README.md"), "extra docs");
+		await writeMetadata(claudeDir, ["skills/shopify/SKILL.md"]);
+		await writeSkill(claudeDir, "skills/shopify");
+
+		const executor = new CopyExecutor([]);
+		executor.setMultiKitContext(claudeDir, "engineer");
+		await executor.copyFiles(sourceDir, claudeDir);
+
+		expect(existsSync(join(claudeDir, "skills", "shopify", "README.md"))).toBe(true);
+		expect(executor.getIgnoredSkillDirectories()).toEqual([]);
+	});
+
+	it("preserves skills already listed as ignored in metadata", async () => {
+		const sourceDir = join(tempDir, "source");
+		const claudeDir = join(tempDir, "dest");
+		await writeSkill(sourceDir, "skills/shopify");
+		await writeMetadata(claudeDir, [], ["skills/shopify"]);
+
+		const executor = new CopyExecutor([]);
+		executor.setMultiKitContext(claudeDir, "engineer");
+		await executor.copyFiles(sourceDir, claudeDir);
+
+		expect(existsSync(join(claudeDir, "skills", "shopify", "SKILL.md"))).toBe(false);
+		expect(executor.getIgnoredSkillDirectories()).toEqual(["skills/shopify"]);
+	});
+
+	it("reinstalls an ignored skill when deleted-skill preservation is disabled", async () => {
+		const sourceDir = join(tempDir, "source");
+		const claudeDir = join(tempDir, "dest");
+		await writeSkill(sourceDir, "skills/shopify");
+		await writeMetadata(claudeDir, ["skills/shopify/SKILL.md"], ["skills/shopify"]);
+
+		const executor = new CopyExecutor([]);
+		executor.setMultiKitContext(claudeDir, "engineer");
+		executor.setPreserveDeletedSkills(false);
+		await executor.copyFiles(sourceDir, claudeDir);
+
+		expect(existsSync(join(claudeDir, "skills", "shopify", "SKILL.md"))).toBe(true);
+		expect(executor.getIgnoredSkillDirectories()).toEqual([]);
+	});
+});
+
+async function writeSkill(root: string, skillRoot: string): Promise<void> {
+	const skillDir = join(root, ...skillRoot.split("/"));
+	await mkdir(skillDir, { recursive: true });
+	await writeFile(join(skillDir, "SKILL.md"), "# Shopify\n");
+}
+
+async function writeMetadata(
+	claudeDir: string,
+	trackedPaths: string[],
+	ignoredSkills: string[] = [],
+): Promise<void> {
+	await mkdir(claudeDir, { recursive: true });
+	const metadata: Metadata = {
+		kits: {
+			engineer: {
+				version: "1.0.0",
+				installedAt: ISO_DATE,
+				files: trackedPaths.map((path) => ({
+					path,
+					checksum: CHECKSUM,
+					ownership: "ck",
+					installedVersion: "1.0.0",
+				})),
+				ignoredSkills,
+			},
+		},
+		scope: "global",
+	};
+	await writeFile(join(claudeDir, "metadata.json"), JSON.stringify(metadata));
+}

--- a/src/__tests__/services/file-operations/manifest-writer-multikit.test.ts
+++ b/src/__tests__/services/file-operations/manifest-writer-multikit.test.ts
@@ -91,6 +91,58 @@ describe("ManifestWriter multi-kit", () => {
 			expect(metadata.kits?.engineer?.version).toBe("v2.0.0");
 		});
 
+		it("preserves ignored skills when rewriting kit metadata", async () => {
+			const existing: Metadata = {
+				kits: {
+					engineer: {
+						version: "v1.0.0",
+						installedAt: "2024-01-01T00:00:00.000Z",
+						ignoredSkills: ["skills/shopify"],
+					},
+				},
+				scope: "local",
+			};
+			await writeFile(join(testDir, "metadata.json"), JSON.stringify(existing));
+
+			const writer = new ManifestWriter();
+			await writer.writeManifest(testDir, "ClaudeKit Engineer", "v2.0.0", "local", "engineer");
+
+			const content = await readFile(join(testDir, "metadata.json"), "utf-8");
+			const metadata = JSON.parse(content) as Metadata;
+
+			expect(metadata.kits?.engineer?.ignoredSkills).toEqual(["skills/shopify"]);
+		});
+
+		it("clears ignored skills after the skill is tracked again", async () => {
+			const existing: Metadata = {
+				kits: {
+					engineer: {
+						version: "v1.0.0",
+						installedAt: "2024-01-01T00:00:00.000Z",
+						ignoredSkills: ["skills/shopify"],
+					},
+				},
+				scope: "local",
+			};
+			await writeFile(join(testDir, "metadata.json"), JSON.stringify(existing));
+			await mkdir(join(testDir, "skills", "shopify"), { recursive: true });
+			await writeFile(join(testDir, "skills", "shopify", "SKILL.md"), "# Shopify\n");
+
+			const writer = new ManifestWriter();
+			await writer.addTrackedFile(
+				join(testDir, "skills", "shopify", "SKILL.md"),
+				"skills/shopify/SKILL.md",
+				"ck",
+				"v2.0.0",
+			);
+			await writer.writeManifest(testDir, "ClaudeKit Engineer", "v2.0.0", "local", "engineer");
+
+			const content = await readFile(join(testDir, "metadata.json"), "utf-8");
+			const metadata = JSON.parse(content) as Metadata;
+
+			expect(metadata.kits?.engineer?.ignoredSkills).toBeUndefined();
+		});
+
 		it("migrates legacy format before writing", async () => {
 			// Pre-create legacy metadata
 			const legacy: Metadata = {

--- a/src/commands/init/phases/merge-handler.ts
+++ b/src/commands/init/phases/merge-handler.ts
@@ -95,6 +95,7 @@ export async function handleMerge(ctx: InitContext): Promise<InitContext> {
 
 	merger.setGlobalFlag(ctx.options.global);
 	merger.setForceOverwriteSettings(ctx.options.forceOverwriteSettings);
+	merger.setPreserveDeletedSkills(!ctx.options.forceOverwrite && !ctx.options.fresh);
 	merger.setRestoreCkHooks(ctx.options.restoreCkHooks);
 	merger.setProjectDir(ctx.resolvedDir);
 	merger.setKitName(ctx.kit.name);
@@ -220,6 +221,7 @@ export async function handleMerge(ctx: InitContext): Promise<InitContext> {
 		releaseTag: installedVersion,
 		mode: ctx.options.global ? "global" : "local",
 		kitType: ctx.kitType,
+		ignoredSkills: merger.getIgnoredSkillDirectories(),
 	});
 
 	return {

--- a/src/domains/installation/file-merger.ts
+++ b/src/domains/installation/file-merger.ts
@@ -66,6 +66,10 @@ export class FileMerger {
 		this.copyExecutor.setForceOverwriteSettings(force);
 	}
 
+	setPreserveDeletedSkills(preserve: boolean): void {
+		this.copyExecutor.setPreserveDeletedSkills(preserve);
+	}
+
 	/**
 	 * Restore CK-owned hook registrations during update self-heal.
 	 */
@@ -186,5 +190,9 @@ export class FileMerger {
 	 */
 	getFileConflicts(): FileConflictInfo[] {
 		return this.copyExecutor.getFileConflicts();
+	}
+
+	getIgnoredSkillDirectories(): string[] {
+		return this.copyExecutor.getIgnoredSkillDirectories();
 	}
 }

--- a/src/domains/installation/merger/copy-executor.ts
+++ b/src/domains/installation/merger/copy-executor.ts
@@ -5,6 +5,10 @@ import { type KitType, USER_CONFIG_PATTERNS } from "@/types";
 import { copy, pathExists } from "fs-extra";
 import ignore, { type Ignore } from "ignore";
 import { type FileConflictInfo, SelectiveMerger } from "../selective-merger.js";
+import {
+	findIgnoredSkillDirectories,
+	shouldSkipIgnoredSkill,
+} from "./deleted-skill-preservation.js";
 import { FileScanner } from "./file-scanner.js";
 import { SettingsProcessor } from "./settings-processor.js";
 
@@ -56,6 +60,8 @@ export class CopyExecutor {
 	// Multi-kit context
 	private claudeDir: string | null = null;
 	private installingKit: KitType | null = null;
+	private ignoredSkillDirectories: Set<string> = new Set();
+	private preserveDeletedSkills = true;
 
 	constructor(neverCopyPatterns: string[]) {
 		this.userConfigChecker = ignore().add(USER_CONFIG_PATTERNS);
@@ -94,6 +100,10 @@ export class CopyExecutor {
 	 */
 	setForceOverwriteSettings(force: boolean): void {
 		this.settingsProcessor.setForceOverwriteSettings(force);
+	}
+
+	setPreserveDeletedSkills(preserve: boolean): void {
+		this.preserveDeletedSkills = preserve;
 	}
 
 	/**
@@ -206,8 +216,10 @@ export class CopyExecutor {
 	 */
 	async copyFiles(sourceDir: string, destDir: string): Promise<void> {
 		const files = await this.fileScanner.getFiles(sourceDir, sourceDir);
+		await this.loadIgnoredSkillDirectories(files, sourceDir, destDir);
 		let copiedCount = 0;
 		let skippedCount = 0;
+		let ignoredSkillSkipped = 0;
 
 		for (const file of files) {
 			const relativePath = relative(sourceDir, file);
@@ -219,6 +231,12 @@ export class CopyExecutor {
 			if (this.fileScanner.shouldNeverCopy(normalizedRelativePath)) {
 				logger.debug(`Skipping security-sensitive file: ${normalizedRelativePath}`);
 				skippedCount++;
+				continue;
+			}
+
+			if (this.shouldSkipIgnoredSkill(normalizedRelativePath)) {
+				logger.debug(`Preserving ignored skill file: ${normalizedRelativePath}`);
+				ignoredSkillSkipped++;
 				continue;
 			}
 
@@ -285,6 +303,8 @@ export class CopyExecutor {
 		if (copiedCount > 0) parts.push(`Updated ${copiedCount} file(s)`);
 		if (this.unchangedSkipped > 0) parts.push(`skipped ${this.unchangedSkipped} unchanged`);
 		if (this.sharedSkipped > 0) parts.push(`preserved ${this.sharedSkipped} shared`);
+		if (ignoredSkillSkipped > 0)
+			parts.push(`preserved ${ignoredSkillSkipped} ignored skill file(s)`);
 		if (skippedCount > 0) parts.push(`skipped ${skippedCount} protected`);
 
 		if (parts.length > 0) {
@@ -331,6 +351,10 @@ export class CopyExecutor {
 		return this.fileConflicts;
 	}
 
+	getIgnoredSkillDirectories(): string[] {
+		return Array.from(this.ignoredSkillDirectories).sort();
+	}
+
 	/**
 	 * Track a file as installed
 	 */
@@ -343,5 +367,27 @@ export class CopyExecutor {
 			this.installedDirectories.add(`${dir}/`);
 			dir = dirname(dir);
 		}
+	}
+
+	private async loadIgnoredSkillDirectories(
+		files: string[],
+		sourceDir: string,
+		destDir: string,
+	): Promise<void> {
+		this.ignoredSkillDirectories.clear();
+		if (!this.preserveDeletedSkills) return;
+		if (!this.claudeDir || !this.installingKit) return;
+
+		this.ignoredSkillDirectories = await findIgnoredSkillDirectories({
+			files,
+			sourceDir,
+			destDir,
+			claudeDir: this.claudeDir,
+			installingKit: this.installingKit,
+		});
+	}
+
+	private shouldSkipIgnoredSkill(normalizedRelativePath: string): boolean {
+		return shouldSkipIgnoredSkill(normalizedRelativePath, this.ignoredSkillDirectories);
 	}
 }

--- a/src/domains/installation/merger/deleted-skill-preservation.ts
+++ b/src/domains/installation/merger/deleted-skill-preservation.ts
@@ -1,0 +1,104 @@
+import { dirname, join, relative } from "node:path";
+import { getKitMetadata } from "@/domains/migration/metadata-migration.js";
+import { readManifest } from "@/services/file-operations/manifest/manifest-reader.js";
+import type { KitType } from "@/types";
+import { pathExists } from "fs-extra";
+
+interface IgnoredSkillOptions {
+	files: string[];
+	sourceDir: string;
+	destDir: string;
+	claudeDir: string;
+	installingKit: KitType;
+}
+
+export async function findIgnoredSkillDirectories({
+	files,
+	sourceDir,
+	destDir,
+	claudeDir,
+	installingKit,
+}: IgnoredSkillOptions): Promise<Set<string>> {
+	const sourceSkillRoots = findSourceSkillRoots(files, sourceDir);
+	const ignoredSkillDirectories = new Set<string>();
+
+	if (sourceSkillRoots.size === 0) return ignoredSkillDirectories;
+
+	const metadata = await readManifest(claudeDir);
+	const kitMetadata = metadata ? getKitMetadata(metadata, installingKit) : null;
+	if (!kitMetadata) return ignoredSkillDirectories;
+
+	const previouslyTrackedRoots = new Set<string>();
+	for (const file of kitMetadata.files ?? []) {
+		const skillRoot = findSkillRoot(file.path, sourceSkillRoots.keys());
+		if (skillRoot) previouslyTrackedRoots.add(skillRoot);
+	}
+
+	const existingIgnoredRoots = new Set(
+		(kitMetadata.ignoredSkills ?? []).flatMap((path) => {
+			const root = normalizeSkillRoot(path);
+			return root ? [root] : [];
+		}),
+	);
+
+	for (const [metadataRoot, sourceRoot] of sourceSkillRoots) {
+		const destSkillRoot = join(destDir, ...sourceRoot.split("/"));
+		const skillExists = await pathExists(destSkillRoot);
+		if (
+			existingIgnoredRoots.has(metadataRoot) ||
+			(!skillExists && previouslyTrackedRoots.has(metadataRoot))
+		) {
+			ignoredSkillDirectories.add(metadataRoot);
+		}
+	}
+
+	return ignoredSkillDirectories;
+}
+
+export function shouldSkipIgnoredSkill(
+	normalizedRelativePath: string,
+	ignoredSkillDirectories: Iterable<string>,
+): boolean {
+	const metadataPath = toMetadataPath(normalizedRelativePath);
+	if (!metadataPath) return false;
+	return findSkillRoot(metadataPath, ignoredSkillDirectories) !== null;
+}
+
+function findSourceSkillRoots(files: string[], sourceDir: string): Map<string, string> {
+	const sourceSkillRoots = new Map<string, string>();
+
+	for (const file of files) {
+		const normalizedPath = relative(sourceDir, file).replace(/\\/g, "/");
+		const metadataPath = toMetadataPath(normalizedPath);
+		if (!metadataPath?.endsWith("/SKILL.md")) continue;
+
+		const metadataRoot = dirname(metadataPath).replace(/\\/g, "/");
+		const sourceRoot = dirname(normalizedPath).replace(/\\/g, "/");
+		sourceSkillRoots.set(metadataRoot, sourceRoot);
+	}
+
+	return sourceSkillRoots;
+}
+
+function toMetadataPath(normalizedRelativePath: string): string | null {
+	const path = normalizedRelativePath.replace(/^\.claude\//, "");
+	return path.startsWith("skills/") ? path : null;
+}
+
+function normalizeSkillRoot(path: string): string | null {
+	const normalized = path
+		.replace(/\\/g, "/")
+		.replace(/^\.claude\//, "")
+		.replace(/\/+$/, "");
+	return normalized.startsWith("skills/") && normalized.split("/").length >= 2 ? normalized : null;
+}
+
+function findSkillRoot(path: string, skillRoots: Iterable<string>): string | null {
+	const normalizedPath = path.replace(/\\/g, "/").replace(/^\.claude\//, "");
+	for (const root of skillRoots) {
+		if (normalizedPath === `${root}/SKILL.md` || normalizedPath.startsWith(`${root}/`)) {
+			return root;
+		}
+	}
+	return null;
+}

--- a/src/services/file-operations/manifest-writer.ts
+++ b/src/services/file-operations/manifest-writer.ts
@@ -105,6 +105,7 @@ export class ManifestWriter {
 		version: string,
 		scope: "local" | "global",
 		kitType?: KitType,
+		ignoredSkills?: string[],
 	): Promise<void> {
 		return writeManifest(
 			claudeDir,
@@ -114,6 +115,7 @@ export class ManifestWriter {
 			kitType,
 			this.getTrackedFiles(),
 			this.getUserConfigFiles(),
+			ignoredSkills,
 		);
 	}
 

--- a/src/services/file-operations/manifest/manifest-tracker.ts
+++ b/src/services/file-operations/manifest/manifest-tracker.ts
@@ -246,6 +246,8 @@ export interface WriteManifestOptions {
 	mode: "local" | "global";
 	/** Kit type for manifest metadata */
 	kitType?: KitType;
+	/** Skill roots intentionally skipped because the user removed them */
+	ignoredSkills?: string[];
 }
 
 /**
@@ -327,6 +329,7 @@ export async function trackFilesWithProgress(
 		manifestOptions.kitType,
 		tracker.getTrackedFiles(),
 		tracker.getUserConfigFiles(),
+		manifestOptions.ignoredSkills,
 	);
 
 	return trackResult;

--- a/src/services/file-operations/manifest/manifest-updater.ts
+++ b/src/services/file-operations/manifest/manifest-updater.ts
@@ -26,6 +26,7 @@ export async function writeManifest(
 	kitType: KitType | undefined,
 	trackedFiles: TrackedFile[],
 	userConfigFiles: string[],
+	ignoredSkills: string[] = [],
 ): Promise<void> {
 	const metadataPath = join(claudeDir, "metadata.json");
 
@@ -61,18 +62,31 @@ export async function writeManifest(
 			}
 		}
 
+		const existingKits = existingMetadata.kits || {};
+		const normalizedTrackedPaths = trackedFiles.map((file) => normalizeMetadataPath(file.path));
+		const existingIgnoredSkills = existingKits[kit]?.ignoredSkills ?? [];
+		const mergedIgnoredSkills = uniqueNormalizedSkillRoots([
+			...existingIgnoredSkills,
+			...ignoredSkills,
+		]).filter(
+			(skillRoot) =>
+				!normalizedTrackedPaths.some(
+					(path) => path === `${skillRoot}/SKILL.md` || path.startsWith(`${skillRoot}/`),
+				),
+		);
+
 		// Build kit-specific metadata
 		const installedAt = new Date().toISOString();
 		const kitMetadata: KitMetadata = {
 			version,
 			installedAt,
 			files: trackedFiles.length > 0 ? trackedFiles : undefined,
+			ignoredSkills: mergedIgnoredSkills.length > 0 ? mergedIgnoredSkills : undefined,
 		};
 
 		// Detect multi-kit scenario: are there OTHER kits besides the one being installed?
 		// - If installing "marketing" and "engineer" already exists → otherKitsExist = true
 		// - If re-installing "engineer" and only "engineer" exists → otherKitsExist = false
-		const existingKits = existingMetadata.kits || {};
 		const otherKitsExist = Object.keys(existingKits).some((k) => k !== kit);
 
 		// Build metadata with multi-kit structure
@@ -107,6 +121,29 @@ export async function writeManifest(
 			logger.debug(`Released lock on ${metadataPath}`);
 		}
 	}
+}
+
+function normalizeMetadataPath(path: string): string {
+	return path
+		.replace(/\\/g, "/")
+		.replace(/^\.claude\//, "")
+		.replace(/\/+$/, "");
+}
+
+function normalizeSkillRoot(path: string): string | null {
+	const normalized = normalizeMetadataPath(path);
+	return normalized.startsWith("skills/") && normalized.split("/").length >= 2 ? normalized : null;
+}
+
+function uniqueNormalizedSkillRoots(paths: string[]): string[] {
+	return Array.from(
+		new Set(
+			paths.flatMap((path) => {
+				const root = normalizeSkillRoot(path);
+				return root ? [root] : [];
+			}),
+		),
+	).sort();
 }
 
 /**

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -49,6 +49,8 @@ export const KitMetadataSchema = z.object({
 	installedAt: z.string(),
 	// Enhanced file ownership tracking (pip RECORD pattern)
 	files: z.array(TrackedFileSchema).optional(),
+	// Skill roots intentionally removed by the user and skipped on future updates.
+	ignoredSkills: z.array(z.string()).optional(),
 	// Sync feature fields
 	lastUpdateCheck: z.string().optional(), // ISO timestamp of last update check
 	dismissedVersion: z.string().optional(), // Version user dismissed (don't nag)


### PR DESCRIPTION
## Summary
- Preserve CK-managed skill dirs that users removed by recording per-kit ignored skill roots.
- Skip ignored skills on subsequent init/update unless `--force-overwrite` or `--fresh` reinstalls them.
- Add regression coverage for global/local skill path normalization and metadata persistence.

## Test plan
- [x] Unit tests pass (`bun test src/__tests__/domains/installation/merger/copy-executor-deleted-skills.test.ts src/__tests__/services/file-operations/manifest-writer-multikit.test.ts`)
- [x] Lint/typecheck pass (`bun run ci:local`)
- [x] Build succeeds (`bun run ci:local`)
- [x] No debug code remaining
- [x] Breaking changes documented (none)

Docs impact: minor

Closes #876