### PR TITLE
fix: resolve CLAUDE_PROJECT_DIR in project-scope codex hook migration

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.4.0-dev.7",
-	"generatedAt": "2026-06-09T16:16:57.263Z",
+	"version": "4.4.0-dev.8",
+	"generatedAt": "2026-06-10T03:42:08.231Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/src/commands/portable/__tests__/claude-to-codex-hooks.test.ts
+++ b/src/commands/portable/__tests__/claude-to-codex-hooks.test.ts
@@ -455,3 +455,267 @@ describe("rewriteCommandPath — commandSubstitutions (GH-730 N1 fix)", () => {
 		expect(result).toBe(`node "${wrapperPath}"`);
 	});
 });
+
+// ---- GH-883 unit tests: $CLAUDE_PROJECT_DIR variable forms ----------
+
+const PROJECT_DIR = "/Users/testuser/my-project";
+const PROJECT_DIR_WITH_SPACE = "/Users/test user/proj";
+
+describe("rewriteCommandPath — Phase 1 substitution: $CLAUDE_PROJECT_DIR forms", () => {
+	// Shared setup: hook at .claude/hooks/simplify-gate.cjs, wrapper at .codex/hooks/abc-simplify-gate.cjs
+	const relHook = ".claude/hooks/simplify-gate.cjs";
+	const originalAbsPath = `${PROJECT_DIR}/${relHook}`;
+	const wrapperAbsPath = `${PROJECT_DIR}/.codex/hooks/abc123-simplify-gate.cjs`;
+
+	function makeSubs() {
+		return new Map([[originalAbsPath, wrapperAbsPath]]);
+	}
+
+	it("form 1 — fully quoted $CLAUDE_PROJECT_DIR/<rel> → wrapper (quoted)", () => {
+		const cmd = `node "$CLAUDE_PROJECT_DIR/${relHook}"`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: `${PROJECT_DIR}/.claude/hooks`,
+			targetDir: `${PROJECT_DIR}/.codex/hooks`,
+			commandSubstitutions: makeSubs(),
+			projectDir: PROJECT_DIR,
+		});
+		expect(result).toBe(`node "${wrapperAbsPath}"`);
+		expect(result).not.toContain("$CLAUDE_PROJECT_DIR");
+	});
+
+	it("form 2 — var-only quoted $CLAUDE_PROJECT_DIR/<rel> (Claude Code standard) → wrapper (quoted)", () => {
+		const cmd = `node "$CLAUDE_PROJECT_DIR"/${relHook}`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: `${PROJECT_DIR}/.claude/hooks`,
+			targetDir: `${PROJECT_DIR}/.codex/hooks`,
+			commandSubstitutions: makeSubs(),
+			projectDir: PROJECT_DIR,
+		});
+		expect(result).toBe(`node "${wrapperAbsPath}"`);
+		expect(result).not.toContain("$CLAUDE_PROJECT_DIR");
+	});
+
+	it("form 3a — braced quoted ${CLAUDE_PROJECT_DIR}/<rel> → wrapper (quoted)", () => {
+		const cmd = `node "\${CLAUDE_PROJECT_DIR}"/${relHook}`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: `${PROJECT_DIR}/.claude/hooks`,
+			targetDir: `${PROJECT_DIR}/.codex/hooks`,
+			commandSubstitutions: makeSubs(),
+			projectDir: PROJECT_DIR,
+		});
+		expect(result).toBe(`node "${wrapperAbsPath}"`);
+		expect(result).not.toContain("CLAUDE_PROJECT_DIR");
+	});
+
+	it("form 3b — bare braced ${CLAUDE_PROJECT_DIR}/<rel> → wrapper (unquoted)", () => {
+		const cmd = `node \${CLAUDE_PROJECT_DIR}/${relHook}`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: `${PROJECT_DIR}/.claude/hooks`,
+			targetDir: `${PROJECT_DIR}/.codex/hooks`,
+			commandSubstitutions: makeSubs(),
+			projectDir: PROJECT_DIR,
+		});
+		expect(result).toBe(`node ${wrapperAbsPath}`);
+		expect(result).not.toContain("CLAUDE_PROJECT_DIR");
+	});
+
+	it("form 4 — bare $CLAUDE_PROJECT_DIR/<rel> → wrapper (unquoted)", () => {
+		const cmd = `node $CLAUDE_PROJECT_DIR/${relHook}`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: `${PROJECT_DIR}/.claude/hooks`,
+			targetDir: `${PROJECT_DIR}/.codex/hooks`,
+			commandSubstitutions: makeSubs(),
+			projectDir: PROJECT_DIR,
+		});
+		expect(result).toBe(`node ${wrapperAbsPath}`);
+		expect(result).not.toContain("$CLAUDE_PROJECT_DIR");
+	});
+
+	it("form 5 — Windows %CLAUDE_PROJECT_DIR%/<rel> bare → wrapper (quoted)", () => {
+		const cmd = `node %CLAUDE_PROJECT_DIR%/${relHook}`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: `${PROJECT_DIR}/.claude/hooks`,
+			targetDir: `${PROJECT_DIR}/.codex/hooks`,
+			commandSubstitutions: makeSubs(),
+			projectDir: PROJECT_DIR,
+		});
+		expect(result).toBe(`node "${wrapperAbsPath}"`);
+		expect(result).not.toContain("CLAUDE_PROJECT_DIR");
+	});
+
+	it("form 2 end-to-end: balanced quotes, no doubling", () => {
+		// Claude Code's standard emission: `node "$CLAUDE_PROJECT_DIR"/.claude/hooks/simplify-gate.cjs`
+		const cmd = `node "$CLAUDE_PROJECT_DIR"/${relHook}`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: `${PROJECT_DIR}/.claude/hooks`,
+			targetDir: `${PROJECT_DIR}/.codex/hooks`,
+			commandSubstitutions: makeSubs(),
+			projectDir: PROJECT_DIR,
+		});
+		// Must be exactly `node "<wrapperAbsPath>"` — one opening, one closing quote
+		expect(result).toBe(`node "${wrapperAbsPath}"`);
+		// No doubled quotes
+		expect(result).not.toContain('""');
+	});
+});
+
+describe("rewriteCommandPath — Phase 2 fallback: residual $CLAUDE_PROJECT_DIR token resolution", () => {
+	// Non-wrappable hook: no substitution map entry, falls through to fallback.
+	const srcDir = `${PROJECT_DIR}/.claude/hooks`;
+	const tgtDir = `${PROJECT_DIR}/.codex/hooks`;
+
+	it('form 1 fallback — bash "$CLAUDE_PROJECT_DIR/.codex/hooks/runner.sh" → absolute path, no residual token', () => {
+		// After dir rewrite, command still has $CLAUDE_PROJECT_DIR — must be resolved.
+		const cmd = `bash "$CLAUDE_PROJECT_DIR/.codex/hooks/runner.sh"`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: srcDir,
+			targetDir: tgtDir,
+			projectDir: PROJECT_DIR,
+		});
+		expect(result).toBe(`bash "${PROJECT_DIR}/.codex/hooks/runner.sh"`);
+		expect(result).not.toContain("CLAUDE_PROJECT_DIR");
+	});
+
+	it("form 1 fallback — closing quote consumed, no doubled quote (H1 trap)", () => {
+		const cmd = `bash "$CLAUDE_PROJECT_DIR/.codex/hooks/runner.sh"`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: srcDir,
+			targetDir: tgtDir,
+			projectDir: PROJECT_DIR,
+		});
+		// Must not have doubled closing quote
+		expect(result).not.toContain('""');
+		// Must end with exactly one closing quote after the path
+		expect(result).toMatch(/runner\.sh"$/);
+	});
+
+	it('form 2 fallback — bash "$CLAUDE_PROJECT_DIR"/.codex/hooks/runner.sh → absolute path', () => {
+		const cmd = `bash "$CLAUDE_PROJECT_DIR"/.codex/hooks/runner.sh`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: srcDir,
+			targetDir: tgtDir,
+			projectDir: PROJECT_DIR,
+		});
+		expect(result).toBe(`bash "${PROJECT_DIR}/.codex/hooks/runner.sh"`);
+		expect(result).not.toContain("CLAUDE_PROJECT_DIR");
+	});
+
+	it('form 3a fallback — bash "${CLAUDE_PROJECT_DIR}"/.codex/hooks/runner.sh → absolute path', () => {
+		const cmd = `bash "\${CLAUDE_PROJECT_DIR}"/.codex/hooks/runner.sh`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: srcDir,
+			targetDir: tgtDir,
+			projectDir: PROJECT_DIR,
+		});
+		expect(result).toBe(`bash "${PROJECT_DIR}/.codex/hooks/runner.sh"`);
+		expect(result).not.toContain("CLAUDE_PROJECT_DIR");
+	});
+
+	it("form 3b fallback — bash ${CLAUDE_PROJECT_DIR}/.codex/hooks/runner.sh → absolute path (quoted output)", () => {
+		const cmd = "bash ${CLAUDE_PROJECT_DIR}/.codex/hooks/runner.sh";
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: srcDir,
+			targetDir: tgtDir,
+			projectDir: PROJECT_DIR,
+		});
+		expect(result).toBe(`bash "${PROJECT_DIR}/.codex/hooks/runner.sh"`);
+		expect(result).not.toContain("CLAUDE_PROJECT_DIR");
+	});
+
+	it("Windows bare fallback — bash %CLAUDE_PROJECT_DIR%/.codex/hooks/runner.sh → absolute path (quoted)", () => {
+		const cmd = "bash %CLAUDE_PROJECT_DIR%/.codex/hooks/runner.sh";
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: srcDir,
+			targetDir: tgtDir,
+			projectDir: PROJECT_DIR,
+		});
+		expect(result).toBe(`bash "${PROJECT_DIR}/.codex/hooks/runner.sh"`);
+		expect(result).not.toContain("CLAUDE_PROJECT_DIR");
+	});
+
+	it('Windows quoted bare fallback — bash "%CLAUDE_PROJECT_DIR%/.codex/hooks/runner.sh" → absolute path', () => {
+		const cmd = `bash "%CLAUDE_PROJECT_DIR%/.codex/hooks/runner.sh"`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: srcDir,
+			targetDir: tgtDir,
+			projectDir: PROJECT_DIR,
+		});
+		expect(result).toBe(`bash "${PROJECT_DIR}/.codex/hooks/runner.sh"`);
+		expect(result).not.toContain("CLAUDE_PROJECT_DIR");
+	});
+
+	it('bare-var no-suffix form 6 — cd "$CLAUDE_PROJECT_DIR" && node x.cjs → absolute path', () => {
+		const cmd = `cd "$CLAUDE_PROJECT_DIR" && node x.cjs`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: srcDir,
+			targetDir: tgtDir,
+			projectDir: PROJECT_DIR,
+		});
+		expect(result).toBe(`cd "${PROJECT_DIR}" && node x.cjs`);
+		expect(result).not.toContain("CLAUDE_PROJECT_DIR");
+	});
+
+	it("negative — echo $CLAUDE_PROJECT_DIRS is NOT rewritten (superset var name)", () => {
+		const cmd = "echo $CLAUDE_PROJECT_DIRS";
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: srcDir,
+			targetDir: tgtDir,
+			projectDir: PROJECT_DIR,
+		});
+		expect(result).toBe("echo $CLAUDE_PROJECT_DIRS");
+		expect(result).toContain("$CLAUDE_PROJECT_DIRS");
+	});
+
+	it("path with spaces — quotes preserved and balanced", () => {
+		const cmd = `bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/runner.sh`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: `${PROJECT_DIR_WITH_SPACE}/.claude/hooks`,
+			targetDir: `${PROJECT_DIR_WITH_SPACE}/.codex/hooks`,
+			projectDir: PROJECT_DIR_WITH_SPACE,
+		});
+		expect(result).toBe(`bash "${PROJECT_DIR_WITH_SPACE}/.claude/hooks/runner.sh"`);
+		expect(result).not.toContain("CLAUDE_PROJECT_DIR");
+		expect(result).not.toContain('""');
+	});
+
+	it("combined $HOME and $CLAUDE_PROJECT_DIR — both rewritten", () => {
+		// A runner command that references the global node-hook-runner (home) AND a project hook
+		const cmd = `bash "$HOME/.claude/hooks/node-hook-runner.sh" "$CLAUDE_PROJECT_DIR"/.claude/hooks/simplify-gate.cjs`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: `${PROJECT_DIR}/.claude/hooks`,
+			targetDir: `${PROJECT_DIR}/.codex/hooks`,
+			projectDir: PROJECT_DIR,
+		});
+		// $HOME form stays as-is (no home substitution map, dir rewrite covers it only if src matches)
+		// $CLAUDE_PROJECT_DIR form must be resolved
+		expect(result).not.toContain("$CLAUDE_PROJECT_DIR");
+	});
+
+	it("projectDir undefined — output identical to pre-change behavior (global-scope regression)", () => {
+		const cmd = `node "$HOME/.claude/hooks/session-init.cjs"`;
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: "$HOME/.claude/hooks",
+			targetDir: "$HOME/.codex/hooks",
+		});
+		// No projectDir — existing dir-rewrite behavior unchanged
+		expect(result).toBe(`node "$HOME/.codex/hooks/session-init.cjs"`);
+		expect(result).not.toContain("CLAUDE_PROJECT_DIR");
+	});
+
+	it("shell metacharacter after path — semicolon is NOT swallowed into quoted path", () => {
+		// Probe: `node $CLAUDE_PROJECT_DIR/x.cjs;echo hi` must not produce
+		// `node "/proj/x.cjs;echo" hi`. The `;` must remain outside the quoted token.
+		const cmd = "node $CLAUDE_PROJECT_DIR/.claude/hooks/x.cjs;echo hi";
+		const result = rewriteCommandPath(cmd, {
+			sourceDir: `${PROJECT_DIR}/.claude/hooks`,
+			targetDir: `${PROJECT_DIR}/.codex/hooks`,
+			projectDir: PROJECT_DIR,
+		});
+		// The path token must be resolved to the quoted absolute path WITHOUT the `;echo hi` suffix
+		expect(result).toBe(`node "${PROJECT_DIR}/.claude/hooks/x.cjs";echo hi`);
+		// The resolved path must not contain the semicolon
+		expect(result).not.toContain('x.cjs;echo"');
+		// The original env var token must be gone
+		expect(result).not.toContain("CLAUDE_PROJECT_DIR");
+	});
+});

--- a/src/commands/portable/__tests__/codex-hook-compat-integration.test.ts
+++ b/src/commands/portable/__tests__/codex-hook-compat-integration.test.ts
@@ -909,10 +909,9 @@ describe("codex hook compat — N1: wrapper paths written to hooks.json commands
 		// Re-read the hooks.json written by the previous test (same project dir)
 		// This test is deliberately separate to assert disk state independently.
 		const hooksJsonPath = join(testProjectDir, ".codex", "hooks.json");
-		if (!existsSync(hooksJsonPath)) {
-			// If previous test failed to produce the file, skip rather than cascade failure
-			return;
-		}
+		// Hard assertion: file must exist — early return would let this pass vacuously
+		// if the previous test failed to produce the file.
+		expect(existsSync(hooksJsonPath)).toBe(true);
 
 		const written = readJson(hooksJsonPath) as {
 			hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
@@ -932,4 +931,455 @@ describe("codex hook compat — N1: wrapper paths written to hooks.json commands
 			}
 		}
 	}, 10000);
+});
+
+// ---- Fix #883 — project-scope $CLAUDE_PROJECT_DIR in hook commands ----------
+
+describe("project-scope migration resolves $CLAUDE_PROJECT_DIR (#883)", () => {
+	/**
+	 * Regression test for GH-883.
+	 *
+	 * Claude Code emits project-scope hooks as:
+	 *   node "$CLAUDE_PROJECT_DIR"/.claude/hooks/<name>.cjs  (form 2, var-only quoted)
+	 *
+	 * Before the fix, the converter only recognised $HOME / ~ / %USERPROFILE% prefix
+	 * forms. $CLAUDE_PROJECT_DIR tokens survived into .codex/hooks.json. Codex never
+	 * defines this env var, so every migrated hook exited 1 on every fire.
+	 *
+	 * After the fix:
+	 *   - wrappable .cjs hooks → absolute hash-prefixed wrapper paths (no env var)
+	 *   - non-wrappable .sh hooks → absolute projectDir-resolved path (no env var)
+	 *   - second migration run → no duplicate entries (stable absolute-path keys)
+	 *   - pre-broken installs (re-run `ck migrate`) → broken entries pruned,
+	 *     exactly one correct entry per hook, hooksPruned > 0
+	 */
+
+	const issue883Dir = join(testRoot, "issue-883-project-dir");
+
+	let targetHookAbsPaths: string[] = [];
+	let testProjectDir883: string;
+	let sourceHooksDir883: string;
+	let codexHooksDir883: string;
+
+	beforeAll(() => {
+		// Mirror provider convention: project-scoped hooks live under
+		// <project>/.claude/hooks/ (source) and <project>/.codex/hooks/ (target).
+		testProjectDir883 = join(issue883Dir, "project");
+		sourceHooksDir883 = join(testProjectDir883, ".claude", "hooks");
+		codexHooksDir883 = join(testProjectDir883, ".codex", "hooks");
+
+		mkdirSync(sourceHooksDir883, { recursive: true });
+		mkdirSync(codexHooksDir883, { recursive: true });
+		mkdirSync(join(testProjectDir883, ".claude"), { recursive: true });
+		mkdirSync(join(testProjectDir883, ".codex"), { recursive: true });
+
+		// Wrappable .cjs hook — Claude settings.json commands reference the source path via the env var form
+		const cjsName = "simplify-gate.cjs";
+		const sourceHookPath = join(sourceHooksDir883, cjsName);
+		writeFileSync(
+			sourceHookPath,
+			`#!/usr/bin/env node\n"use strict";\nprocess.stdout.write(JSON.stringify({result:"ok"}));\nprocess.exit(0);\n`,
+			{ mode: 0o755 },
+		);
+
+		// Installer copies hook files to .codex/hooks/ before migrateHooksSettings runs.
+		// migrateHooksSettings receives TARGET paths as installedHookAbsolutePaths, while
+		// Claude's settings.json commands still reference SOURCE paths via the env var form.
+		const targetHookPath = join(codexHooksDir883, cjsName);
+		writeFileSync(
+			targetHookPath,
+			`#!/usr/bin/env node\n"use strict";\nprocess.stdout.write(JSON.stringify({result:"ok"}));\nprocess.exit(0);\n`,
+			{ mode: 0o755 },
+		);
+		targetHookAbsPaths = [targetHookPath];
+
+		// Non-wrappable .sh runner — placed in both source and target dirs
+		writeFileSync(join(sourceHooksDir883, "runner.sh"), "#!/bin/bash\necho ok\n", { mode: 0o755 });
+		writeFileSync(join(codexHooksDir883, "runner.sh"), "#!/bin/bash\necho ok\n", { mode: 0o755 });
+	});
+
+	it("#883 headline: no CLAUDE_PROJECT_DIR token survives in written hooks.json", async () => {
+		// Claude Code's exact emission form (form 2: var-only quoted) for project-scope hooks
+		const settingsJson = {
+			hooks: {
+				PreToolUse: [
+					{
+						matcher: "Bash",
+						hooks: [
+							{
+								type: "command",
+								// Form 2 — "$CLAUDE_PROJECT_DIR"/<rel> — the standard Claude Code emission
+								command: `node "$CLAUDE_PROJECT_DIR"/.claude/hooks/simplify-gate.cjs`,
+							},
+						],
+					},
+				],
+				SessionStart: [
+					{
+						matcher: "startup",
+						hooks: [
+							{
+								type: "command",
+								command: `node "$CLAUDE_PROJECT_DIR"/.claude/hooks/simplify-gate.cjs`,
+							},
+						],
+					},
+				],
+			},
+		};
+		writeFileSync(
+			join(testProjectDir883, ".claude", "settings.json"),
+			JSON.stringify(settingsJson, null, 2),
+		);
+
+		process.chdir(testProjectDir883);
+
+		const result = await migrateHooksSettings({
+			sourceProvider: "claude-code",
+			targetProvider: "codex",
+			installedHookFiles: ["simplify-gate.cjs"],
+			global: false,
+			installedHookAbsolutePaths: targetHookAbsPaths,
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.status).toBe("registered");
+		expect(result.hooksRegistered).toBeGreaterThan(0);
+
+		const hooksJsonPath = join(testProjectDir883, ".codex", "hooks.json");
+		expect(existsSync(hooksJsonPath)).toBe(true);
+
+		const rawJson = readFileSync(hooksJsonPath, "utf8");
+
+		// HEADLINE ASSERTION: zero occurrences of CLAUDE_PROJECT_DIR anywhere in the file
+		expect(rawJson).not.toContain("CLAUDE_PROJECT_DIR");
+	}, 15000);
+
+	it("#883: wrappable hook commands are absolute hash-prefixed wrappers", async () => {
+		const hooksJsonPath = join(testProjectDir883, ".codex", "hooks.json");
+		// Hard assertion: file must exist — early return would let this pass vacuously.
+		expect(existsSync(hooksJsonPath)).toBe(true);
+
+		const written = readJson(hooksJsonPath) as {
+			hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+		};
+
+		const allCommands: string[] = [];
+		for (const groups of Object.values(written.hooks)) {
+			for (const group of groups) {
+				for (const entry of group.hooks) {
+					allCommands.push(entry.command);
+				}
+			}
+		}
+
+		// Every command must be an absolute path — no relative paths, no env var tokens
+		for (const cmd of allCommands) {
+			expect(cmd).not.toContain("CLAUDE_PROJECT_DIR");
+			// Command must reference an absolute path (starts with /)
+			expect(cmd).toMatch(/\/[^"]+\.cjs/);
+			// Must be a hash-prefixed wrapper: {8 hex chars}-<name>.cjs
+			expect(cmd).toMatch(/\/[0-9a-f]{8}-[^/]+\.cjs/);
+		}
+	}, 10000);
+
+	it("#883: wrapper files exist on disk at the referenced paths", async () => {
+		const hooksJsonPath = join(testProjectDir883, ".codex", "hooks.json");
+		// Hard assertion: file must exist — early return would let this pass vacuously.
+		expect(existsSync(hooksJsonPath)).toBe(true);
+
+		const written = readJson(hooksJsonPath) as {
+			hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+		};
+
+		const pathPattern = /node\s+"([^"]+\.cjs)"/g;
+		for (const groups of Object.values(written.hooks)) {
+			for (const group of groups) {
+				for (const entry of group.hooks) {
+					const matches = [...entry.command.matchAll(pathPattern)];
+					for (const m of matches) {
+						const referencedPath = m[1];
+						expect(existsSync(referencedPath)).toBe(true);
+					}
+				}
+			}
+		}
+	}, 10000);
+
+	it("#883: non-wrappable .sh hook is resolved to absolute project path", async () => {
+		// Write a settings.json that has the .sh runner (non-wrappable — .sh excluded from wrappers)
+		const shTestDir = join(issue883Dir, "sh-test");
+		const shSourceHooksDir = join(shTestDir, ".claude", "hooks");
+		const shCodexHooksDir = join(shTestDir, ".codex", "hooks");
+		mkdirSync(shSourceHooksDir, { recursive: true });
+		mkdirSync(shCodexHooksDir, { recursive: true });
+		writeFileSync(join(shSourceHooksDir, "runner.sh"), "#!/bin/bash\necho ok\n", { mode: 0o755 });
+		writeFileSync(join(shCodexHooksDir, "runner.sh"), "#!/bin/bash\necho ok\n", { mode: 0o755 });
+
+		const shSettingsJson = {
+			hooks: {
+				PreToolUse: [
+					{
+						matcher: "Bash",
+						hooks: [
+							{
+								type: "command",
+								command: `bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/runner.sh`,
+							},
+						],
+					},
+				],
+			},
+		};
+		writeFileSync(
+			join(shTestDir, ".claude", "settings.json"),
+			JSON.stringify(shSettingsJson, null, 2),
+		);
+
+		process.chdir(shTestDir);
+
+		const result = await migrateHooksSettings({
+			sourceProvider: "claude-code",
+			targetProvider: "codex",
+			installedHookFiles: ["runner.sh"],
+			global: false,
+			// No installedHookAbsolutePaths: .sh is non-wrappable (CJS-only wrapper path)
+		});
+
+		expect(result.success).toBe(true);
+
+		const hooksJsonPath = join(shTestDir, ".codex", "hooks.json");
+		// Hard assertion: the .sh non-wrappable hook must have been written.
+		// An early return here would let the test pass vacuously if the file wasn't written.
+		expect(existsSync(hooksJsonPath)).toBe(true);
+
+		const rawJson = readFileSync(hooksJsonPath, "utf8");
+		// No CLAUDE_PROJECT_DIR env var in any output
+		expect(rawJson).not.toContain("CLAUDE_PROJECT_DIR");
+
+		// Pin: the resolved command must contain the absolute project path and the .sh basename
+		// with balanced quotes (not just absence of the env var token).
+		const written = readJson(hooksJsonPath) as {
+			hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+		};
+		const allCommands: string[] = [];
+		for (const groups of Object.values(written.hooks)) {
+			for (const group of groups) {
+				for (const entry of group.hooks) {
+					allCommands.push(entry.command);
+				}
+			}
+		}
+		// Every command must reference the absolute resolved path with balanced quotes
+		for (const cmd of allCommands) {
+			expect(cmd).toContain(`${shTestDir}/.codex/hooks/runner.sh`);
+			// Must be quoted (path may contain spaces)
+			expect(cmd).toMatch(/"[^"]*runner\.sh[^"]*"/);
+		}
+	}, 15000);
+
+	it("#883 idempotency: second migration produces no duplicate entries", async () => {
+		// Restore cwd to project dir (afterEach resets it between tests)
+		process.chdir(testProjectDir883);
+
+		// Delete the hooks.json from prior tests so we start fresh for this assertion
+		const hooksJsonPath = join(testProjectDir883, ".codex", "hooks.json");
+		if (existsSync(hooksJsonPath)) {
+			rmSync(hooksJsonPath);
+		}
+
+		const settingsJson = {
+			hooks: {
+				PreToolUse: [
+					{
+						matcher: "Bash",
+						hooks: [
+							{
+								type: "command",
+								command: `node "$CLAUDE_PROJECT_DIR"/.claude/hooks/simplify-gate.cjs`,
+							},
+						],
+					},
+				],
+			},
+		};
+		writeFileSync(
+			join(testProjectDir883, ".claude", "settings.json"),
+			JSON.stringify(settingsJson, null, 2),
+		);
+
+		// First migration run
+		await migrateHooksSettings({
+			sourceProvider: "claude-code",
+			targetProvider: "codex",
+			installedHookFiles: ["simplify-gate.cjs"],
+			global: false,
+			installedHookAbsolutePaths: targetHookAbsPaths,
+		});
+
+		const countHooksInSection = (
+			hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>,
+		): number => {
+			let n = 0;
+			for (const groups of Object.values(hooks)) {
+				for (const g of groups) n += g.hooks.length;
+			}
+			return n;
+		};
+
+		const afterFirst = readJson(hooksJsonPath) as {
+			hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+		};
+		const countAfterFirst = countHooksInSection(afterFirst.hooks);
+		expect(countAfterFirst).toBeGreaterThan(0);
+
+		// Second migration run (idempotent)
+		process.chdir(testProjectDir883);
+		await migrateHooksSettings({
+			sourceProvider: "claude-code",
+			targetProvider: "codex",
+			installedHookFiles: ["simplify-gate.cjs"],
+			global: false,
+			installedHookAbsolutePaths: targetHookAbsPaths,
+		});
+
+		const afterSecond = readJson(hooksJsonPath) as {
+			hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+		};
+		const countAfterSecond = countHooksInSection(afterSecond.hooks);
+
+		// No duplicates: hook count must remain the same after second run
+		expect(countAfterSecond).toBe(countAfterFirst);
+
+		// Still no env var tokens after second run
+		const rawJson = readFileSync(hooksJsonPath, "utf8");
+		expect(rawJson).not.toContain("CLAUDE_PROJECT_DIR");
+	}, 20000);
+
+	it("#883 H2 self-heal: pre-broken hooks.json entries are pruned and replaced with fixed entries", async () => {
+		const selfHealDir = join(issue883Dir, "self-heal");
+		const selfHealSourceHooks = join(selfHealDir, ".claude", "hooks");
+		const selfHealCodexHooks = join(selfHealDir, ".codex", "hooks");
+		mkdirSync(selfHealSourceHooks, { recursive: true });
+		mkdirSync(selfHealCodexHooks, { recursive: true });
+
+		// Write hook files on disk (both source and target)
+		writeFileSync(
+			join(selfHealSourceHooks, "simplify-gate.cjs"),
+			`#!/usr/bin/env node\n"use strict";\nprocess.stdout.write(JSON.stringify({result:"ok"}));\nprocess.exit(0);\n`,
+			{ mode: 0o755 },
+		);
+		const selfHealTargetHookPath = join(selfHealCodexHooks, "simplify-gate.cjs");
+		writeFileSync(
+			selfHealTargetHookPath,
+			`#!/usr/bin/env node\n"use strict";\nprocess.stdout.write(JSON.stringify({result:"ok"}));\nprocess.exit(0);\n`,
+			{ mode: 0o755 },
+		);
+
+		// Pre-seed .codex/hooks.json with OLD broken entries that the field reporter will hit.
+		// Form 2: "$CLAUDE_PROJECT_DIR"/<rel> targeting .codex/hooks/ (post-Phase-2-fallback form)
+		// Form 1: "$CLAUDE_PROJECT_DIR/<rel>" (fully-quoted form also encountered in broken installs)
+		const brokenHooksJson = {
+			hooks: {
+				PreToolUse: [
+					{
+						matcher: "Bash",
+						hooks: [
+							{
+								type: "command",
+								// Form 2: var-only quoted — most common broken form from Phase-2 fallback
+								command: `node "$CLAUDE_PROJECT_DIR"/.codex/hooks/simplify-gate.cjs`,
+							},
+						],
+					},
+				],
+				SessionStart: [
+					{
+						matcher: "startup",
+						hooks: [
+							{
+								type: "command",
+								// Form 1: fully-quoted variant also seen in broken installs
+								command: `node "$CLAUDE_PROJECT_DIR/.codex/hooks/simplify-gate.cjs"`,
+							},
+						],
+					},
+				],
+			},
+		};
+		const selfHealHooksJsonPath = join(selfHealDir, ".codex", "hooks.json");
+		writeFileSync(selfHealHooksJsonPath, JSON.stringify(brokenHooksJson, null, 2));
+
+		// Source settings.json with the correct Claude Code form (what Claude wrote)
+		const settingsJson = {
+			hooks: {
+				PreToolUse: [
+					{
+						matcher: "Bash",
+						hooks: [
+							{
+								type: "command",
+								command: `node "$CLAUDE_PROJECT_DIR"/.claude/hooks/simplify-gate.cjs`,
+							},
+						],
+					},
+				],
+				SessionStart: [
+					{
+						matcher: "startup",
+						hooks: [
+							{
+								type: "command",
+								command: `node "$CLAUDE_PROJECT_DIR"/.claude/hooks/simplify-gate.cjs`,
+							},
+						],
+					},
+				],
+			},
+		};
+		writeFileSync(
+			join(selfHealDir, ".claude", "settings.json"),
+			JSON.stringify(settingsJson, null, 2),
+		);
+
+		process.chdir(selfHealDir);
+
+		const result = await migrateHooksSettings({
+			sourceProvider: "claude-code",
+			targetProvider: "codex",
+			installedHookFiles: ["simplify-gate.cjs"],
+			global: false,
+			installedHookAbsolutePaths: [selfHealTargetHookPath],
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.status).toBe("registered");
+		// hooksPruned must reflect the broken entries that were removed by self-heal
+		expect(result.hooksPruned).toBeGreaterThan(0);
+
+		const rawJson = readFileSync(selfHealHooksJsonPath, "utf8");
+
+		// No CLAUDE_PROJECT_DIR tokens remain in the healed file
+		expect(rawJson).not.toContain("CLAUDE_PROJECT_DIR");
+
+		const written = readJson(selfHealHooksJsonPath) as {
+			hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+		};
+
+		// Exactly one hook entry per event: the fixed absolute-wrapper command.
+		// Broken entries were pruned; the new correct entry was deduplicated into one.
+		for (const groups of Object.values(written.hooks)) {
+			let totalHooks = 0;
+			for (const group of groups) {
+				totalHooks += group.hooks.length;
+				for (const entry of group.hooks) {
+					// Each surviving entry must be an absolute hash-prefixed wrapper
+					expect(entry.command).not.toContain("CLAUDE_PROJECT_DIR");
+					expect(entry.command).toMatch(/\/[0-9a-f]{8}-[^/]+\.cjs/);
+				}
+			}
+			// Only one hook per event (broken entries pruned, one correct entry merged)
+			expect(totalHooks).toBe(1);
+		}
+	}, 20000);
 });

--- a/src/commands/portable/__tests__/hooks-settings-merger.test.ts
+++ b/src/commands/portable/__tests__/hooks-settings-merger.test.ts
@@ -1092,3 +1092,245 @@ describe("mapHookEventsForProvider (Gemini CLI)", () => {
 		expect(entry?.timeout).toBe(5000);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Phase 2 tests: codex-gated broken-entry prune (pruneVariableTokenBrokenEntries)
+// ---------------------------------------------------------------------------
+
+describe("mergeHooksIntoSettings — broken CLAUDE_PROJECT_DIR entry prune (Phase 2)", () => {
+	it("drops form-2 broken entry: $CLAUDE_PROJECT_DIR/.codex/hooks/x.cjs (quoted var)", async () => {
+		// Form 2 per plan.md: `"$CLAUDE_PROJECT_DIR"/.codex/hooks/x.cjs` — var-only quoted
+		const path = join(testDir, "prune-var-form2.json");
+		const brokenCmd = 'node "$CLAUDE_PROJECT_DIR"/.codex/hooks/broken.cjs';
+		writeFileSync(
+			path,
+			JSON.stringify({
+				hooks: {
+					SessionStart: [{ hooks: [{ type: "command", command: brokenCmd }] }],
+				},
+			}),
+		);
+		const result = await mergeHooksIntoSettings(
+			path,
+			{ SessionStart: [{ hooks: [{ type: "command", command: "echo ok" }] }] },
+			{ targetProvider: "codex" },
+		);
+		expect(result.hooksPruned).toBeGreaterThanOrEqual(1);
+		const content = JSON.parse(await Bun.file(path).text());
+		const commands = content.hooks.SessionStart.flatMap((g: { hooks: { command: string }[] }) =>
+			g.hooks.map((h) => h.command),
+		);
+		expect(commands).not.toContain(brokenCmd);
+	});
+
+	it("drops form-1 broken entry: $CLAUDE_PROJECT_DIR/.codex/hooks/y.cjs (fully quoted)", async () => {
+		// Form 1 per plan.md: `"$CLAUDE_PROJECT_DIR/.codex/hooks/y.cjs"` — fully quoted
+		const path = join(testDir, "prune-var-form1.json");
+		const brokenCmd = 'node "$CLAUDE_PROJECT_DIR/.codex/hooks/y.cjs"';
+		writeFileSync(
+			path,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [{ hooks: [{ type: "command", command: brokenCmd }] }],
+				},
+			}),
+		);
+		const result = await mergeHooksIntoSettings(
+			path,
+			{ PreToolUse: [{ hooks: [{ type: "command", command: "echo ok" }] }] },
+			{ targetProvider: "codex" },
+		);
+		expect(result.hooksPruned).toBeGreaterThanOrEqual(1);
+		const content = JSON.parse(await Bun.file(path).text());
+		const commands = content.hooks.PreToolUse.flatMap((g: { hooks: { command: string }[] }) =>
+			g.hooks.map((h) => h.command),
+		);
+		expect(commands).not.toContain(brokenCmd);
+	});
+
+	it("drops Windows-form broken entry: %CLAUDE_PROJECT_DIR%/.codex/hooks/z.cjs", async () => {
+		// Windows form per plan.md §5
+		const path = join(testDir, "prune-var-windows.json");
+		const brokenCmd = 'node "%CLAUDE_PROJECT_DIR%/.codex/hooks/z.cjs"';
+		writeFileSync(
+			path,
+			JSON.stringify({
+				hooks: {
+					UserPromptSubmit: [{ hooks: [{ type: "command", command: brokenCmd }] }],
+				},
+			}),
+		);
+		const result = await mergeHooksIntoSettings(
+			path,
+			{ UserPromptSubmit: [{ hooks: [{ type: "command", command: "echo ok" }] }] },
+			{ targetProvider: "codex" },
+		);
+		expect(result.hooksPruned).toBeGreaterThanOrEqual(1);
+		const content = JSON.parse(await Bun.file(path).text());
+		const commands = content.hooks.UserPromptSubmit.flatMap((g: { hooks: { command: string }[] }) =>
+			g.hooks.map((h) => h.command),
+		);
+		expect(commands).not.toContain(brokenCmd);
+	});
+
+	it("counts all three broken forms into hooksPruned", async () => {
+		// All three variable forms in a single hooks.json — verify count is 3.
+		const path = join(testDir, "prune-var-all-forms.json");
+		writeFileSync(
+			path,
+			JSON.stringify({
+				hooks: {
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command: 'node "$CLAUDE_PROJECT_DIR"/.codex/hooks/x.cjs',
+								},
+								{
+									type: "command",
+									command: 'node "$CLAUDE_PROJECT_DIR/.codex/hooks/y.cjs"',
+								},
+								{
+									type: "command",
+									command: 'node "%CLAUDE_PROJECT_DIR%/.codex/hooks/z.cjs"',
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+		const result = await mergeHooksIntoSettings(
+			path,
+			{ SessionStart: [{ hooks: [{ type: "command", command: "echo ok" }] }] },
+			{ targetProvider: "codex" },
+		);
+		expect(result.hooksPruned).toBe(3);
+		const content = JSON.parse(await Bun.file(path).text());
+		const commands = content.hooks.SessionStart.flatMap((g: { hooks: { command: string }[] }) =>
+			g.hooks.map((h) => h.command),
+		);
+		expect(commands).not.toContain('node "$CLAUDE_PROJECT_DIR"/.codex/hooks/x.cjs');
+		expect(commands).not.toContain('node "$CLAUDE_PROJECT_DIR/.codex/hooks/y.cjs"');
+		expect(commands).not.toContain('node "%CLAUDE_PROJECT_DIR%/.codex/hooks/z.cjs"');
+	});
+
+	it("leaves broken entries untouched when targetProvider is NOT codex", async () => {
+		// The var is legitimate in Claude Code settings — prune must be codex-gated.
+		// Use ${CLAUDE_PROJECT_DIR} form (braces, no surrounding quotes): the char
+		// before the '/' is '}', which extractAbsolutePaths does NOT anchor on, so
+		// pruneStaleFileHooks won't catch it — only pruneVariableTokenBrokenEntries
+		// would prune it, and that function is codex-gated.
+		const path = join(testDir, "prune-var-non-codex.json");
+		const claudeCmd = "node ${CLAUDE_PROJECT_DIR}/.claude/hooks/hook.cjs";
+		writeFileSync(
+			path,
+			JSON.stringify({
+				hooks: {
+					SessionStart: [{ hooks: [{ type: "command", command: claudeCmd }] }],
+				},
+			}),
+		);
+		// No targetProvider → defaults to undefined (non-codex), so var-token prune is skipped.
+		const result = await mergeHooksIntoSettings(path, {
+			SessionStart: [{ hooks: [{ type: "command", command: "echo ok" }] }],
+		});
+		expect(result.hooksPruned).toBe(0);
+		const content = JSON.parse(await Bun.file(path).text());
+		const commands = content.hooks.SessionStart.flatMap((g: { hooks: { command: string }[] }) =>
+			g.hooks.map((h) => h.command),
+		);
+		expect(commands).toContain(claudeCmd);
+	});
+
+	it("preserves user-owned $CLAUDE_PROJECT_DIR command NOT referencing CK hook dirs", async () => {
+		// User hook that happens to use $CLAUDE_PROJECT_DIR for a custom script —
+		// must NOT be pruned because the path does not reference .claude/hooks/ or .codex/hooks/.
+		const path = join(testDir, "prune-var-user-owned.json");
+		const userCmd = 'node "$CLAUDE_PROJECT_DIR"/scripts/own.cjs';
+		writeFileSync(
+			path,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							hooks: [
+								{ type: "command", command: userCmd },
+								{
+									type: "command",
+									command: 'node "$CLAUDE_PROJECT_DIR"/.codex/hooks/broken.cjs',
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+		const result = await mergeHooksIntoSettings(
+			path,
+			{ PreToolUse: [{ hooks: [{ type: "command", command: "echo ok" }] }] },
+			{ targetProvider: "codex" },
+		);
+		// Only the CK-dir entry is pruned; user hook survives.
+		expect(result.hooksPruned).toBe(1);
+		const content = JSON.parse(await Bun.file(path).text());
+		const commands = content.hooks.PreToolUse.flatMap((g: { hooks: { command: string }[] }) =>
+			g.hooks.map((h) => h.command),
+		);
+		expect(commands).toContain(userCmd);
+		expect(commands).not.toContain('node "$CLAUDE_PROJECT_DIR"/.codex/hooks/broken.cjs');
+	});
+
+	it("also drops .claude/hooks/ reference with var token (broken from previous migrate)", async () => {
+		// After a partial migrate, command may still reference .claude/hooks/ with the var.
+		const path = join(testDir, "prune-var-claude-dir.json");
+		const brokenCmd = 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-init.cjs';
+		writeFileSync(
+			path,
+			JSON.stringify({
+				hooks: {
+					SessionStart: [{ hooks: [{ type: "command", command: brokenCmd }] }],
+				},
+			}),
+		);
+		const result = await mergeHooksIntoSettings(
+			path,
+			{ SessionStart: [{ hooks: [{ type: "command", command: "echo ok" }] }] },
+			{ targetProvider: "codex" },
+		);
+		expect(result.hooksPruned).toBeGreaterThanOrEqual(1);
+		const content = JSON.parse(await Bun.file(path).text());
+		const commands = content.hooks.SessionStart.flatMap((g: { hooks: { command: string }[] }) =>
+			g.hooks.map((h) => h.command),
+		);
+		expect(commands).not.toContain(brokenCmd);
+	});
+});
+
+// Regression guard: generic-pipeline var-preserving dir rewrite.
+// rewriteHookPaths does a substring replaceAll on the hooks dir —
+// it matches regardless of prefix (including $CLAUDE_PROJECT_DIR).
+// No behavior change; this test asserts the existing behavior is preserved.
+describe("rewriteHookPaths — regression guard: var-prefixed command dir rewrite", () => {
+	it("rewrites .claude/hooks/ to .factory/hooks/ even when preceded by $CLAUDE_PROJECT_DIR", () => {
+		// Regression guard (plan.md §Out-of-Scope): generic-pipeline rewrite already handles
+		// var-prefixed forms via substring replaceAll. Assert var is preserved, only dir changes.
+		const hooks = {
+			PreToolUse: [
+				{
+					hooks: [
+						{
+							type: "command",
+							command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/x.cjs',
+						},
+					],
+				},
+			],
+		};
+		const result = rewriteHookPaths(hooks, ".claude/hooks", ".factory/hooks");
+		expect(result.PreToolUse[0].hooks[0].command).toBe(
+			'node "$CLAUDE_PROJECT_DIR"/.factory/hooks/x.cjs',
+		);
+	});
+});

--- a/src/commands/portable/converters/claude-to-codex-hooks.ts
+++ b/src/commands/portable/converters/claude-to-codex-hooks.ts
@@ -57,6 +57,14 @@ export interface PathRewriteMap {
 	 * against `homedir()` before comparison.
 	 */
 	commandSubstitutions?: Map<string, string>;
+	/**
+	 * Absolute project root for project-scope migrations (process.cwd() at migrate time).
+	 * When set, $CLAUDE_PROJECT_DIR variable forms in commands are resolved against it:
+	 * Phase 1 candidates gain project-dir-variable forms, and the Phase 2 fallback
+	 * replaces residual $CLAUDE_PROJECT_DIR tokens with this absolute path.
+	 * Undefined for global-scope migrations (no behavior change).
+	 */
+	projectDir?: string;
 }
 
 /**
@@ -201,6 +209,9 @@ export function rewriteCommandPath(command: string, pathRewrite: PathRewriteMap)
 		// So the command always uses forward slashes and literal `$HOME`, never
 		// the platform abs path or `%USERPROFILE%`. We must match that form.
 		const homeForward = normalizeSlashes(home);
+		const projectDirForward = pathRewrite.projectDir
+			? normalizeSlashes(pathRewrite.projectDir)
+			: null;
 
 		for (const [originalAbsPath, wrapperAbsPath] of pathRewrite.commandSubstitutions) {
 			// Forward-slash form of the original absolute path key.
@@ -216,21 +227,14 @@ export function rewriteCommandPath(command: string, pathRewrite: PathRewriteMap)
 				relFromHome = "";
 			}
 
-			// Build candidates covering every form Claude Code may write in a command:
-			//   1. Raw absolute path (both slash forms) — primary form on POSIX
-			//   2. $HOME/<rel>  ← Claude's universal form on ALL platforms (THE missing one)
-			//   3. ~/<rel>
-			//   4. %USERPROFILE%/<rel>  — Windows belt-and-suspenders
-			//   5. ${HOME}/<rel>
-			const candidates: string[] = [
-				originalAbsForward, // forward-slash absolute (covers POSIX and normalized Windows)
-				originalAbsPath, // raw key (may have backslashes on Windows)
-			];
-			if (relFromHome !== null && relFromHome !== "") {
-				candidates.push(`$HOME/${relFromHome}`); // Claude's universal form
-				candidates.push(`~/${relFromHome}`);
-				candidates.push(`%USERPROFILE%/${relFromHome}`);
-				candidates.push(`\${HOME}/${relFromHome}`);
+			// Compute the path relative to projectDir (if set and originalAbsPath is under it).
+			let relFromProject: string | null = null;
+			if (projectDirForward !== null) {
+				if (originalAbsForward.startsWith(`${projectDirForward}/`)) {
+					relFromProject = originalAbsForward.slice(projectDirForward.length + 1);
+				} else if (originalAbsForward === projectDirForward) {
+					relFromProject = "";
+				}
 			}
 
 			// Normalize both the command and each candidate to forward slashes before
@@ -238,15 +242,81 @@ export function rewriteCommandPath(command: string, pathRewrite: PathRewriteMap)
 			// The wrapper output uses the wrapperAbsPath as-is; callers (hooks-settings-merger)
 			// supply absolute platform-appropriate wrapper paths.
 			const wrapperForward = normalizeSlashes(wrapperAbsPath);
-			for (const candidate of candidates) {
-				const candidateNorm = normalizeSlashes(candidate);
+
+			// Build candidates covering every form Claude Code may write in a command.
+			// Each candidate is a {text, replacement} pair so quoted forms can carry
+			// a quoted wrapper path (one pair of quotes, no doubling).
+			//
+			//   1. Raw absolute path (both slash forms) — primary form on POSIX
+			//   2. $HOME/<rel>  ← Claude's universal form on ALL platforms (THE missing one)
+			//   3. ~/<rel>
+			//   4. %USERPROFILE%/<rel>  — Windows belt-and-suspenders
+			//   5. ${HOME}/<rel>
+			//   6-9. $CLAUDE_PROJECT_DIR forms (longest/most-specific first):
+			//      a. "$CLAUDE_PROJECT_DIR/<rel>"  — fully quoted (replacement: "<wrapper>")
+			//      b. "$CLAUDE_PROJECT_DIR"/<rel>  — var-only quoted, Claude Code standard (replacement: "<wrapper>")
+			//      c. "${CLAUDE_PROJECT_DIR}"/<rel> — braced quoted (replacement: "<wrapper>")
+			//      d. ${CLAUDE_PROJECT_DIR}/<rel>  — braced bare (replacement: wrapper)
+			//      e. $CLAUDE_PROJECT_DIR/<rel>    — bare (replacement: wrapper)
+			//      f. %CLAUDE_PROJECT_DIR%/<rel>   — Windows quoted/bare forms
+			const candidates: Array<{ text: string; replacement: string }> = [
+				{ text: originalAbsForward, replacement: wrapperForward },
+				{ text: originalAbsPath, replacement: wrapperForward },
+			];
+			if (relFromHome !== null && relFromHome !== "") {
+				candidates.push({ text: `$HOME/${relFromHome}`, replacement: wrapperForward }); // Claude's universal form
+				candidates.push({ text: `~/${relFromHome}`, replacement: wrapperForward });
+				candidates.push({ text: `%USERPROFILE%/${relFromHome}`, replacement: wrapperForward });
+				candidates.push({ text: `\${HOME}/${relFromHome}`, replacement: wrapperForward });
+			}
+			if (relFromProject !== null && relFromProject !== "") {
+				// Quoted fully: "$CLAUDE_PROJECT_DIR/<rel>" → "<wrapper>"
+				// (includes both outer quotes so they are replaced as a unit — no doubling)
+				candidates.push({
+					text: `"$CLAUDE_PROJECT_DIR/${relFromProject}"`,
+					replacement: `"${wrapperForward}"`,
+				});
+				// Var-only quoted (Claude Code standard): "$CLAUDE_PROJECT_DIR"/<rel> → "<wrapper>"
+				candidates.push({
+					text: `"$CLAUDE_PROJECT_DIR"/${relFromProject}`,
+					replacement: `"${wrapperForward}"`,
+				});
+				// Braced quoted: "${CLAUDE_PROJECT_DIR}"/<rel> → "<wrapper>"
+				candidates.push({
+					text: `"\${CLAUDE_PROJECT_DIR}"/${relFromProject}`,
+					replacement: `"${wrapperForward}"`,
+				});
+				// Windows quoted: "%CLAUDE_PROJECT_DIR%"/<rel> → "<wrapper>"
+				candidates.push({
+					text: `"%CLAUDE_PROJECT_DIR%"/${relFromProject}`,
+					replacement: `"${wrapperForward}"`,
+				});
+				// Braced bare: ${CLAUDE_PROJECT_DIR}/<rel> → wrapper
+				candidates.push({
+					text: `\${CLAUDE_PROJECT_DIR}/${relFromProject}`,
+					replacement: wrapperForward,
+				});
+				// Bare: $CLAUDE_PROJECT_DIR/<rel> → wrapper
+				candidates.push({
+					text: `$CLAUDE_PROJECT_DIR/${relFromProject}`,
+					replacement: wrapperForward,
+				});
+				// Windows bare: %CLAUDE_PROJECT_DIR%/<rel> → "<wrapper>" (always quoted, per plan)
+				candidates.push({
+					text: `%CLAUDE_PROJECT_DIR%/${relFromProject}`,
+					replacement: `"${wrapperForward}"`,
+				});
+			}
+
+			for (const { text, replacement } of candidates) {
+				const candidateNorm = normalizeSlashes(text);
 				const rewrittenNorm = normalizeSlashes(rewritten);
 				if (rewrittenNorm.includes(candidateNorm)) {
 					// Replace every matched hook script path with its wrapper. Do not
 					// return early: runner commands can contain both a shell runner and
 					// the actual Node hook path, and all matching hook paths must be
 					// processed before the directory-level fallback rewrites leftovers.
-					rewritten = replaceCommandCandidate(rewrittenNorm, candidateNorm, wrapperForward);
+					rewritten = replaceCommandCandidate(rewrittenNorm, candidateNorm, replacement);
 				}
 			}
 		}
@@ -265,10 +335,103 @@ export function rewriteCommandPath(command: string, pathRewrite: PathRewriteMap)
 			: `${pathRewrite.targetDir}/`,
 	);
 	// Short-circuit when source and target are identical (no-op rewrite)
-	if (src === tgt) return rewritten;
-	const normalizedRewritten = normalizeSlashes(rewritten);
-	if (!normalizedRewritten.includes(src)) return rewritten;
-	return normalizedRewritten.replaceAll(src, tgt);
+	if (src !== tgt) {
+		const normalizedRewritten = normalizeSlashes(rewritten);
+		if (normalizedRewritten.includes(src)) {
+			rewritten = normalizedRewritten.replaceAll(src, tgt);
+		}
+	}
+
+	// Phase 2 residual: resolve any remaining $CLAUDE_PROJECT_DIR tokens when projectDir is set.
+	// Non-wrappable hooks (e.g. .sh, runner scripts) may not have a substitution map entry and
+	// will reach here still containing the env-var token — emit the absolute project path instead.
+	//
+	// Replacement order: quoted + longest first to prevent partial matches and double-quote
+	// accumulation (H1 trap: the closing quote of a fully-quoted form MUST be consumed, not
+	// left as a dangler — e.g. `"$CLAUDE_PROJECT_DIR/runner.sh"` → `"/proj/runner.sh"`, NOT
+	// `"/proj/runner.sh""`).
+	//
+	// Negative guard: token must be followed by `/`, end-of-string, `"`, `'`, or whitespace —
+	// this prevents matching `$CLAUDE_PROJECT_DIRS` or URL substrings.
+	if (pathRewrite.projectDir) {
+		const pd = normalizeSlashes(pathRewrite.projectDir);
+
+		// Replacement order: handle most-specific / longest forms first to prevent
+		// partial-match corruption and double-quote accumulation (H1 trap).
+		//
+		// Key invariant: forms that include the var-token's opening or closing quote in
+		// their match pattern must consume BOTH quotes in a single pass so the replacement
+		// emits exactly ONE pair of quotes — never `"path""` or `"path`.
+
+		// Pass 1: fully-quoted form 1 with mandatory suffix — "$CLAUDE_PROJECT_DIR/<suffix>"
+		// Requires at least one `/` after the var name so form 2 ("$CLAUDE_PROJECT_DIR"/<suffix>)
+		// is not accidentally consumed here (form 2 has the closing quote immediately after the var).
+		rewritten = rewritten.replace(
+			/"(\$CLAUDE_PROJECT_DIR)(\/[^"]+)"/g,
+			(_match, _varRef: string, suffix: string) => `"${pd}${suffix}"`,
+		);
+
+		// Pass 2: var-only quoted form 2 — "$CLAUDE_PROJECT_DIR"/<suffix>
+		// Also handles bare-var form 6 when there is no suffix: cd "$CLAUDE_PROJECT_DIR" && ...
+		// Suffix class excludes whitespace, quotes, AND shell metacharacters (;, &, |, (, )) to
+		// prevent swallowing command separators into the quoted path (e.g. `node $X/f.cjs;echo hi`
+		// must NOT produce `node "/proj/f.cjs;echo" hi`).
+		rewritten = rewritten.replace(
+			/"(\$CLAUDE_PROJECT_DIR)"(\/[^\s"';&|()]*)?/g,
+			(_match, _varRef: string, suffix: string | undefined) => `"${pd}${suffix ?? ""}"`,
+		);
+
+		// Pass 3a: braced, var-only quoted with suffix — "${CLAUDE_PROJECT_DIR}"/<suffix>
+		// Same metacharacter exclusion as pass 2.
+		rewritten = rewritten.replace(
+			/"\$\{CLAUDE_PROJECT_DIR\}"(\/[^\s"';&|()]*)?/g,
+			(_match, suffix: string | undefined) => `"${pd}${suffix ?? ""}"`,
+		);
+
+		// Pass 3b: braced bare — ${CLAUDE_PROJECT_DIR}/<suffix>
+		// Emit quoted output for safety (paths may contain spaces).
+		// Same metacharacter exclusion as pass 2.
+		rewritten = rewritten.replace(
+			/\$\{CLAUDE_PROJECT_DIR\}(\/[^\s"';&|()]*)?/g,
+			(_match, suffix: string | undefined) => `"${pd}${suffix ?? ""}"`,
+		);
+
+		// Pass 4a: Windows fully-quoted form — "%CLAUDE_PROJECT_DIR%/<suffix>"
+		// Must run before the var-only quoted form (pass 4b) to consume the full suffix.
+		// Fully-quoted: suffix delimited by the closing `"` so `[^"]+` is correct here.
+		rewritten = rewritten.replace(
+			/"%CLAUDE_PROJECT_DIR%(\/[^"]+)"/g,
+			(_match, suffix: string) => `"${pd}${suffix}"`,
+		);
+
+		// Pass 4b: Windows var-only quoted form — "%CLAUDE_PROJECT_DIR%"/<suffix>
+		// Same metacharacter exclusion as pass 2.
+		rewritten = rewritten.replace(
+			/"%CLAUDE_PROJECT_DIR%"(\/[^\s"';&|()]*)?/g,
+			(_match, suffix: string | undefined) => `"${pd}${suffix ?? ""}"`,
+		);
+
+		// Pass 4c: Windows bare form — %CLAUDE_PROJECT_DIR%/<suffix>
+		// Anchor end: followed by whitespace, quote, or end-of-string to avoid false matches.
+		// Same metacharacter exclusion as pass 2.
+		rewritten = rewritten.replace(
+			/%CLAUDE_PROJECT_DIR%(\/[^\s"';&|()]*)?(?=[\s"']|$)/g,
+			(_match, suffix: string | undefined) => `"${pd}${suffix ?? ""}"`,
+		);
+
+		// Pass 5: bare dollar form — $CLAUDE_PROJECT_DIR/<suffix> (no braces, no quotes)
+		// Negative lookahead `(?![A-Za-z0-9_])` prevents matching `$CLAUDE_PROJECT_DIRS` or
+		// any other superset variable name. Captures optional `/suffix` greedily up to
+		// whitespace, quote, shell metacharacter, or end-of-string.
+		// Note: passes 1–4 have already consumed any quoted or braced occurrences, so only
+		// truly bare tokens remain here.
+		rewritten = rewritten.replace(
+			/\$CLAUDE_PROJECT_DIR(?![A-Za-z0-9_])(\/[^\s"';&|()]*)?/g,
+			(_match, suffix: string | undefined) => `"${pd}${suffix ?? ""}"`,
+		);
+	}
+
+	return rewritten;
 }
 
 function replaceCommandCandidate(command: string, candidate: string, replacement: string): string {
@@ -281,8 +444,17 @@ function replaceCommandCandidate(command: string, candidate: string, replacement
 }
 
 function isRelativeCommandCandidate(candidate: string): boolean {
+	// Quoted candidates (starting with `"`) and variable-prefixed candidates that are
+	// fully-specified tokens already contain their own delimiters — use plain replaceAll.
+	// Word-boundary regex is only needed for truly relative bare paths (no leading / or $).
 	return (
-		!candidate.startsWith("/") && !candidate.startsWith("$HOME/") && !candidate.startsWith("~/")
+		!candidate.startsWith("/") &&
+		!candidate.startsWith("$HOME/") &&
+		!candidate.startsWith("~/") &&
+		!candidate.startsWith('"') &&
+		!candidate.startsWith("$CLAUDE_PROJECT_DIR") &&
+		!candidate.startsWith("${CLAUDE_PROJECT_DIR}") &&
+		!candidate.startsWith("%CLAUDE_PROJECT_DIR%")
 	);
 }
 

--- a/src/commands/portable/hooks-settings-merger.ts
+++ b/src/commands/portable/hooks-settings-merger.ts
@@ -355,10 +355,20 @@ export async function mergeHooksIntoSettings(
 
 	const existingHooks = (existingSettings.hooks ?? {}) as HooksSection;
 	const incompatibleCleanup = pruneIncompatibleHookRegistrations(existingHooks, options);
+	// Self-heal broken-install entries: drop codex-target entries whose command
+	// still contains a $CLAUDE_PROJECT_DIR variable token referencing a CK hook
+	// dir (.claude/hooks/ or .codex/hooks/). Codex never defines this var — these
+	// entries always exit 1 and cannot be deduplicated away by re-running migrate
+	// (different command string). Must run BEFORE pruneStaleFileHooks so that
+	// var-token entries are counted here; some forms are also caught by the
+	// stale-path prune (which extracts the root-relative path), and we want the
+	// count to reflect intentional var-token removal rather than a path-check side
+	// effect. Gated to codex only — the var is legitimate in Claude Code settings.
+	const brokenCleanup = pruneVariableTokenBrokenEntries(incompatibleCleanup.hooks, options);
 	// Self-heal stale ck-managed entries: drop hooks whose command is an
 	// absolute file path pointing at a missing file. Fixes the "duplicates"
 	// symptom after users purge ~/.codex/hooks/ without clearing hooks.json (#739).
-	const pruned = pruneStaleFileHooks(incompatibleCleanup.hooks);
+	const pruned = pruneStaleFileHooks(brokenCleanup.hooks);
 	const merged = deduplicateMerge(pruned, newHooks);
 	existingSettings.hooks = merged;
 
@@ -374,7 +384,10 @@ export async function mergeHooksIntoSettings(
 		throw new Error(`Failed to write settings: ${err}. Backup preserved at: ${backupPath}`);
 	}
 
-	return { backupPath, hooksPruned: incompatibleCleanup.hooksPruned };
+	return {
+		backupPath,
+		hooksPruned: incompatibleCleanup.hooksPruned + brokenCleanup.hooksPruned,
+	};
 }
 
 function pruneIncompatibleHookRegistrations(
@@ -406,6 +419,55 @@ function pruneIncompatibleHookRegistrations(
 	}
 
 	return { hooks: pruned, hooksPruned };
+}
+
+/**
+ * Drop Codex-target entries that contain a $CLAUDE_PROJECT_DIR variable token
+ * AND reference a CK-managed hook dir (.claude/hooks/ or .codex/hooks/).
+ *
+ * These entries are by definition broken under Codex: Codex never defines
+ * CLAUDE_PROJECT_DIR, so every such hook exits 1 on every fire. They survive
+ * re-runs of `ck migrate` because deduplicateMerge keys on exact command string
+ * (old broken ≠ new fixed → both kept). This explicit prune repairs field-broken
+ * installs without risking user-owned commands that happen to reference the var
+ * for other purposes (e.g. `node "$CLAUDE_PROJECT_DIR"/scripts/own.cjs`).
+ *
+ * Gated to targetProvider === "codex": the var is legitimate in Claude Code settings.
+ */
+function pruneVariableTokenBrokenEntries(
+	hooks: HooksSection,
+	options: MergeHooksOptions,
+): { hooks: HooksSection; hooksPruned: number } {
+	if (options.targetProvider !== "codex") return { hooks, hooksPruned: 0 };
+
+	// Matches all CLAUDE_PROJECT_DIR variable forms (plan.md §"$CLAUDE_PROJECT_DIR forms"):
+	//   $CLAUDE_PROJECT_DIR  ${CLAUDE_PROJECT_DIR}  %CLAUDE_PROJECT_DIR%
+	const varPattern = /\$\{?CLAUDE_PROJECT_DIR\}?|%CLAUDE_PROJECT_DIR%/;
+	// CK-managed hook dirs referenced by broken entries.
+	const ckHookDirPattern = /\.claude\/hooks\/|\.codex\/hooks\//;
+
+	let hooksPruned = 0;
+	const result: HooksSection = {};
+
+	for (const [event, groups] of Object.entries(hooks)) {
+		const keptGroups: HookGroup[] = [];
+		for (const group of groups) {
+			const keptHooks = group.hooks.filter((entry) => {
+				const cmd = entry.command;
+				// Drop only when BOTH conditions hold: var token present AND targets CK hook dir.
+				// This preserves user hooks like `node "$CLAUDE_PROJECT_DIR"/scripts/own.cjs`.
+				if (varPattern.test(cmd) && ckHookDirPattern.test(cmd)) {
+					hooksPruned += 1;
+					return false;
+				}
+				return true;
+			});
+			if (keptHooks.length > 0) keptGroups.push({ ...group, hooks: keptHooks });
+		}
+		if (keptGroups.length > 0) result[event] = keptGroups;
+	}
+
+	return { hooks: result, hooksPruned };
 }
 
 function commandTargetsHookDir(command: string, targetHooksDir: string): boolean {
@@ -820,6 +882,11 @@ async function migrateHooksSettingsForCodex(
 		? targetSettingsPath
 		: join(process.cwd(), targetSettingsPath);
 
+	// Capture project root once, at the same point resolvedSourcePath is computed.
+	// Passed to the converter so $CLAUDE_PROJECT_DIR forms are resolved to absolute
+	// paths for project-scope migrations. Undefined for global scope (no env var to resolve).
+	const projectDir: string | undefined = isGlobal ? undefined : process.cwd();
+
 	// Step 3: Read source hooks
 	const sourceHooksResult = await inspectHooksSettings(resolvedSourcePath);
 	if (sourceHooksResult.status === "missing-file") {
@@ -977,11 +1044,15 @@ async function migrateHooksSettingsForCodex(
 	// commandSubstitutions (per-file map) takes precedence over the directory-level rewrite in
 	// rewriteCommandPath. For hooks not covered by the map, directory rewrite still applies as
 	// fallback so non-wrapper code paths remain functional.
+	// projectDir is threaded here (ONE call site) so the converter can resolve
+	// $CLAUDE_PROJECT_DIR variable forms to absolute paths for project-scope migrations.
+	// Global-scope migrations pass undefined → no behavior change.
 	const effectiveTargetDir = targetHooksDir || sourceHooksDir;
 	const converted = convertClaudeHooksToCodex(filtered, capabilities, {
 		sourceDir: sourceHooksDir,
 		targetDir: effectiveTargetDir,
 		commandSubstitutions: commandSubstitutions.size > 0 ? commandSubstitutions : undefined,
+		projectDir,
 	});
 
 	// Count hooks to register


### PR DESCRIPTION
## Problem

After a project-scope `ck migrate` to Codex, every migrated hook fails on fire:

```
PreToolUse hook (failed)
error: hook exited with code 1
```

`.codex/hooks.json` contained commands like `node "$CLAUDE_PROJECT_DIR"/.codex/hooks/simplify-gate.cjs`. Codex never defines `$CLAUDE_PROJECT_DIR`, so the variable expands empty and Node resolves a nonexistent root path.

Closes #883

## Root Cause

Project-scope Claude hooks are registered as `node "$CLAUDE_PROJECT_DIR"/.claude/hooks/<name>.cjs`. The codex migration pipeline only recognized `$HOME`/`~`/`%USERPROFILE%`/`${HOME}` path forms, so:

1. Per-file wrapper substitution never matched, and commands were not rewritten to the generated hash-prefixed wrappers.
2. The directory-level fallback rewrote only the `.claude/hooks/` to `.codex/hooks/` substring, leaving the unsupported env var in place and pointing at the copied original hook.

Design note: Codex runs hooks with the session cwd (which can be a subdirectory) and provides no project-dir env var, so the fix emits absolute paths resolved at migration time. Verified against the official Codex hooks documentation.

## Changes

| File | Change |
|------|--------|
| `src/commands/portable/converters/claude-to-codex-hooks.ts` | Optional `projectDir` on `PathRewriteMap`; substitution candidates for quoted, braced, percent, and bare `CLAUDE_PROJECT_DIR` forms; directory fallback resolves residual tokens to the absolute project dir with a shell-metachar-safe suffix class |
| `src/commands/portable/hooks-settings-merger.ts` | Threads `projectDir` for project-scope codex migrations; prunes existing codex entries still carrying `CLAUDE_PROJECT_DIR` tokens so re-running `ck migrate` heals broken installs (counted in `hooksPruned`) |
| `src/commands/portable/__tests__/claude-to-codex-hooks.test.ts` | Variable-form I/O matrix tests incl. path-with-spaces, quote balance, metachar, and negative cases |
| `src/commands/portable/__tests__/hooks-settings-merger.test.ts` | Prune coverage for all variable forms; non-codex targets and user-owned var commands preserved; generic-pipeline regression guard |
| `src/commands/portable/__tests__/codex-hook-compat-integration.test.ts` | End-to-end project-scope fixture: zero `CLAUDE_PROJECT_DIR` tokens in written hooks.json, absolute hash-prefixed wrapper commands, wrapper files on disk, idempotent re-run, self-heal of pre-broken entries |

## Recovery for affected users

Re-running `ck migrate --agent codex` in the project now removes the broken entries and writes fixed ones. Two caveats:

- `.codex/hooks.json` contains machine-absolute paths after migration. Do not commit it for shared use across machines; each teammate runs `ck migrate` themselves.
- After moving or renaming the project directory, re-run `ck migrate --agent codex`.

## Validation

- [x] Integration test verified red on pre-fix code, green post-fix
- [x] `bun run ci:local` green (typecheck, lint, build, 4940 tests, help-parity drift, ui:build, prepublish)
- [x] Pre-push hook gate passed (ci:local + ui vitest suite)
- [x] Global-scope migration output unchanged (regression-guarded)
