### PR TITLE
fix(migrate): clean codex hook warning output

### DIFF
--- a/src/commands/migrate/__tests__/migrate-command.integration.test.ts
+++ b/src/commands/migrate/__tests__/migrate-command.integration.test.ts
@@ -122,7 +122,7 @@ describe("resolveMigrationMode", () => {
 // ---------------------------------------------------------------------------
 
 describe("appendMigrationWarningMessages", () => {
-	it("appends structured hook warning messages even when migration succeeds", () => {
+	it("summarizes structured hook warnings even when migration succeeds", () => {
 		const messages: string[] = ["existing warning"];
 
 		appendMigrationWarningMessages(messages, [
@@ -136,17 +136,23 @@ describe("appendMigrationWarningMessages", () => {
 				hookFile: "usage-context-awareness.cjs",
 				message: "Skipped excluded hook usage-context-awareness.cjs",
 			},
+			{
+				reason: "missing-hook-file",
+				hookFile: "custom-hook.cjs",
+				message: "Hook file not installed: custom-hook.cjs",
+			},
 		]);
 
 		expect(messages).toEqual([
 			"existing warning",
-			"Skipped unsupported Codex hook event SubagentStart",
-			"Skipped excluded hook usage-context-awareness.cjs",
+			"Skipped Codex-incompatible Claude hook event(s): SubagentStart.",
+			"Skipped Claude-only/generated hook file(s) for Codex: usage-context-awareness.cjs.",
+			"Skipped hook registration(s) whose files are not installed: custom-hook.cjs. Run `ck init --restore-ck-hooks` if these hooks should exist.",
 		]);
 	});
 
-	it("deduplicates repeated warning messages", () => {
-		const messages: string[] = ["Skipped unsupported Codex hook event Notification"];
+	it("deduplicates repeated warning summaries", () => {
+		const messages: string[] = ["Skipped Codex-incompatible Claude hook event(s): Notification."];
 
 		appendMigrationWarningMessages(messages, [
 			{
@@ -156,7 +162,21 @@ describe("appendMigrationWarningMessages", () => {
 			},
 		]);
 
-		expect(messages).toEqual(["Skipped unsupported Codex hook event Notification"]);
+		expect(messages).toEqual(["Skipped Codex-incompatible Claude hook event(s): Notification."]);
+	});
+
+	it("does not warn about generated-context hooks that Codex migration disables intentionally", () => {
+		const messages: string[] = [];
+
+		appendMigrationWarningMessages(messages, [
+			{
+				reason: "missing-hook-file",
+				hookFile: "session-init.cjs",
+				message: "Hook file not installed: session-init.cjs",
+			},
+		]);
+
+		expect(messages).toEqual([]);
 	});
 });
 

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -211,11 +211,65 @@ export function appendMigrationWarningMessages(
 	warnings: MigrationWarning[] | undefined,
 ): void {
 	if (!warnings) return;
+	for (const message of formatMigrationWarningMessages(warnings)) {
+		if (!target.includes(message)) target.push(message);
+	}
+}
+
+function formatMigrationWarningMessages(warnings: MigrationWarning[]): string[] {
+	const unsupportedEvents = collectWarningValues(warnings, "unsupported-event", "event");
+	const excludedHooks = collectWarningValues(warnings, "excluded-hook", "hookFile");
+	const missingHooks = collectWarningValues(warnings, "missing-hook-file", "hookFile").filter(
+		(hookFile) => !isGeneratedContextHookName(hookFile),
+	);
+	const groupedReasons = new Set(["unsupported-event", "excluded-hook", "missing-hook-file"]);
+	const messages: string[] = [];
+
+	if (unsupportedEvents.length > 0) {
+		messages.push(
+			`Skipped Codex-incompatible Claude hook event(s): ${summarizeValues(unsupportedEvents)}.`,
+		);
+	}
+	if (excludedHooks.length > 0) {
+		messages.push(
+			`Skipped Claude-only/generated hook file(s) for Codex: ${summarizeValues(excludedHooks)}.`,
+		);
+	}
+	if (missingHooks.length > 0) {
+		messages.push(
+			`Skipped hook registration(s) whose files are not installed: ${summarizeValues(missingHooks)}. Run \`ck init --restore-ck-hooks\` if these hooks should exist.`,
+		);
+	}
+
 	for (const warning of warnings) {
-		if (!target.includes(warning.message)) {
-			target.push(warning.message);
+		if (!groupedReasons.has(warning.reason) && !messages.includes(warning.message)) {
+			messages.push(warning.message);
 		}
 	}
+
+	return messages;
+}
+
+function collectWarningValues(
+	warnings: MigrationWarning[],
+	reason: string,
+	field: "event" | "hookFile",
+): string[] {
+	return Array.from(
+		new Set(
+			warnings
+				.filter((warning) => warning.reason === reason)
+				.map((warning) => warning[field])
+				.filter((value): value is string => typeof value === "string" && value.length > 0),
+		),
+	).sort((a, b) => a.localeCompare(b));
+}
+
+function summarizeValues(values: string[], maxValues = 8): string {
+	const visible = values.slice(0, maxValues);
+	const suffix =
+		values.length > visible.length ? `, and ${values.length - visible.length} more` : "";
+	return `${visible.join(", ")}${suffix}`;
 }
 
 export function appendFallbackSkillActionsToPlan(
@@ -678,7 +732,7 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			);
 		}
 		if (disabledGeneratedHooks.length > 0) {
-			logger.warning(
+			logger.verbose(
 				`[migrate] Disabling ${disabledGeneratedHooks.length} generated-context hook(s): ${disabledGeneratedHooks.map((item) => item.name).join(", ")}`,
 			);
 		}

--- a/src/commands/portable/__tests__/hooks-settings-merger.test.ts
+++ b/src/commands/portable/__tests__/hooks-settings-merger.test.ts
@@ -10,7 +10,7 @@ import {
 	readHooksFromSettings,
 	rewriteHookPaths,
 } from "../hooks-settings-merger.js";
-import type { ProviderType } from "../types.js";
+import type { MigrationWarning, ProviderType } from "../types.js";
 
 const testDir = join(tmpdir(), "claudekit-hooks-merger-test");
 const normalizePathForAssert = (value: string | null | undefined) =>
@@ -140,6 +140,34 @@ describe("filterToInstalledHooks", () => {
 		expect(result.SessionStart[0].hooks).toHaveLength(1);
 		expect(result.SessionStart[0].hooks[0].command).toContain("session-init.cjs");
 		expect(result.PreToolUse[0].hooks).toHaveLength(1);
+	});
+
+	it("reports project-dir hook references by basename when source files are missing", () => {
+		const warnings: MigrationWarning[] = [];
+		const projectHooks = {
+			SessionStart: [
+				{
+					hooks: [
+						{
+							type: "command",
+							command:
+								'bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/node-hook-runner.sh "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-init.cjs',
+						},
+					],
+				},
+			],
+		};
+
+		const result = filterToInstalledHooks(projectHooks, ["node-hook-runner.sh"], {
+			targetProvider: "codex",
+			warnings,
+		});
+
+		expect(result.SessionStart).toBeUndefined();
+		expect(warnings.some((warning) => warning.hookFile === "session-init.cjs")).toBe(true);
+		expect(warnings.some((warning) => warning.hookFile?.includes("CLAUDE_PROJECT_DIR"))).toBe(
+			false,
+		);
 	});
 
 	it("drops entire event when no hooks match", () => {

--- a/src/commands/portable/hook-migration-compatibility.ts
+++ b/src/commands/portable/hook-migration-compatibility.ts
@@ -35,12 +35,22 @@ const HOOK_REF_EXTENSIONS = new Set([".js", ".cjs", ".mjs", ".ts", ".sh", ".ps1"
 
 export function normalizeHookAssetPath(value: string): string {
 	return value
+		.trim()
 		.replace(/\\/g, "/")
 		.replace(/^["']|["']$/g, "")
 		.replace(/[),;]+$/, "")
+		.replace(/^["']|["']$/g, "")
 		.replace(/^\.\//, "")
+		.replace(/^\$CLAUDE_PROJECT_DIR"?\/\.claude\/hooks\//, "")
+		.replace(/^\$CLAUDE_PROJECT_DIR"?\/\.codex\/hooks\//, "")
+		.replace(/^\$\{CLAUDE_PROJECT_DIR\}"?\/\.claude\/hooks\//, "")
+		.replace(/^\$\{CLAUDE_PROJECT_DIR\}"?\/\.codex\/hooks\//, "")
+		.replace(/^%CLAUDE_PROJECT_DIR%"?\/\.claude\/hooks\//, "")
+		.replace(/^%CLAUDE_PROJECT_DIR%"?\/\.codex\/hooks\//, "")
 		.replace(/^\$HOME\/\.claude\/hooks\//, "")
 		.replace(/^\$HOME\/\.codex\/hooks\//, "")
+		.replace(/^%USERPROFILE%\/\.claude\/hooks\//, "")
+		.replace(/^%USERPROFILE%\/\.codex\/hooks\//, "")
 		.replace(/^~\/\.claude\/hooks\//, "")
 		.replace(/^~\/\.codex\/hooks\//, "")
 		.replace(/^\.claude\/hooks\//, "")


### PR DESCRIPTION
## Summary

- Group Codex hook migration warnings by category instead of surfacing repeated low-level lines.
- Suppress generated-context missing-hook noise because those hooks are intentionally disabled for Codex migration.
- Normalize env-var hook references to basenames so users see actionable filenames instead of raw `$CLAUDE_PROJECT_DIR` fragments.

## Root Cause

`ck migrate --agent codex --hooks` appended structured hook migration warnings directly to the post-migration output. That made expected compatibility filtering and generated-hook cleanup look like broken installs, and missing-hook warnings could expose raw env-var path fragments.

## Changes

| File | Change |
|------|--------|
| `src/commands/migrate/migrate-command.ts` | Summarize hook warnings, filter generated-context missing-hook warnings, and move generated-context cleanup logging to verbose output. |
| `src/commands/portable/hook-migration-compatibility.ts` | Normalize `$CLAUDE_PROJECT_DIR`, `${CLAUDE_PROJECT_DIR}`, `%CLAUDE_PROJECT_DIR%`, and `%USERPROFILE%` hook paths to hook basenames. |
| `src/commands/migrate/__tests__/migrate-command.integration.test.ts` | Cover grouped warnings, summary dedupe, and generated-context warning suppression. |
| `src/commands/portable/__tests__/hooks-settings-merger.test.ts` | Cover basename reporting for missing `$CLAUDE_PROJECT_DIR` hook references. |

## Docs Impact

No docs change. The pre-push manifest/reference check regenerated `cli-manifest.json` and `docs/cli-reference.md` with no meaningful drift.

## Test plan

- [x] `bun test src/commands/migrate/__tests__/migrate-command.integration.test.ts src/commands/portable/__tests__/hooks-settings-merger.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun test`
- [x] Isolated temp-home CLI smoke for `ck migrate --agent codex --global --yes --hooks` verified no raw `$CLAUDE_PROJECT_DIR` warning and no raw `Hook file not installed` line.
- [x] Pre-push local CI parity gate passed, including full Bun tests, help parity, manifest/docs drift check, UI build, package verification, and UI vitest.
