### PR TITLE
fix: install Codex plugin during Engineer updates

### DIFF
--- a/src/__tests__/commands/update-cli-auto-init.test.ts
+++ b/src/__tests__/commands/update-cli-auto-init.test.ts
@@ -162,6 +162,7 @@ describe("promptKitUpdate auto-init behavior", () => {
 			isCancelFn: isCancelMock,
 			detectInstallModeFn: () => makeInstallModeReport(tempDir, "plugin"),
 			hasTrackedPluginSuppliedLegacyFilesFn: () => false,
+			shouldRefreshCodexPluginFn: async () => false,
 		};
 		return {
 			deps,
@@ -286,6 +287,20 @@ describe("promptKitUpdate auto-init behavior", () => {
 		await promptKitUpdate(false, true, deps);
 		expect(execCount()).toBe(0);
 		expect(spawnCount()).toBe(0);
+	});
+
+	test("reinstalls latest global engineer kit when Codex plugin is missing (--yes mode)", async () => {
+		const { deps, execCount, spawnCount, capturedExecCmd } = makeDeps();
+		deps.getLatestReleaseTagFn = async () => "v1.0.0";
+		deps.shouldRefreshCodexPluginFn = async () => true;
+
+		await promptKitUpdate(false, true, deps);
+
+		expect(execCount()).toBe(1);
+		expect(spawnCount()).toBe(0);
+		expect(capturedExecCmd()).toContain("ck init -g");
+		expect(capturedExecCmd()).toContain("--kit engineer");
+		expect(capturedExecCmd()).toContain("--restore-ck-hooks");
 	});
 
 	test("reinstalls latest legacy global engineer kit to migrate plugin format (--yes mode)", async () => {

--- a/src/__tests__/commands/update-cli-prompt-kit.test.ts
+++ b/src/__tests__/commands/update-cli-prompt-kit.test.ts
@@ -68,6 +68,7 @@ describe("promptKitUpdate version display", () => {
 					legacy: { installed: false, version: null },
 				}) satisfies InstallModeReport,
 			hasTrackedPluginSuppliedLegacyFilesFn: () => false,
+			shouldRefreshCodexPluginFn: async () => false,
 		};
 		return { deps, stopCalls, wasExecCalled: () => execCalled };
 	}

--- a/src/commands/init/phases/__tests__/plugin-install-handler.test.ts
+++ b/src/commands/init/phases/__tests__/plugin-install-handler.test.ts
@@ -8,6 +8,7 @@ import {
 	stagePluginSource,
 } from "@/commands/init/phases/plugin-install-handler.js";
 import type { InitContext } from "@/commands/init/types.js";
+import type { CodexPluginInstallResult } from "@/domains/installation/plugin/codex-plugin-installer.js";
 import type { MigrateResult } from "@/domains/installation/plugin/migrate-legacy-to-plugin.js";
 
 const okResult: MigrateResult = {
@@ -17,6 +18,10 @@ const okResult: MigrateResult = {
 	backupDir: null,
 	removedPaths: [],
 	receiptPath: null,
+};
+const okCodexResult: CodexPluginInstallResult = {
+	action: "installed",
+	pluginVerified: true,
 };
 
 describe("handlePluginInstall (init Phase 7.5)", () => {
@@ -76,21 +81,29 @@ describe("handlePluginInstall (init Phase 7.5)", () => {
 		expect(called).toBe(false);
 	});
 
-	test("engineer + global: stages source and calls migrate with claudeDir", async () => {
+	test("engineer + global: stages source and installs Claude and Codex plugins", async () => {
 		const calls: Array<{ pluginSourceDir: string; claudeDir?: string }> = [];
+		const codexCalls: string[] = [];
 		await handlePluginInstall(ctxOf(), {
 			migrate: async (o) => {
 				calls.push({ pluginSourceDir: o.pluginSourceDir, claudeDir: o.claudeDir });
 				return okResult;
+			},
+			installCodex: async (o) => {
+				codexCalls.push(o.pluginSourceDir);
+				return okCodexResult;
 			},
 			stageBaseDir: stageBase,
 		});
 		expect(calls).toHaveLength(1);
 		expect(calls[0].claudeDir).toBe(claudeDir);
 		expect(calls[0].pluginSourceDir).toBe(stageBase);
+		expect(codexCalls).toEqual([stageBase]);
 		// staged payload + synthesized marketplace exist
 		expect(existsSync(join(stageBase, ".claude", ".claude-plugin", "plugin.json"))).toBe(true);
+		expect(existsSync(join(stageBase, ".claude", ".codex-plugin", "plugin.json"))).toBe(true);
 		expect(existsSync(join(stageBase, ".claude-plugin", "marketplace.json"))).toBe(true);
+		expect(existsSync(join(stageBase, ".agents", "plugins", "marketplace.json"))).toBe(true);
 	});
 
 	test("migrate throwing never fails init (legacy copy retained)", async () => {
@@ -120,14 +133,23 @@ describe("stagePluginSource", () => {
 		await rm(root, { recursive: true, force: true });
 	});
 
-	test("copies .claude payload and writes marketplace.json with source ./.claude", () => {
+	test("copies .claude payload and writes Claude and Codex marketplace files", () => {
 		const base = join(root, "stage");
 		const result = stagePluginSource(join(root, "extract"), base);
 		expect(result).toBe(base);
 		expect(existsSync(join(base, ".claude", ".claude-plugin", "plugin.json"))).toBe(true);
-		const mkt = JSON.parse(readFileSync(join(base, ".claude-plugin", "marketplace.json"), "utf-8"));
-		expect(mkt.plugins[0].name).toBe("ck");
-		expect(mkt.plugins[0].source).toBe("./.claude");
+		expect(existsSync(join(base, ".claude", ".codex-plugin", "plugin.json"))).toBe(true);
+		const claudeMarketplace = JSON.parse(
+			readFileSync(join(base, ".claude-plugin", "marketplace.json"), "utf-8"),
+		);
+		expect(claudeMarketplace.plugins[0].name).toBe("ck");
+		expect(claudeMarketplace.plugins[0].source).toBe("./.claude");
+		const codexMarketplace = JSON.parse(
+			readFileSync(join(base, ".agents", "plugins", "marketplace.json"), "utf-8"),
+		);
+		expect(codexMarketplace.plugins[0].name).toBe("ck");
+		expect(codexMarketplace.plugins[0].source.path).toBe("./.claude");
+		expect(codexMarketplace.plugins[0].policy.installation).toBe("AVAILABLE");
 	});
 
 	test("throws when archive has no .claude payload", () => {

--- a/src/commands/init/phases/plugin-install-handler.ts
+++ b/src/commands/init/phases/plugin-install-handler.ts
@@ -1,6 +1,10 @@
-import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { InitContext } from "@/commands/init/types.js";
+import {
+	type CodexPluginInstallResult,
+	installCodexPlugin,
+} from "@/domains/installation/plugin/codex-plugin-installer.js";
 import {
 	type MigrateResult,
 	migrateLegacyToPlugin,
@@ -13,6 +17,8 @@ const ENGINEER_KIT = "engineer";
 export interface PluginInstallDeps {
 	/** Injectable for tests; defaults to the real migrate flow. */
 	migrate?: typeof migrateLegacyToPlugin;
+	/** Injectable for tests; defaults to the real Codex plugin install flow. */
+	installCodex?: typeof installCodexPlugin;
 	/** Override the staged-source base dir (tests). */
 	stageBaseDir?: string;
 }
@@ -36,13 +42,26 @@ export async function handlePluginInstall(
 	}
 
 	const migrate = deps.migrate ?? migrateLegacyToPlugin;
+	const installCodex = deps.installCodex ?? installCodexPlugin;
 	try {
 		const pluginSourceDir = stagePluginSource(ctx.extractDir, deps.stageBaseDir);
-		const result = await migrate({ pluginSourceDir, claudeDir: ctx.claudeDir });
-		logPluginResult(result);
+		try {
+			const result = await migrate({ pluginSourceDir, claudeDir: ctx.claudeDir });
+			logPluginResult(result);
+		} catch (err) {
+			logger.verbose(
+				`Claude plugin install skipped (legacy copy retained): ${(err as Error).message}`,
+			);
+		}
+		try {
+			const result = await installCodex({ pluginSourceDir });
+			logCodexPluginResult(result);
+		} catch (err) {
+			logger.verbose(`Codex plugin install skipped: ${(err as Error).message}`);
+		}
 	} catch (err) {
 		// Never fail init over the plugin path — the legacy copy from handleMerge stands.
-		logger.verbose(`Plugin install skipped (legacy copy retained): ${(err as Error).message}`);
+		logger.verbose(`Plugin staging skipped (legacy copy retained): ${(err as Error).message}`);
 	}
 	return ctx;
 }
@@ -63,9 +82,11 @@ export function stagePluginSource(extractDir: string, stageBaseDir?: string): st
 
 	rmSync(base, { recursive: true, force: true });
 	mkdirSync(base, { recursive: true });
-	cpSync(payloadSrc, join(base, ".claude"), { recursive: true });
+	const stagedPayload = join(base, ".claude");
+	cpSync(payloadSrc, stagedPayload, { recursive: true });
+	ensureCodexPluginManifest(stagedPayload);
 
-	const marketplace = {
+	const claudeMarketplace = {
 		name: "claudekit",
 		owner: { name: "ClaudeKit" },
 		plugins: [{ name: "ck", source: "./.claude", description: "ClaudeKit Engineer" }],
@@ -73,10 +94,92 @@ export function stagePluginSource(extractDir: string, stageBaseDir?: string): st
 	mkdirSync(join(base, ".claude-plugin"), { recursive: true });
 	writeFileSync(
 		join(base, ".claude-plugin", "marketplace.json"),
-		`${JSON.stringify(marketplace, null, 2)}\n`,
+		`${JSON.stringify(claudeMarketplace, null, 2)}\n`,
+		"utf-8",
+	);
+
+	const codexMarketplace = {
+		name: "claudekit",
+		interface: { displayName: "ClaudeKit" },
+		plugins: [
+			{
+				name: "ck",
+				source: { source: "local", path: "./.claude" },
+				policy: { installation: "AVAILABLE", authentication: "ON_INSTALL" },
+				category: "Productivity",
+			},
+		],
+	};
+	mkdirSync(join(base, ".agents", "plugins"), { recursive: true });
+	writeFileSync(
+		join(base, ".agents", "plugins", "marketplace.json"),
+		`${JSON.stringify(codexMarketplace, null, 2)}\n`,
 		"utf-8",
 	);
 	return base;
+}
+
+function ensureCodexPluginManifest(pluginRoot: string): void {
+	const manifestPath = join(pluginRoot, ".codex-plugin", "plugin.json");
+	if (existsSync(manifestPath)) return;
+
+	const claudeManifest = readJsonSafe(join(pluginRoot, ".claude-plugin", "plugin.json"));
+	const manifest = pruneUndefined({
+		name: stringField(claudeManifest, "name") ?? "ck",
+		version: stringField(claudeManifest, "version") ?? "0.0.0",
+		description:
+			stringField(claudeManifest, "description") ??
+			"ClaudeKit Engineer — multi-agent planning, code review, debugging, and workflow skills for Codex.",
+		author: authorField(claudeManifest),
+		homepage: stringField(claudeManifest, "homepage"),
+		repository: stringField(claudeManifest, "repository"),
+		license: stringField(claudeManifest, "license"),
+		keywords: ["claudekit", "codex", "skills", "agents", "workflow"],
+		skills: "./skills/",
+		interface: {
+			displayName: "ClaudeKit Engineer",
+			shortDescription: "ClaudeKit planning, review, debugging, and workflow skills.",
+			longDescription:
+				"ClaudeKit Engineer provides planning, code review, debugging, testing, browser workflow, and implementation skills for Codex.",
+			developerName: "ClaudeKit",
+			category: "Productivity",
+			capabilities: ["Skills"],
+			websiteURL: "https://github.com/claudekit/claudekit-engineer",
+		},
+	});
+
+	mkdirSync(join(pluginRoot, ".codex-plugin"), { recursive: true });
+	writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+}
+
+function readJsonSafe(filePath: string): Record<string, unknown> | null {
+	try {
+		const parsed = JSON.parse(readFileSync(filePath, "utf-8"));
+		return isRecord(parsed) ? parsed : null;
+	} catch {
+		return null;
+	}
+}
+
+function stringField(source: Record<string, unknown> | null, key: string): string | undefined {
+	const value = source?.[key];
+	return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function authorField(source: Record<string, unknown> | null): { name: string } {
+	const author = source?.author;
+	if (isRecord(author) && typeof author.name === "string" && author.name.trim() !== "") {
+		return { name: author.name };
+	}
+	return { name: "ClaudeKit" };
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(value: T): Record<string, unknown> {
+	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function logPluginResult(result: MigrateResult): void {
@@ -95,6 +198,20 @@ function logPluginResult(result: MigrateResult): void {
 			break;
 		case "install-failed":
 			logger.verbose(`Plugin install did not verify; kept the legacy copy. ${result.error ?? ""}`);
+			break;
+	}
+}
+
+function logCodexPluginResult(result: CodexPluginInstallResult): void {
+	switch (result.action) {
+		case "installed":
+			logger.info("Installed ClaudeKit Engineer as a Codex plugin.");
+			break;
+		case "skipped-codex-unsupported":
+			logger.verbose("Codex plugin support unavailable; skipped Codex plugin install.");
+			break;
+		case "install-failed":
+			logger.verbose(`Codex plugin install did not verify. ${result.error ?? ""}`);
 			break;
 	}
 }

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -17,6 +17,7 @@ import {
 	repairLegacyHookPrompts,
 	repairMissingHookFileReferences,
 } from "@/domains/health-checks/checkers/hook-health-checker.js";
+import { shouldRefreshCodexPlugin } from "@/domains/installation/plugin/codex-plugin-installer.js";
 import {
 	type InstallModeReport,
 	detectInstallMode,
@@ -374,6 +375,7 @@ export interface PromptKitUpdateDeps {
 	countMissingHookFileReferencesFn?: (projectDir: string) => Promise<number>;
 	detectInstallModeFn?: (claudeDir: string) => InstallModeReport;
 	hasTrackedPluginSuppliedLegacyFilesFn?: (claudeDir: string) => boolean;
+	shouldRefreshCodexPluginFn?: () => Promise<boolean>;
 }
 
 async function findMissingHookDependencies(claudeDir: string): Promise<string[]> {
@@ -430,6 +432,7 @@ export async function promptKitUpdate(
 		const detectInstallModeFn = deps?.detectInstallModeFn ?? detectInstallMode;
 		const hasTrackedPluginSuppliedLegacyFilesFn =
 			deps?.hasTrackedPluginSuppliedLegacyFilesFn ?? hasTrackedPluginSuppliedLegacyFiles;
+		const shouldRefreshCodexPluginFn = deps?.shouldRefreshCodexPluginFn ?? shouldRefreshCodexPlugin;
 		const setup = await getSetupFn();
 		const hasLocal = !!setup.project.metadata;
 		const hasGlobal = !!setup.global.metadata;
@@ -545,6 +548,12 @@ export async function promptKitUpdate(
 					if (needsPluginMigration) {
 						logger.warning(
 							`Detected ${installMode.mode} global Engineer install; migrating to plugin format`,
+						);
+						forceKitReinstall = true;
+					}
+					if (await shouldRefreshCodexPluginFn()) {
+						logger.warning(
+							"Detected missing Codex ClaudeKit plugin; reinstalling global Engineer content",
 						);
 						forceKitReinstall = true;
 					}

--- a/src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts
+++ b/src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import {
+	CodexPluginInstaller,
+	type CodexRunResult,
+	installCodexPlugin,
+	resolveCodexExecutable,
+	shouldRefreshCodexPlugin,
+	shouldRunCodexInShell,
+} from "@/domains/installation/plugin/codex-plugin-installer.js";
+
+function ok(stdout = "", stderr = ""): CodexRunResult {
+	return { ok: true, stdout, stderr, code: 0 };
+}
+
+function fail(stderr = "failed"): CodexRunResult {
+	return { ok: false, stdout: "", stderr, code: 1 };
+}
+
+describe("CodexPluginInstaller", () => {
+	test("uses the Windows command shim through a shell", () => {
+		expect(resolveCodexExecutable("win32")).toBe("codex.cmd");
+		expect(shouldRunCodexInShell("win32")).toBe(true);
+		expect(resolveCodexExecutable("linux")).toBe("codex");
+		expect(shouldRunCodexInShell("linux")).toBe(false);
+	});
+
+	test("installs ck@claudekit through a local marketplace", async () => {
+		const calls: string[][] = [];
+		const installer = new CodexPluginInstaller(async (args) => {
+			calls.push(args);
+			if (args.join(" ") === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (args.join(" ") === "plugin --help") return ok("plugin marketplace add");
+			if (args.join(" ") === "plugin marketplace add /tmp/plugin-source") return ok();
+			if (args.join(" ") === "plugin add ck@claudekit") return ok();
+			if (args.join(" ") === "plugin list --json") {
+				return ok(
+					JSON.stringify({
+						installed: [
+							{
+								pluginId: "ck@claudekit",
+								installed: true,
+								enabled: true,
+							},
+						],
+					}),
+				);
+			}
+			return fail(`unexpected command: ${args.join(" ")}`);
+		});
+
+		const result = await installCodexPlugin({
+			pluginSourceDir: "/tmp/plugin-source",
+			installer,
+		});
+
+		expect(result).toEqual({ action: "installed", pluginVerified: true });
+		expect(calls).toEqual([
+			["--version"],
+			["plugin", "--help"],
+			["plugin", "marketplace", "add", "/tmp/plugin-source"],
+			["plugin", "add", "ck@claudekit"],
+			["plugin", "list", "--json"],
+		]);
+	});
+
+	test("skips when Codex lacks plugin support", async () => {
+		const installer = new CodexPluginInstaller(async (args) => {
+			if (args.join(" ") === "--version") return ok("codex-cli 0.142.0");
+			if (args.join(" ") === "plugin --help") return fail("unknown command");
+			return fail("should not install");
+		});
+
+		await expect(
+			installCodexPlugin({ pluginSourceDir: "/tmp/source", installer }),
+		).resolves.toEqual({
+			action: "skipped-codex-unsupported",
+			pluginVerified: false,
+		});
+	});
+
+	test("reports marketplace add failures", async () => {
+		const installer = new CodexPluginInstaller(async (args) => {
+			if (args.join(" ") === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (args.join(" ") === "plugin --help") return ok("plugin marketplace add");
+			if (args.join(" ") === "plugin marketplace add /tmp/source") return fail("bad marketplace");
+			return fail("should not install");
+		});
+
+		const result = await installCodexPlugin({ pluginSourceDir: "/tmp/source", installer });
+
+		expect(result.action).toBe("install-failed");
+		expect(result.pluginVerified).toBe(false);
+		expect(result.error).toContain("bad marketplace");
+	});
+
+	test("asks update self-heal to refresh only when supported Codex is missing ck", async () => {
+		const installed = new CodexPluginInstaller(async (args) => {
+			if (args.join(" ") === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (args.join(" ") === "plugin --help") return ok("plugin marketplace add");
+			if (args.join(" ") === "plugin list --json") {
+				return ok(
+					JSON.stringify({
+						installed: [{ pluginId: "ck@claudekit", installed: true, enabled: true }],
+					}),
+				);
+			}
+			return fail("unexpected");
+		});
+		await expect(shouldRefreshCodexPlugin(installed)).resolves.toBe(false);
+
+		const missing = new CodexPluginInstaller(async (args) => {
+			if (args.join(" ") === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (args.join(" ") === "plugin --help") return ok("plugin marketplace add");
+			if (args.join(" ") === "plugin list --json") return ok(JSON.stringify({ installed: [] }));
+			return fail("unexpected");
+		});
+		await expect(shouldRefreshCodexPlugin(missing)).resolves.toBe(true);
+	});
+});

--- a/src/domains/installation/plugin/codex-plugin-installer.ts
+++ b/src/domains/installation/plugin/codex-plugin-installer.ts
@@ -1,0 +1,172 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+	CK_MARKETPLACE_NAME,
+	CK_PLUGIN_NAME,
+} from "@/domains/installation/plugin/install-mode-detector.js";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+export interface CodexRunResult {
+	ok: boolean;
+	stdout: string;
+	stderr: string;
+	code: number | null;
+}
+
+export interface CodexRunOptions {
+	/** Override CODEX_HOME for tests and isolated smoke runs. */
+	codexHome?: string;
+	timeoutMs?: number;
+}
+
+export type CodexRunner = (args: string[], opts?: CodexRunOptions) => Promise<CodexRunResult>;
+
+export function resolveCodexExecutable(platformName: NodeJS.Platform = process.platform): string {
+	return platformName === "win32" ? "codex.cmd" : "codex";
+}
+
+export function shouldRunCodexInShell(platformName: NodeJS.Platform = process.platform): boolean {
+	return platformName === "win32";
+}
+
+export const defaultCodexRunner: CodexRunner = async (args, opts) => {
+	const env = { ...process.env };
+	if (opts?.codexHome) env.CODEX_HOME = opts.codexHome;
+	try {
+		const { stdout, stderr } = await execFileAsync(resolveCodexExecutable(), args, {
+			env,
+			shell: shouldRunCodexInShell(),
+			timeout: opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+			maxBuffer: 10 * 1024 * 1024,
+		});
+		return { ok: true, stdout: String(stdout), stderr: String(stderr), code: 0 };
+	} catch (err) {
+		const e = err as {
+			stdout?: string | Buffer;
+			stderr?: string | Buffer;
+			code?: number;
+			message?: string;
+		};
+		return {
+			ok: false,
+			stdout: e.stdout ? String(e.stdout) : "",
+			stderr: e.stderr ? String(e.stderr) : (e.message ?? ""),
+			code: typeof e.code === "number" ? e.code : null,
+		};
+	}
+};
+
+export type CodexPluginInstallAction = "installed" | "skipped-codex-unsupported" | "install-failed";
+
+export interface CodexPluginInstallResult {
+	action: CodexPluginInstallAction;
+	pluginVerified: boolean;
+	error?: string;
+}
+
+export interface InstallCodexPluginOptions {
+	/** Staged kit dir containing .agents/plugins/marketplace.json. */
+	pluginSourceDir: string;
+	installer?: CodexPluginInstaller;
+	codexHome?: string;
+}
+
+export class CodexPluginInstaller {
+	constructor(
+		private readonly run: CodexRunner = defaultCodexRunner,
+		private readonly codexHome?: string,
+	) {}
+
+	private opts(timeoutMs?: number): CodexRunOptions {
+		return { codexHome: this.codexHome, timeoutMs };
+	}
+
+	async isCodexAvailable(): Promise<boolean> {
+		return (await this.run(["--version"], this.opts(15_000))).ok;
+	}
+
+	async isPluginSupported(): Promise<boolean> {
+		const r = await this.run(["plugin", "--help"], this.opts(15_000));
+		return r.ok && /marketplace/i.test(r.stdout + r.stderr);
+	}
+
+	async marketplaceAdd(source: string): Promise<CodexRunResult> {
+		return this.run(["plugin", "marketplace", "add", source], this.opts());
+	}
+
+	async add(): Promise<CodexRunResult> {
+		return this.run(["plugin", "add", `${CK_PLUGIN_NAME}@${CK_MARKETPLACE_NAME}`], this.opts());
+	}
+
+	async listJson(): Promise<CodexRunResult> {
+		return this.run(["plugin", "list", "--json"], this.opts(15_000));
+	}
+
+	async verifyInstalled(): Promise<boolean> {
+		const r = await this.listJson();
+		if (!r.ok) return false;
+		try {
+			const parsed = JSON.parse(r.stdout) as {
+				installed?: Array<{ pluginId?: string; enabled?: boolean; installed?: boolean }>;
+			};
+			return (parsed.installed ?? []).some(
+				(plugin) =>
+					plugin.pluginId === `${CK_PLUGIN_NAME}@${CK_MARKETPLACE_NAME}` &&
+					plugin.installed === true &&
+					plugin.enabled === true,
+			);
+		} catch {
+			return false;
+		}
+	}
+}
+
+export async function installCodexPlugin(
+	opts: InstallCodexPluginOptions,
+): Promise<CodexPluginInstallResult> {
+	const installer = opts.installer ?? new CodexPluginInstaller(undefined, opts.codexHome);
+
+	if (!(await installer.isCodexAvailable()) || !(await installer.isPluginSupported())) {
+		return { action: "skipped-codex-unsupported", pluginVerified: false };
+	}
+
+	const added = await installer.marketplaceAdd(opts.pluginSourceDir);
+	if (!added.ok) {
+		return {
+			action: "install-failed",
+			pluginVerified: false,
+			error: `codex marketplace add failed: ${added.stderr.trim()}`,
+		};
+	}
+
+	const installed = await installer.add();
+	if (!installed.ok) {
+		return {
+			action: "install-failed",
+			pluginVerified: false,
+			error: `codex plugin add failed: ${installed.stderr.trim()}`,
+		};
+	}
+
+	const verified = await installer.verifyInstalled();
+	if (!verified) {
+		return {
+			action: "install-failed",
+			pluginVerified: false,
+			error: "codex plugin did not verify after install",
+		};
+	}
+
+	return { action: "installed", pluginVerified: true };
+}
+
+export async function shouldRefreshCodexPlugin(
+	installer: CodexPluginInstaller = new CodexPluginInstaller(),
+): Promise<boolean> {
+	if (!(await installer.isCodexAvailable()) || !(await installer.isPluginSupported())) {
+		return false;
+	}
+	return !(await installer.verifyInstalled());
+}

--- a/tests/integration/plugin-install-e2e.test.ts
+++ b/tests/integration/plugin-install-e2e.test.ts
@@ -4,6 +4,10 @@ import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { stagePluginSource } from "@/commands/init/phases/plugin-install-handler.js";
+import {
+	CodexPluginInstaller,
+	installCodexPlugin,
+} from "@/domains/installation/plugin/codex-plugin-installer.js";
 import { detectInstallMode } from "@/domains/installation/plugin/install-mode-detector.js";
 import { migrateLegacyToPlugin } from "@/domains/installation/plugin/migrate-legacy-to-plugin.js";
 
@@ -20,9 +24,29 @@ const KIT_CLAUDE_DIR =
 	process.env.ENGINEER_KIT_DIR ?? "/Users/kaitran/claudekit/claudekit-engineer/claude";
 
 const describeOrSkip =
-	RUN && existsSync(join(KIT_CLAUDE_DIR, ".claude-plugin", "plugin.json"))
+	RUN &&
+	existsSync(join(KIT_CLAUDE_DIR, ".claude-plugin", "plugin.json")) &&
+	commandWorks("claude", ["plugin", "--help"], /marketplace/i)
 		? describe
 		: describe.skip;
+const describeCodexOrSkip =
+	RUN &&
+	existsSync(join(KIT_CLAUDE_DIR, ".codex-plugin", "plugin.json")) &&
+	commandWorks("codex", ["plugin", "--help"], /marketplace/i)
+		? describe
+		: describe.skip;
+
+function commandWorks(command: string, args: string[], match?: RegExp): boolean {
+	try {
+		const output = execFileSync(command, args, {
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		return match ? match.test(output) : true;
+	} catch {
+		return false;
+	}
+}
 
 describeOrSkip("plugin install e2e (real claude binary, sandboxed)", () => {
 	let sandbox: string; // CLAUDE_CONFIG_DIR
@@ -67,5 +91,39 @@ describeOrSkip("plugin install e2e (real claude binary, sandboxed)", () => {
 			encoding: "utf-8",
 		});
 		expect(details).toMatch(/Skills \(\d{2,}\)/); // dozens of skills
+	}, 120_000);
+});
+
+describeCodexOrSkip("Codex plugin install e2e (real codex binary, sandboxed)", () => {
+	let codexHome: string;
+	let extractDir: string;
+	let stageDir: string;
+
+	beforeAll(() => {
+		const root = join(tmpdir(), `ck-codex-e2e-${Date.now()}`);
+		codexHome = join(root, "codex-home");
+		extractDir = join(root, "extract");
+		stageDir = join(root, "stage");
+		mkdirSync(codexHome, { recursive: true });
+		mkdirSync(join(extractDir, ".claude"), { recursive: true });
+		cpSync(KIT_CLAUDE_DIR, join(extractDir, ".claude"), { recursive: true });
+	});
+
+	afterAll(() => {
+		try {
+			rmSync(join(extractDir, ".."), { recursive: true, force: true });
+		} catch {}
+	});
+
+	test("installs ck@claudekit from the staged Codex marketplace", async () => {
+		const pluginSourceDir = stagePluginSource(extractDir, stageDir);
+		expect(existsSync(join(pluginSourceDir, ".agents", "plugins", "marketplace.json"))).toBe(true);
+
+		const result = await installCodexPlugin({ pluginSourceDir, codexHome });
+
+		expect(result).toEqual({ action: "installed", pluginVerified: true });
+		await expect(new CodexPluginInstaller(undefined, codexHome).verifyInstalled()).resolves.toBe(
+			true,
+		);
 	}, 120_000);
 });


### PR DESCRIPTION
## Summary
- Add a best-effort Codex plugin installer for plugin-capable Codex CLI builds.
- Stage modern Codex marketplace metadata during plugin-backed init while preserving the existing Claude plugin migration path.
- Let post-update self-heal rerun Engineer init when Codex is installed but `ck@claudekit` is missing or disabled.

## Validation
- `bun run typecheck && bun run lint && bun run build`
- `bun test src/domains/installation/plugin/__tests__ src/commands/init/phases/__tests__/plugin-install-handler.test.ts src/__tests__/commands/update-cli-auto-init.test.ts`
- `bun test src/__tests__/commands/update-cli-prompt-kit.test.ts src/__tests__/commands/update-cli-auto-init.test.ts src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts`
- `CK_RUN_CLI_INTEGRATION=1 ENGINEER_KIT_DIR=<engineer-kit>/claude bun test tests/integration/plugin-install-e2e.test.ts`
- Linux temp-home Codex alpha E2E: Codex plugin path passed; Claude path skipped because `claude` was unavailable.
- Windows temp-home Codex alpha E2E: Claude and Codex plugin paths passed.

## Docs Impact
- None. This is internal install/update behavior and test coverage.

## Release Impact
- `ck update --dev -y` can refresh the native Codex plugin when plugin-capable Codex is present.
- Older Codex builds skip the native plugin install non-fatally and keep the existing install flow.
