### PR TITLE
fix(sync): apply deletion-only cleanup

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.4.0-dev.5",
-	"generatedAt": "2026-06-06T16:23:35.839Z",
+	"version": "4.4.0-dev.6",
+	"generatedAt": "2026-06-08T13:18:11.103Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/__tests__/commands/init/phases/sync-handler-deletions.test.ts
+++ b/src/__tests__/commands/init/phases/sync-handler-deletions.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, mock } from "bun:test";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { executeSyncMerge } from "@/commands/init/phases/sync-handler.js";
+import type { InitContext, SyncContext } from "@/commands/init/types.js";
+import type { TrackedFile } from "@/types";
+
+const checksum = "a".repeat(64);
+
+function createPrompts() {
+	return {
+		selectKit: mock(async () => "engineer" as const),
+		getDirectory: mock(async () => "."),
+		selectVersionEnhanced: mock(async () => "v1.0.0"),
+		confirm: mock(async () => true),
+		intro: mock(() => {}),
+		outro: mock(() => {}),
+		note: mock(() => {}),
+	};
+}
+
+function createTrackedFile(path: string, ownership: TrackedFile["ownership"]): TrackedFile {
+	return {
+		path,
+		checksum,
+		ownership,
+		installedVersion: "1.0.0",
+	};
+}
+
+function createSyncContext(overrides: {
+	projectDir: string;
+	claudeDir: string;
+	upstreamDir: string;
+	trackedFiles: TrackedFile[];
+	prompts: ReturnType<typeof createPrompts>;
+}): SyncContext {
+	return {
+		rawOptions: {} as SyncContext["rawOptions"],
+		options: {
+			kit: "engineer",
+			dir: overrides.projectDir,
+			beta: false,
+			global: false,
+			yes: true,
+			fresh: false,
+			force: false,
+			refresh: false,
+			exclude: [],
+			only: [],
+			installSkills: false,
+			withSudo: false,
+			skipSetup: false,
+			forceOverwrite: false,
+			forceOverwriteSettings: false,
+			restoreCkHooks: false,
+			dryRun: false,
+			prefix: true,
+			sync: true,
+			useGit: false,
+		},
+		prompts: overrides.prompts as unknown as InitContext["prompts"],
+		explicitDir: true,
+		isNonInteractive: true,
+		kitType: "engineer",
+		resolvedDir: overrides.projectDir,
+		extractDir: overrides.upstreamDir,
+		claudeDir: overrides.claudeDir,
+		customClaudeFiles: [],
+		includePatterns: [],
+		installSkills: false,
+		cancelled: false,
+		syncInProgress: true,
+		syncTrackedFiles: overrides.trackedFiles,
+		syncCurrentVersion: "1.0.0",
+		syncLatestVersion: "1.0.1",
+	};
+}
+
+describe("executeSyncMerge deletions", () => {
+	it("removes CK-owned deprecated files even when there are no sync updates", async () => {
+		const previousTestHome = process.env.CK_TEST_HOME;
+		const projectDir = await makeTempDir("ck-sync-delete-project-");
+		const upstreamDir = await makeTempDir("ck-sync-delete-upstream-");
+		process.env.CK_TEST_HOME = await makeTempDir("ck-sync-delete-home-");
+		try {
+			const claudeDir = join(projectDir, ".claude");
+			const staleRelPath = "rules/stale-routing.md";
+			const stalePath = join(claudeDir, staleRelPath);
+			const trackedFiles = [createTrackedFile(staleRelPath, "ck")];
+			const prompts = createPrompts();
+
+			await mkdir(join(claudeDir, "rules"), { recursive: true });
+			await writeFile(stalePath, "stale rule\n");
+			await writeFile(
+				join(claudeDir, "metadata.json"),
+				JSON.stringify(
+					{
+						kits: {
+							engineer: {
+								version: "1.0.0",
+								installedAt: "2026-06-08T00:00:00.000Z",
+								files: trackedFiles,
+							},
+						},
+						scope: "local",
+					},
+					null,
+					2,
+				),
+			);
+			await writeFile(
+				join(upstreamDir, "metadata.json"),
+				JSON.stringify(
+					{
+						version: "1.0.1",
+						name: "claudekit-engineer",
+						description: "test source metadata",
+						deletions: [staleRelPath],
+					},
+					null,
+					2,
+				),
+			);
+
+			const result = await executeSyncMerge(
+				createSyncContext({ projectDir, claudeDir, upstreamDir, trackedFiles, prompts }),
+			);
+
+			expect(result.cancelled).toBe(true);
+			expect(await Bun.file(stalePath).exists()).toBe(false);
+			expect(prompts.outro).toHaveBeenCalledWith("Config sync completed successfully");
+
+			const metadata = JSON.parse(await readFile(join(claudeDir, "metadata.json"), "utf-8"));
+			expect(metadata.kits.engineer.files).toHaveLength(0);
+		} finally {
+			if (previousTestHome === undefined) {
+				process.env.CK_TEST_HOME = undefined;
+			} else {
+				process.env.CK_TEST_HOME = previousTestHome;
+			}
+		}
+	});
+});
+
+async function makeTempDir(prefix: string): Promise<string> {
+	return await mkdtemp(join(tmpdir(), prefix));
+}

--- a/src/commands/init/phases/sync-handler.ts
+++ b/src/commands/init/phases/sync-handler.ts
@@ -5,6 +5,7 @@
 
 import { copyFile, mkdir, open, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { handleDeletions } from "@/domains/installation/deletion-handler.js";
 import {
 	ConfigVersionChecker,
 	MergeUI,
@@ -279,12 +280,13 @@ export async function executeSyncMerge(ctx: InitContext): Promise<InitContext> {
 
 		// Load source metadata to get deletions array
 		// This prevents "Skipping invalid path" warnings for intentionally deleted files
+		let sourceMetadata: ClaudeKitMetadata | null = null;
 		let deletions: string[] = [];
 		try {
 			const sourceMetadataPath = join(upstreamDir, "metadata.json");
 			if (await pathExists(sourceMetadataPath)) {
 				const content = await readFile(sourceMetadataPath, "utf-8");
-				const sourceMetadata = JSON.parse(content) as ClaudeKitMetadata;
+				sourceMetadata = JSON.parse(content) as ClaudeKitMetadata;
 				deletions = sourceMetadata.deletions || [];
 			}
 		} catch (error) {
@@ -307,7 +309,9 @@ export async function executeSyncMerge(ctx: InitContext): Promise<InitContext> {
 		// Display plan summary
 		displaySyncPlan(plan);
 
-		if (plan.autoUpdate.length === 0 && plan.needsReview.length === 0) {
+		const hasSyncUpdates = plan.autoUpdate.length > 0 || plan.needsReview.length > 0;
+		const hasDeletionPatterns = deletions.length > 0;
+		if (!hasSyncUpdates && !hasDeletionPatterns) {
 			ctx.prompts.note("All files are up to date or user-owned.", "No Changes Needed");
 			return { ...ctx, cancelled: true };
 		}
@@ -316,6 +320,38 @@ export async function executeSyncMerge(ctx: InitContext): Promise<InitContext> {
 		const backupDir = PathResolver.getBackupDir();
 		await createBackup(ctx.claudeDir, trackedFiles, backupDir);
 		logger.success(`Backup created at ${pc.dim(backupDir)}`);
+
+		if (sourceMetadata?.deletions && sourceMetadata.deletions.length > 0) {
+			try {
+				const deletionResult = await handleDeletions(sourceMetadata, ctx.claudeDir, ctx.kitType);
+
+				if (deletionResult.deletedPaths.length > 0) {
+					logger.info(`Removed ${deletionResult.deletedPaths.length} deprecated file(s)`);
+					for (const path of deletionResult.deletedPaths) {
+						logger.verbose(`  - ${path}`);
+					}
+				}
+
+				if (deletionResult.preservedPaths.length > 0) {
+					logger.verbose(`Preserved ${deletionResult.preservedPaths.length} user-owned file(s)`);
+				}
+
+				if (!hasSyncUpdates) {
+					if (deletionResult.deletedPaths.length > 0) {
+						ctx.prompts.outro("Config sync completed successfully");
+					} else {
+						ctx.prompts.note("All files are up to date or user-owned.", "No Changes Needed");
+					}
+					return { ...ctx, cancelled: true };
+				}
+			} catch (error) {
+				logger.debug(`Cleanup of deprecated files failed during sync: ${error}`);
+				if (!hasSyncUpdates) {
+					ctx.prompts.note("All files are up to date or user-owned.", "No Changes Needed");
+					return { ...ctx, cancelled: true };
+				}
+			}
+		}
 
 		// Apply auto-updates
 		if (plan.autoUpdate.length > 0) {


### PR DESCRIPTION
## Summary
- Run metadata deletion cleanup during sync even when there are no file updates to apply.
- Preserve the backup-before-change behavior for deletion-only sync runs.
- Add a regression test proving CK-owned deprecated files are removed and metadata is cleaned.
- Refresh the generated CLI manifest for the current dev version.

## Validation
- bunx biome check src/commands/init/phases/sync-handler.ts src/__tests__/commands/init/phases/sync-handler-deletions.test.ts
- bun test src/__tests__/commands/init/phases/sync-handler-deletions.test.ts src/__tests__/commands/init/phases/sync-handler-filter-deletion-paths.test.ts src/__tests__/domains/installation/deletion-handler.test.ts
- bun run typecheck
- pre-push local CI parity: 4889 pass, 59 skip, 0 fail; UI vitest: 153 pass

## Release Impact
- Users receiving metadata-only deletions through sync/update now unload CK-owned stale files instead of seeing a no-op sync.