### PR TITLE
fix(doctor): repair global hooks rooted at project dir

### DIFF
--- a/src/__tests__/commands/update-cli-auto-init.test.ts
+++ b/src/__tests__/commands/update-cli-auto-init.test.ts
@@ -33,11 +33,19 @@ async function writeMetadata(dir: string, version = "1.0.0") {
 
 async function writeGlobalHookState(
 	dir: string,
-	options: { disabled?: Record<string, boolean>; includeSessionState?: boolean } = {},
+	options: {
+		disabled?: Record<string, boolean>;
+		includeSessionState?: boolean;
+		projectScopedCommands?: boolean;
+	} = {},
 ) {
-	const hooks = [{ type: "command", command: 'node "$HOME/.claude/hooks/simplify-gate.cjs"' }];
+	const commandFor = (name: string) =>
+		options.projectScopedCommands
+			? `node "$CLAUDE_PROJECT_DIR"/.claude/hooks/${name}.cjs`
+			: `node "$HOME/.claude/hooks/${name}.cjs"`;
+	const hooks = [{ type: "command", command: commandFor("simplify-gate") }];
 	if (options.includeSessionState) {
-		hooks.push({ type: "command", command: 'node "$HOME/.claude/hooks/session-state.cjs"' });
+		hooks.push({ type: "command", command: commandFor("session-state") });
 	}
 
 	await writeFile(
@@ -286,6 +294,22 @@ describe("promptKitUpdate auto-init behavior", () => {
 		expect(capturedExecCmd()).toContain("--restore-ck-hooks");
 	});
 
+	test("restores global hook registrations that point at CLAUDE_PROJECT_DIR (--yes mode)", async () => {
+		await writeGlobalHookState(tempDir, {
+			includeSessionState: true,
+			projectScopedCommands: true,
+		});
+
+		const { deps, execCount, spawnCount, capturedExecCmd } = makeDeps();
+		deps.getLatestReleaseTagFn = async () => "v1.0.0";
+		await promptKitUpdate(false, true, deps);
+
+		expect(execCount()).toBe(1);
+		expect(spawnCount()).toBe(0);
+		expect(capturedExecCmd()).toContain("ck init -g");
+		expect(capturedExecCmd()).toContain("--restore-ck-hooks");
+	});
+
 	test("does not force global hook restore for hooks explicitly disabled in .ck.json", async () => {
 		await writeGlobalHookState(tempDir, {
 			disabled: { "session-state": false },
@@ -362,6 +386,39 @@ describe("promptKitUpdate auto-init behavior", () => {
 		await writeDisabledHooks(tempDir, {});
 
 		await expect(countMissingCkHookRegistrations(tempDir, "engineer")).resolves.toBe(1);
+	});
+
+	test("counts global managed hooks registered with project-scoped roots as missing", async () => {
+		await writeManagedHooksManifest(tempDir, ["session-init"]);
+		await writeFile(
+			join(tempDir, "settings.json"),
+			JSON.stringify(
+				{
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-init.cjs',
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+		await writeDisabledHooks(tempDir, {});
+
+		await expect(
+			countMissingCkHookRegistrations(tempDir, "engineer", { isGlobal: true }),
+		).resolves.toBe(1);
+		await expect(
+			countMissingCkHookRegistrations(tempDir, "engineer", { isGlobal: false }),
+		).resolves.toBe(0);
 	});
 
 	test("does not count an explicitly disabled managed hook", async () => {

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker-corpus.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker-corpus.test.ts
@@ -126,11 +126,20 @@ async function assertGlobalCommandConverges(
 	ctx: TestContext,
 	command: string,
 	expectedPattern: RegExp,
+	options: { managedHooks?: string[] } = {},
 ): Promise<void> {
 	// Write to a temp location (not the CK_TEST_HOME global dir to avoid root confusion).
 	const settingsDir = join(ctx.tempDir, "global-test", ".claude");
 	const settingsPath = join(settingsDir, "settings.local.json");
 	await mkdir(settingsDir, { recursive: true });
+	if (options.managedHooks) {
+		const hooksDir = join(settingsDir, "hooks");
+		await mkdir(hooksDir, { recursive: true });
+		await writeFile(
+			join(hooksDir, "managed-hooks.json"),
+			JSON.stringify({ managedHooks: options.managedHooks }),
+		);
+	}
 
 	const fixture = {
 		hooks: {
@@ -454,11 +463,10 @@ describe("hook-health-checker corpus: full convergence cycle per stale shape", (
 		await assertGlobalCommandConverges(ctx, 'node "$HOME"/.claude/hooks/foo.cjs', /\$HOME/);
 	});
 
-	test('no-op: node "$CLAUDE_PROJECT_DIR"/.claude/hooks/foo.cjs in global settings — canonical form, not flagged', async () => {
+	test('no-op: user-authored node "$CLAUDE_PROJECT_DIR"/.claude/hooks/foo.cjs in global settings stays allowed', async () => {
 		// node "$CLAUDE_PROJECT_DIR"/.claude/... is in the canonical var-only-quoted form.
-		// isAlreadyCanonical() returns true → collectHookCommandFindings skips it → 0 findings.
-		// The health-checker does NOT re-root cross-scope canonical commands; only SettingsProcessor
-		// does intentional cross-scope normalization (during install with root=$HOME).
+		// Without a CK managed-hooks manifest, the health-checker preserves the historical
+		// no-op behavior for user-authored cross-scope hooks.
 		const settingsDir = join(ctx.tempDir, "global-test2", ".claude");
 		const settingsPath = join(settingsDir, "settings.local.json");
 		await mkdir(settingsDir, { recursive: true });
@@ -477,6 +485,15 @@ describe("hook-health-checker corpus: full convergence cycle per stale shape", (
 		};
 		const findings = await findStaleHookCommandsInFile(settingsFile);
 		expect(findings).toHaveLength(0); // isAlreadyCanonical gate prevents flagging
+	});
+
+	test('converges: CK-managed node "$CLAUDE_PROJECT_DIR"/.claude hook in global settings', async () => {
+		await assertGlobalCommandConverges(
+			ctx,
+			'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/foo.cjs',
+			/\$HOME/,
+			{ managedHooks: ["foo"] },
+		);
 	});
 
 	// --- Stale shapes: unquoted var ---

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts
@@ -625,6 +625,65 @@ describe("checkHookCommandPaths", () => {
 			'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-state.cjs',
 		);
 	});
+
+	test("auto-fix converges for managed global project-root hooks under custom global dir", async () => {
+		const globalDir = join(tempDir, ".claude");
+		await mkdir(join(globalDir, "hooks"), { recursive: true });
+		await writeFile(
+			join(globalDir, "hooks", "managed-hooks.json"),
+			JSON.stringify({ managedHooks: ["session-init"] }),
+		);
+		const settingsPath = join(globalDir, "settings.json");
+		await writeFile(
+			settingsPath,
+			JSON.stringify(
+				{
+					statusLine: {
+						type: "command",
+						command: 'node "$CLAUDE_PROJECT_DIR"/.claude/statusline.cjs',
+					},
+					hooks: {
+						UserPromptSubmit: [
+							{
+								hooks: [
+									{
+										type: "command",
+										command: 'node "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-init.cjs',
+									},
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const result = await checkHookCommandPaths(projectDir);
+
+		expect(result.status).toBe("fail");
+		expect(result.details).toContain("global settings.json");
+		expect(result.details).toContain("statusLine");
+		expect(result.details).toContain("UserPromptSubmit");
+		expect(result.autoFixable).toBe(true);
+
+		const fixResult = await result.fix?.execute();
+		expect(fixResult?.success).toBe(true);
+
+		const repaired = JSON.parse(await readFile(settingsPath, "utf-8")) as {
+			statusLine: { command: string };
+			hooks: { UserPromptSubmit: Array<{ hooks: Array<{ command: string }> }> };
+		};
+		const normalizedGlobalDir = globalDir.replace(/\\/g, "/");
+		expect(repaired.statusLine.command).toBe(`node "${normalizedGlobalDir}/statusline.cjs"`);
+		expect(repaired.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+			`node "${normalizedGlobalDir}/hooks/session-init.cjs"`,
+		);
+
+		const after = await checkHookCommandPaths(projectDir);
+		expect(after.status).toBe("pass");
+	});
 });
 
 describe("checkLegacyHookPrompts", () => {

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -20,7 +20,6 @@ import {
 import { getInstalledKits } from "@/domains/migration/metadata-migration.js";
 import { versionsMatch } from "@/domains/versioning/checking/version-utils.js";
 import { getClaudeKitSetup } from "@/services/file-operations/claudekit-scanner.js";
-import { normalizeCommand } from "@/shared/command-normalizer.js";
 import { parseJsonContent } from "@/shared/json-content.js";
 import { logger } from "@/shared/logger.js";
 import { confirm, isCancel, log, spinner } from "@/shared/safe-prompts.js";
@@ -63,6 +62,10 @@ interface CkConfigSnapshot {
 
 interface ManagedHooksManifest {
 	managedHooks?: string[];
+}
+
+interface HookRegistrationStatus {
+	hasCorrectScope: boolean;
 }
 
 // ─── Kit selection ────────────────────────────────────────────────────────────
@@ -143,31 +146,42 @@ function extractCkHookName(command: string): string | null {
 	return match?.[1] ?? null;
 }
 
-function collectSettingsHookCommands(settings: CkSettingsSnapshot): Set<string> {
-	const commands = new Set<string>();
+function commandUsesProjectDirRoot(command: string): boolean {
+	return /\$\{?CLAUDE_PROJECT_DIR\}?|%CLAUDE_PROJECT_DIR%/.test(command);
+}
+
+/** Live CK hook registrations currently present in settings.json. */
+function collectSettingsHookRegistrations(
+	settings: CkSettingsSnapshot,
+	options: { isGlobal?: boolean } = {},
+): Map<string, HookRegistrationStatus> {
+	const registrations = new Map<string, HookRegistrationStatus>();
+
+	const addCommand = (command: string) => {
+		const hookName = extractCkHookName(command);
+		if (!hookName) return;
+
+		const previous = registrations.get(hookName);
+		const hasCorrectScope =
+			previous?.hasCorrectScope ||
+			!(options.isGlobal === true && commandUsesProjectDirRoot(command));
+		registrations.set(hookName, { hasCorrectScope });
+	};
+
 	for (const entries of Object.values(settings.hooks ?? {})) {
 		for (const entry of entries) {
 			if (typeof entry.command === "string") {
-				commands.add(normalizeCommand(entry.command));
+				addCommand(entry.command);
 			}
 			for (const hook of entry.hooks ?? []) {
 				if (typeof hook.command === "string") {
-					commands.add(normalizeCommand(hook.command));
+					addCommand(hook.command);
 				}
 			}
 		}
 	}
-	return commands;
-}
 
-/** Live CK hook names currently registered in settings.json. */
-function collectSettingsHookNames(settings: CkSettingsSnapshot): Set<string> {
-	const names = new Set<string>();
-	for (const command of collectSettingsHookCommands(settings)) {
-		const hookName = extractCkHookName(command);
-		if (hookName) names.add(hookName);
-	}
-	return names;
+	return registrations;
 }
 
 /** Read the kit-shipped managed-hooks manifest from the hooks directory. */
@@ -225,6 +239,7 @@ async function readDisabledHookNames(claudeDir: string): Promise<Set<string>> {
 export async function countMissingCkHookRegistrations(
 	claudeDir: string,
 	kit?: KitType,
+	options: { isGlobal?: boolean } = {},
 ): Promise<number> {
 	void kit;
 	const settingsPath = join(claudeDir, "settings.json");
@@ -234,7 +249,7 @@ export async function countMissingCkHookRegistrations(
 	if (managedHooks.length === 0) return 0;
 
 	const settings = parseJsonContent<CkSettingsSnapshot>(await readFile(settingsPath, "utf-8"));
-	const liveHookNames = collectSettingsHookNames(settings);
+	const liveHookRegistrations = collectSettingsHookRegistrations(settings, options);
 	const disabledHooks = await readDisabledHookNames(claudeDir);
 	const hooksDir = join(claudeDir, "hooks");
 
@@ -242,7 +257,7 @@ export async function countMissingCkHookRegistrations(
 	for (const name of managedHooks) {
 		if (disabledHooks.has(name)) continue;
 		if (!existsSync(join(hooksDir, `${name}.cjs`))) continue;
-		if (!liveHookNames.has(name)) missing++;
+		if (!liveHookRegistrations.get(name)?.hasCorrectScope) missing++;
 	}
 	return missing;
 }
@@ -492,6 +507,7 @@ export async function promptKitUpdate(
 				const missingHookRegistrations = await countMissingCkHookRegistrations(
 					selectedClaudeDir,
 					selection.kit,
+					{ isGlobal: selection.isGlobal },
 				);
 				if (missingHookRegistrations > 0) {
 					logger.warning(

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -175,6 +175,15 @@ function isProjectScopedCanonicalHookCommand(cmd: string): boolean {
 	);
 }
 
+function isProjectScopedStatusLineCommand(cmd: string): boolean {
+	return (
+		/^node\s+"\$CLAUDE_PROJECT_DIR"\/\.claude\/statusline\.cjs(?:\s|$)/.test(cmd) ||
+		/^bash\s+"\$CLAUDE_PROJECT_DIR"\/\.claude\/hooks\/node-hook-runner\.sh\s+"\$CLAUDE_PROJECT_DIR"\/\.claude\/statusline\.cjs(?:\s|$)/.test(
+			cmd,
+		)
+	);
+}
+
 function extractHookNames(command: string): string[] {
 	const normalized = command.replace(/\\/g, "/");
 	const names: string[] = [];
@@ -200,8 +209,10 @@ function isManagedHookCommand(command: string, settingsFile: ClaudeSettingsFile)
 function shouldRepairManagedGlobalProjectRoot(
 	command: string,
 	settingsFile: ClaudeSettingsFile,
+	eventName?: string,
 ): boolean {
 	if (settingsFile.root === "$CLAUDE_PROJECT_DIR") return false;
+	if (eventName === "statusLine" && isProjectScopedStatusLineCommand(command)) return true;
 	if (!isProjectScopedCanonicalHookCommand(command)) return false;
 	return isManagedHookCommand(command, settingsFile);
 }
@@ -236,37 +247,67 @@ function isAlreadyCanonical(cmd: string): boolean {
 	);
 }
 
+function isAlreadyCanonicalForSettingsFile(cmd: string, settingsFile: ClaudeSettingsFile): boolean {
+	if (isAlreadyCanonical(cmd)) return true;
+
+	const root = settingsFile.root.replace(/\\/g, "/").replace(/\/+$/, "");
+	if (root === "$HOME" || root === "$CLAUDE_PROJECT_DIR") return false;
+
+	const command = cmd.replace(/\\/g, "/");
+	const escapedRoot = escapeRegex(root);
+	return (
+		new RegExp(`^node\\s+"${escapedRoot}/[^"]+"`).test(command) ||
+		new RegExp(
+			`^bash\\s+"${escapedRoot}/hooks/node-hook-runner\\.sh"\\s+"${escapedRoot}/[^"]+"`,
+		).test(command)
+	);
+}
+
 function collectHookCommandFindings(
 	settings: SettingsJson,
 	settingsFile: ClaudeSettingsFile,
 ): HookCommandFinding[] {
-	if (!settings.hooks) {
-		return [];
+	const findings: HookCommandFinding[] = [];
+
+	const collectCommand = (eventName: string, command: string, matcher?: string): void => {
+		// Skip canonical cross-scope user hooks, but repair CK-managed global
+		// hooks that still point at the active project.
+		if (
+			isAlreadyCanonicalForSettingsFile(command, settingsFile) &&
+			!shouldRepairManagedGlobalProjectRoot(command, settingsFile, eventName)
+		) {
+			return;
+		}
+
+		const repair = repairClaudeHookCommandPath(command, settingsFile.root);
+		if (!repair.changed || !repair.issue) {
+			return;
+		}
+
+		findings.push({
+			path: settingsFile.path,
+			label: settingsFile.label,
+			eventName,
+			matcher,
+			command,
+			expected: repair.command,
+			issue: repair.issue,
+		});
+	};
+
+	const statusLine = settings.statusLine as { command?: unknown } | undefined;
+	if (typeof statusLine?.command === "string") {
+		collectCommand("statusLine", statusLine.command);
 	}
 
-	const findings: HookCommandFinding[] = [];
+	if (!settings.hooks) {
+		return findings;
+	}
+
 	for (const [eventName, entries] of Object.entries(settings.hooks)) {
 		for (const entry of entries) {
 			if ("command" in entry && typeof entry.command === "string") {
-				// Skip canonical cross-scope user hooks, but repair CK-managed global
-				// hooks that still point at the active project.
-				if (
-					isAlreadyCanonical(entry.command) &&
-					!shouldRepairManagedGlobalProjectRoot(entry.command, settingsFile)
-				) {
-					continue;
-				}
-				const repair = repairClaudeHookCommandPath(entry.command, settingsFile.root);
-				if (repair.changed && repair.issue) {
-					findings.push({
-						path: settingsFile.path,
-						label: settingsFile.label,
-						eventName,
-						command: entry.command,
-						expected: repair.command,
-						issue: repair.issue,
-					});
-				}
+				collectCommand(eventName, entry.command);
 			}
 
 			if (!("hooks" in entry) || !entry.hooks) {
@@ -278,29 +319,7 @@ function collectHookCommandFindings(
 					continue;
 				}
 
-				// Skip canonical cross-scope user hooks, but repair CK-managed global
-				// hooks that still point at the active project.
-				if (
-					isAlreadyCanonical(hook.command) &&
-					!shouldRepairManagedGlobalProjectRoot(hook.command, settingsFile)
-				) {
-					continue;
-				}
-
-				const repair = repairClaudeHookCommandPath(hook.command, settingsFile.root);
-				if (!repair.changed || !repair.issue) {
-					continue;
-				}
-
-				findings.push({
-					path: settingsFile.path,
-					label: settingsFile.label,
-					eventName,
-					matcher: "matcher" in entry ? entry.matcher : undefined,
-					command: hook.command,
-					expected: repair.command,
-					issue: repair.issue,
-				});
+				collectCommand(eventName, hook.command, "matcher" in entry ? entry.matcher : undefined);
 			}
 		}
 	}
@@ -329,7 +348,7 @@ export async function findStaleHookCommandsInFile(
 
 async function repairHookCommandsInSettingsFile(settingsFile: ClaudeSettingsFile): Promise<number> {
 	const settings = await SettingsMerger.readSettingsFile(settingsFile.path);
-	if (!settings?.hooks) {
+	if (!settings) {
 		return 0;
 	}
 
@@ -346,28 +365,39 @@ async function repairHookCommandsInSettingsFile(settingsFile: ClaudeSettingsFile
 	const repairMap = new Map<string, string>(findings.map((f) => [f.command, f.expected]));
 
 	let repaired = 0;
-	for (const entries of Object.values(settings.hooks)) {
-		for (const entry of entries) {
-			if ("command" in entry && typeof entry.command === "string") {
-				const fixed = repairMap.get(entry.command);
-				if (fixed !== undefined) {
-					entry.command = fixed;
-					repaired++;
+	const statusLine = settings.statusLine as { command?: unknown } | undefined;
+	if (typeof statusLine?.command === "string") {
+		const fixed = repairMap.get(statusLine.command);
+		if (fixed !== undefined) {
+			statusLine.command = fixed;
+			repaired++;
+		}
+	}
+
+	if (settings.hooks) {
+		for (const entries of Object.values(settings.hooks)) {
+			for (const entry of entries) {
+				if ("command" in entry && typeof entry.command === "string") {
+					const fixed = repairMap.get(entry.command);
+					if (fixed !== undefined) {
+						entry.command = fixed;
+						repaired++;
+					}
 				}
-			}
 
-			if (!("hooks" in entry) || !entry.hooks) {
-				continue;
-			}
-
-			for (const hook of entry.hooks) {
-				if (!hook.command) {
+				if (!("hooks" in entry) || !entry.hooks) {
 					continue;
 				}
-				const fixed = repairMap.get(hook.command);
-				if (fixed !== undefined) {
-					hook.command = fixed;
-					repaired++;
+
+				for (const hook of entry.hooks) {
+					if (!hook.command) {
+						continue;
+					}
+					const fixed = repairMap.get(hook.command);
+					if (fixed !== undefined) {
+						hook.command = fixed;
+						repaired++;
+					}
 				}
 			}
 		}

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { type SettingsJson, SettingsMerger } from "@/domains/config/settings-merger.js";
 import { isLegacyDescriptiveNamePrompt } from "@/domains/installation/merger/zombie-wirings-pruner.js";
 import { CLAUDEKIT_CLI_NPM_PACKAGE_NAME } from "@/shared/claudekit-constants.js";
@@ -40,6 +40,7 @@ export interface ClaudeSettingsFile {
 	path: string;
 	label: string;
 	root: string;
+	managedHookNames?: Set<string>;
 }
 
 export interface HookCommandFinding {
@@ -107,8 +108,22 @@ function getCanonicalGlobalCommandRoot(): string {
 	return configuredGlobalDir === defaultGlobalDir ? "$HOME" : configuredGlobalDir;
 }
 
+function readManagedHookNamesForClaudeDir(claudeDir: string): Set<string> {
+	const manifestPath = join(claudeDir, "hooks", "managed-hooks.json");
+	if (!existsSync(manifestPath)) return new Set();
+
+	try {
+		const data = JSON.parse(readFileSync(manifestPath, "utf-8")) as { managedHooks?: unknown };
+		if (!Array.isArray(data.managedHooks)) return new Set();
+		return new Set(data.managedHooks.filter((name): name is string => typeof name === "string"));
+	} catch {
+		return new Set();
+	}
+}
+
 function getClaudeSettingsFiles(projectDir: string): ClaudeSettingsFile[] {
 	const globalClaudeDir = PathResolver.getGlobalKitDir();
+	const globalManagedHookNames = readManagedHookNamesForClaudeDir(globalClaudeDir);
 	const ccsSettingsDir = join(process.env.CK_TEST_HOME ?? homedir(), ".ccs");
 	const candidates: ClaudeSettingsFile[] = [
 		{
@@ -125,11 +140,13 @@ function getClaudeSettingsFiles(projectDir: string): ClaudeSettingsFile[] {
 			path: resolve(globalClaudeDir, "settings.json"),
 			label: "global settings.json",
 			root: getCanonicalGlobalCommandRoot(),
+			managedHookNames: globalManagedHookNames,
 		},
 		{
 			path: resolve(globalClaudeDir, "settings.local.json"),
 			label: "global settings.local.json",
 			root: getCanonicalGlobalCommandRoot(),
+			managedHookNames: globalManagedHookNames,
 		},
 	];
 
@@ -147,6 +164,46 @@ function getClaudeSettingsFiles(projectDir: string): ClaudeSettingsFile[] {
 	}
 
 	return candidates.filter((candidate) => existsSync(candidate.path));
+}
+
+function isProjectScopedCanonicalHookCommand(cmd: string): boolean {
+	return (
+		/^node\s+"\$CLAUDE_PROJECT_DIR"\/\.claude\/\S+/.test(cmd) ||
+		/^bash\s+"\$CLAUDE_PROJECT_DIR"\/\.claude\/hooks\/node-hook-runner\.sh\s+"\$CLAUDE_PROJECT_DIR"\/\.claude\/\S+/.test(
+			cmd,
+		)
+	);
+}
+
+function extractHookNames(command: string): string[] {
+	const normalized = command.replace(/\\/g, "/");
+	const names: string[] = [];
+	const pattern = /\/hooks\/([^/"'\s]+)\.(?:cjs|mjs|js)(?:["'\s]|$)/g;
+	for (const match of normalized.matchAll(pattern)) {
+		if (match[1]) names.push(match[1]);
+	}
+	return names;
+}
+
+function getManagedHookNames(settingsFile: ClaudeSettingsFile): Set<string> {
+	return (
+		settingsFile.managedHookNames ?? readManagedHookNamesForClaudeDir(dirname(settingsFile.path))
+	);
+}
+
+function isManagedHookCommand(command: string, settingsFile: ClaudeSettingsFile): boolean {
+	const managedHookNames = getManagedHookNames(settingsFile);
+	if (managedHookNames.size === 0) return false;
+	return extractHookNames(command).some((name) => managedHookNames.has(name));
+}
+
+function shouldRepairManagedGlobalProjectRoot(
+	command: string,
+	settingsFile: ClaudeSettingsFile,
+): boolean {
+	if (settingsFile.root === "$CLAUDE_PROJECT_DIR") return false;
+	if (!isProjectScopedCanonicalHookCommand(command)) return false;
+	return isManagedHookCommand(command, settingsFile);
 }
 
 /**
@@ -191,8 +248,14 @@ function collectHookCommandFindings(
 	for (const [eventName, entries] of Object.entries(settings.hooks)) {
 		for (const entry of entries) {
 			if ("command" in entry && typeof entry.command === "string") {
-				// Skip commands already in any canonical form — cross-scope references are valid.
-				if (isAlreadyCanonical(entry.command)) continue;
+				// Skip canonical cross-scope user hooks, but repair CK-managed global
+				// hooks that still point at the active project.
+				if (
+					isAlreadyCanonical(entry.command) &&
+					!shouldRepairManagedGlobalProjectRoot(entry.command, settingsFile)
+				) {
+					continue;
+				}
 				const repair = repairClaudeHookCommandPath(entry.command, settingsFile.root);
 				if (repair.changed && repair.issue) {
 					findings.push({
@@ -215,8 +278,14 @@ function collectHookCommandFindings(
 					continue;
 				}
 
-				// Skip commands already in any canonical form — cross-scope references are valid.
-				if (isAlreadyCanonical(hook.command)) continue;
+				// Skip canonical cross-scope user hooks, but repair CK-managed global
+				// hooks that still point at the active project.
+				if (
+					isAlreadyCanonical(hook.command) &&
+					!shouldRepairManagedGlobalProjectRoot(hook.command, settingsFile)
+				) {
+					continue;
+				}
 
 				const repair = repairClaudeHookCommandPath(hook.command, settingsFile.root);
 				if (!repair.changed || !repair.issue) {


### PR DESCRIPTION
## Summary
- detect CK-managed global Claude Code hook registrations that still point at `$CLAUDE_PROJECT_DIR`
- include global `statusLine` commands in stale path detection/repair when they point at the active project
- let doctor repair those registrations to the global Claude dir, including custom global config dirs, while preserving user-authored cross-scope hooks without a managed manifest
- treat wrong-root managed global hooks as missing during `ck update -g --yes` self-heal so restore mode runs even when the kit version already matches

## Validation
- [x] `bun test src/__tests__/domains/health-checks/checkers/hook-health-checker.test.ts`
- [x] `bun test src/__tests__/domains/health-checks/checkers/hook-health-checker-corpus.test.ts`
- [x] `bun test src/__tests__/commands/update-cli-auto-init.test.ts`
- [x] one-off repro for custom global dir detect/fix/re-detect convergence
- [x] `bun test`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] pre-commit quality gate
- [x] pre-push local CI parity, packaging check, and UI vitest suite
- [x] GitHub Actions CI

## Docs impact
- None. This is internal doctor/update repair behavior for existing global hook installs.

## User-facing risk
- Low. The hook repair path is limited to CK-managed hook names from `hooks/managed-hooks.json`; custom cross-scope hook commands remain untouched. The statusLine repair is scoped to the project-rooted CK statusline command shape.