### PR TITLE
fix: converge hook self-heal tracking

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.4.0-dev.4",
-	"generatedAt": "2026-06-03T00:33:01.386Z",
+	"version": "4.4.0-dev.5",
+	"generatedAt": "2026-06-06T16:23:35.839Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/__tests__/commands/update-cli-auto-init.test.ts
+++ b/src/__tests__/commands/update-cli-auto-init.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PromptKitUpdateDeps } from "@/commands/update-cli.js";
 import { promptKitUpdate } from "@/commands/update-cli.js";
+import { countMissingCkHookRegistrations } from "@/commands/update/post-update-handler.js";
 
 const confirmMock = mock(async (_options: { message: string }) => true);
 const isCancelMock = mock((value: unknown) => value === "cancelled");
@@ -304,6 +305,60 @@ describe("promptKitUpdate auto-init behavior", () => {
 		expect(execCount()).toBe(1);
 		expect(capturedExecCmd()).toContain("ck init -g");
 		expect(capturedExecCmd()).not.toContain("--restore-ck-hooks");
+	});
+
+	test("counts missing hook registrations by hook identity instead of stale command variants", async () => {
+		await writeFile(
+			join(tempDir, "settings.json"),
+			JSON.stringify(
+				{
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: 'node "$HOME/.claude/hooks/session-init.cjs"',
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+		await writeFile(
+			join(tempDir, ".ck.json"),
+			JSON.stringify(
+				{
+					hooks: {
+						"privacy-block": false,
+					},
+					kits: {
+						"ClaudeKit Engineer": {
+							installedSettings: {
+								hooks: [
+									"node $HOME/.claude/hooks/session-init.cjs",
+									"bash $HOME/.claude/hooks/node-hook-runner.sh $HOME/.claude/hooks/session-init.cjs",
+									"node $HOME/.claude/hooks/post-edit-simplify-reminder.cjs",
+									"bash $HOME/.claude/hooks/node-hook-runner.sh $HOME/.claude/hooks/post-edit-simplify-reminder.cjs",
+									"node $HOME/.claude/hooks/privacy-block.cjs",
+									"bash $HOME/.claude/hooks/node-hook-runner.sh $HOME/.claude/hooks/privacy-block.cjs",
+									"node $HOME/.claude/hooks/task-completed-handler.cjs",
+								],
+								mcpServers: [],
+							},
+						},
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		await expect(countMissingCkHookRegistrations(tempDir, "engineer")).resolves.toBe(1);
 	});
 
 	test("reinstalls local kit when latest project settings have broken hook registrations (--yes mode)", async () => {

--- a/src/__tests__/domains/installation/merger/settings-processor.test.ts
+++ b/src/__tests__/domains/installation/merger/settings-processor.test.ts
@@ -167,6 +167,63 @@ describe("SettingsProcessor custom global dir support", () => {
 		expect(commands.some((command) => command.includes("session-state.cjs"))).toBe(true);
 	});
 
+	it("restore mode refreshes installed-settings tracking to the current source baseline", async () => {
+		await writeHookSourceSettings();
+		await writeFile(destFile, JSON.stringify({ hooks: {} }, null, 2));
+		await writeFile(
+			join(customClaudeDir, ".ck.json"),
+			JSON.stringify(
+				{
+					kits: {
+						engineer: {
+							installedSettings: {
+								hooks: [
+									"node $HOME/.claude/hooks/session-init.cjs",
+									"node $HOME/.claude/hooks/usage-quota-cache-refresh.cjs",
+									"bash $HOME/.claude/hooks/node-hook-runner.sh $HOME/.claude/hooks/session-init.cjs",
+									"bash $HOME/.claude/hooks/node-hook-runner.sh $HOME/.claude/hooks/usage-quota-cache-refresh.cjs",
+									"node $HOME/.claude/hooks/team-context-inject.cjs",
+									"node $HOME/.claude/hooks/post-edit-simplify-reminder.cjs",
+									"node $HOME/.claude/hooks/task-completed-handler.cjs",
+									"node $HOME/.claude/hooks/teammate-idle-handler.cjs",
+								],
+								mcpServers: [],
+							},
+						},
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const processor = createProcessor();
+		processor.setRestoreCkHooks(true);
+		await processor.processSettingsJson(sourceFile, destFile);
+
+		const ckJson = JSON.parse(await readFile(join(customClaudeDir, ".ck.json"), "utf-8")) as {
+			kits: { engineer: { installedSettings: { hooks: string[] } } };
+		};
+		const trackedHooks = ckJson.kits.engineer.installedSettings.hooks;
+
+		expect(trackedHooks.some((command) => command.includes("node-hook-runner.sh"))).toBe(false);
+		expect(trackedHooks.some((command) => command.includes("team-context-inject.cjs"))).toBe(false);
+		expect(
+			trackedHooks.some((command) => command.includes("post-edit-simplify-reminder.cjs")),
+		).toBe(false);
+		expect(trackedHooks.some((command) => command.includes("session-init.cjs"))).toBe(true);
+		expect(trackedHooks.some((command) => command.includes("usage-quota-cache-refresh.cjs"))).toBe(
+			true,
+		);
+		expect(trackedHooks.some((command) => command.includes("session-state.cjs"))).toBe(true);
+		expect(trackedHooks.some((command) => command.includes("task-completed-handler.cjs"))).toBe(
+			true,
+		);
+		expect(trackedHooks.some((command) => command.includes("teammate-idle-handler.cjs"))).toBe(
+			true,
+		);
+	});
+
 	it("restore mode does not re-add hooks explicitly disabled in .ck.json", async () => {
 		await writeHookSourceSettings();
 		await writeFile(destFile, JSON.stringify({ hooks: {} }, null, 2));

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -44,6 +44,7 @@ const execAsync = promisify(exec);
 // Only allow alphanumeric chars and hyphens in provider names (defense-in-depth against injection)
 const SAFE_PROVIDER_NAME = /^[a-z0-9-]+$/;
 const HOOK_DEPENDENCY_EXTENSIONS = [".js", ".cjs", ".mjs", ".json"];
+const DYNAMIC_INJECTED_HOOKS = new Set(["task-completed-handler", "teammate-idle-handler"]);
 
 interface CkSettingsSnapshot {
 	hooks?: Record<string, Array<{ command?: string; hooks?: Array<{ command?: string }> }>>;
@@ -127,7 +128,6 @@ export async function readMetadataFile(claudeDir: string): Promise<Metadata | nu
 }
 
 function extractCkHookName(command: string): string | null {
-	if (!command.trim().startsWith("node ")) return null;
 	const normalized = command.replace(/\\/g, "/");
 	const match = normalized.match(/\/hooks\/([^/"'\s]+)\.(?:cjs|mjs|js)(?:["'\s]|$)/);
 	return match?.[1] ?? null;
@@ -181,21 +181,33 @@ export async function countMissingCkHookRegistrations(
 	const settings = parseJsonContent<CkSettingsSnapshot>(await readFile(settingsPath, "utf-8"));
 	const config = parseJsonContent<CkConfigSnapshot>(await readFile(configPath, "utf-8"));
 	const existingCommands = collectSettingsHookCommands(settings);
+	const existingHookNames = new Set<string>();
+	for (const command of existingCommands) {
+		const hookName = extractCkHookName(command);
+		if (hookName) existingHookNames.add(hookName);
+	}
 	const disabledHooks = new Set(
 		Object.entries(config.hooks ?? {})
 			.filter(([, enabled]) => enabled === false)
 			.map(([name]) => name),
 	);
 
-	let missing = 0;
+	const missingHookNames = new Set<string>();
+	const missingCommands = new Set<string>();
 	for (const command of getInstalledHookCommands(config, kit)) {
 		const hookName = extractCkHookName(command);
-		if (hookName && disabledHooks.has(hookName)) continue;
-		if (!existingCommands.has(normalizeCommand(command))) {
-			missing++;
+		if (hookName) {
+			if (disabledHooks.has(hookName) || DYNAMIC_INJECTED_HOOKS.has(hookName)) continue;
+			if (!existingHookNames.has(hookName)) missingHookNames.add(hookName);
+			continue;
+		}
+
+		const normalizedCommand = normalizeCommand(command);
+		if (!existingCommands.has(normalizedCommand)) {
+			missingCommands.add(normalizedCommand);
 		}
 	}
-	return missing;
+	return missingHookNames.size + missingCommands.size;
 }
 
 // ─── Init command builder ─────────────────────────────────────────────────────

--- a/src/domains/installation/merger/settings-processor.ts
+++ b/src/domains/installation/merger/settings-processor.ts
@@ -12,6 +12,8 @@ import type { InstalledSettings } from "@/types";
 import { copy, pathExists, readFile, writeFile } from "fs-extra";
 import semver from "semver";
 
+const DYNAMIC_INJECTED_HOOKS = new Set(["task-completed-handler", "teammate-idle-handler"]);
+
 /**
  * SettingsProcessor handles settings.json processing with selective merge and path transformation
  */
@@ -266,20 +268,6 @@ export class SettingsProcessor {
 			logger.warning(`Duplicate hooks skipped: ${mergeResult.conflictsDetected.length}`);
 		}
 
-		// Update tracking with newly installed items
-		if (
-			this.tracker &&
-			(mergeResult.newlyInstalledHooks.length > 0 || mergeResult.newlyInstalledServers.length > 0)
-		) {
-			for (const hook of mergeResult.newlyInstalledHooks) {
-				this.tracker.trackHook(hook, installedSettings);
-			}
-			for (const server of mergeResult.newlyInstalledServers) {
-				this.tracker.trackMcpServer(server, installedSettings);
-			}
-			await this.tracker.saveInstalledSettings(installedSettings);
-		}
-
 		if (this.migrateLegacyStatusLineRunner(mergeResult.merged, sourceSettings)) {
 			logger.info("Migrated legacy statusLine runner command to current ClaudeKit statusline");
 		}
@@ -312,6 +300,8 @@ export class SettingsProcessor {
 		// Write merged settings
 		await SettingsMerger.writeSettingsFile(destFile, mergeResult.merged);
 		logger.success("Merged settings.json (user customizations preserved)");
+
+		await this.refreshInstalledSettingsTracking(sourceSettings, installedSettings);
 
 		// Inject team hooks if supported
 		await this.injectTeamHooksIfSupported(destFile, mergeResult.merged);
@@ -636,7 +626,13 @@ export class SettingsProcessor {
 	private async trackInstalledSettings(settings: SettingsJson): Promise<void> {
 		if (!this.tracker) return;
 
+		await this.tracker.saveInstalledSettings(this.collectInstalledSettings(settings));
+		logger.debug("Tracked installed settings for fresh install");
+	}
+
+	private collectInstalledSettings(settings: SettingsJson): InstalledSettings {
 		const installedSettings: InstalledSettings = { hooks: [], mcpServers: [] };
+		if (!this.tracker) return installedSettings;
 
 		// Track all hooks
 		if (settings.hooks) {
@@ -663,8 +659,34 @@ export class SettingsProcessor {
 			}
 		}
 
-		await this.tracker.saveInstalledSettings(installedSettings);
-		logger.debug("Tracked installed settings for fresh install");
+		return installedSettings;
+	}
+
+	private async refreshInstalledSettingsTracking(
+		sourceSettings: SettingsJson,
+		previousInstalledSettings: InstalledSettings,
+	): Promise<void> {
+		if (!this.tracker) return;
+
+		const trackingSource = structuredClone(sourceSettings);
+		this.fixHookCommandPaths(trackingSource);
+		const refreshedSettings = this.collectInstalledSettings(trackingSource);
+		this.preserveDynamicInjectedHookTracking(previousInstalledSettings, refreshedSettings);
+		await this.tracker.saveInstalledSettings(refreshedSettings);
+		logger.debug("Refreshed installed settings tracking baseline");
+	}
+
+	private preserveDynamicInjectedHookTracking(
+		previousInstalledSettings: InstalledSettings,
+		refreshedSettings: InstalledSettings,
+	): void {
+		if (!previousInstalledSettings.hooks || !this.tracker) return;
+
+		for (const command of previousInstalledSettings.hooks) {
+			const hookName = this.extractCkHookName(command);
+			if (!hookName || !DYNAMIC_INJECTED_HOOKS.has(hookName)) continue;
+			this.tracker.trackHook(command, refreshedSettings);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Count update-time missing hook registrations by hook identity instead of stale command-string variants.
- Refresh `.ck.json` installed-settings tracking to the current source baseline after successful `ck init` merges.
- Preserve dynamic team-hook deletion tracking while pruning stale legacy/static hook history.

Closes #878

## Root Cause

`ck update --dev -y` used historical `.ck.json` installed hook tracking as the expected active hook set. Legacy runner commands and retired static hooks stayed in the tracker after `ck init --restore-ck-hooks`, so the next update detected the same missing registrations again.

## Changes

| File | Change |
|------|--------|
| `src/commands/update/post-update-handler.ts` | Dedupes missing-hook detection by hook name and excludes dynamic team-hook history from update self-heal. |
| `src/domains/installation/merger/settings-processor.ts` | Rebuilds installed-settings tracking from the current source settings after successful merges, preserving dynamic team-hook deletion history. |
| `src/__tests__/commands/update-cli-auto-init.test.ts` | Covers stale direct/runner command variants, disabled hooks, and dynamic hooks. |
| `src/__tests__/domains/installation/merger/settings-processor.test.ts` | Covers tracker convergence after restore mode. |
| `cli-manifest.json` | Regenerates the CLI manifest for the current dev release baseline. |

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun test src/__tests__/commands/update-cli-auto-init.test.ts src/__tests__/domains/installation/merger/settings-processor.test.ts`
- [x] `bun test`
- [x] pre-push quality gate, including UI build, package verification, and UI vitest suite
