### PR TITLE
feat: add Kiro skill and migrate support

### DIFF
--- a/__tests__/commands/portable/converters.test.ts
+++ b/__tests__/commands/portable/converters.test.ts
@@ -109,6 +109,18 @@ describe("direct-copy converter", () => {
 			await rm(dir, { recursive: true, force: true });
 		}
 	});
+
+	it("rewrites Claude paths to Kiro paths for direct-copy Kiro targets", () => {
+		const item = makeItem({
+			body: "Use .claude/skills/cook/SKILL.md, .claude/agents/reviewer.md, and .claude/rules/typescript.md.",
+		});
+		const result = convertDirectCopy(item, "kiro");
+
+		expect(result.content).toContain(".kiro/skills/cook/SKILL.md");
+		expect(result.content).toContain(".kiro/agents/reviewer.md");
+		expect(result.content).toContain(".kiro/steering/typescript.md");
+		expect(result.content).not.toContain(".claude/");
+	});
 });
 
 describe("fm-strip converter", () => {
@@ -274,6 +286,50 @@ describe("fm-to-fm converter", () => {
 			expect(result.content).toContain('description: "Cursor agent description"');
 			expect(result.content).toContain("alwaysApply: false");
 			expect(result.content).toContain("Do test things.");
+		});
+	});
+
+	describe("kiro", () => {
+		it("produces Kiro custom subagent markdown with mapped tools", () => {
+			const item = makeItem({
+				name: "code-reviewer",
+				description: "Review code for correctness.",
+				frontmatter: {
+					tools: "Read,Edit,Bash,WebFetch",
+					model: "claude-sonnet-4",
+				},
+				body: "You are a senior code reviewer.",
+			});
+			const result = convertFmToFm(item, "kiro");
+
+			expect(result.filename).toBe("code-reviewer.md");
+			expect(result.content).toContain('name: "code-reviewer"');
+			expect(result.content).toContain('description: "Review code for correctness."');
+			expect(result.content).toContain('tools: ["read","write","shell","web"]');
+			expect(result.content).toContain('model: "claude-sonnet-4"');
+			expect(result.content).toContain("You are a senior code reviewer.");
+		});
+
+		it("maps Claude MCP tool names to Kiro MCP tool selectors", () => {
+			const item = makeItem({
+				frontmatter: {
+					tools: "mcp__context7__resolve-library-id,Read",
+				},
+			});
+			const result = convertFmToFm(item, "kiro");
+
+			expect(result.content).toContain('tools: ["@context7/resolve-library-id","read"]');
+		});
+
+		it("rewrites Claude paths inside Kiro custom subagent prompts", () => {
+			const item = makeItem({
+				body: "Use .claude/agents/reviewer.md and .claude/rules/typescript.md.",
+			});
+			const result = convertFmToFm(item, "kiro");
+
+			expect(result.content).toContain(".kiro/agents/reviewer.md");
+			expect(result.content).toContain(".kiro/steering/typescript.md");
+			expect(result.content).not.toContain(".claude/");
 		});
 	});
 

--- a/__tests__/commands/portable/provider-registry.test.ts
+++ b/__tests__/commands/portable/provider-registry.test.ts
@@ -223,8 +223,8 @@ describe("Provider Registry", () => {
 			}
 		});
 
-		it("kiro has subagents: none (steering context, not delegation)", () => {
-			expect(providers.kiro.subagents).toBe("none");
+		it("kiro has subagents: full", () => {
+			expect(providers.kiro.subagents).toBe("full");
 		});
 	});
 
@@ -307,6 +307,25 @@ describe("Provider Registry", () => {
 			const config = providers.kilo;
 			expect(config.agents?.writeStrategy).toBe("yaml-merge");
 			expect(config.agents?.format).toBe("fm-to-yaml");
+		});
+
+		it("kiro supports workspace and global skills", () => {
+			const config = providers.kiro;
+			expect(config.skills?.projectPath).toBe(".kiro/skills");
+			const globalPath = config.skills?.globalPath?.replace(/\\/g, "/") ?? "";
+			expect(globalPath).toContain(".kiro/skills");
+		});
+
+		it("kiro supports custom subagents plus steering-backed rules and config but not commands or hooks", () => {
+			const config = providers.kiro;
+			expect(config.agents?.projectPath).toBe(".kiro/agents");
+			expect(config.rules?.projectPath).toBe(".kiro/steering");
+			expect(config.config?.projectPath).toBe(".kiro/steering/project.md");
+			expect(config.agents?.format).toBe("fm-to-fm");
+			expect(config.rules?.format).toBe("md-to-kiro-steering");
+			expect(config.config?.format).toBe("md-to-kiro-steering");
+			expect(config.commands).toBeNull();
+			expect(config.hooks).toBeNull();
 		});
 	});
 });

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.4.0-dev.11",
-	"generatedAt": "2026-06-11T04:14:28.944Z",
+	"version": "4.4.0-dev.12",
+	"generatedAt": "2026-06-15T16:23:21.983Z",
 	"commands": {
 		"agents": {
 			"name": "agents",
@@ -1342,7 +1342,7 @@
 			"sections": [
 				{
 					"title": "Gotchas",
-					"content": "  --install and --reconcile are mutually exclusive — pass only one\n  --reinstall-empty-dirs and --respect-deletions are mutually exclusive — pass only one\n  Default mode is smart-detected: no/stale registry → install, valid registry → reconcile\n  --respect-deletions disables the auto-reinstall heuristic for empty directories\n  --force overrides skip decisions per item; --reinstall-empty-dirs is a per-directory heuristic\n  Codex commands migrate as skills: project scope writes .agents/skills, global scope writes ~/.agents/skills"
+					"content": "  --install and --reconcile are mutually exclusive — pass only one\n  --reinstall-empty-dirs and --respect-deletions are mutually exclusive — pass only one\n  Default mode is smart-detected: no/stale registry → install, valid registry → reconcile\n  --respect-deletions disables the auto-reinstall heuristic for empty directories\n  --force overrides skip decisions per item; --reinstall-empty-dirs is a per-directory heuristic\n  Codex commands migrate as skills: project scope writes .agents/skills, global scope writes ~/.agents/skills\n  Kiro agents migrate as custom subagents; rules/config migrate as steering files; skills copy to .kiro/skills; commands/hooks are skipped"
 				}
 			]
 		},
@@ -1867,7 +1867,7 @@
 						},
 						{
 							"flags": "-a, --agent <agent>",
-							"description": "Target agent(s) - can be specified multiple times. Valid: claude-code, cursor, codex, opencode, goose, gemini-cli, antigravity, github-copilot, amp, kilo, roo, windsurf, cline, openhands"
+							"description": "Target agent(s) - can be specified multiple times. Valid: claude-code, cursor, codex, opencode, goose, gemini-cli, antigravity, github-copilot, amp, kilo, kiro, roo, windsurf, cline, openhands"
 						},
 						{
 							"flags": "-g, --global",
@@ -1925,7 +1925,7 @@
 			"sections": [
 				{
 					"title": "Supported Agents",
-					"content": "  claude-code     Claude Code CLI\n  cursor          Cursor IDE\n  codex           Codex CLI\n  opencode        OpenCode\n  goose           Goose AI\n  gemini-cli      Gemini CLI\n  antigravity     Antigravity Agent\n  github-copilot  GitHub Copilot\n  amp             Amp\n  kilo            Kilo Code\n  roo             Roo Code\n  windsurf        Windsurf IDE\n  cline           Cline\n  openhands       OpenHands"
+					"content": "  claude-code     Claude Code CLI\n  cursor          Cursor IDE\n  codex           Codex CLI\n  opencode        OpenCode\n  goose           Goose AI\n  gemini-cli      Gemini CLI\n  antigravity     Antigravity Agent\n  github-copilot  GitHub Copilot\n  amp             Amp\n  kilo            Kilo Code\n  kiro            Kiro\n  roo             Roo Code\n  windsurf        Windsurf IDE\n  cline           Cline\n  openhands       OpenHands"
 				},
 				{
 					"title": "Notes",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -689,6 +689,7 @@ Migrate Claude Code agents, commands, skills, config, rules, and hooks to other 
   --respect-deletions disables the auto-reinstall heuristic for empty directories
   --force overrides skip decisions per item; --reinstall-empty-dirs is a per-directory heuristic
   Codex commands migrate as skills: project scope writes .agents/skills, global scope writes ~/.agents/skills
+  Kiro agents migrate as custom subagents; rules/config migrate as steering files; skills copy to .kiro/skills; commands/hooks are skipped
 
 
 ## ck new
@@ -931,7 +932,7 @@ Install, uninstall, and manage ClaudeKit skills across coding agents
 | `-u, --uninstall` | Uninstall skill(s) from agent(s) | — |
 | `--sync` | Sync registry with filesystem (clean orphaned entries) | — |
 | `-n, --name <skill>` | Skill name to install or uninstall | — |
-| `-a, --agent <agent>` | Target agent(s) - can be specified multiple times. Valid: claude-code, cursor, codex, opencode, goose, gemini-cli, antigravity, github-copilot, amp, kilo, roo, windsurf, cline, openhands | — |
+| `-a, --agent <agent>` | Target agent(s) - can be specified multiple times. Valid: claude-code, cursor, codex, opencode, goose, gemini-cli, antigravity, github-copilot, amp, kilo, kiro, roo, windsurf, cline, openhands | — |
 | `-g, --global` | Install to user's home directory (available across projects) | — |
 | `--all` | Install to all supported agents | — |
 | `-y, --yes` | Non-interactive mode (skip confirmations) | — |
@@ -960,6 +961,7 @@ Install, uninstall, and manage ClaudeKit skills across coding agents
   github-copilot  GitHub Copilot
   amp             Amp
   kilo            Kilo Code
+  kiro            Kiro
   roo             Roo Code
   windsurf        Windsurf IDE
   cline           Cline
@@ -1072,4 +1074,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-06-09T16:16:57.335Z -->
+<!-- generated: 2026-06-15T16:23:22.117Z -->

--- a/src/commands/migrate/__tests__/skill-directory-installer.test.ts
+++ b/src/commands/migrate/__tests__/skill-directory-installer.test.ts
@@ -205,6 +205,33 @@ describe("installSkillDirectories", () => {
 		);
 	});
 
+	it("kiro: installs skill to path derived from registry (.kiro/skills/<name>)", async () => {
+		const customPath = join(testDir, ".kiro", "skills");
+		const skill = makeSkill("my-skill", join(sourceDir, "my-skill"));
+
+		const origKiroSkills = originalProviders.kiro.skills;
+		if (origKiroSkills) {
+			originalProviders.kiro.skills = { ...origKiroSkills, projectPath: customPath };
+		}
+
+		const results = await installSkillDirectories([skill], ["kiro"], { global: false });
+
+		originalProviders.kiro.skills = origKiroSkills;
+
+		expect(results).toHaveLength(1);
+		expect(results[0].success).toBe(true);
+		expect(results[0].path).toBe(join(customPath, "my-skill"));
+		expect(existsSync(join(customPath, "my-skill", "SKILL.md"))).toBe(true);
+		expect(addPortableInstallationMock).toHaveBeenCalledWith(
+			"my-skill",
+			"skill",
+			"kiro",
+			false,
+			join(customPath, "my-skill"),
+			expect.any(String),
+		);
+	});
+
 	// Regression: #817 — symlinked target basePath must not clobber the source.
 	// Setup: user has ~/.agents/skills -> ~/.claude/skills (single source of truth).
 	// Before the fix, resolve()-only comparison would proceed with rename+copy and
@@ -268,6 +295,35 @@ describe("installSkillDirectories", () => {
 			"my-skill",
 			"skill",
 			"windsurf",
+			true,
+			join(globalCustomPath, "my-skill"),
+			expect.any(String),
+		);
+	});
+
+	it("kiro global: installs skill to global path derived from registry", async () => {
+		const globalCustomPath = join(testDir, ".kiro-global", "skills");
+		const skill = makeSkill("my-skill", join(sourceDir, "my-skill"));
+
+		const origKiroSkills = originalProviders.kiro.skills;
+		if (origKiroSkills) {
+			originalProviders.kiro.skills = {
+				...origKiroSkills,
+				globalPath: globalCustomPath,
+			};
+		}
+
+		const results = await installSkillDirectories([skill], ["kiro"], { global: true });
+
+		originalProviders.kiro.skills = origKiroSkills;
+
+		expect(results).toHaveLength(1);
+		expect(results[0].success).toBe(true);
+		expect(results[0].path).toBe(join(globalCustomPath, "my-skill"));
+		expect(addPortableInstallationMock).toHaveBeenCalledWith(
+			"my-skill",
+			"skill",
+			"kiro",
 			true,
 			join(globalCustomPath, "my-skill"),
 			expect.any(String),

--- a/src/commands/portable/__tests__/md-to-kiro-steering.test.ts
+++ b/src/commands/portable/__tests__/md-to-kiro-steering.test.ts
@@ -15,6 +15,28 @@ function createMockItem(overrides: Partial<PortableItem> = {}): PortableItem {
 }
 
 describe("md-to-kiro-steering", () => {
+	describe("portable type coverage", () => {
+		it("converts rules and config into Kiro steering files", () => {
+			const types = ["rules", "config"] as const;
+
+			for (const type of types) {
+				const result = convertMdToKiroSteering(
+					createMockItem({
+						type,
+						name: `${type}-context`,
+						body: `${type} context body.`,
+					}),
+					"kiro",
+				);
+
+				expect(result.filename).toBe(`${type}-context.md`);
+				expect(result.content).toStartWith("---\ninclusion:");
+				expect(result.content).toContain(`# ${type}-context`);
+				expect(result.content).toContain(`${type} context body.`);
+			}
+		});
+	});
+
 	describe("YAML frontmatter generation", () => {
 		it("adds YAML frontmatter with inclusion: always by default", () => {
 			const item = createMockItem();
@@ -24,12 +46,12 @@ describe("md-to-kiro-steering", () => {
 			expect(result.content).toContain("inclusion: always");
 		});
 
-		it("quotes fileMatch glob patterns in YAML", () => {
+		it("quotes fileMatchPattern glob patterns in YAML", () => {
 			const item = createMockItem({ name: "typescript-rules" });
 			const result = convertMdToKiroSteering(item, "kiro");
 
 			// Glob should be quoted to handle YAML special chars
-			expect(result.content).toContain('fileMatch: "**/*.{ts,tsx}"');
+			expect(result.content).toContain('fileMatchPattern: "**/*.{ts,tsx}"');
 		});
 	});
 
@@ -161,53 +183,6 @@ describe("md-to-kiro-steering", () => {
 			// Should not inject h1 when h3 exists as top-level
 			expect(result.content).not.toContain("# my-rule");
 			expect(result.content).toContain("### Existing H3 Section");
-		});
-	});
-
-	describe("agent metadata warnings", () => {
-		it("warns when agent has model field", () => {
-			const item = createMockItem({
-				type: "agent",
-				frontmatter: { model: "opus" },
-			});
-			const result = convertMdToKiroSteering(item, "kiro");
-
-			expect(result.warnings.some((w) => w.includes("Agent metadata not supported"))).toBe(true);
-			expect(result.warnings.some((w) => w.includes("model"))).toBe(true);
-		});
-
-		it("warns when agent has tools field", () => {
-			const item = createMockItem({
-				type: "agent",
-				frontmatter: { tools: "Read, Write, Bash" },
-			});
-			const result = convertMdToKiroSteering(item, "kiro");
-
-			expect(result.warnings.some((w) => w.includes("tools"))).toBe(true);
-		});
-
-		it("warns when agent has multiple unsupported fields", () => {
-			const item = createMockItem({
-				type: "agent",
-				frontmatter: { model: "opus", tools: "all", memory: "full" },
-			});
-			const result = convertMdToKiroSteering(item, "kiro");
-
-			const warning = result.warnings.find((w) => w.includes("not supported"));
-			expect(warning).toContain("model");
-			expect(warning).toContain("tools");
-			expect(warning).toContain("memory");
-		});
-
-		it("does NOT warn for rules without agent fields", () => {
-			const item = createMockItem({
-				type: "rules",
-				frontmatter: { name: "My Rule" },
-			});
-			const result = convertMdToKiroSteering(item, "kiro");
-
-			const agentWarnings = result.warnings.filter((w) => w.includes("Agent metadata"));
-			expect(agentWarnings).toHaveLength(0);
 		});
 	});
 

--- a/src/commands/portable/__tests__/portable-installer.test.ts
+++ b/src/commands/portable/__tests__/portable-installer.test.ts
@@ -708,6 +708,100 @@ describe("nested command flattening", () => {
 	});
 });
 
+describe("Kiro migration targets", () => {
+	beforeEach(() => {
+		addPortableInstallationMock.mockClear();
+		addPortableInstallationMock.mockImplementation(async () => undefined);
+	});
+
+	test("installs agents as Kiro custom subagents and rules/config as Kiro steering files", async () => {
+		const tempDir = await mkdtemp(join(process.cwd(), ".tmp-portable-kiro-steering-"));
+		const agentsDir = join(tempDir, ".kiro", "agents");
+		const steeringDir = join(tempDir, ".kiro", "steering");
+		const configPath = join(steeringDir, "project.md");
+		const agentPathConfig = getPathConfig("kiro", "agents");
+		const rulesPathConfig = getPathConfig("kiro", "rules");
+		const configPathConfig = getPathConfig("kiro", "config");
+		const originalAgentPath = agentPathConfig.projectPath;
+		const originalRulesPath = rulesPathConfig.projectPath;
+		const originalConfigPath = configPathConfig.projectPath;
+
+		try {
+			agentPathConfig.projectPath = agentsDir;
+			rulesPathConfig.projectPath = steeringDir;
+			configPathConfig.projectPath = configPath;
+
+			const agentResults = await installPortableItems(
+				[
+					makePortableItem({
+						type: "agent",
+						name: "reviewer",
+						frontmatter: { name: "Reviewer", tools: "Read,Edit" },
+						body: "Review code changes.",
+					}),
+				],
+				["kiro"],
+				"agent",
+				{ global: false },
+			);
+
+			const ruleResults = await installPortableItems(
+				[
+					makePortableItem({
+						type: "rules",
+						name: "typescript-rules",
+						frontmatter: {},
+						body: "Prefer strict TypeScript.",
+					}),
+				],
+				["kiro"],
+				"rules",
+				{ global: false },
+			);
+
+			const configResults = await installPortableItems(
+				[
+					makePortableItem({
+						type: "config",
+						name: "project",
+						frontmatter: {},
+						body: "Project context for Kiro.",
+					}),
+				],
+				["kiro"],
+				"config",
+				{ global: false },
+			);
+
+			expect(agentResults[0].success).toBe(true);
+			expect(ruleResults[0].success).toBe(true);
+			expect(configResults[0].success).toBe(true);
+
+			const agentContent = await readFile(join(agentsDir, "reviewer.md"), "utf-8");
+			const ruleContent = await readFile(join(steeringDir, "typescript-rules.md"), "utf-8");
+			const configContent = await readFile(configPath, "utf-8");
+
+			expect(agentContent).toContain('name: "reviewer"');
+			expect(agentContent).toContain('description: "Sample portable item"');
+			expect(agentContent).toContain('tools: ["read","write"]');
+			expect(agentContent).toContain("Review code changes.");
+
+			expect(ruleContent).toContain("inclusion: fileMatch");
+			expect(ruleContent).toContain('fileMatchPattern: "**/*.{ts,tsx}"');
+			expect(ruleContent).toContain("Prefer strict TypeScript.");
+
+			expect(configContent).toContain("inclusion: always");
+			expect(configContent).toContain("# project");
+			expect(configContent).toContain("Project context for Kiro.");
+		} finally {
+			agentPathConfig.projectPath = originalAgentPath;
+			rulesPathConfig.projectPath = originalRulesPath;
+			configPathConfig.projectPath = originalConfigPath;
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});
+
 describe("cross-kind section preservation (issue #415)", () => {
 	beforeEach(() => {
 		addPortableInstallationMock.mockClear();

--- a/src/commands/portable/__tests__/provider-registry.test.ts
+++ b/src/commands/portable/__tests__/provider-registry.test.ts
@@ -140,8 +140,15 @@ describe("provider-registry", () => {
 			expect(providers.kiro.config?.projectPath).toBe(".kiro/steering/project.md");
 		});
 
+		it("kiro config globalPath is ~/.kiro/steering/project.md", () => {
+			const globalPath = providers.kiro.config?.globalPath?.replace(/\\/g, "/") ?? "";
+			expect(globalPath).toContain(".kiro/steering/project.md");
+		});
+
 		it("kiro rules use per-file to .kiro/steering", () => {
 			expect(providers.kiro.rules?.projectPath).toBe(".kiro/steering");
+			const globalPath = providers.kiro.rules?.globalPath?.replace(/\\/g, "/") ?? "";
+			expect(globalPath).toContain(".kiro/steering");
 			expect(providers.kiro.rules?.writeStrategy).toBe("per-file");
 		});
 
@@ -153,6 +160,11 @@ describe("provider-registry", () => {
 			expect(providers.kiro.skills?.projectPath).toBe(".kiro/skills");
 		});
 
+		it("kiro skills globalPath is ~/.kiro/skills", () => {
+			const globalPath = providers.kiro.skills?.globalPath?.replace(/\\/g, "/") ?? "";
+			expect(globalPath).toContain(".kiro/skills");
+		});
+
 		it("kiro does not support hooks", () => {
 			expect(providers.kiro.hooks).toBeNull();
 		});
@@ -161,13 +173,39 @@ describe("provider-registry", () => {
 			expect(providers.kiro.commands).toBeNull();
 		});
 
-		it("kiro has no subagent support (uses steering for context, not delegation)", () => {
-			expect(providers.kiro.subagents).toBe("none");
+		it("kiro has full subagent support", () => {
+			expect(providers.kiro.subagents).toBe("full");
 		});
 
-		it("kiro agents map to steering directory", () => {
-			expect(providers.kiro.agents?.projectPath).toBe(".kiro/steering");
-			expect(providers.kiro.agents?.format).toBe("md-to-kiro-steering");
+		it("kiro agents map to custom subagent directory", () => {
+			expect(providers.kiro.agents?.projectPath).toBe(".kiro/agents");
+			const globalPath = providers.kiro.agents?.globalPath?.replace(/\\/g, "/") ?? "";
+			expect(globalPath).toContain(".kiro/agents");
+			expect(providers.kiro.agents?.format).toBe("fm-to-fm");
+		});
+
+		it("getPortableBasePath exposes Kiro workspace and global paths for all supported types", () => {
+			expect(getPortableBasePath("kiro", "agents", { global: false })).toBe(".kiro/agents");
+			expect(getPortableBasePath("kiro", "rules", { global: false })).toBe(".kiro/steering");
+			expect(getPortableBasePath("kiro", "config", { global: false })).toBe(
+				".kiro/steering/project.md",
+			);
+			expect(getPortableBasePath("kiro", "skills", { global: false })).toBe(".kiro/skills");
+			expect(getPortableBasePath("kiro", "commands", { global: false })).toBeNull();
+			expect(getPortableBasePath("kiro", "hooks", { global: false })).toBeNull();
+
+			expect(
+				getPortableBasePath("kiro", "agents", { global: true })?.replace(/\\/g, "/"),
+			).toContain(".kiro/agents");
+			expect(getPortableBasePath("kiro", "rules", { global: true })?.replace(/\\/g, "/")).toContain(
+				".kiro/steering",
+			);
+			expect(
+				getPortableBasePath("kiro", "config", { global: true })?.replace(/\\/g, "/"),
+			).toContain(".kiro/steering/project.md");
+			expect(
+				getPortableBasePath("kiro", "skills", { global: true })?.replace(/\\/g, "/"),
+			).toContain(".kiro/skills");
 		});
 	});
 

--- a/src/commands/portable/converters/direct-copy.ts
+++ b/src/commands/portable/converters/direct-copy.ts
@@ -29,6 +29,15 @@ const PROVIDER_CONFIG_DIR: Partial<Record<ProviderType, string>> = {
 	"github-copilot": ".github/",
 };
 
+function rewriteKiroPaths(content: string): string {
+	return content
+		.replace(/\.claude\/skills\//g, ".kiro/skills/")
+		.replace(/\.claude\/agents\//g, ".kiro/agents/")
+		.replace(/\.claude\/rules\//g, ".kiro/steering/")
+		.replace(/\.claude\/commands\//g, "Claude Code commands/")
+		.replace(/\.claude\/hooks\//g, "Claude Code hooks/");
+}
+
 /**
  * Return the file content, replacing .claude/ paths for non-Claude providers.
  */
@@ -50,9 +59,13 @@ export function convertDirectCopy(item: PortableItem, provider?: ProviderType): 
 
 	// Replace .claude/ paths with provider-specific config dir
 	if (provider && provider !== "claude-code") {
-		const targetDir = PROVIDER_CONFIG_DIR[provider];
-		if (targetDir) {
-			content = content.replace(/\.claude\//g, targetDir);
+		if (provider === "kiro") {
+			content = rewriteKiroPaths(content);
+		} else {
+			const targetDir = PROVIDER_CONFIG_DIR[provider];
+			if (targetDir) {
+				content = content.replace(/\.claude\//g, targetDir);
+			}
 		}
 	}
 	if (provider === "codex" && item.type === "hooks") {

--- a/src/commands/portable/converters/fm-to-fm.ts
+++ b/src/commands/portable/converters/fm-to-fm.ts
@@ -1,8 +1,9 @@
 /**
  * FM-to-FM converter — transform frontmatter fields for target provider
- * Used by: GitHub Copilot (.agent.md), Cursor (.mdc), OpenCode (.md)
+ * Used by: GitHub Copilot (.agent.md), Cursor (.mdc), Kiro (.md), OpenCode (.md)
  */
 import type { ConversionResult, PortableItem, ProviderType } from "../types.js";
+import { stripClaudeRefs } from "./md-strip.js";
 
 /** Copilot built-in tool names mapped from Claude Code tool names */
 const COPILOT_TOOL_MAP: Record<string, string> = {
@@ -15,6 +16,21 @@ const COPILOT_TOOL_MAP: Record<string, string> = {
 	Bash: "run_in_terminal",
 	WebFetch: "fetch",
 	WebSearch: "fetch",
+};
+
+/** Kiro custom subagent tool categories mapped from Claude Code tool names. */
+const KIRO_TOOL_MAP: Record<string, string> = {
+	Read: "read",
+	Glob: "read",
+	Grep: "read",
+	LS: "read",
+	Edit: "write",
+	Write: "write",
+	MultiEdit: "write",
+	NotebookEdit: "write",
+	Bash: "shell",
+	WebFetch: "web",
+	WebSearch: "web",
 };
 
 /**
@@ -95,6 +111,83 @@ function convertForCursor(item: PortableItem): ConversionResult {
 		content,
 		filename: `${item.name}.mdc`,
 		warnings: [],
+	};
+}
+
+function mapKiroTools(toolsStr: string | undefined): { tools: string[]; warnings: string[] } {
+	const warnings: string[] = [];
+	if (!toolsStr || toolsStr.trim().length === 0) {
+		return {
+			tools: ["@builtin"],
+			warnings: ["No Claude tools declared; granting Kiro built-in tools by default"],
+		};
+	}
+
+	const tools = new Set<string>();
+	const unmapped: string[] = [];
+	for (const rawTool of toolsStr.split(",")) {
+		const tool = rawTool.trim();
+		if (!tool) continue;
+
+		const mapped = KIRO_TOOL_MAP[tool];
+		if (mapped) {
+			tools.add(mapped);
+			continue;
+		}
+
+		const mcpMatch = /^mcp__(.+?)__(.+)$/.exec(tool);
+		if (mcpMatch) {
+			tools.add(`@${mcpMatch[1]}/${mcpMatch[2]}`);
+			continue;
+		}
+
+		unmapped.push(tool);
+	}
+
+	if (unmapped.length > 0) {
+		warnings.push(`Claude tools not mapped to Kiro custom subagent tools: ${unmapped.join(", ")}`);
+	}
+
+	if (tools.size === 0) {
+		tools.add("@builtin");
+		warnings.push("No mapped Kiro tools remained; granting Kiro built-in tools by default");
+	}
+
+	return { tools: Array.from(tools), warnings };
+}
+
+function pushYamlString(lines: string[], key: string, value: unknown): void {
+	if (typeof value === "string" && value.trim().length > 0) {
+		lines.push(`${key}: ${JSON.stringify(value.trim())}`);
+	}
+}
+
+/**
+ * Convert for Kiro IDE custom subagent .md format.
+ * Ref: https://kiro.dev/docs/chat/subagents/
+ */
+function convertKiroAgent(item: PortableItem): ConversionResult {
+	const mappedTools = mapKiroTools(item.frontmatter.tools);
+	const stripped = stripClaudeRefs(item.body, { provider: "kiro" });
+	const warnings = [...mappedTools.warnings, ...stripped.warnings];
+	const name = item.name;
+	const description = item.description || `Custom subagent: ${name}`;
+
+	const fmLines = ["---"];
+	pushYamlString(fmLines, "name", name);
+	pushYamlString(fmLines, "description", description);
+	fmLines.push(`tools: ${JSON.stringify(mappedTools.tools)}`);
+	pushYamlString(
+		fmLines,
+		"model",
+		typeof item.frontmatter.model === "string" ? item.frontmatter.model : "",
+	);
+	fmLines.push("---");
+
+	return {
+		content: `${fmLines.join("\n")}\n\n${stripped.content}\n`,
+		filename: `${item.name}.md`,
+		warnings,
 	};
 }
 
@@ -223,6 +316,8 @@ export function convertFmToFm(item: PortableItem, provider: ProviderType): Conve
 			return convertForCopilot(item);
 		case "cursor":
 			return convertForCursor(item);
+		case "kiro":
+			return convertKiroAgent(item);
 		case "opencode":
 			// Route agents vs commands based on item type
 			if (item.type === "command") return convertOpenCodeCommand(item);

--- a/src/commands/portable/converters/md-to-kiro-steering.ts
+++ b/src/commands/portable/converters/md-to-kiro-steering.ts
@@ -1,6 +1,6 @@
 /**
  * md-to-kiro-steering converter
- * Converts Claude Code config/rules/agents to Kiro steering format with YAML frontmatter.
+ * Converts Claude Code config/rules to Kiro steering format with YAML frontmatter.
  * Used by: Kiro IDE
  */
 import type { ConversionResult, PortableItem, ProviderType } from "../types.js";
@@ -9,7 +9,7 @@ import { stripClaudeRefs } from "./md-strip.js";
 /** Kiro steering inclusion modes */
 type KiroInclusionMode = "always" | "fileMatch" | "manual" | "auto";
 
-/** Language/framework to fileMatch glob mapping */
+/** Language/framework to fileMatchPattern glob mapping */
 const LANGUAGE_GLOB_MAP: Record<string, string> = {
 	typescript: "**/*.{ts,tsx}",
 	javascript: "**/*.{js,jsx,mjs,cjs}",
@@ -31,9 +31,6 @@ const LANGUAGE_GLOB_MAP: Record<string, string> = {
 	vue: "**/*.vue",
 	svelte: "**/*.svelte",
 };
-
-/** Agent frontmatter fields that have no Kiro equivalent */
-const UNSUPPORTED_AGENT_FIELDS = ["model", "tools", "memory", "argumentHint"];
 
 /**
  * Detect if item name suggests a language/framework-specific rule.
@@ -62,16 +59,16 @@ function detectLanguageGlob(itemName: string): string | null {
 }
 
 /**
- * Determine inclusion mode and optional fileMatch pattern
+ * Determine inclusion mode and optional fileMatchPattern glob
  */
 function determineInclusionMode(item: PortableItem): {
 	mode: KiroInclusionMode;
-	fileMatch?: string;
+	fileMatchPattern?: string;
 } {
-	// Language-specific rules use fileMatch
+	// Language-specific rules use fileMatch inclusion with a fileMatchPattern field.
 	const languageGlob = detectLanguageGlob(item.name);
 	if (languageGlob) {
-		return { mode: "fileMatch", fileMatch: languageGlob };
+		return { mode: "fileMatch", fileMatchPattern: languageGlob };
 	}
 
 	// Check description for language hints
@@ -84,7 +81,7 @@ function determineInclusionMode(item: PortableItem): {
 			fmDescription.startsWith(`${lang} `) ||
 			fmDescription.endsWith(` ${lang}`)
 		) {
-			return { mode: "fileMatch", fileMatch: LANGUAGE_GLOB_MAP[lang] };
+			return { mode: "fileMatch", fileMatchPattern: LANGUAGE_GLOB_MAP[lang] };
 		}
 	}
 
@@ -96,31 +93,15 @@ function determineInclusionMode(item: PortableItem): {
  * Build YAML frontmatter for Kiro steering file.
  * Note: Globs are quoted to handle YAML special characters.
  */
-function buildSteeringFrontmatter(mode: KiroInclusionMode, fileMatch?: string): string {
+function buildSteeringFrontmatter(mode: KiroInclusionMode, fileMatchPattern?: string): string {
 	const lines = ["---"];
 	lines.push(`inclusion: ${mode}`);
-	if (mode === "fileMatch" && fileMatch) {
+	if (mode === "fileMatch" && fileMatchPattern) {
 		// Quote glob to handle YAML special chars (*, {, })
-		lines.push(`fileMatch: "${fileMatch}"`);
+		lines.push(`fileMatchPattern: "${fileMatchPattern}"`);
 	}
 	lines.push("---");
 	return lines.join("\n");
-}
-
-/**
- * Check for unsupported agent frontmatter fields
- */
-function checkUnsupportedFields(item: PortableItem): string[] {
-	const warnings: string[] = [];
-	const presentFields = UNSUPPORTED_AGENT_FIELDS.filter(
-		(field) => item.frontmatter[field] !== undefined,
-	);
-
-	if (presentFields.length > 0) {
-		warnings.push(`Agent metadata not supported by Kiro (dropped): ${presentFields.join(", ")}`);
-	}
-
-	return warnings;
 }
 
 /**
@@ -140,20 +121,15 @@ export function convertMdToKiroSteering(
 ): ConversionResult {
 	const warnings: string[] = [];
 
-	// Check for unsupported agent fields
-	if (item.type === "agent") {
-		warnings.push(...checkUnsupportedFields(item));
-	}
-
 	// Strip Claude-specific references
 	const stripped = stripClaudeRefs(item.body, { provider });
 	warnings.push(...stripped.warnings);
 
 	// Determine inclusion mode
-	const { mode, fileMatch } = determineInclusionMode(item);
+	const { mode, fileMatchPattern } = determineInclusionMode(item);
 
 	// Build frontmatter
-	const frontmatter = buildSteeringFrontmatter(mode, fileMatch);
+	const frontmatter = buildSteeringFrontmatter(mode, fileMatchPattern);
 
 	// Compose content — skip heading injection if body already has one
 	const heading = item.frontmatter.name || item.name;
@@ -167,8 +143,8 @@ export function convertMdToKiroSteering(
 	}
 
 	// Add info about inclusion mode
-	if (mode === "fileMatch" && fileMatch) {
-		warnings.push(`Using fileMatch mode with pattern: ${fileMatch}`);
+	if (mode === "fileMatch" && fileMatchPattern) {
+		warnings.push(`Using fileMatch mode with pattern: ${fileMatchPattern}`);
 	}
 
 	return {

--- a/src/commands/portable/provider-registry.ts
+++ b/src/commands/portable/provider-registry.ts
@@ -508,45 +508,50 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 	kiro: {
 		name: "kiro",
 		displayName: "Kiro IDE",
-		subagents: "none", // Kiro uses steering for context injection, not agent delegation
+		subagents: "full",
 		agents: {
-			projectPath: ".kiro/steering",
-			globalPath: null, // Kiro is project-first; no global agents path
-			format: "md-to-kiro-steering",
+			projectPath: ".kiro/agents",
+			globalPath: join(home, ".kiro/agents"),
+			format: "fm-to-fm",
 			writeStrategy: "per-file",
 			fileExtension: ".md",
 		},
 		commands: null, // Kiro does not support commands
 		skills: {
 			projectPath: ".kiro/skills",
-			globalPath: null, // Kiro skills are project-level only
+			globalPath: join(home, ".kiro/skills"),
 			format: "direct-copy",
 			writeStrategy: "per-file",
 			fileExtension: ".md",
 		},
 		config: {
 			projectPath: ".kiro/steering/project.md",
-			globalPath: null, // Kiro config is project-level only
+			globalPath: join(home, ".kiro/steering/project.md"),
 			format: "md-to-kiro-steering",
 			writeStrategy: "single-file",
 			fileExtension: ".md",
 		},
 		rules: {
 			projectPath: ".kiro/steering",
-			globalPath: null, // Kiro rules are project-level only
+			globalPath: join(home, ".kiro/steering"),
 			format: "md-to-kiro-steering",
 			writeStrategy: "per-file",
 			fileExtension: ".md",
 		},
-		hooks: null, // Kiro hooks are YAML-based, incompatible with Claude Code JS hooks
+		hooks: null, // Kiro has its own hook definitions; Claude Code hooks are not compatible.
 		settingsJsonPath: null, // Kiro uses .kiro/settings/mcp.json (incompatible format)
 		detect: async () =>
+			hasBinaryInPath("kiro") ||
 			hasAnyInstallSignal([
 				join(cwd, ".kiro/steering"),
 				join(cwd, ".kiro/skills"),
 				join(cwd, ".kiro/hooks"),
 				join(cwd, ".kiro/agents"),
 				join(cwd, ".kiro/settings/mcp.json"),
+				join(home, ".kiro/steering"),
+				join(home, ".kiro/skills"),
+				join(home, ".kiro/agents"),
+				join(home, ".kiro/settings/mcp.json"),
 			]),
 	},
 	windsurf: {

--- a/src/commands/skills/__tests__/agents.test.ts
+++ b/src/commands/skills/__tests__/agents.test.ts
@@ -27,8 +27,8 @@ describe("agents", () => {
 	});
 
 	describe("agents registry", () => {
-		it("should have 14 agents defined", () => {
-			expect(Object.keys(agents).length).toBe(14);
+		it("should have 15 agents defined", () => {
+			expect(Object.keys(agents).length).toBe(15);
 		});
 
 		it("should have required fields for each agent", () => {
@@ -60,6 +60,13 @@ describe("agents", () => {
 			expect(opencode.displayName).toBe("OpenCode");
 			expect(opencode.projectPath).toBe(".claude/skills");
 			expect(opencode.globalPath).toBe(join(home, ".claude/skills"));
+		});
+
+		it("should have kiro agent with workspace and global skill paths", () => {
+			const kiro = agents.kiro;
+			expect(kiro.displayName).toBe("Kiro");
+			expect(kiro.projectPath).toBe(".kiro/skills");
+			expect(kiro.globalPath).toBe(join(home, ".kiro/skills"));
 		});
 	});
 
@@ -115,6 +122,15 @@ describe("agents", () => {
 		it("should handle skill names with special characters", () => {
 			const path = getInstallPath("my-skill-v2", "cursor", { global: true });
 			expect(path).toBe(join(home, ".cursor/skills/my-skill-v2"));
+		});
+
+		it("should return Kiro workspace and global skill paths", () => {
+			expect(getInstallPath("my-skill", "kiro", { global: false })).toBe(
+				join(".kiro/skills", "my-skill"),
+			);
+			expect(getInstallPath("my-skill", "kiro", { global: true })).toBe(
+				join(home, ".kiro/skills/my-skill"),
+			);
 		});
 
 		it("should work for all agents", () => {

--- a/src/commands/skills/__tests__/skills-installer.test.ts
+++ b/src/commands/skills/__tests__/skills-installer.test.ts
@@ -174,6 +174,22 @@ description: OpenCode native Claude-compatible skill
 			expect(result.success).toBe(true);
 		});
 
+		it("should install skill to Kiro global skills directory", async () => {
+			const kiroSkillPath = join(home, ".kiro/skills/installer-test-skill");
+			rmSync(kiroSkillPath, { recursive: true, force: true });
+
+			try {
+				const result = await installSkillForAgent(testSkill, "kiro", { global: true });
+
+				expect(result.success).toBe(true);
+				expect(result.agent).toBe("kiro");
+				expect(result.path).toBe(kiroSkillPath);
+				expect(existsSync(join(kiroSkillPath, "SKILL.md"))).toBe(true);
+			} finally {
+				rmSync(kiroSkillPath, { recursive: true, force: true });
+			}
+		});
+
 		it("should return error for file at target path", async () => {
 			// Create a file where directory should be
 			const blockingPath = join(installBase, "blocking-skill");

--- a/src/commands/skills/agents.ts
+++ b/src/commands/skills/agents.ts
@@ -126,6 +126,23 @@ export const agents: Record<AgentType, AgentConfig> = {
 		globalPath: join(home, ".kilocode/skills"),
 		detect: async () => existsSync(join(home, ".kilocode")),
 	},
+	kiro: {
+		name: "kiro",
+		displayName: "Kiro",
+		projectPath: ".kiro/skills",
+		globalPath: join(home, ".kiro/skills"),
+		detect: async () =>
+			hasAnyInstallSignal([
+				join(process.cwd(), ".kiro/skills"),
+				join(process.cwd(), ".kiro/steering"),
+				join(process.cwd(), ".kiro/agents"),
+				join(process.cwd(), ".kiro/settings/mcp.json"),
+				join(home, ".kiro/skills"),
+				join(home, ".kiro/steering"),
+				join(home, ".kiro/agents"),
+				join(home, ".kiro/settings/mcp.json"),
+			]),
+	},
 	roo: {
 		name: "roo",
 		displayName: "Roo Code",

--- a/src/commands/skills/types.ts
+++ b/src/commands/skills/types.ts
@@ -15,6 +15,7 @@ export const AgentType = z.enum([
 	"github-copilot",
 	"amp",
 	"kilo",
+	"kiro",
 	"roo",
 	"windsurf",
 	"cline",

--- a/src/domains/help/commands/migrate-command-help.ts
+++ b/src/domains/help/commands/migrate-command-help.ts
@@ -148,6 +148,7 @@ export const migrateCommandHelp: CommandHelp = {
 				"  --respect-deletions disables the auto-reinstall heuristic for empty directories",
 				"  --force overrides skip decisions per item; --reinstall-empty-dirs is a per-directory heuristic",
 				"  Codex commands migrate as skills: project scope writes .agents/skills, global scope writes ~/.agents/skills",
+				"  Kiro agents migrate as custom subagents; rules/config migrate as steering files; skills copy to .kiro/skills; commands/hooks are skipped",
 			].join("\n"),
 		},
 	],

--- a/src/domains/help/commands/skills-command-help.ts
+++ b/src/domains/help/commands/skills-command-help.ts
@@ -2,7 +2,7 @@
  * Skills Command Help
  *
  * Help definition for the 'skills' command.
- * Handles cross-agent skill distribution for 14 coding agents.
+ * Handles cross-agent skill distribution for 15 coding agents.
  */
 
 import type { CommandHelp } from "../help-types.js";
@@ -53,7 +53,7 @@ export const skillsCommandHelp: CommandHelp = {
 				{
 					flags: "-a, --agent <agent>",
 					description:
-						"Target agent(s) - can be specified multiple times. Valid: claude-code, cursor, codex, opencode, goose, gemini-cli, antigravity, github-copilot, amp, kilo, roo, windsurf, cline, openhands",
+						"Target agent(s) - can be specified multiple times. Valid: claude-code, cursor, codex, opencode, goose, gemini-cli, antigravity, github-copilot, amp, kilo, kiro, roo, windsurf, cline, openhands",
 				},
 				{
 					flags: "-g, --global",
@@ -121,6 +121,7 @@ export const skillsCommandHelp: CommandHelp = {
   github-copilot  GitHub Copilot
   amp             Amp
   kilo            Kilo Code
+  kiro            Kiro
   roo             Roo Code
   windsurf        Windsurf IDE
   cline           Cline

--- a/tests/domains/help/migrate-command-help.test.ts
+++ b/tests/domains/help/migrate-command-help.test.ts
@@ -13,5 +13,8 @@ describe("migrate command help", () => {
 				.flatMap((group) => group.options)
 				.find((option) => option.flags === "--dry-run")?.description,
 		).toContain("destinations");
+		expect(
+			(migrateCommandHelp.sections ?? []).map((section) => section.content).join("\n"),
+		).toContain("Kiro agents migrate as custom subagents");
 	});
 });


### PR DESCRIPTION
## Summary
- Add Kiro to `ck skills` with workspace/global `.kiro/skills` install paths.
- Update `ck migrate` Kiro support so agents install as Kiro custom subagents in `.kiro/agents`, while rules and config target Kiro steering files in `.kiro/steering`.
- Keep unsupported Kiro surfaces explicit: commands and Claude Code hook migration are skipped, while skills copy as Agent Skills directories.

## Docs Impact
- Updated generated CLI manifest and CLI reference for Kiro skills/migrate behavior.

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run help:check-parity`
- `bun test`
- pre-push local CI parity, packaged CLI verification, and UI vitest suite