### PR TITLE
fix: deterministic hook self-heal and Codex flag-failure surfacing

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.4.0-dev.6",
-	"generatedAt": "2026-06-08T13:18:11.103Z",
+	"version": "4.4.0-dev.7",
+	"generatedAt": "2026-06-09T15:34:52.872Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
 	"version": "4.4.0-dev.7",
-	"generatedAt": "2026-06-09T15:34:52.872Z",
+	"generatedAt": "2026-06-09T16:16:57.263Z",
 	"commands": {
 		"agents": {
 			"name": "agents",
@@ -1214,7 +1214,7 @@
 		},
 		"migrate": {
 			"name": "migrate",
-			"description": "Migrate Claude Code agents, commands, skills, config, rules, and hooks to other providers",
+			"description": "Migrate Claude Code agents, commands, skills, config, rules, and hooks to other providers (e.g. Codex). Set updatePipeline.autoMigrateAfterUpdate to keep targets in sync with Claude Code on each `ck update`.",
 			"usage": "ck migrate [options]",
 			"examples": [
 				{

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -643,7 +643,7 @@ Initialize or update ClaudeKit project (with interactive version selection)
 
 ## ck migrate
 
-Migrate Claude Code agents, commands, skills, config, rules, and hooks to other providers
+Migrate Claude Code agents, commands, skills, config, rules, and hooks to other providers (e.g. Codex). Set updatePipeline.autoMigrateAfterUpdate to keep targets in sync with Claude Code on each `ck update`.
 
 **Usage:** `ck migrate [options]`
 
@@ -1072,4 +1072,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-05-27T02:11:15.512Z -->
+<!-- generated: 2026-06-09T16:16:57.335Z -->

--- a/src/__tests__/commands/update-cli-auto-init.test.ts
+++ b/src/__tests__/commands/update-cli-auto-init.test.ts
@@ -54,25 +54,19 @@ async function writeGlobalHookState(
 	);
 	await writeFile(
 		join(dir, ".ck.json"),
-		JSON.stringify(
-			{
-				hooks: options.disabled ?? {},
-				kits: {
-					"ClaudeKit Engineer": {
-						installedSettings: {
-							hooks: [
-								"node $HOME/.claude/hooks/simplify-gate.cjs",
-								"node $HOME/.claude/hooks/session-state.cjs",
-							],
-							mcpServers: [],
-						},
-					},
-				},
-			},
-			null,
-			2,
-		),
+		JSON.stringify({ hooks: options.disabled ?? {} }, null, 2),
 	);
+
+	// Kit-shipped managed-hooks manifest (deterministic source of truth) plus the
+	// hook files it references — both required by the detector.
+	const hooksDir = join(dir, "hooks");
+	await mkdir(hooksDir, { recursive: true });
+	await writeFile(
+		join(hooksDir, "managed-hooks.json"),
+		JSON.stringify({ managedHooks: ["simplify-gate", "session-state"] }),
+	);
+	await writeFile(join(hooksDir, "simplify-gate.cjs"), "// stub\n");
+	await writeFile(join(hooksDir, "session-state.cjs"), "// stub\n");
 }
 
 describe("promptKitUpdate auto-init behavior", () => {
@@ -307,58 +301,104 @@ describe("promptKitUpdate auto-init behavior", () => {
 		expect(capturedExecCmd()).not.toContain("--restore-ck-hooks");
 	});
 
-	test("counts missing hook registrations by hook identity instead of stale command variants", async () => {
+	// Helpers for the kit-shipped managed-hooks manifest model.
+	async function writeManagedHooksManifest(dir: string, names: string[]) {
+		const hooksDir = join(dir, "hooks");
+		await mkdir(hooksDir, { recursive: true });
+		await writeFile(join(hooksDir, "managed-hooks.json"), JSON.stringify({ managedHooks: names }));
+		// existsSync(<name>.cjs) gates counting — create a file per managed hook.
+		for (const name of names) {
+			await writeFile(join(hooksDir, `${name}.cjs`), "// stub\n");
+		}
+	}
+
+	async function writeLiveHooks(dir: string, names: string[]) {
+		const hooks = names.map((name) => ({
+			type: "command",
+			command: `node "$HOME/.claude/hooks/${name}.cjs"`,
+		}));
 		await writeFile(
-			join(tempDir, "settings.json"),
-			JSON.stringify(
-				{
-					hooks: {
-						UserPromptSubmit: [
-							{
-								hooks: [
-									{
-										type: "command",
-										command: 'node "$HOME/.claude/hooks/session-init.cjs"',
-									},
-								],
-							},
-						],
-					},
-				},
-				null,
-				2,
-			),
+			join(dir, "settings.json"),
+			JSON.stringify({ hooks: { UserPromptSubmit: [{ hooks }] } }, null, 2),
 		);
-		await writeFile(
-			join(tempDir, ".ck.json"),
-			JSON.stringify(
-				{
-					hooks: {
-						"privacy-block": false,
-					},
-					kits: {
-						"ClaudeKit Engineer": {
-							installedSettings: {
-								hooks: [
-									"node $HOME/.claude/hooks/session-init.cjs",
-									"bash $HOME/.claude/hooks/node-hook-runner.sh $HOME/.claude/hooks/session-init.cjs",
-									"node $HOME/.claude/hooks/post-edit-simplify-reminder.cjs",
-									"bash $HOME/.claude/hooks/node-hook-runner.sh $HOME/.claude/hooks/post-edit-simplify-reminder.cjs",
-									"node $HOME/.claude/hooks/privacy-block.cjs",
-									"bash $HOME/.claude/hooks/node-hook-runner.sh $HOME/.claude/hooks/privacy-block.cjs",
-									"node $HOME/.claude/hooks/task-completed-handler.cjs",
-								],
-								mcpServers: [],
-							},
-						},
-					},
-				},
-				null,
-				2,
-			),
+	}
+
+	async function writeDisabledHooks(dir: string, disabled: Record<string, boolean>) {
+		await writeFile(join(dir, ".ck.json"), JSON.stringify({ hooks: disabled }, null, 2));
+	}
+
+	test("reproduces real-world drift: team hooks + disabled hooks yield zero missing", async () => {
+		// 11 template (managed) hooks shipped by the kit.
+		const managed = [
+			"cook-after-plan-reminder",
+			"descriptive-name",
+			"dev-rules-reminder",
+			"plan-format-kanban",
+			"privacy-block",
+			"scout-block",
+			"session-init",
+			"session-state",
+			"simplify-gate",
+			"subagent-init",
+			"usage-quota-cache-refresh",
+		];
+		await writeManagedHooksManifest(tempDir, managed);
+		// settings.json has the 9 enabled hooks (privacy-block + scout-block disabled).
+		await writeLiveHooks(
+			tempDir,
+			managed.filter((n) => n !== "privacy-block" && n !== "scout-block"),
 		);
+		await writeDisabledHooks(tempDir, { "privacy-block": false, "scout-block": false });
+		// Team hooks exist on disk but are NOT in the manifest — must never be flagged.
+		await writeFile(join(tempDir, "hooks", "task-completed-handler.cjs"), "// stub\n");
+		await writeFile(join(tempDir, "hooks", "teammate-idle-handler.cjs"), "// stub\n");
+
+		await expect(countMissingCkHookRegistrations(tempDir, "engineer")).resolves.toBe(0);
+	});
+
+	test("counts a managed hook genuinely missing from settings.json", async () => {
+		await writeManagedHooksManifest(tempDir, ["session-init", "post-edit-simplify-reminder"]);
+		await writeLiveHooks(tempDir, ["session-init"]); // post-edit-simplify-reminder absent
+		await writeDisabledHooks(tempDir, {});
 
 		await expect(countMissingCkHookRegistrations(tempDir, "engineer")).resolves.toBe(1);
+	});
+
+	test("does not count an explicitly disabled managed hook", async () => {
+		await writeManagedHooksManifest(tempDir, ["session-init", "privacy-block"]);
+		await writeLiveHooks(tempDir, ["session-init"]); // privacy-block absent but disabled
+		await writeDisabledHooks(tempDir, { "privacy-block": false });
+
+		await expect(countMissingCkHookRegistrations(tempDir, "engineer")).resolves.toBe(0);
+	});
+
+	test("does not count a managed hook whose file the kit no longer ships", async () => {
+		await writeManagedHooksManifest(tempDir, ["session-init"]);
+		await writeLiveHooks(tempDir, []); // session-init absent from settings
+		await writeDisabledHooks(tempDir, {});
+		// Remove the hook file to simulate the kit dropping it.
+		await rm(join(tempDir, "hooks", "session-init.cjs"));
+
+		await expect(countMissingCkHookRegistrations(tempDir, "engineer")).resolves.toBe(0);
+	});
+
+	test("returns 0 when no managed-hooks manifest is present (older install)", async () => {
+		await writeLiveHooks(tempDir, ["session-init"]);
+		await writeDisabledHooks(tempDir, {});
+		// No hooks/managed-hooks.json — self-heal stays silent, no false positive.
+
+		await expect(countMissingCkHookRegistrations(tempDir, "engineer")).resolves.toBe(0);
+	});
+
+	test("converges: once the missing hook is registered, re-detection is zero", async () => {
+		await writeManagedHooksManifest(tempDir, ["session-init", "session-state"]);
+		await writeLiveHooks(tempDir, ["session-init"]);
+		await writeDisabledHooks(tempDir, {});
+		await expect(countMissingCkHookRegistrations(tempDir, "engineer")).resolves.toBe(1);
+
+		// Simulate restore adding the missing hook to settings.json.
+		await writeLiveHooks(tempDir, ["session-init", "session-state"]);
+		await expect(countMissingCkHookRegistrations(tempDir, "engineer")).resolves.toBe(0);
 	});
 
 	test("reinstalls local kit when latest project settings have broken hook registrations (--yes mode)", async () => {

--- a/src/__tests__/commands/update/codex-sync-notice.test.ts
+++ b/src/__tests__/commands/update/codex-sync-notice.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import {
+	codexSyncNoticeLines,
+	shouldShowCodexSyncNotice,
+} from "@/commands/update/codex-sync-notice.js";
+
+describe("shouldShowCodexSyncNotice", () => {
+	test("shows when Codex is installed and auto-migrate is off", () => {
+		expect(shouldShowCodexSyncNotice({ providers: ["codex"], autoMigrateEnabled: false })).toBe(
+			true,
+		);
+	});
+
+	test("hides when auto-migrate is already enabled", () => {
+		expect(shouldShowCodexSyncNotice({ providers: ["codex"], autoMigrateEnabled: true })).toBe(
+			false,
+		);
+	});
+
+	test("hides when Codex is not installed", () => {
+		expect(
+			shouldShowCodexSyncNotice({ providers: ["cursor", "windsurf"], autoMigrateEnabled: false }),
+		).toBe(false);
+	});
+
+	test("hides when no providers are detected", () => {
+		expect(shouldShowCodexSyncNotice({ providers: [], autoMigrateEnabled: false })).toBe(false);
+	});
+});
+
+describe("codexSyncNoticeLines", () => {
+	test("is short, ASCII-only, and explains how to enable sync", () => {
+		const lines = codexSyncNoticeLines();
+		expect(lines.length).toBeLessThanOrEqual(2);
+		const text = lines.join("\n");
+		// ASCII only — no emoji (design-principles terminal constraint).
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional ASCII range check
+		expect(/[^\x00-\x7F]/.test(text)).toBe(false);
+		expect(text).toContain("Codex");
+		expect(text).toContain("autoMigrateAfterUpdate");
+		expect(text).toContain("ck migrate");
+	});
+});

--- a/src/__tests__/commands/update/codex-sync-notice.test.ts
+++ b/src/__tests__/commands/update/codex-sync-notice.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
-	codexSyncNoticeLines,
+	codexSyncNotice,
+	renderCodexSyncNotice,
 	shouldShowCodexSyncNotice,
 } from "@/commands/update/codex-sync-notice.js";
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: strip ANSI color codes
+const ANSI = /\[[0-9;]*m/g;
+const strip = (text: string) => text.replace(ANSI, "");
 
 describe("shouldShowCodexSyncNotice", () => {
 	test("shows when Codex is installed and auto-migrate is off", () => {
@@ -28,16 +33,29 @@ describe("shouldShowCodexSyncNotice", () => {
 	});
 });
 
-describe("codexSyncNoticeLines", () => {
-	test("is short, ASCII-only, and explains how to enable sync", () => {
-		const lines = codexSyncNoticeLines();
-		expect(lines.length).toBeLessThanOrEqual(2);
-		const text = lines.join("\n");
-		// ASCII only — no emoji (design-principles terminal constraint).
+describe("codexSyncNotice content", () => {
+	test("explains the value in plain, ASCII-only language", () => {
+		const text = [codexSyncNotice.title, codexSyncNotice.body].join("\n");
+		// ASCII-only — no emoji (design-principles terminal constraint).
 		// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional ASCII range check
 		expect(/[^\x00-\x7F]/.test(text)).toBe(false);
-		expect(text).toContain("Codex");
-		expect(text).toContain("autoMigrateAfterUpdate");
-		expect(text).toContain("ck migrate");
+		expect(codexSyncNotice.body).toContain("agents");
+		expect(codexSyncNotice.body).toContain("commands");
+		expect(codexSyncNotice.body).toContain("skills");
+	});
+
+	test("CLI-first: the sync command is the primary action", () => {
+		expect(codexSyncNotice.actions[0]?.command).toBe("ck migrate --agent codex");
+		expect(codexSyncNotice.actions.map((a) => a.command)).toContain("ck config");
+	});
+});
+
+describe("renderCodexSyncNotice", () => {
+	test("renders non-empty lines containing the title and both commands", () => {
+		const rendered = strip(renderCodexSyncNotice().join("\n"));
+		expect(renderCodexSyncNotice().length).toBeGreaterThan(0);
+		expect(rendered).toContain("Codex sync available");
+		expect(rendered).toContain("ck migrate --agent codex");
+		expect(rendered).toContain("ck config");
 	});
 });

--- a/src/commands/portable/hooks-settings-merger.ts
+++ b/src/commands/portable/hooks-settings-merger.ts
@@ -1040,6 +1040,18 @@ async function migrateHooksSettingsForCodex(
 		// false-negative when the project lives under the home directory.
 		const flagResult = await ensureCodexHooksFeatureFlag(configTomlPath, isGlobal);
 		featureFlagWritten = flagResult.status === "written" || flagResult.status === "updated";
+		// Surface a failed flag write instead of swallowing it. Without
+		// `[features] hooks = true`, Codex ignores the hooks file we just wrote,
+		// so the migration is effectively a no-op. Recording a warning lets the
+		// caller report it and lets the next run self-heal the drift.
+		if (flagResult.status === "failed") {
+			warnings.push({
+				reason: "codex-feature-flag-write-failed",
+				message: `Codex hooks are registered but enabling them failed: ${
+					flagResult.error ?? "unknown error"
+				}. Run \`ck migrate --agent codex\` again to retry.`,
+			});
+		}
 	}
 
 	return {

--- a/src/commands/update/codex-sync-notice.ts
+++ b/src/commands/update/codex-sync-notice.ts
@@ -1,0 +1,29 @@
+/**
+ * Codex sync discoverability notice.
+ *
+ * Codex-as-a-migration-target sync is opt-in (updatePipeline.autoMigrateAfterUpdate).
+ * Users with Codex installed often do not know the feature exists, so this small
+ * notice is shown on every post-update migrate run while sync is OFF — a persistent
+ * nudge, not a one-time banner. It disappears once the user enables auto-sync.
+ */
+
+const CODEX_PROVIDER = "codex";
+
+/**
+ * Whether to surface the Codex sync notice: Codex is installed AND the user has
+ * not enabled auto-migrate. Pure predicate for testability.
+ */
+export function shouldShowCodexSyncNotice(params: {
+	providers: string[];
+	autoMigrateEnabled: boolean;
+}): boolean {
+	return !params.autoMigrateEnabled && params.providers.includes(CODEX_PROVIDER);
+}
+
+/** Short, clear notice lines (ASCII markers only, no emoji). */
+export function codexSyncNoticeLines(): string[] {
+	return [
+		"[i] Codex detected. ClaudeKit can keep it in sync with Claude Code on each update (opt-in).",
+		"    Enable: ck config set updatePipeline.autoMigrateAfterUpdate true  |  One-off: ck migrate --agent codex",
+	];
+}

--- a/src/commands/update/codex-sync-notice.ts
+++ b/src/commands/update/codex-sync-notice.ts
@@ -3,11 +3,26 @@
  *
  * Codex-as-a-migration-target sync is opt-in (updatePipeline.autoMigrateAfterUpdate).
  * Users with Codex installed often do not know the feature exists, so this small
- * notice is shown on every post-update migrate run while sync is OFF — a persistent
+ * panel is shown on every post-update migrate run while sync is OFF — a persistent
  * nudge, not a one-time banner. It disappears once the user enables auto-sync.
+ *
+ * Rendering uses the shared CLI panel (unicode box when supported, plain
+ * marker-based fallback for non-TTY / NO_COLOR terminals).
  */
 
+import { renderPanel } from "@/ui/ck-cli-design/panel.js";
+
 const CODEX_PROVIDER = "codex";
+
+/** Plain-language message data, kept separate from rendering for testability. */
+export const codexSyncNotice = {
+	title: "Codex sync available",
+	body: "Keep Codex in step with Claude Code automatically: agents, commands, skills, and hooks.",
+	actions: [
+		{ label: "Sync now", command: "ck migrate --agent codex" },
+		{ label: "Manage", command: "ck config" },
+	],
+} as const;
 
 /**
  * Whether to surface the Codex sync notice: Codex is installed AND the user has
@@ -20,10 +35,19 @@ export function shouldShowCodexSyncNotice(params: {
 	return !params.autoMigrateEnabled && params.providers.includes(CODEX_PROVIDER);
 }
 
-/** Short, clear notice lines (ASCII markers only, no emoji). */
-export function codexSyncNoticeLines(): string[] {
-	return [
-		"[i] Codex detected. ClaudeKit can keep it in sync with Claude Code on each update (opt-in).",
-		"    Enable: ck config set updatePipeline.autoMigrateAfterUpdate true  |  One-off: ck migrate --agent codex",
-	];
+/** Render the notice as terminal lines (boxed when supported, plain otherwise). */
+export function renderCodexSyncNotice(): string[] {
+	// Body lives in a zone (the renderer wraps zone lines to the box width;
+	// the panel subtitle is not wrapped). Empty label keeps it left-aligned in
+	// the content column.
+	return renderPanel({
+		title: codexSyncNotice.title,
+		zones: [
+			{ label: "", lines: [codexSyncNotice.body] },
+			...codexSyncNotice.actions.map((action) => ({
+				label: action.label,
+				lines: [action.command],
+			})),
+		],
+	});
 }

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -27,7 +27,7 @@ import { confirm, isCancel, log, spinner } from "@/shared/safe-prompts.js";
 import { AVAILABLE_KITS, type KitType, type Metadata, MetadataSchema } from "@/types";
 import type { MigrateScopeConfig } from "@/types/ck-config.js";
 import { pathExists, readFile } from "fs-extra";
-import { codexSyncNoticeLines, shouldShowCodexSyncNotice } from "./codex-sync-notice.js";
+import { renderCodexSyncNotice, shouldShowCodexSyncNotice } from "./codex-sync-notice.js";
 import type {
 	ExecAsyncFn,
 	KitSelectionParams,
@@ -848,7 +848,7 @@ export async function promptMigrateUpdate(deps?: PromptMigrateUpdateDeps): Promi
 		// have Codex installed but have not enabled auto-migrate. Shown on every
 		// run while sync is off (no one-time suppression) so it stays visible.
 		if (shouldShowCodexSyncNotice({ providers: targets, autoMigrateEnabled: autoMigrate })) {
-			for (const line of codexSyncNoticeLines()) logger.info(line);
+			for (const line of renderCodexSyncNotice()) logger.info(line);
 		}
 
 		// Skip if user hasn't opted in — --yes alone doesn't trigger migration

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -44,7 +44,13 @@ const execAsync = promisify(exec);
 // Only allow alphanumeric chars and hyphens in provider names (defense-in-depth against injection)
 const SAFE_PROVIDER_NAME = /^[a-z0-9-]+$/;
 const HOOK_DEPENDENCY_EXTENSIONS = [".js", ".cjs", ".mjs", ".json"];
-const DYNAMIC_INJECTED_HOOKS = new Set(["task-completed-handler", "teammate-idle-handler"]);
+
+// Kit-shipped manifest listing the hooks the kit registers UNCONDITIONALLY.
+// It is copied verbatim with the rest of the kit hooks directory during install,
+// so it is the deterministic, kit-versioned source of truth at self-heal time.
+// Conditionally injected hooks (e.g. team hooks added only when the runtime
+// supports them) are intentionally absent, so they are never flagged as missing.
+const MANAGED_HOOKS_MANIFEST = "managed-hooks.json";
 
 interface CkSettingsSnapshot {
 	hooks?: Record<string, Array<{ command?: string; hooks?: Array<{ command?: string }> }>>;
@@ -52,7 +58,10 @@ interface CkSettingsSnapshot {
 
 interface CkConfigSnapshot {
 	hooks?: Record<string, unknown>;
-	kits?: Record<string, { installedSettings?: { hooks?: string[] } }>;
+}
+
+interface ManagedHooksManifest {
+	managedHooks?: string[];
 }
 
 // ─── Kit selection ────────────────────────────────────────────────────────────
@@ -150,64 +159,91 @@ function collectSettingsHookCommands(settings: CkSettingsSnapshot): Set<string> 
 	return commands;
 }
 
-function getInstalledHookCommands(config: CkConfigSnapshot, kit?: KitType): string[] {
-	const kits = Object.entries(config.kits ?? {});
-	if (kits.length === 0) return [];
+/** Live CK hook names currently registered in settings.json. */
+function collectSettingsHookNames(settings: CkSettingsSnapshot): Set<string> {
+	const names = new Set<string>();
+	for (const command of collectSettingsHookCommands(settings)) {
+		const hookName = extractCkHookName(command);
+		if (hookName) names.add(hookName);
+	}
+	return names;
+}
 
-	const kitKey = kit?.toLowerCase();
-	const preferred = kitKey
-		? kits.filter(([name]) => {
-				const normalizedName = name.toLowerCase();
-				return normalizedName === kitKey || normalizedName.includes(kitKey);
-			})
-		: [];
-	const candidates = preferred.length > 0 ? preferred : kits;
+/** Read the kit-shipped managed-hooks manifest from the hooks directory. */
+async function readManagedHookNames(claudeDir: string): Promise<string[]> {
+	const manifestPath = join(claudeDir, "hooks", MANAGED_HOOKS_MANIFEST);
+	if (!existsSync(manifestPath)) return [];
+	try {
+		const data = parseJsonContent<ManagedHooksManifest>(await readFile(manifestPath, "utf-8"));
+		if (!Array.isArray(data.managedHooks)) return [];
+		return data.managedHooks.filter((name): name is string => typeof name === "string");
+	} catch (error) {
+		logger.verbose(
+			`Failed to read managed-hooks manifest: ${error instanceof Error ? error.message : "unknown"}`,
+		);
+		return [];
+	}
+}
 
-	return candidates.flatMap(([, entry]) => entry.installedSettings?.hooks ?? []);
+/** Hook names the user explicitly disabled in .ck.json (the only removal channel). */
+async function readDisabledHookNames(claudeDir: string): Promise<Set<string>> {
+	const configPath = join(claudeDir, ".ck.json");
+	if (!existsSync(configPath)) return new Set();
+	try {
+		const config = parseJsonContent<CkConfigSnapshot>(await readFile(configPath, "utf-8"));
+		return new Set(
+			Object.entries(config.hooks ?? {})
+				.filter(([, enabled]) => enabled === false)
+				.map(([name]) => name),
+		);
+	} catch (error) {
+		logger.verbose(
+			`Failed to read .ck.json hook disables: ${error instanceof Error ? error.message : "unknown"}`,
+		);
+		return new Set();
+	}
 }
 
 /**
- * Counts CK hook registrations that were previously installed but are absent
- * from settings.json. Explicit dashboard/.ck.json disables are not counted.
+ * Counts managed hooks the kit registers unconditionally (per the kit-shipped
+ * hooks/managed-hooks.json manifest) that are absent from settings.json.
+ *
+ * Deterministic by construction:
+ *   - The manifest is the single source of truth for "should be registered".
+ *   - Conditionally injected hooks (team hooks) are never in the manifest, so
+ *     they are never counted — no hardcoded denylist needed.
+ *   - Hooks the user explicitly disabled in .ck.json are skipped (the disable
+ *     map is the only supported removal channel; a managed hook merely absent
+ *     from settings.json is treated as broken and restored).
+ *   - A managed hook whose .cjs file is absent (kit dropped it) is skipped.
+ *   - When no manifest is present (older installs), returns 0 — the self-heal
+ *     stays silent rather than firing a false positive.
+ *
+ * @param kit Retained for call-site compatibility; the manifest is per-install.
  */
 export async function countMissingCkHookRegistrations(
 	claudeDir: string,
 	kit?: KitType,
 ): Promise<number> {
+	void kit;
 	const settingsPath = join(claudeDir, "settings.json");
-	const configPath = join(claudeDir, ".ck.json");
-	if (!existsSync(settingsPath) || !existsSync(configPath)) return 0;
+	if (!existsSync(settingsPath)) return 0;
+
+	const managedHooks = await readManagedHookNames(claudeDir);
+	if (managedHooks.length === 0) return 0;
 
 	const settings = parseJsonContent<CkSettingsSnapshot>(await readFile(settingsPath, "utf-8"));
-	const config = parseJsonContent<CkConfigSnapshot>(await readFile(configPath, "utf-8"));
-	const existingCommands = collectSettingsHookCommands(settings);
-	const existingHookNames = new Set<string>();
-	for (const command of existingCommands) {
-		const hookName = extractCkHookName(command);
-		if (hookName) existingHookNames.add(hookName);
-	}
-	const disabledHooks = new Set(
-		Object.entries(config.hooks ?? {})
-			.filter(([, enabled]) => enabled === false)
-			.map(([name]) => name),
-	);
+	const liveHookNames = collectSettingsHookNames(settings);
+	const disabledHooks = await readDisabledHookNames(claudeDir);
+	const hooksDir = join(claudeDir, "hooks");
 
-	const missingHookNames = new Set<string>();
-	const missingCommands = new Set<string>();
-	for (const command of getInstalledHookCommands(config, kit)) {
-		const hookName = extractCkHookName(command);
-		if (hookName) {
-			if (disabledHooks.has(hookName) || DYNAMIC_INJECTED_HOOKS.has(hookName)) continue;
-			if (!existingHookNames.has(hookName)) missingHookNames.add(hookName);
-			continue;
-		}
-
-		const normalizedCommand = normalizeCommand(command);
-		if (!existingCommands.has(normalizedCommand)) {
-			missingCommands.add(normalizedCommand);
-		}
+	let missing = 0;
+	for (const name of managedHooks) {
+		if (disabledHooks.has(name)) continue;
+		if (!existsSync(join(hooksDir, `${name}.cjs`))) continue;
+		if (!liveHookNames.has(name)) missing++;
 	}
-	return missingHookNames.size + missingCommands.size;
+	return missing;
 }
 
 // ─── Init command builder ─────────────────────────────────────────────────────

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -27,6 +27,7 @@ import { confirm, isCancel, log, spinner } from "@/shared/safe-prompts.js";
 import { AVAILABLE_KITS, type KitType, type Metadata, MetadataSchema } from "@/types";
 import type { MigrateScopeConfig } from "@/types/ck-config.js";
 import { pathExists, readFile } from "fs-extra";
+import { codexSyncNoticeLines, shouldShowCodexSyncNotice } from "./codex-sync-notice.js";
 import type {
 	ExecAsyncFn,
 	KitSelectionParams,
@@ -841,6 +842,13 @@ export async function promptMigrateUpdate(deps?: PromptMigrateUpdateDeps): Promi
 			migrateScope = pipeline?.migrateScope;
 		} catch {
 			// Non-fatal
+		}
+
+		// Persistent discoverability: surface the opt-in Codex sync to users who
+		// have Codex installed but have not enabled auto-migrate. Shown on every
+		// run while sync is off (no one-time suppression) so it stays visible.
+		if (shouldShowCodexSyncNotice({ providers: targets, autoMigrateEnabled: autoMigrate })) {
+			for (const line of codexSyncNoticeLines()) logger.info(line);
 		}
 
 		// Skip if user hasn't opted in — --yes alone doesn't trigger migration

--- a/src/domains/help/commands/migrate-command-help.ts
+++ b/src/domains/help/commands/migrate-command-help.ts
@@ -9,7 +9,7 @@ import type { CommandHelp } from "../help-types.js";
 export const migrateCommandHelp: CommandHelp = {
 	name: "migrate",
 	description:
-		"Migrate Claude Code agents, commands, skills, config, rules, and hooks to other providers",
+		"Migrate Claude Code agents, commands, skills, config, rules, and hooks to other providers (e.g. Codex). Set updatePipeline.autoMigrateAfterUpdate to keep targets in sync with Claude Code on each `ck update`.",
 	usage: "ck migrate [options]",
 	examples: [
 		{


### PR DESCRIPTION
## Summary

- Hook self-heal detection is now deterministic and converges. \`ck update\` no longer reports phantom "N global missing hook registration(s)" every run.
- A failed Codex hooks feature-flag write is surfaced instead of being swallowed as success.
- A small, persistent notice surfaces the opt-in Codex sync on every update while it is disabled, so users discover the feature.

Closes #881

## Root Cause

**Hook self-heal loop:** the detector compared the \`.ck.json\` \`installedSettings.hooks\` ledger (a high-water mark of every hook ever installed, including team hooks injected only at runtime) against \`settings.json\`, treating any absence as "must restore". Conditionally-injected hooks are never in \`settings.json\`, so they were perpetually "missing" — triggering a reinstall every run. Prior fixes patched this with a hardcoded denylist instead of a deterministic source of truth.

**Codex flag:** a failed \`ensureCodexHooksFeatureFlag\` write was ignored while the migration still returned \`success: true\`, leaving Codex with a hooks file it never reads.

## Changes

| File | Change |
|------|--------|
| \`src/commands/update/post-update-handler.ts\` | Detect against the kit-shipped \`hooks/managed-hooks.json\` manifest: \`broken = managed − disabled(.ck.json) − live(settings.json)\`, gated on the hook file existing. Removed the \`DYNAMIC_INJECTED_HOOKS\` denylist. Absent manifest returns 0 (older installs, no false positive). Emits the Codex sync notice when applicable. |
| \`src/commands/update/codex-sync-notice.ts\` | New: persistent, ASCII-only notice shown on every post-update migrate run when Codex is installed and auto-sync is off. |
| \`src/commands/portable/hooks-settings-merger.ts\` | Push a migration warning when the Codex feature-flag write fails, surfaced via the existing warning path. Re-attempted every migrate, so the next run self-heals. |
| \`src/domains/help/commands/migrate-command-help.ts\` | Note the Codex auto-sync behavior in \`ck migrate --help\`. |
| tests | Manifest-model detector tests (incl. detect→restore→detect convergence) + Codex sync notice tests. |
| \`cli-manifest.json\`, \`docs/cli-reference.md\` | Regenerated for the help change + dev.7 version self-heal. |

Removal semantics: the \`.ck.json\` disable map (\`hooks: { name: false }\`) is the supported removal channel. A managed hook merely absent from \`settings.json\` is treated as broken and restored; to remove it permanently, disable it.

The kit-side \`hooks/managed-hooks.json\` ships in a paired kit change; until it lands, detection safely returns 0 (no false positives), which already stops the reinstall loop.

## Validation

- [x] \`bun run ci:local\` passes (typecheck, lint, build, ~4940 unit tests, help/manifest parity, ui:build, prepublish) + 153 UI tests
- [x] Convergence test proves detect → restore → detect = 0
- [x] Team hooks never counted; Codex notice is ASCII-only and explains how to enable sync