### PR TITLE
fix: support Antigravity 2 migration paths

### DIFF
--- a/__tests__/commands/portable/converters.test.ts
+++ b/__tests__/commands/portable/converters.test.ts
@@ -127,18 +127,32 @@ describe("direct-copy converter", () => {
 			body: [
 				"Use .claude/skills/cook/SKILL.md.",
 				"Delegate to .claude/agents/reviewer.md.",
+				"Delegate to .claude/agents/team/frontend.md.",
 				"Follow .claude/rules/typescript.md.",
-				"Run .claude/commands/ship.md.",
+				"Run .claude/commands/docs/ship.md.",
+				"Check .claude/hooks/session-start.cjs.",
 			].join(" "),
 		});
 		const result = convertDirectCopy(item, "antigravity");
 
 		expect(result.content).toContain(".agents/skills/cook/SKILL.md");
-		expect(result.content).toContain(".agents/skills/reviewer.md");
+		expect(result.content).toContain(".agents/agents.md");
 		expect(result.content).toContain(".agents/rules/typescript.md");
-		expect(result.content).toContain(".agents/workflows/ship.md");
+		expect(result.content).toContain(".agents/workflows/docs-ship.md");
+		expect(result.content).toContain("Claude Code hooks/session-start.cjs");
 		expect(result.content).not.toContain(".claude/");
 		expect(result.content).not.toContain(".agent/");
+	});
+
+	it("rewrites global Antigravity skill refs without inventing a global agents path", () => {
+		const item = makeItem({
+			body: "Use .claude/skills/cook/SKILL.md and .claude/agents/reviewer.md.",
+		});
+		const result = convertDirectCopy(item, "antigravity", { global: true });
+
+		expect(result.content).toContain("~/.gemini/config/skills/cook/SKILL.md");
+		expect(result.content).toContain(".agents/agents.md");
+		expect(result.content).not.toContain("~/.gemini/config/skills/agent-reviewer");
 	});
 });
 
@@ -565,6 +579,18 @@ describe("skill-md converter", () => {
 		const result = convertToSkillMd(item);
 
 		expect(result.filename).toBe("my-skill/SKILL.md");
+	});
+
+	it("can rewrite Antigravity skill refs when used for SKILL.md-compatible providers", () => {
+		const item = makeItem({
+			type: "agent",
+			name: "reviewer",
+			body: "Read .claude/skills/cook/SKILL.md before reviewing.",
+		});
+		const result = convertToSkillMd(item, "antigravity", { global: true });
+
+		expect(result.filename).toBe("reviewer/SKILL.md");
+		expect(result.content).toContain("~/.gemini/config/skills/cook/SKILL.md");
 	});
 });
 

--- a/__tests__/commands/portable/converters.test.ts
+++ b/__tests__/commands/portable/converters.test.ts
@@ -121,6 +121,25 @@ describe("direct-copy converter", () => {
 		expect(result.content).toContain(".kiro/steering/typescript.md");
 		expect(result.content).not.toContain(".claude/");
 	});
+
+	it("rewrites Claude paths to Antigravity 2.0 .agents paths", () => {
+		const item = makeItem({
+			body: [
+				"Use .claude/skills/cook/SKILL.md.",
+				"Delegate to .claude/agents/reviewer.md.",
+				"Follow .claude/rules/typescript.md.",
+				"Run .claude/commands/ship.md.",
+			].join(" "),
+		});
+		const result = convertDirectCopy(item, "antigravity");
+
+		expect(result.content).toContain(".agents/skills/cook/SKILL.md");
+		expect(result.content).toContain(".agents/skills/reviewer.md");
+		expect(result.content).toContain(".agents/rules/typescript.md");
+		expect(result.content).toContain(".agents/workflows/ship.md");
+		expect(result.content).not.toContain(".claude/");
+		expect(result.content).not.toContain(".agent/");
+	});
 });
 
 describe("fm-strip converter", () => {

--- a/__tests__/commands/portable/provider-registry.test.ts
+++ b/__tests__/commands/portable/provider-registry.test.ts
@@ -164,7 +164,6 @@ describe("Provider Registry", () => {
 			for (const p of agentProviders) {
 				expect(skillProviders).toContain(p);
 			}
-			// Antigravity agents are projected into skills because 2.0 exposes SKILL.md directories.
 			expect(skillProviders).toContain("antigravity");
 			expect(agentProviders).toContain("antigravity");
 		});
@@ -241,12 +240,12 @@ describe("Provider Registry", () => {
 			expect(config.agents?.charLimit).toBe(12000);
 		});
 
-		it("antigravity migrates Claude agents as Antigravity skills", () => {
+		it("antigravity migrates Claude agents into native agents.md", () => {
 			const config = providers.antigravity;
-			expect(config.agents?.projectPath).toBe(".agents/skills");
-			const agentsGlobal = config.agents?.globalPath?.replace(/\\/g, "/") ?? "";
-			expect(agentsGlobal).toContain(".gemini/config/skills");
-			expect(config.agents?.format).toBe("skill-md");
+			expect(config.agents?.projectPath).toBe(".agents/agents.md");
+			expect(config.agents?.globalPath).toBeNull();
+			expect(config.agents?.format).toBe("fm-strip");
+			expect(config.agents?.writeStrategy).toBe("merge-single");
 		});
 
 		it("antigravity uses correct paths for commands, skills, config, rules", () => {

--- a/__tests__/commands/portable/provider-registry.test.ts
+++ b/__tests__/commands/portable/provider-registry.test.ts
@@ -47,9 +47,8 @@ describe("Provider Registry", () => {
 		it("returns providers with non-null agents config", () => {
 			const withAgents = getProvidersSupporting("agents");
 
-			// 15 of 16 providers support agents (antigravity has agents=null)
-			expect(withAgents).toHaveLength(15);
-			expect(withAgents).not.toContain("antigravity");
+			expect(withAgents).toHaveLength(16);
+			expect(withAgents).toContain("antigravity");
 
 			// Verify each has non-null agents config
 			for (const provider of withAgents) {
@@ -165,9 +164,9 @@ describe("Provider Registry", () => {
 			for (const p of agentProviders) {
 				expect(skillProviders).toContain(p);
 			}
-			// Antigravity supports skills but not agents (agents ARE skills in Antigravity)
+			// Antigravity agents are projected into skills because 2.0 exposes SKILL.md directories.
 			expect(skillProviders).toContain("antigravity");
-			expect(agentProviders).not.toContain("antigravity");
+			expect(agentProviders).toContain("antigravity");
 		});
 
 		it("skills paths align with agents for providers", () => {
@@ -242,25 +241,28 @@ describe("Provider Registry", () => {
 			expect(config.agents?.charLimit).toBe(12000);
 		});
 
-		it("antigravity has no agents (agents are skills in Antigravity)", () => {
+		it("antigravity migrates Claude agents as Antigravity skills", () => {
 			const config = providers.antigravity;
-			expect(config.agents).toBeNull();
+			expect(config.agents?.projectPath).toBe(".agents/skills");
+			const agentsGlobal = config.agents?.globalPath?.replace(/\\/g, "/") ?? "";
+			expect(agentsGlobal).toContain(".gemini/config/skills");
+			expect(config.agents?.format).toBe("skill-md");
 		});
 
 		it("antigravity uses correct paths for commands, skills, config, rules", () => {
 			const config = providers.antigravity;
 			// Commands (workflows): project only, no verified global path
 			expect(config.commands).not.toBeNull();
-			expect(config.commands?.projectPath).toBe(".agent/workflows");
+			expect(config.commands?.projectPath).toBe(".agents/workflows");
 			expect(config.commands?.globalPath).toBeNull();
 
-			// Skills: project .agent/skills/, global ~/.gemini/antigravity/skills
-			expect(config.skills?.projectPath).toBe(".agent/skills");
+			// Skills: project .agents/skills/, global ~/.gemini/config/skills
+			expect(config.skills?.projectPath).toBe(".agents/skills");
 			const skillsGlobal = config.skills?.globalPath?.replace(/\\/g, "/") ?? "";
-			expect(skillsGlobal).toContain(".gemini/antigravity/skills");
+			expect(skillsGlobal).toContain(".gemini/config/skills");
 
-			// Rules: project .agent/rules/, no verified global path
-			expect(config.rules?.projectPath).toBe(".agent/rules");
+			// Rules: project .agents/rules/, no verified global path
+			expect(config.rules?.projectPath).toBe(".agents/rules");
 			expect(config.rules?.globalPath).toBeNull();
 
 			// Config: GEMINI.md → ~/.gemini/GEMINI.md (shared with Gemini CLI)

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
 	"version": "4.4.0-dev.13",
-	"generatedAt": "2026-06-15T16:50:39.245Z",
+	"generatedAt": "2026-06-15T17:47:28.348Z",
 	"commands": {
 		"agents": {
 			"name": "agents",
@@ -1342,7 +1342,7 @@
 			"sections": [
 				{
 					"title": "Gotchas",
-					"content": "  --install and --reconcile are mutually exclusive — pass only one\n  --reinstall-empty-dirs and --respect-deletions are mutually exclusive — pass only one\n  Default mode is smart-detected: no/stale registry → install, valid registry → reconcile\n  --respect-deletions disables the auto-reinstall heuristic for empty directories\n  --force overrides skip decisions per item; --reinstall-empty-dirs is a per-directory heuristic\n  Codex commands migrate as skills: project scope writes .agents/skills, global scope writes ~/.agents/skills\n  Kiro agents migrate as custom subagents; rules/config migrate as steering files; skills copy to .kiro/skills; commands/hooks are skipped"
+					"content": "  --install and --reconcile are mutually exclusive — pass only one\n  --reinstall-empty-dirs and --respect-deletions are mutually exclusive — pass only one\n  Default mode is smart-detected: no/stale registry → install, valid registry → reconcile\n  --respect-deletions disables the auto-reinstall heuristic for empty directories\n  --force overrides skip decisions per item; --reinstall-empty-dirs is a per-directory heuristic\n  Codex commands migrate as skills: project scope writes .agents/skills, global scope writes ~/.agents/skills\n  Antigravity 2.0 agents migrate to .agents/agents.md; skills remain .agents/skills/<name>/SKILL.md\n  Kiro agents migrate as custom subagents; rules/config migrate as steering files; skills copy to .kiro/skills; commands/hooks are skipped"
 				}
 			]
 		},

--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
-	"version": "4.4.0-dev.12",
-	"generatedAt": "2026-06-15T16:23:21.983Z",
+	"version": "4.4.0-dev.13",
+	"generatedAt": "2026-06-15T16:50:39.245Z",
 	"commands": {
 		"agents": {
 			"name": "agents",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -689,6 +689,7 @@ Migrate Claude Code agents, commands, skills, config, rules, and hooks to other 
   --respect-deletions disables the auto-reinstall heuristic for empty directories
   --force overrides skip decisions per item; --reinstall-empty-dirs is a per-directory heuristic
   Codex commands migrate as skills: project scope writes .agents/skills, global scope writes ~/.agents/skills
+  Antigravity 2.0 agents migrate to .agents/agents.md; skills remain .agents/skills/<name>/SKILL.md
   Kiro agents migrate as custom subagents; rules/config migrate as steering files; skills copy to .kiro/skills; commands/hooks are skipped
 
 
@@ -1074,4 +1075,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-06-15T16:23:22.117Z -->
+<!-- generated: 2026-06-15T17:47:28.452Z -->

--- a/src/commands/migrate/__tests__/migrate-command.integration.test.ts
+++ b/src/commands/migrate/__tests__/migrate-command.integration.test.ts
@@ -10,12 +10,20 @@
  *   - validateMutualExclusion guard
  */
 import { describe, expect, it } from "bun:test";
-import type { ReconcileBanner } from "../../portable/reconcile-types.js";
+import type {
+	ReconcileAction,
+	ReconcileBanner,
+	ReconcilePlan,
+} from "../../portable/reconcile-types.js";
+import type { PortableInstallResult } from "../../portable/types.js";
+import type { SkillInfo } from "../../skills/types.js";
 import type { MigrateOptions } from "../migrate-command.js";
 import {
+	appendFallbackSkillActionsToPlan,
 	appendMigrationWarningMessages,
 	renderBanners,
 	resolveMigrationMode,
+	shouldRunDeleteAction,
 	validateMutualExclusion,
 } from "../migrate-command.js";
 import { renderBannerLines } from "../migrate-ui-summary.js";
@@ -149,6 +157,157 @@ describe("appendMigrationWarningMessages", () => {
 		]);
 
 		expect(messages).toEqual(["Skipped unsupported Codex hook event Notification"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// appendFallbackSkillActionsToPlan
+// ---------------------------------------------------------------------------
+
+describe("appendFallbackSkillActionsToPlan", () => {
+	const basePlan: ReconcilePlan = {
+		actions: [
+			{
+				action: "install",
+				global: false,
+				item: "reviewer",
+				provider: "antigravity",
+				reason: "New item, not previously installed",
+				targetPath: ".agents/agents.md",
+				type: "agent",
+			},
+		],
+		banners: [],
+		hasConflicts: false,
+		summary: {
+			conflict: 0,
+			delete: 0,
+			install: 1,
+			skip: 0,
+			update: 0,
+		},
+	};
+	const skills: SkillInfo[] = [
+		{
+			description: "Cook implementation",
+			name: "cook",
+			path: "/tmp/.claude/skills/cook",
+		},
+	];
+
+	it("adds directory skill actions so migrate plan matches actual writes", () => {
+		const plan = appendFallbackSkillActionsToPlan(basePlan, skills, ["antigravity"], false);
+
+		expect(plan.summary.install).toBe(2);
+		expect(plan.actions).toContainEqual(
+			expect.objectContaining({
+				action: "install",
+				global: false,
+				isDirectoryItem: true,
+				item: "cook",
+				provider: "antigravity",
+				targetPath: ".agents/skills/cook",
+				type: "skill",
+			}),
+		);
+	});
+
+	it("does not duplicate existing skill actions", () => {
+		const planWithSkill: ReconcilePlan = {
+			...basePlan,
+			actions: [
+				...basePlan.actions,
+				{
+					action: "install",
+					global: false,
+					isDirectoryItem: true,
+					item: "cook",
+					provider: "antigravity",
+					reason: "New item, not previously installed",
+					targetPath: ".agents/skills/cook",
+					type: "skill",
+				},
+			],
+			summary: { ...basePlan.summary, install: 2 },
+		};
+
+		const plan = appendFallbackSkillActionsToPlan(planWithSkill, skills, ["antigravity"], false);
+
+		expect(plan.summary.install).toBe(2);
+		expect(plan.actions.filter((action) => action.type === "skill")).toHaveLength(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// shouldRunDeleteAction
+// ---------------------------------------------------------------------------
+
+describe("shouldRunDeleteAction", () => {
+	const pathMigrationDelete: ReconcileAction = {
+		action: "delete",
+		item: "reviewer",
+		type: "agent",
+		provider: "antigravity",
+		global: false,
+		targetPath: ".agent/skills/reviewer/SKILL.md",
+		reason: "Provider path migrated: .agent/skills -> .agents/agents.md",
+		reasonCode: "path-migrated-cleanup",
+	};
+
+	it("suppresses path-migration cleanup when replacement write failed", () => {
+		const failedResults: PortableInstallResult[] = [
+			{
+				provider: "antigravity",
+				providerDisplayName: "Antigravity",
+				success: false,
+				path: ".agents/agents.md",
+				portableType: "agent",
+				itemName: "reviewer",
+				error: "Permission denied",
+			},
+		];
+
+		expect(shouldRunDeleteAction(pathMigrationDelete, failedResults)).toBe(false);
+	});
+
+	it("allows path-migration cleanup after replacement write succeeds", () => {
+		const successfulResults: PortableInstallResult[] = [
+			{
+				provider: "antigravity",
+				providerDisplayName: "Antigravity",
+				success: true,
+				path: ".agents/agents.md",
+				portableType: "agent",
+				itemName: "reviewer",
+			},
+		];
+
+		expect(shouldRunDeleteAction(pathMigrationDelete, successfulResults)).toBe(true);
+	});
+
+	it("allows command prompt cleanup after replacement command is written as a skill", () => {
+		const codexPromptDelete: ReconcileAction = {
+			action: "delete",
+			global: false,
+			item: "local",
+			provider: "codex",
+			reason: "Legacy Codex prompt command path migrated to skills",
+			reasonCode: "path-migrated-cleanup",
+			targetPath: ".codex/prompts/local.md",
+			type: "command",
+		};
+		const successfulResults: PortableInstallResult[] = [
+			{
+				itemName: "SKILL",
+				path: ".agents/skills/source-command-local/SKILL.md",
+				portableType: "command",
+				provider: "codex",
+				providerDisplayName: "Codex",
+				success: true,
+			},
+		];
+
+		expect(shouldRunDeleteAction(codexPromptDelete, successfulResults)).toBe(true);
 	});
 });
 

--- a/src/commands/migrate/__tests__/skill-directory-installer.test.ts
+++ b/src/commands/migrate/__tests__/skill-directory-installer.test.ts
@@ -232,6 +232,56 @@ describe("installSkillDirectories", () => {
 		);
 	});
 
+	it("antigravity: rewrites only SKILL.md references to 2.0 paths during migrate", async () => {
+		const customPath = join(testDir, ".agents", "skills");
+		const sourcePath = join(testDir, "antigravity-source", "ag-skill");
+		rmSync(sourcePath, { recursive: true, force: true });
+		mkdirSync(sourcePath, { recursive: true });
+		writeFileSync(
+			join(sourcePath, "SKILL.md"),
+			[
+				"# AG Skill",
+				"",
+				"Use .claude/skills/cook/SKILL.md.",
+				"Ask .claude/agents/reviewer.md.",
+				"Run .claude/commands/docs/release.md.",
+				"Follow .claude/rules/style.md.",
+				"Check .claude/hooks/session-start.cjs.",
+			].join("\n"),
+		);
+		writeFileSync(join(sourcePath, "helper.js"), ".claude/agents/reviewer.md");
+
+		const skill = makeSkill("ag-skill", sourcePath);
+		const origAntigravitySkills = originalProviders.antigravity.skills;
+		if (origAntigravitySkills) {
+			originalProviders.antigravity.skills = {
+				...origAntigravitySkills,
+				projectPath: customPath,
+			};
+		}
+
+		try {
+			const results = await installSkillDirectories([skill], ["antigravity"], { global: false });
+
+			expect(results).toHaveLength(1);
+			expect(results[0].success).toBe(true);
+			expect(results[0].path).toBe(join(customPath, "ag-skill"));
+
+			const content = readFileSync(join(customPath, "ag-skill", "SKILL.md"), "utf-8");
+			const helper = readFileSync(join(customPath, "ag-skill", "helper.js"), "utf-8");
+			expect(content).toContain(".agents/skills/cook/SKILL.md");
+			expect(content).toContain(".agents/agents.md");
+			expect(content).toContain(".agents/workflows/docs-release.md");
+			expect(content).toContain(".agents/rules/style.md");
+			expect(content).toContain("Claude Code hooks/session-start.cjs");
+			expect(content).not.toContain(".claude/");
+			expect(helper).toBe(".claude/agents/reviewer.md");
+		} finally {
+			originalProviders.antigravity.skills = origAntigravitySkills;
+			rmSync(sourcePath, { recursive: true, force: true });
+		}
+	});
+
 	// Regression: #817 — symlinked target basePath must not clobber the source.
 	// Setup: user has ~/.agents/skills -> ~/.claude/skills (single source of truth).
 	// Before the fix, resolve()-only comparison would proceed with rename+copy and

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -69,6 +69,7 @@ import {
 import type {
 	ReconcileAction,
 	ReconcileBanner,
+	ReconcilePlan,
 	ReconcileProviderInput,
 	SourceItemState,
 	TargetFileState,
@@ -215,6 +216,59 @@ export function appendMigrationWarningMessages(
 			target.push(warning.message);
 		}
 	}
+}
+
+export function appendFallbackSkillActionsToPlan(
+	plan: ReconcilePlan,
+	skills: SkillInfo[],
+	selectedProviders: ProviderType[],
+	installGlobally: boolean,
+): ReconcilePlan {
+	if (skills.length === 0) return plan;
+
+	const existingSkillKeys = new Set(
+		plan.actions
+			.filter((action) => action.type === "skill")
+			.map((action) => `${action.provider}\0${String(action.global)}\0${action.item}`),
+	);
+	const fallbackActions: ReconcileAction[] = [];
+
+	for (const provider of selectedProviders.filter((entry) =>
+		getProvidersSupporting("skills").includes(entry),
+	)) {
+		const global = resolvePortableTypeGlobal(provider, "skill", installGlobally);
+		const basePath = getPortableBasePath(provider, "skills", { global });
+		if (!basePath) continue;
+
+		for (const skill of skills) {
+			const key = `${provider}\0${String(global)}\0${skill.name}`;
+			if (existingSkillKeys.has(key)) continue;
+			existingSkillKeys.add(key);
+			fallbackActions.push({
+				action: "install",
+				global,
+				isDirectoryItem: true,
+				item: skill.name,
+				provider,
+				reason: "New item, not previously installed",
+				reasonCode: "new-item",
+				reasonCopy: "New - not previously installed",
+				targetPath: join(basePath, skill.name),
+				type: "skill",
+			});
+		}
+	}
+
+	if (fallbackActions.length === 0) return plan;
+
+	return {
+		...plan,
+		actions: [...plan.actions, ...fallbackActions],
+		summary: {
+			...plan.summary,
+			install: plan.summary.install + fallbackActions.length,
+		},
+	};
 }
 
 /**
@@ -450,6 +504,65 @@ async function executeDeleteAction(
 			error: error instanceof Error ? error.message : "Delete action failed",
 		};
 	}
+}
+
+function hasSuccessfulReplacementWrite(
+	action: ReconcileAction,
+	results: PortableInstallResult[],
+): boolean {
+	return results.some(
+		(result) =>
+			result.success &&
+			!result.skipped &&
+			result.provider === action.provider &&
+			replacementTypeMatches(action.type, result.portableType) &&
+			replacementItemMatches(action, result) &&
+			result.path.length > 0 &&
+			resolve(result.path) !== resolve(action.targetPath),
+	);
+}
+
+function replacementTypeMatches(
+	actionType: ReconcileAction["type"],
+	resultType: PortableInstallResult["portableType"],
+): boolean {
+	return resultType === actionType || (actionType === "command" && resultType === "skill");
+}
+
+function replacementItemMatches(action: ReconcileAction, result: PortableInstallResult): boolean {
+	if (result.itemName === action.item || result.itemName === undefined) return true;
+
+	const parts = result.path.replace(/\\/g, "/").split("/");
+	const leaf = parts.at(-1) ?? "";
+	const parent = parts.at(-2) ?? "";
+	const leafName = leaf.replace(/\.[^.]+$/, "");
+	return (
+		leafName === action.item ||
+		parent === action.item ||
+		(action.type === "command" && parent === `source-command-${action.item}`)
+	);
+}
+
+export function shouldRunDeleteAction(
+	action: ReconcileAction,
+	results: PortableInstallResult[],
+): boolean {
+	if (action.reasonCode !== "path-migrated-cleanup") return true;
+	return hasSuccessfulReplacementWrite(action, results);
+}
+
+function createSkippedPathMigrationCleanupResult(action: ReconcileAction): PortableInstallResult {
+	return {
+		operation: "delete",
+		portableType: action.type,
+		itemName: action.item,
+		provider: action.provider as ProviderType,
+		providerDisplayName: providers[action.provider as ProviderType]?.displayName || action.provider,
+		success: true,
+		path: action.targetPath,
+		skipped: true,
+		skipReason: "Legacy path cleanup skipped because no successful replacement write was recorded",
+	};
 }
 
 /**
@@ -887,15 +1000,20 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			? false
 			: (options.reinstallEmptyDirs ?? true);
 
-		const plan = reconcile({
-			sourceItems: sourceStates,
-			registry,
-			targetStates,
-			providerConfigs,
-			force: options.force,
-			typeDirectoryStates,
-			respectDeletions: !reinstallEmptyDirs,
-		});
+		const plan = appendFallbackSkillActionsToPlan(
+			reconcile({
+				sourceItems: sourceStates,
+				registry,
+				targetStates,
+				providerConfigs,
+				force: options.force,
+				typeDirectoryStates,
+				respectDeletions: !reinstallEmptyDirs,
+			}),
+			effectiveSkills,
+			selectedProviders,
+			installGlobally,
+		);
 
 		reconcileSpinner.stop("Plan computed");
 
@@ -909,16 +1027,7 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 
 		// Dry-run: show plan and exit
 		if (options.dryRun) {
-			displayMigrationSummary(
-				plan,
-				buildDryRunFallbackResults(
-					effectiveSkills,
-					selectedProviders,
-					installGlobally,
-					plan.actions,
-				),
-				{ color: useColor, dryRun: true },
-			);
+			displayMigrationSummary(plan, [], { color: useColor, dryRun: true });
 			return;
 		}
 
@@ -1062,27 +1171,6 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 				const item = hookByName.get(action.item);
 				if (!item || !getProvidersSupporting("hooks").includes(provider)) continue;
 				writeTasks.push({ item, provider, type: "hooks", global: action.global });
-			}
-		}
-
-		// Skills are directory-based and not fully represented in current reconcile source states.
-		// Preserve existing migration behavior until skills become first-class reconcile actions.
-		const plannedSkillActions = plannedExecActions.filter(
-			(action) => action.type === "skill",
-		).length;
-		if (effectiveSkills.length > 0 && plannedSkillActions === 0) {
-			const skillProviders = selectedProviders.filter((pv) =>
-				getProvidersSupporting("skills").includes(pv),
-			);
-			for (const provider of skillProviders) {
-				for (const skill of effectiveSkills) {
-					writeTasks.push({
-						item: skill,
-						provider,
-						type: "skill",
-						global: resolvePortableTypeGlobal(provider, "skill", installGlobally),
-					});
-				}
 			}
 		}
 
@@ -1258,6 +1346,11 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		await processMetadataDeletions(skillSource, installGlobally);
 
 		for (const deleteAction of plannedDeleteActions) {
+			if (!shouldRunDeleteAction(deleteAction, allResults)) {
+				allResults.push(createSkippedPathMigrationCleanupResult(deleteAction));
+				progressSink.tick("Cleanup");
+				continue;
+			}
 			allResults.push(
 				await executeDeleteAction(deleteAction, {
 					preservePaths: writtenPaths,
@@ -1573,39 +1666,4 @@ function progressLabelForType(type: string): string {
 		default:
 			return "Migrating";
 	}
-}
-
-function buildDryRunFallbackResults(
-	skills: SkillInfo[],
-	selectedProviders: ProviderType[],
-	installGlobally: boolean,
-	plannedActions: ReconcileAction[],
-): PortableInstallResult[] {
-	const plannedSkillActions = plannedActions.filter((action) => action.type === "skill").length;
-	if (skills.length === 0 || plannedSkillActions > 0) {
-		return [];
-	}
-
-	const results: PortableInstallResult[] = [];
-	for (const provider of selectedProviders.filter((entry) =>
-		getProvidersSupporting("skills").includes(entry),
-	)) {
-		const basePath = getPortableBasePath(provider, "skills", {
-			global: resolvePortableTypeGlobal(provider, "skill", installGlobally),
-		});
-		if (!basePath) continue;
-		for (const skill of skills) {
-			results.push({
-				itemName: skill.name,
-				operation: "apply",
-				path: join(basePath, skill.name),
-				portableType: "skill",
-				provider,
-				providerDisplayName: providers[provider].displayName,
-				success: true,
-			});
-		}
-	}
-
-	return results;
 }

--- a/src/commands/migrate/skill-directory-installer.ts
+++ b/src/commands/migrate/skill-directory-installer.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
-import { cp, mkdir, realpath, rename, rm } from "node:fs/promises";
+import { cp, mkdir, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { rewriteAntigravityPaths } from "../portable/converters/direct-copy.js";
 import { addPortableInstallation } from "../portable/portable-registry.js";
 import { providers } from "../portable/provider-registry.js";
 import type { PortableInstallResult, ProviderType } from "../portable/types.js";
@@ -28,6 +29,23 @@ async function canonicalize(path: string): Promise<string> {
 		} catch {
 			return resolve(path);
 		}
+	}
+}
+
+async function rewriteInstalledSkillMd(
+	targetDir: string,
+	provider: ProviderType,
+	options: { global: boolean },
+): Promise<void> {
+	if (provider !== "antigravity") return;
+
+	const skillMdPath = join(targetDir, "SKILL.md");
+	if (!existsSync(skillMdPath)) return;
+
+	const content = await readFile(skillMdPath, "utf-8");
+	const rewritten = rewriteAntigravityPaths(content, { global: options.global });
+	if (rewritten !== content) {
+		await writeFile(skillMdPath, rewritten, "utf-8");
 	}
 }
 
@@ -149,6 +167,7 @@ export async function installSkillDirectories(
 				try {
 					await cp(skill.path, targetDir, { recursive: true, force: true });
 					copied = true;
+					await rewriteInstalledSkillMd(targetDir, provider, options);
 
 					await addPortableInstallation(
 						skill.name,

--- a/src/commands/portable/__tests__/md-strip.test.ts
+++ b/src/commands/portable/__tests__/md-strip.test.ts
@@ -641,6 +641,11 @@ describe("convertMdStrip", () => {
 			const droid = convertMdStrip(item, "droid");
 			expect(droid.content).toContain(".factory/commands/release.md");
 			expect(droid.content).toContain("AGENTS.md");
+
+			const antigravity = convertMdStrip(item, "antigravity");
+			expect(antigravity.content).toContain(".agents/workflows/release.md");
+			expect(antigravity.content).toContain(".agents/rules/style.md");
+			expect(antigravity.content).toContain("GEMINI.md");
 		});
 
 		it("should map project-scoped Codex command refs to project skills", () => {

--- a/src/commands/portable/__tests__/md-strip.test.ts
+++ b/src/commands/portable/__tests__/md-strip.test.ts
@@ -626,26 +626,39 @@ describe("convertMdStrip", () => {
 
 		it("should map CLAUDE paths to provider-specific targets", () => {
 			const item = makeItem(
-				"See .claude/commands/release.md and .claude/rules/style.md in CLAUDE.md",
+				"See .claude/agents/reviewer.md, .claude/commands/docs/release.md, and .claude/rules/style.md in CLAUDE.md",
 				"test",
 			);
 
 			const codex = convertMdStrip(item, "codex");
-			expect(codex.content).toContain(".agents/skills/source-command-release/SKILL.md");
+			expect(codex.content).toContain(".agents/skills/source-command-docs-release/SKILL.md");
 			expect(codex.content).toContain("AGENTS.md");
 
 			const opencode = convertMdStrip(item, "opencode");
-			expect(opencode.content).toContain(".opencode/commands/release.md");
+			expect(opencode.content).toContain(".opencode/commands/docs/release.md");
 			expect(opencode.content).toContain("AGENTS.md");
 
 			const droid = convertMdStrip(item, "droid");
-			expect(droid.content).toContain(".factory/commands/release.md");
+			expect(droid.content).toContain(".factory/commands/docs/release.md");
 			expect(droid.content).toContain("AGENTS.md");
 
 			const antigravity = convertMdStrip(item, "antigravity");
-			expect(antigravity.content).toContain(".agents/workflows/release.md");
+			expect(antigravity.content).toContain(".agents/agents.md");
+			expect(antigravity.content).toContain(".agents/workflows/docs-release.md");
 			expect(antigravity.content).toContain(".agents/rules/style.md");
 			expect(antigravity.content).toContain("GEMINI.md");
+		});
+
+		it("should map global Antigravity skill refs without inventing a global agents path", () => {
+			const item = makeItem(
+				"See .claude/agents/reviewer.md and .claude/skills/cook/SKILL.md.",
+				"test",
+			);
+			const result = convertMdStrip(item, "antigravity", { global: true });
+
+			expect(result.content).toContain(".agents/agents.md");
+			expect(result.content).toContain("~/.gemini/config/skills/cook/SKILL.md");
+			expect(result.content).not.toContain("~/.gemini/config/skills/agent-reviewer");
 		});
 
 		it("should map project-scoped Codex command refs to project skills", () => {

--- a/src/commands/portable/__tests__/portable-installer.test.ts
+++ b/src/commands/portable/__tests__/portable-installer.test.ts
@@ -802,6 +802,96 @@ describe("Kiro migration targets", () => {
 	});
 });
 
+describe("Antigravity 2.0 migration targets", () => {
+	beforeEach(() => {
+		addPortableInstallationMock.mockClear();
+		addPortableInstallationMock.mockImplementation(async () => undefined);
+	});
+
+	test("installs agents as skills and commands/rules into .agents namespaces", async () => {
+		const tempDir = await mkdtemp(join(process.cwd(), ".tmp-portable-antigravity-"));
+		const skillsDir = join(tempDir, ".agents", "skills");
+		const workflowsDir = join(tempDir, ".agents", "workflows");
+		const rulesDir = join(tempDir, ".agents", "rules");
+		const agentPathConfig = getPathConfig("antigravity", "agents");
+		const commandPathConfig = getPathConfig("antigravity", "commands");
+		const rulesPathConfig = getPathConfig("antigravity", "rules");
+		const originalAgentPath = agentPathConfig.projectPath;
+		const originalCommandPath = commandPathConfig.projectPath;
+		const originalRulesPath = rulesPathConfig.projectPath;
+
+		try {
+			agentPathConfig.projectPath = skillsDir;
+			commandPathConfig.projectPath = workflowsDir;
+			rulesPathConfig.projectPath = rulesDir;
+
+			const agentResults = await installPortableItems(
+				[
+					makePortableItem({
+						type: "agent",
+						name: "reviewer",
+						frontmatter: { name: "Reviewer", description: "Review code", tools: "Read" },
+						description: "Review code",
+						body: "Use .claude/skills/cook/SKILL.md while reviewing.",
+					}),
+				],
+				["antigravity"],
+				"agent",
+				{ global: false },
+			);
+
+			const commandResults = await installPortableItems(
+				[
+					makePortableItem({
+						type: "command",
+						name: "release",
+						frontmatter: { description: "Prepare release" },
+						body: "Follow .claude/rules/release.md before shipping.",
+					}),
+				],
+				["antigravity"],
+				"command",
+				{ global: false },
+			);
+
+			const ruleResults = await installPortableItems(
+				[
+					makePortableItem({
+						type: "rules",
+						name: "typescript",
+						frontmatter: {},
+						body: "Prefer strict TypeScript and check .claude/commands/release.md.",
+					}),
+				],
+				["antigravity"],
+				"rules",
+				{ global: false },
+			);
+
+			expect(agentResults[0].success).toBe(true);
+			expect(commandResults[0].success).toBe(true);
+			expect(ruleResults[0].success).toBe(true);
+
+			const agentContent = await readFile(join(skillsDir, "reviewer", "SKILL.md"), "utf-8");
+			const commandContent = await readFile(join(workflowsDir, "release.md"), "utf-8");
+			const ruleContent = await readFile(join(rulesDir, "typescript.md"), "utf-8");
+
+			expect(agentContent).toContain("name: Reviewer");
+			expect(agentContent).toContain("# Reviewer");
+			expect(agentContent).toContain(".agents/skills/cook/SKILL.md");
+			expect(commandContent).toContain(".agents/rules/release.md");
+			expect(commandContent).not.toContain(".agent/");
+			expect(ruleContent).toContain(".agents/workflows/release.md");
+			expect(ruleContent).not.toContain(".agent/");
+		} finally {
+			agentPathConfig.projectPath = originalAgentPath;
+			commandPathConfig.projectPath = originalCommandPath;
+			rulesPathConfig.projectPath = originalRulesPath;
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});
+
 describe("cross-kind section preservation (issue #415)", () => {
 	beforeEach(() => {
 		addPortableInstallationMock.mockClear();

--- a/src/commands/portable/__tests__/portable-installer.test.ts
+++ b/src/commands/portable/__tests__/portable-installer.test.ts
@@ -808,9 +808,9 @@ describe("Antigravity 2.0 migration targets", () => {
 		addPortableInstallationMock.mockImplementation(async () => undefined);
 	});
 
-	test("installs agents as skills and commands/rules into .agents namespaces", async () => {
+	test("installs agents into agents.md and commands/rules into .agents namespaces", async () => {
 		const tempDir = await mkdtemp(join(process.cwd(), ".tmp-portable-antigravity-"));
-		const skillsDir = join(tempDir, ".agents", "skills");
+		const agentsFile = join(tempDir, ".agents", "agents.md");
 		const workflowsDir = join(tempDir, ".agents", "workflows");
 		const rulesDir = join(tempDir, ".agents", "rules");
 		const agentPathConfig = getPathConfig("antigravity", "agents");
@@ -821,7 +821,7 @@ describe("Antigravity 2.0 migration targets", () => {
 		const originalRulesPath = rulesPathConfig.projectPath;
 
 		try {
-			agentPathConfig.projectPath = skillsDir;
+			agentPathConfig.projectPath = agentsFile;
 			commandPathConfig.projectPath = workflowsDir;
 			rulesPathConfig.projectPath = rulesDir;
 
@@ -872,12 +872,13 @@ describe("Antigravity 2.0 migration targets", () => {
 			expect(commandResults[0].success).toBe(true);
 			expect(ruleResults[0].success).toBe(true);
 
-			const agentContent = await readFile(join(skillsDir, "reviewer", "SKILL.md"), "utf-8");
+			const agentContent = await readFile(agentsFile, "utf-8");
 			const commandContent = await readFile(join(workflowsDir, "release.md"), "utf-8");
 			const ruleContent = await readFile(join(rulesDir, "typescript.md"), "utf-8");
 
-			expect(agentContent).toContain("name: Reviewer");
-			expect(agentContent).toContain("# Reviewer");
+			expect(agentResults[0].path).toBe(agentsFile);
+			expect(agentContent).toContain("# Agents");
+			expect(agentContent).toContain("## Agent: Reviewer");
 			expect(agentContent).toContain(".agents/skills/cook/SKILL.md");
 			expect(commandContent).toContain(".agents/rules/release.md");
 			expect(commandContent).not.toContain(".agent/");

--- a/src/commands/portable/__tests__/provider-registry.test.ts
+++ b/src/commands/portable/__tests__/provider-registry.test.ts
@@ -209,6 +209,21 @@ describe("provider-registry", () => {
 		});
 	});
 
+	describe("antigravity entries", () => {
+		it("antigravity 2.0 uses .agents workspace paths and ~/.gemini/config skills", () => {
+			expect(providers.antigravity.agents?.projectPath).toBe(".agents/skills");
+			expect(providers.antigravity.agents?.format).toBe("skill-md");
+			expect(providers.antigravity.commands?.projectPath).toBe(".agents/workflows");
+			expect(providers.antigravity.skills?.projectPath).toBe(".agents/skills");
+			expect(providers.antigravity.rules?.projectPath).toBe(".agents/rules");
+
+			const skillsGlobal = providers.antigravity.skills?.globalPath?.replace(/\\/g, "/") ?? "";
+			const agentsGlobal = providers.antigravity.agents?.globalPath?.replace(/\\/g, "/") ?? "";
+			expect(skillsGlobal).toContain(".gemini/config/skills");
+			expect(agentsGlobal).toContain(".gemini/config/skills");
+		});
+	});
+
 	describe("hooks entries", () => {
 		const PROVIDERS_WITH_HOOKS: ProviderType[] = ["claude-code", "droid", "codex", "gemini-cli"];
 
@@ -374,14 +389,16 @@ describe("provider-registry", () => {
 			expect(skillCollisions[0].providers).toContain("amp");
 		});
 
-		it("antigravity uses different path (.agent/skills) — no collision with codex+amp", () => {
+		it("antigravity shares .agents/skills with codex+amp in project scope", () => {
 			const collisions = detectProviderPathCollisions(["codex", "amp", "antigravity"], {
 				global: false,
 			});
 			const skillCollisions = collisions.filter((c) => c.portableType === "skills");
-			// codex+amp collide on .agents/skills, but antigravity uses .agent/skills (no collision)
 			expect(skillCollisions).toHaveLength(1);
-			expect(skillCollisions[0].providers).not.toContain("antigravity");
+			expect(skillCollisions[0].path).toBe(".agents/skills");
+			expect(skillCollisions[0].providers).toContain("codex");
+			expect(skillCollisions[0].providers).toContain("amp");
+			expect(skillCollisions[0].providers).toContain("antigravity");
 		});
 
 		it("returns empty array when no providers collide", () => {

--- a/src/commands/portable/__tests__/provider-registry.test.ts
+++ b/src/commands/portable/__tests__/provider-registry.test.ts
@@ -211,16 +211,16 @@ describe("provider-registry", () => {
 
 	describe("antigravity entries", () => {
 		it("antigravity 2.0 uses .agents workspace paths and ~/.gemini/config skills", () => {
-			expect(providers.antigravity.agents?.projectPath).toBe(".agents/skills");
-			expect(providers.antigravity.agents?.format).toBe("skill-md");
+			expect(providers.antigravity.agents?.projectPath).toBe(".agents/agents.md");
+			expect(providers.antigravity.agents?.globalPath).toBeNull();
+			expect(providers.antigravity.agents?.format).toBe("fm-strip");
+			expect(providers.antigravity.agents?.writeStrategy).toBe("merge-single");
 			expect(providers.antigravity.commands?.projectPath).toBe(".agents/workflows");
 			expect(providers.antigravity.skills?.projectPath).toBe(".agents/skills");
 			expect(providers.antigravity.rules?.projectPath).toBe(".agents/rules");
 
 			const skillsGlobal = providers.antigravity.skills?.globalPath?.replace(/\\/g, "/") ?? "";
-			const agentsGlobal = providers.antigravity.agents?.globalPath?.replace(/\\/g, "/") ?? "";
 			expect(skillsGlobal).toContain(".gemini/config/skills");
-			expect(agentsGlobal).toContain(".gemini/config/skills");
 		});
 	});
 
@@ -389,7 +389,7 @@ describe("provider-registry", () => {
 			expect(skillCollisions[0].providers).toContain("amp");
 		});
 
-		it("antigravity shares .agents/skills with codex+amp in project scope", () => {
+		it("antigravity shares .agents/skills with codex+amp for project skills only", () => {
 			const collisions = detectProviderPathCollisions(["codex", "amp", "antigravity"], {
 				global: false,
 			});

--- a/src/commands/portable/__tests__/reconciler-manifest-integration.test.ts
+++ b/src/commands/portable/__tests__/reconciler-manifest-integration.test.ts
@@ -268,4 +268,112 @@ describe("No manifest fallback", () => {
 		// Should complete without errors
 		expect(plan.summary.delete).toBe(0);
 	});
+
+	test("uses built-in Antigravity 2.0 path migrations without manifest", () => {
+		const installedAt = "2024-01-01T00:00:00.000Z";
+		const registry: PortableRegistryV3 = {
+			version: "3.0",
+			installations: [
+				{
+					item: "project-skill",
+					type: "skill",
+					provider: "antigravity",
+					global: false,
+					path: ".agent/skills/project-skill",
+					installedAt,
+					sourcePath: "skills/project-skill/SKILL.md",
+					sourceChecksum: "abc",
+					targetChecksum: "def",
+					installSource: "kit",
+				},
+				{
+					item: "reviewer",
+					type: "agent",
+					provider: "antigravity",
+					global: false,
+					path: ".agent/skills/reviewer/SKILL.md",
+					installedAt,
+					sourcePath: "agents/reviewer.md",
+					sourceChecksum: "abc",
+					targetChecksum: "def",
+					installSource: "kit",
+				},
+				{
+					item: "global-skill",
+					type: "skill",
+					provider: "antigravity",
+					global: true,
+					path: "/home/user/.gemini/antigravity/skills/global-skill",
+					installedAt,
+					sourcePath: "skills/global-skill/SKILL.md",
+					sourceChecksum: "abc",
+					targetChecksum: "def",
+					installSource: "kit",
+				},
+				{
+					item: "release",
+					type: "command",
+					provider: "antigravity",
+					global: false,
+					path: ".agent/workflows/release.md",
+					installedAt,
+					sourcePath: "commands/release.md",
+					sourceChecksum: "abc",
+					targetChecksum: "def",
+					installSource: "kit",
+				},
+				{
+					item: "style",
+					type: "rules",
+					provider: "antigravity",
+					global: false,
+					path: ".agent/rules/style.md",
+					installedAt,
+					sourcePath: "rules/style.md",
+					sourceChecksum: "abc",
+					targetChecksum: "def",
+					installSource: "kit",
+				},
+				{
+					item: "new-path",
+					type: "skill",
+					provider: "antigravity",
+					global: false,
+					path: ".agents/skills/new-path",
+					installedAt,
+					sourcePath: "skills/new-path/SKILL.md",
+					sourceChecksum: "abc",
+					targetChecksum: "def",
+					installSource: "kit",
+				},
+			],
+		};
+
+		const input: ReconcileInput = {
+			sourceItems: [],
+			registry,
+			targetStates: new Map(),
+			manifest: null,
+			providerConfigs: [],
+		};
+
+		const plan = reconcile(input);
+		const migrationDeletes = plan.actions.filter(
+			(action) =>
+				action.action === "delete" &&
+				action.provider === "antigravity" &&
+				action.reasonCode === "path-migrated-cleanup",
+		);
+
+		expect(migrationDeletes.map((action) => action.targetPath).sort()).toEqual([
+			".agent/rules/style.md",
+			".agent/skills/project-skill",
+			".agent/skills/reviewer/SKILL.md",
+			".agent/workflows/release.md",
+			"/home/user/.gemini/antigravity/skills/global-skill",
+		]);
+		expect(migrationDeletes.some((action) => action.targetPath.includes(".agents/skills"))).toBe(
+			false,
+		);
+	});
 });

--- a/src/commands/portable/__tests__/reconciler-manifest-integration.test.ts
+++ b/src/commands/portable/__tests__/reconciler-manifest-integration.test.ts
@@ -346,6 +346,18 @@ describe("No manifest fallback", () => {
 					targetChecksum: "def",
 					installSource: "kit",
 				},
+				{
+					item: "manual-antigravity-skill",
+					type: "skill",
+					provider: "antigravity",
+					global: false,
+					path: ".agent/skills/manual-antigravity-skill",
+					installedAt,
+					sourcePath: "manual",
+					sourceChecksum: "abc",
+					targetChecksum: "def",
+					installSource: "manual",
+				},
 			],
 		};
 
@@ -372,6 +384,9 @@ describe("No manifest fallback", () => {
 			".agent/workflows/release.md",
 			"/home/user/.gemini/antigravity/skills/global-skill",
 		]);
+		expect(migrationDeletes.some((action) => action.item === "manual-antigravity-skill")).toBe(
+			false,
+		);
 		expect(migrationDeletes.some((action) => action.targetPath.includes(".agents/skills"))).toBe(
 			false,
 		);

--- a/src/commands/portable/converters/direct-copy.ts
+++ b/src/commands/portable/converters/direct-copy.ts
@@ -37,19 +37,50 @@ function rewriteKiroPaths(content: string): string {
 		.replace(/\.claude\/hooks\//g, "Claude Code hooks/");
 }
 
-export function rewriteAntigravityPaths(content: string): string {
+function splitTrailingPunctuation(pathSuffix: string): { itemPath: string; punctuation: string } {
+	const match = pathSuffix.match(/^(.+?)([.,;:!?]+)?$/);
+	return {
+		itemPath: match?.[1] ?? pathSuffix,
+		punctuation: match?.[2] ?? "",
+	};
+}
+
+export function rewriteAntigravityCommandRefSuffix(suffix: string): string {
+	const { itemPath, punctuation } = splitTrailingPunctuation(suffix);
+	const extIdx = itemPath.lastIndexOf(".");
+	const ext = extIdx >= 0 ? itemPath.substring(extIdx) : "";
+	const nameWithoutExt = extIdx >= 0 ? itemPath.substring(0, extIdx) : itemPath;
+	return `${nameWithoutExt.replace(/[\\/]+/g, "-")}${ext}${punctuation}`;
+}
+
+export function rewriteAntigravityPaths(
+	content: string,
+	options: { global?: boolean } = {},
+): string {
+	const skillsBase = options.global ? "~/.gemini/config/skills/" : ".agents/skills/";
 	return content
-		.replace(/\.claude\/skills\//g, ".agents/skills/")
-		.replace(/\.claude\/agents\//g, ".agents/skills/")
+		.replace(/\.claude\/agents\/([a-zA-Z0-9_./-]+)/g, (_matched, suffix: string) => {
+			const { punctuation } = splitTrailingPunctuation(suffix);
+			return `.agents/agents.md${punctuation}`;
+		})
+		.replace(/\.claude\/commands\/([a-zA-Z0-9_./-]+)/g, (_matched, suffix: string) => {
+			return `.agents/workflows/${rewriteAntigravityCommandRefSuffix(suffix)}`;
+		})
+		.replace(/\.claude\/skills\//g, skillsBase)
 		.replace(/\.claude\/rules\//g, ".agents/rules/")
+		.replace(/\.claude\/agents\//g, ".agents/agents.md")
 		.replace(/\.claude\/commands\//g, ".agents/workflows/")
-		.replace(/\.claude\/hooks\//g, ".agents/hooks/");
+		.replace(/\.claude\/hooks\//g, "Claude Code hooks/");
 }
 
 /**
  * Return the file content, replacing .claude/ paths for non-Claude providers.
  */
-export function convertDirectCopy(item: PortableItem, provider?: ProviderType): ConversionResult {
+export function convertDirectCopy(
+	item: PortableItem,
+	provider?: ProviderType,
+	options: { global?: boolean } = {},
+): ConversionResult {
 	// Preserve source content byte-for-byte when available.
 	// This avoids gray-matter re-parsing malformed legacy frontmatter.
 	let content: string;
@@ -70,7 +101,7 @@ export function convertDirectCopy(item: PortableItem, provider?: ProviderType): 
 		if (provider === "kiro") {
 			content = rewriteKiroPaths(content);
 		} else if (provider === "antigravity") {
-			content = rewriteAntigravityPaths(content);
+			content = rewriteAntigravityPaths(content, options);
 		} else {
 			const targetDir = PROVIDER_CONFIG_DIR[provider];
 			if (targetDir) {

--- a/src/commands/portable/converters/direct-copy.ts
+++ b/src/commands/portable/converters/direct-copy.ts
@@ -16,7 +16,6 @@ const PROVIDER_CONFIG_DIR: Partial<Record<ProviderType, string>> = {
 	opencode: ".opencode/",
 	droid: ".factory/",
 	windsurf: ".windsurf/",
-	antigravity: ".agent/",
 	cursor: ".cursor/",
 	roo: ".roo/",
 	kilo: ".kilocode/",
@@ -36,6 +35,15 @@ function rewriteKiroPaths(content: string): string {
 		.replace(/\.claude\/rules\//g, ".kiro/steering/")
 		.replace(/\.claude\/commands\//g, "Claude Code commands/")
 		.replace(/\.claude\/hooks\//g, "Claude Code hooks/");
+}
+
+export function rewriteAntigravityPaths(content: string): string {
+	return content
+		.replace(/\.claude\/skills\//g, ".agents/skills/")
+		.replace(/\.claude\/agents\//g, ".agents/skills/")
+		.replace(/\.claude\/rules\//g, ".agents/rules/")
+		.replace(/\.claude\/commands\//g, ".agents/workflows/")
+		.replace(/\.claude\/hooks\//g, ".agents/hooks/");
 }
 
 /**
@@ -61,6 +69,8 @@ export function convertDirectCopy(item: PortableItem, provider?: ProviderType): 
 	if (provider && provider !== "claude-code") {
 		if (provider === "kiro") {
 			content = rewriteKiroPaths(content);
+		} else if (provider === "antigravity") {
+			content = rewriteAntigravityPaths(content);
 		} else {
 			const targetDir = PROVIDER_CONFIG_DIR[provider];
 			if (targetDir) {

--- a/src/commands/portable/converters/fm-strip.ts
+++ b/src/commands/portable/converters/fm-strip.ts
@@ -11,7 +11,7 @@ import type { ConversionResult, PortableItem, ProviderType } from "../types.js";
 import { stripClaudeRefs } from "./md-strip.js";
 
 /** Providers whose agent body should be rewritten via stripClaudeRefs */
-const PROVIDERS_WITH_BODY_REWRITING: ProviderType[] = ["gemini-cli"];
+const PROVIDERS_WITH_BODY_REWRITING: ProviderType[] = ["gemini-cli", "antigravity"];
 
 /**
  * Strip frontmatter and return body as plain markdown.
@@ -23,7 +23,7 @@ export function convertFmStrip(item: PortableItem, provider: ProviderType): Conv
 	const heading = item.frontmatter.name || item.name;
 
 	// Determine if this provider merges into a single file
-	const isMergeProvider = ["goose", "gemini-cli", "amp"].includes(provider);
+	const isMergeProvider = ["goose", "gemini-cli", "amp", "antigravity"].includes(provider);
 
 	// Rewrite body for providers that need Claude-specific refs stripped
 	let body = item.body;

--- a/src/commands/portable/converters/index.ts
+++ b/src/commands/portable/converters/index.ts
@@ -31,7 +31,7 @@ export function convertItem(
 	try {
 		switch (format) {
 			case "direct-copy":
-				return convertDirectCopy(item, provider);
+				return convertDirectCopy(item, provider, { global: options.global });
 			case "command-to-codex-skill":
 				return convertCommandToCodexSkill(item);
 			case "fm-to-fm":
@@ -45,7 +45,7 @@ export function convertItem(
 			case "md-to-toml":
 				return convertMdToToml(item);
 			case "skill-md":
-				return convertToSkillMd(item, provider);
+				return convertToSkillMd(item, provider, { global: options.global });
 			case "md-strip":
 				return convertMdStrip(item, provider, { global: options.global });
 			case "md-to-mdc":

--- a/src/commands/portable/converters/index.ts
+++ b/src/commands/portable/converters/index.ts
@@ -45,7 +45,7 @@ export function convertItem(
 			case "md-to-toml":
 				return convertMdToToml(item);
 			case "skill-md":
-				return convertToSkillMd(item);
+				return convertToSkillMd(item, provider);
 			case "md-strip":
 				return convertMdStrip(item, provider, { global: options.global });
 			case "md-to-mdc":

--- a/src/commands/portable/converters/md-strip.ts
+++ b/src/commands/portable/converters/md-strip.ts
@@ -6,6 +6,7 @@ import { homedir } from "node:os";
 import { providers } from "../provider-registry.js";
 import type { ConversionResult, PortableItem, ProviderType } from "../types.js";
 import { getCodexCommandSkillFilenameFromCommandPath } from "./codex-command-skill-path.js";
+import { rewriteAntigravityCommandRefSuffix } from "./direct-copy.js";
 
 /** Maximum content size for regex processing (500KB) */
 const MAX_CONTENT_SIZE = 512_000;
@@ -64,7 +65,9 @@ function getProviderPathTarget(
 		rewriteSuffix:
 			provider === "codex" && type === "commands"
 				? getCodexCommandSkillFilenameFromCommandPath
-				: undefined,
+				: provider === "antigravity" && type === "commands"
+					? rewriteAntigravityCommandRefSuffix
+					: undefined,
 	};
 }
 

--- a/src/commands/portable/converters/skill-md.ts
+++ b/src/commands/portable/converters/skill-md.ts
@@ -13,13 +13,18 @@ import { rewriteAntigravityPaths } from "./direct-copy.js";
 /**
  * Convert a Claude Code agent or command to OpenHands SKILL.md format
  */
-export function convertToSkillMd(item: PortableItem, provider?: ProviderType): ConversionResult {
+export function convertToSkillMd(
+	item: PortableItem,
+	provider?: ProviderType,
+	options: { global?: boolean } = {},
+): ConversionResult {
 	const fm: Record<string, unknown> = {
 		name: item.frontmatter.name || item.name,
 		description: item.description || "",
 	};
 
-	const itemBody = provider === "antigravity" ? rewriteAntigravityPaths(item.body) : item.body;
+	const itemBody =
+		provider === "antigravity" ? rewriteAntigravityPaths(item.body, options) : item.body;
 	const body = `# ${fm.name}\n\n${itemBody}`;
 	const content = matter.stringify(body, fm);
 

--- a/src/commands/portable/converters/skill-md.ts
+++ b/src/commands/portable/converters/skill-md.ts
@@ -7,18 +7,20 @@
  * - They use triggers for auto-injection
  */
 import matter from "gray-matter";
-import type { ConversionResult, PortableItem } from "../types.js";
+import type { ConversionResult, PortableItem, ProviderType } from "../types.js";
+import { rewriteAntigravityPaths } from "./direct-copy.js";
 
 /**
  * Convert a Claude Code agent or command to OpenHands SKILL.md format
  */
-export function convertToSkillMd(item: PortableItem): ConversionResult {
+export function convertToSkillMd(item: PortableItem, provider?: ProviderType): ConversionResult {
 	const fm: Record<string, unknown> = {
 		name: item.frontmatter.name || item.name,
 		description: item.description || "",
 	};
 
-	const body = `# ${fm.name}\n\n${item.body}`;
+	const itemBody = provider === "antigravity" ? rewriteAntigravityPaths(item.body) : item.body;
+	const body = `# ${fm.name}\n\n${itemBody}`;
 	const content = matter.stringify(body, fm);
 
 	// OpenHands uses directory structure: .openhands/skills/<name>/SKILL.md

--- a/src/commands/portable/provider-registry.ts
+++ b/src/commands/portable/provider-registry.ts
@@ -760,13 +760,11 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 		name: "antigravity",
 		displayName: "Antigravity",
 		subagents: "full",
-		// Antigravity 2.0 does not document a static custom-agent file directory.
-		// Preserve Claude agents as Antigravity skills so they are visible in the app.
 		agents: {
-			projectPath: ".agents/skills",
-			globalPath: join(home, ".gemini/config/skills"),
-			format: "skill-md",
-			writeStrategy: "per-file",
+			projectPath: ".agents/agents.md",
+			globalPath: null, // No verified global agents.md path; project-level .agents/agents.md is documented
+			format: "fm-strip",
+			writeStrategy: "merge-single",
 			fileExtension: ".md",
 		},
 		commands: {
@@ -809,6 +807,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			hasBinaryInPath("antigravity") ||
 			hasAnyInstallSignal([
 				join(cwd, ".agents/rules"),
+				join(cwd, ".agents/agents.md"),
 				join(cwd, ".agents/skills"),
 				join(cwd, ".agents/workflows"),
 				join(cwd, ".agents/plugins"),
@@ -818,6 +817,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 				join(cwd, "GEMINI.md"),
 				join(home, ".gemini/config"),
 				join(home, ".gemini/config/skills"),
+				join(home, ".gemini/config/plugins"),
 				join(home, ".gemini/antigravity"), // Global antigravity config dir
 				join(home, ".gemini/antigravity/skills"),
 			]),

--- a/src/commands/portable/provider-registry.ts
+++ b/src/commands/portable/provider-registry.ts
@@ -760,22 +760,28 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 		name: "antigravity",
 		displayName: "Antigravity",
 		subagents: "full",
-		// Antigravity has no separate "agents" concept — agents ARE skills (SKILL.md format).
-		// Claude Code agents are migrated to .agent/skills/ alongside native Antigravity skills.
-		agents: null,
+		// Antigravity 2.0 does not document a static custom-agent file directory.
+		// Preserve Claude agents as Antigravity skills so they are visible in the app.
+		agents: {
+			projectPath: ".agents/skills",
+			globalPath: join(home, ".gemini/config/skills"),
+			format: "skill-md",
+			writeStrategy: "per-file",
+			fileExtension: ".md",
+		},
 		commands: {
-			projectPath: ".agent/workflows",
+			projectPath: ".agents/workflows",
 			globalPath: null, // No verified global workflows path; only project-level confirmed
 			format: "direct-copy",
 			writeStrategy: "per-file",
 			fileExtension: ".md",
-			nestedCommands: false, // Verified: Antigravity workflows are flat single-level files
+			nestedCommands: false, // Antigravity workflows are slash-command style markdown files
 		},
 		skills: {
 			// Skills use <name>/SKILL.md directory format; installSkillDirectories() copies whole dirs
-			// Global: ~/.gemini/antigravity/skills/ (confirmed: Codelabs docs)
-			projectPath: ".agent/skills",
-			globalPath: join(home, ".gemini/antigravity/skills"),
+			// Antigravity 2.0 defaults to .agents/skills and ~/.gemini/config/skills.
+			projectPath: ".agents/skills",
+			globalPath: join(home, ".gemini/config/skills"),
 			format: "direct-copy",
 			writeStrategy: "per-file",
 			fileExtension: ".md",
@@ -790,7 +796,7 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			fileExtension: ".md",
 		},
 		rules: {
-			projectPath: ".agent/rules",
+			projectPath: ".agents/rules",
 			globalPath: null, // No verified global rules path separate from ~/.gemini/GEMINI.md
 			format: "md-strip",
 			writeStrategy: "per-file",
@@ -802,10 +808,16 @@ export const providers: Record<ProviderType, ProviderConfig> = {
 			hasBinaryInPath("agy") ||
 			hasBinaryInPath("antigravity") ||
 			hasAnyInstallSignal([
+				join(cwd, ".agents/rules"),
+				join(cwd, ".agents/skills"),
+				join(cwd, ".agents/workflows"),
+				join(cwd, ".agents/plugins"),
 				join(cwd, ".agent/rules"),
 				join(cwd, ".agent/skills"),
 				join(cwd, ".agent/workflows"),
 				join(cwd, "GEMINI.md"),
+				join(home, ".gemini/config"),
+				join(home, ".gemini/config/skills"),
 				join(home, ".gemini/antigravity"), // Global antigravity config dir
 				join(home, ".gemini/antigravity/skills"),
 			]),
@@ -999,8 +1011,8 @@ export interface ProviderPathCollision {
  * Detect path collisions across selected providers — identifies when multiple
  * providers map to the same target directory for the same portable type and scope.
  *
- * Critical for .agent/ vs .agents/ disambiguation (e.g., codex+amp both target
- * .agents/skills while antigravity targets .agent/skills).
+ * Critical for near-identical provider namespaces and shared targets (e.g.,
+ * codex+amp+antigravity project skills all target .agents/skills).
  */
 export function detectProviderPathCollisions(
 	selectedProviders: ProviderType[],

--- a/src/commands/portable/reconciler.ts
+++ b/src/commands/portable/reconciler.ts
@@ -33,6 +33,36 @@ const BUILT_IN_PROVIDER_PATH_MIGRATIONS = [
 		from: ".codex/prompts",
 		to: ".agents/skills",
 	},
+	{
+		provider: "antigravity",
+		type: "command",
+		from: ".agent/workflows",
+		to: ".agents/workflows",
+	},
+	{
+		provider: "antigravity",
+		type: "skill",
+		from: ".agent/skills",
+		to: ".agents/skills",
+	},
+	{
+		provider: "antigravity",
+		type: "agent",
+		from: ".agent/skills",
+		to: ".agents/skills",
+	},
+	{
+		provider: "antigravity",
+		type: "skill",
+		from: ".gemini/antigravity/skills",
+		to: ".gemini/config/skills",
+	},
+	{
+		provider: "antigravity",
+		type: "rules",
+		from: ".agent/rules",
+		to: ".agents/rules",
+	},
 ] as const;
 
 function normalizePortablePath(value: string): string {

--- a/src/commands/portable/reconciler.ts
+++ b/src/commands/portable/reconciler.ts
@@ -49,7 +49,7 @@ const BUILT_IN_PROVIDER_PATH_MIGRATIONS = [
 		provider: "antigravity",
 		type: "agent",
 		from: ".agent/skills",
-		to: ".agents/skills",
+		to: ".agents/agents.md",
 	},
 	{
 		provider: "antigravity",
@@ -953,6 +953,7 @@ function detectPathMigrations(input: ReconcileInput): Array<{ deleteAction: Reco
 			(e) =>
 				e.provider === migration.provider &&
 				e.type === migration.type &&
+				e.installSource !== "manual" &&
 				pathContainsSegments(e.path, migration.from) &&
 				providerConfigIsActiveForEntry(activeProviderConfigs, e, { emptyMeansAll: true }),
 		);

--- a/src/commands/skills/__tests__/agents.test.ts
+++ b/src/commands/skills/__tests__/agents.test.ts
@@ -68,6 +68,13 @@ describe("agents", () => {
 			expect(kiro.projectPath).toBe(".kiro/skills");
 			expect(kiro.globalPath).toBe(join(home, ".kiro/skills"));
 		});
+
+		it("should have antigravity agent with Antigravity 2.0 skill paths", () => {
+			const antigravity = agents.antigravity;
+			expect(antigravity.displayName).toBe("Antigravity");
+			expect(antigravity.projectPath).toBe(".agents/skills");
+			expect(antigravity.globalPath).toBe(join(home, ".gemini/config/skills"));
+		});
 	});
 
 	describe("detectInstalledAgents", () => {
@@ -130,6 +137,15 @@ describe("agents", () => {
 			);
 			expect(getInstallPath("my-skill", "kiro", { global: true })).toBe(
 				join(home, ".kiro/skills/my-skill"),
+			);
+		});
+
+		it("should return Antigravity 2.0 workspace and global skill paths", () => {
+			expect(getInstallPath("my-skill", "antigravity", { global: false })).toBe(
+				join(".agents/skills", "my-skill"),
+			);
+			expect(getInstallPath("my-skill", "antigravity", { global: true })).toBe(
+				join(home, ".gemini/config/skills/my-skill"),
 			);
 		});
 

--- a/src/commands/skills/__tests__/skills-installer.test.ts
+++ b/src/commands/skills/__tests__/skills-installer.test.ts
@@ -190,6 +190,22 @@ description: OpenCode native Claude-compatible skill
 			}
 		});
 
+		it("should install skill to Antigravity 2.0 global skills directory", async () => {
+			const antigravitySkillPath = join(home, ".gemini/config/skills/installer-test-skill");
+			rmSync(antigravitySkillPath, { recursive: true, force: true });
+
+			try {
+				const result = await installSkillForAgent(testSkill, "antigravity", { global: true });
+
+				expect(result.success).toBe(true);
+				expect(result.agent).toBe("antigravity");
+				expect(result.path).toBe(antigravitySkillPath);
+				expect(existsSync(join(antigravitySkillPath, "SKILL.md"))).toBe(true);
+			} finally {
+				rmSync(antigravitySkillPath, { recursive: true, force: true });
+			}
+		});
+
 		it("should return error for file at target path", async () => {
 			// Create a file where directory should be
 			const blockingPath = join(installBase, "blocking-skill");

--- a/src/commands/skills/__tests__/skills-installer.test.ts
+++ b/src/commands/skills/__tests__/skills-installer.test.ts
@@ -2,7 +2,7 @@
  * Tests for skill installer
  */
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import {
@@ -202,6 +202,77 @@ description: OpenCode native Claude-compatible skill
 				expect(result.path).toBe(antigravitySkillPath);
 				expect(existsSync(join(antigravitySkillPath, "SKILL.md"))).toBe(true);
 			} finally {
+				rmSync(antigravitySkillPath, { recursive: true, force: true });
+			}
+		});
+
+		it("should rewrite Antigravity skill markdown references to 2.0 paths", async () => {
+			const sourcePath = join(testDir, "antigravity-ref-skill");
+			const targetPath = join(".agents/skills", "antigravity-ref-skill");
+			rmSync(sourcePath, { recursive: true, force: true });
+			rmSync(targetPath, { recursive: true, force: true });
+			mkdirSync(sourcePath, { recursive: true });
+			writeFileSync(
+				join(sourcePath, "SKILL.md"),
+				[
+					"---",
+					"name: antigravity-ref-skill",
+					"description: References Claude paths",
+					"---",
+					"",
+					"Use .claude/skills/cook/SKILL.md.",
+					"Ask .claude/agents/reviewer.md.",
+					"Run .claude/commands/docs/release.md.",
+					"Follow .claude/rules/style.md.",
+					"Check .claude/hooks/session-start.cjs.",
+				].join("\n"),
+			);
+			writeFileSync(join(sourcePath, "helper.js"), ".claude/agents/reviewer.md");
+
+			try {
+				const result = await installSkillForAgent(
+					{
+						name: "antigravity-ref-skill",
+						description: "References Claude paths",
+						path: sourcePath,
+					},
+					"antigravity",
+					{ global: false },
+				);
+
+				expect(result.success).toBe(true);
+				const content = readFileSync(join(targetPath, "SKILL.md"), "utf-8");
+				const helper = readFileSync(join(targetPath, "helper.js"), "utf-8");
+				expect(content).toContain(".agents/skills/cook/SKILL.md");
+				expect(content).toContain(".agents/agents.md");
+				expect(content).toContain(".agents/workflows/docs-release.md");
+				expect(content).toContain(".agents/rules/style.md");
+				expect(content).toContain("Claude Code hooks/session-start.cjs");
+				expect(content).not.toContain(".claude/");
+				expect(helper).toBe(".claude/agents/reviewer.md");
+			} finally {
+				rmSync(sourcePath, { recursive: true, force: true });
+				rmSync(targetPath, { recursive: true, force: true });
+			}
+		});
+
+		it("should remove Antigravity 1.x project skill path when installing to 2.0 path", async () => {
+			const legacyPath = join(".agent/skills", testSkill.name);
+			const antigravitySkillPath = join(".agents/skills", testSkill.name);
+			rmSync(legacyPath, { recursive: true, force: true });
+			rmSync(antigravitySkillPath, { recursive: true, force: true });
+			mkdirSync(legacyPath, { recursive: true });
+			writeFileSync(join(legacyPath, "SKILL.md"), "# Legacy Antigravity skill");
+
+			try {
+				const result = await installSkillForAgent(testSkill, "antigravity", { global: false });
+
+				expect(result.success).toBe(true);
+				expect(result.path).toBe(antigravitySkillPath);
+				expect(existsSync(join(antigravitySkillPath, "SKILL.md"))).toBe(true);
+				expect(existsSync(legacyPath)).toBe(false);
+			} finally {
+				rmSync(legacyPath, { recursive: true, force: true });
 				rmSync(antigravitySkillPath, { recursive: true, force: true });
 			}
 		});

--- a/src/commands/skills/__tests__/skills-registry.test.ts
+++ b/src/commands/skills/__tests__/skills-registry.test.ts
@@ -93,6 +93,39 @@ describe("skill-registry", () => {
 			expect(registry.version).toBe("1.0");
 			expect(registry.installations).toEqual([]);
 		});
+
+		it("should migrate Antigravity 1.x skill registry paths to Antigravity 2.0 paths", async () => {
+			await writeRegistry({
+				version: "1.0",
+				installations: [
+					{
+						skill: "project-antigravity",
+						agent: "antigravity",
+						global: false,
+						path: join(".agent/skills", "project-antigravity"),
+						installedAt: new Date().toISOString(),
+						sourcePath: "/src/project-antigravity",
+					},
+					{
+						skill: "global-antigravity",
+						agent: "antigravity",
+						global: true,
+						path: join(home, ".gemini/antigravity/skills/global-antigravity"),
+						installedAt: new Date().toISOString(),
+						sourcePath: "/src/global-antigravity",
+					},
+				],
+			});
+
+			const registry = await readRegistry();
+			const project = registry.installations.find((i) => i.skill === "project-antigravity");
+			const global = registry.installations.find((i) => i.skill === "global-antigravity");
+
+			expect(project?.path.replace(/\\/g, "/")).toBe(".agents/skills/project-antigravity");
+			expect(global?.path.replace(/\\/g, "/")).toContain(
+				".gemini/config/skills/global-antigravity",
+			);
+		});
 	});
 
 	describe("writeRegistry", () => {

--- a/src/commands/skills/agents.ts
+++ b/src/commands/skills/agents.ts
@@ -100,10 +100,19 @@ export const agents: Record<AgentType, AgentConfig> = {
 	antigravity: {
 		name: "antigravity",
 		displayName: "Antigravity",
-		projectPath: ".agent/skills",
-		globalPath: join(home, ".gemini/antigravity/skills"),
+		projectPath: ".agents/skills",
+		globalPath: join(home, ".gemini/config/skills"),
 		detect: async () =>
-			existsSync(join(process.cwd(), ".agent")) || existsSync(join(home, ".gemini/antigravity")),
+			hasAnyInstallSignal([
+				join(process.cwd(), ".agents/skills"),
+				join(process.cwd(), ".agents/rules"),
+				join(process.cwd(), ".agents/plugins"),
+				join(process.cwd(), ".agent/skills"),
+				join(process.cwd(), ".agent/rules"),
+				join(home, ".gemini/config/skills"),
+				join(home, ".gemini/config/plugins"),
+				join(home, ".gemini/antigravity/skills"),
+			]),
 	},
 	"github-copilot": {
 		name: "github-copilot",

--- a/src/commands/skills/skills-installer.ts
+++ b/src/commands/skills/skills-installer.ts
@@ -16,6 +16,10 @@ const LEGACY_SKILL_PATHS: Partial<Record<AgentType, { project: string; global: s
 		project: ".gemini/skills",
 		global: join(homedir(), ".gemini/skills"),
 	},
+	antigravity: {
+		project: ".agent/skills",
+		global: join(homedir(), ".gemini/antigravity/skills"),
+	},
 };
 
 /**

--- a/src/commands/skills/skills-installer.ts
+++ b/src/commands/skills/skills-installer.ts
@@ -2,9 +2,10 @@ import { existsSync } from "node:fs";
 /**
  * Skill installer - copies skills to target agent directories
  */
-import { cp, mkdir, rm, stat } from "node:fs/promises";
+import { cp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { rewriteAntigravityPaths } from "../portable/converters/direct-copy.js";
 import { agents, getInstallPath, isSkillInstalled } from "./agents.js";
 import { addInstallation, readRegistry, writeRegistry } from "./skills-registry.js";
 import type { AgentType, InstallResult, SkillInfo } from "./types.js";
@@ -93,6 +94,23 @@ async function cleanupLegacySkillPath(
 	}
 }
 
+async function rewriteInstalledSkillMd(
+	targetPath: string,
+	agent: AgentType,
+	options: { global: boolean },
+): Promise<void> {
+	if (agent !== "antigravity") return;
+
+	const skillMdPath = join(targetPath, "SKILL.md");
+	if (!existsSync(skillMdPath)) return;
+
+	const content = await readFile(skillMdPath, "utf-8");
+	const rewritten = rewriteAntigravityPaths(content, { global: options.global });
+	if (rewritten !== content) {
+		await writeFile(skillMdPath, rewritten, "utf-8");
+	}
+}
+
 /**
  * Install a skill to a specific agent
  */
@@ -151,6 +169,7 @@ export async function installSkillForAgent(
 			recursive: true,
 			force: true, // Overwrite if exists
 		});
+		await rewriteInstalledSkillMd(targetPath, agent, options);
 
 		// Register installation in central registry
 		await addInstallation(skill.name, agent, options.global, targetPath, skill.path);

--- a/src/commands/skills/skills-registry.ts
+++ b/src/commands/skills/skills-registry.ts
@@ -5,7 +5,7 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join, sep } from "node:path";
+import { dirname, join } from "node:path";
 import { z } from "zod";
 import type { AgentType } from "./types.js";
 
@@ -55,18 +55,53 @@ function getCliVersion(): string {
 
 /** Legacy path segments to migrate in registry entries (old -> new)
  * Keep in sync with LEGACY_SKILL_PATHS in skills-installer.ts */
-const REGISTRY_PATH_MIGRATIONS: Array<{ agent: string; oldSegment: string; newSegment: string }> = [
+const REGISTRY_PATH_MIGRATIONS: Array<{ agent: string; oldPath: string; newPath: string }> = [
 	{
 		agent: "gemini-cli",
-		oldSegment: `${sep}.gemini${sep}skills${sep}`,
-		newSegment: `${sep}.agents${sep}skills${sep}`,
+		oldPath: ".gemini/skills",
+		newPath: ".agents/skills",
 	},
 	{
-		agent: "gemini-cli",
-		oldSegment: `${sep}.gemini${sep}skills`,
-		newSegment: `${sep}.agents${sep}skills`,
+		agent: "antigravity",
+		oldPath: ".agent/skills",
+		newPath: ".agents/skills",
+	},
+	{
+		agent: "antigravity",
+		oldPath: ".gemini/antigravity/skills",
+		newPath: ".gemini/config/skills",
 	},
 ];
+
+function migratePathBySegments(pathValue: string, oldPath: string, newPath: string): string | null {
+	const usesBackslash = pathValue.includes("\\") && !pathValue.includes("/");
+	const separator = usesBackslash ? "\\" : "/";
+	const normalized = pathValue.replace(/\\/g, "/");
+	const oldSegments = oldPath.split("/").filter(Boolean);
+	const newSegments = newPath.split("/").filter(Boolean);
+	const segments = normalized.split("/").filter((segment, index) => index > 0 || segment !== "");
+
+	for (let i = 0; i <= segments.length - oldSegments.length; i++) {
+		let matches = true;
+		for (let j = 0; j < oldSegments.length; j++) {
+			if (segments[i + j] !== oldSegments[j]) {
+				matches = false;
+				break;
+			}
+		}
+		if (!matches) continue;
+
+		const migratedSegments = [
+			...segments.slice(0, i),
+			...newSegments,
+			...segments.slice(i + oldSegments.length),
+		];
+		const prefix = normalized.startsWith("/") ? separator : "";
+		return `${prefix}${migratedSegments.join(separator)}`;
+	}
+
+	return null;
+}
 
 /**
  * Migrate legacy paths in registry entries (e.g., .gemini/skills -> .agents/skills)
@@ -76,8 +111,12 @@ function migrateRegistryPaths(registry: SkillRegistry): boolean {
 	let changed = false;
 	for (const entry of registry.installations) {
 		for (const migration of REGISTRY_PATH_MIGRATIONS) {
-			if (entry.agent === migration.agent && entry.path.includes(migration.oldSegment)) {
-				entry.path = entry.path.replace(migration.oldSegment, migration.newSegment);
+			const migratedPath =
+				entry.agent === migration.agent
+					? migratePathBySegments(entry.path, migration.oldPath, migration.newPath)
+					: null;
+			if (migratedPath) {
+				entry.path = migratedPath;
 				changed = true;
 				break; // Only apply first matching migration per entry
 			}

--- a/src/domains/help/commands/migrate-command-help.ts
+++ b/src/domains/help/commands/migrate-command-help.ts
@@ -148,6 +148,7 @@ export const migrateCommandHelp: CommandHelp = {
 				"  --respect-deletions disables the auto-reinstall heuristic for empty directories",
 				"  --force overrides skip decisions per item; --reinstall-empty-dirs is a per-directory heuristic",
 				"  Codex commands migrate as skills: project scope writes .agents/skills, global scope writes ~/.agents/skills",
+				"  Antigravity 2.0 agents migrate to .agents/agents.md; skills remain .agents/skills/<name>/SKILL.md",
 				"  Kiro agents migrate as custom subagents; rules/config migrate as steering files; skills copy to .kiro/skills; commands/hooks are skipped",
 			].join("\n"),
 		},

--- a/src/domains/web-server/routes/migration-routes.ts
+++ b/src/domains/web-server/routes/migration-routes.ts
@@ -593,6 +593,79 @@ async function executePlanDeleteAction(
 	}
 }
 
+function hasSuccessfulReplacementWriteForDelete(
+	action: {
+		item: string;
+		type: string;
+		provider: string;
+		targetPath: string;
+	},
+	results: PortableInstallResult[],
+): boolean {
+	return results.some(
+		(result) =>
+			result.success &&
+			!result.skipped &&
+			result.provider === action.provider &&
+			replacementTypeMatchesForDelete(action.type, result.portableType) &&
+			replacementItemMatchesForDelete(action, result) &&
+			result.path.length > 0 &&
+			resolve(result.path) !== resolve(action.targetPath),
+	);
+}
+
+function replacementTypeMatchesForDelete(
+	actionType: string,
+	resultType: PortableInstallResult["portableType"],
+): boolean {
+	return resultType === actionType || (actionType === "command" && resultType === "skill");
+}
+
+function replacementItemMatchesForDelete(
+	action: { item: string; type: string },
+	result: PortableInstallResult,
+): boolean {
+	if (result.itemName === action.item || result.itemName === undefined) return true;
+
+	const parts = result.path.replace(/\\/g, "/").split("/");
+	const leaf = parts.at(-1) ?? "";
+	const parent = parts.at(-2) ?? "";
+	const leafName = leaf.replace(/\.[^.]+$/, "");
+	return (
+		leafName === action.item ||
+		parent === action.item ||
+		(action.type === "command" && parent === `source-command-${action.item}`)
+	);
+}
+
+function shouldRunPlanDeleteAction(
+	action: { reasonCode?: string; item: string; type: string; provider: string; targetPath: string },
+	results: PortableInstallResult[],
+): boolean {
+	if (action.reasonCode !== "path-migrated-cleanup") return true;
+	return hasSuccessfulReplacementWriteForDelete(action, results);
+}
+
+function createSkippedPathMigrationCleanupResult(action: {
+	item: string;
+	type: PortableType;
+	provider: string;
+	targetPath: string;
+}): PortableInstallResult {
+	const provider = action.provider as ProviderTypeValue;
+	return {
+		operation: "delete",
+		portableType: action.type,
+		itemName: action.item,
+		provider,
+		providerDisplayName: providers[provider]?.displayName || action.provider,
+		success: true,
+		path: action.targetPath,
+		skipped: true,
+		skipReason: "Legacy path cleanup skipped because no successful replacement write was recorded",
+	};
+}
+
 function countEnabledTypes(include: MigrationIncludeOptions): number {
 	return MIGRATION_TYPES.filter((type) => include[type]).length;
 }
@@ -1958,6 +2031,16 @@ export function registerMigrationRoutes(app: Express, deps?: MigrationRouteDeps)
 				);
 
 				for (const deleteAction of deleteActions) {
+					if (!shouldRunPlanDeleteAction(deleteAction, allResults)) {
+						const skippedDelete = createSkippedPathMigrationCleanupResult({
+							item: deleteAction.item,
+							type: deleteAction.type as PortableType,
+							provider: deleteAction.provider,
+							targetPath: deleteAction.targetPath,
+						});
+						allResults.push(skippedDelete);
+						continue;
+					}
 					const deleteResult = await executePlanDeleteAction(deleteAction, {
 						preservePaths: writtenPaths,
 						removePortableInstallation: registryDeps.removePortableInstallation,


### PR DESCRIPTION
Closes #889

## Summary
- Update Antigravity migration targets for the 2.0 layout: agents merge into `.agents/agents.md`, project skills install to `.agents/skills/<name>/SKILL.md`, rules install to `.agents/rules`, workflows install to `.agents/workflows`, and global skills install to `~/.gemini/config/skills`.
- Rewrite migrated markdown references so Claude `.claude/agents/*`, `.claude/skills/*`, `.claude/commands/*`, `.claude/rules/*`, and hook references point at the Antigravity 2.0 equivalents.
- Add reconcile/dry-run visibility and cleanup guard coverage for migrated skill directories so reruns show and converge on the same paths users actually see in Antigravity.

## Validation
- `bun test src/commands/migrate/__tests__/migrate-command.integration.test.ts src/commands/migrate/__tests__/skill-directory-installer.test.ts src/commands/skills/__tests__/skills-installer.test.ts src/commands/portable/__tests__/portable-installer.test.ts __tests__/commands/portable/converters.test.ts src/commands/portable/__tests__/md-strip.test.ts`
- `bun test` (5031 files/test cases run: 4972 pass, 59 skip, 0 fail)
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run help:check-parity`
- Pre-push local CI parity, package verification, and UI vitests
- Local isolated smoke: `ck migrate --agent antigravity --yes` produced `.agents/agents.md`, `.agents/skills/cook/SKILL.md`, `.agents/rules/style.md`, and `.agents/workflows/docs-release.md` with stale `.claude/*` refs removed from managed markdown.

## Docs Impact
- Regenerated `docs/cli-reference.md` and `cli-manifest.json` for the new migrate help text.
- Follow-up docs PR: claudekit/claudekit-docs#174.