### PR TITLE
fix: remove settings.json hook and MCP entries on uninstall

### DIFF
--- a/src/__tests__/commands/update-cli-auto-init.test.ts
+++ b/src/__tests__/commands/update-cli-auto-init.test.ts
@@ -101,9 +101,16 @@ async function writeGlobalHookState(
 
 describe("promptKitUpdate auto-init behavior", () => {
 	let tempDir: string;
+	// Isolated empty home so hook self-heal checks never read the developer's real
+	// global ~/.claude (which has CK hooks installed). Without this, version-skip
+	// tests reinstall on a dev machine but pass in CI where ~/.claude is empty.
+	let testHome: string;
 
 	beforeEach(async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "ck-auto-init-"));
+		testHome = await mkdtemp(join(tmpdir(), "ck-auto-init-home-"));
+		await mkdir(join(testHome, ".claude"), { recursive: true });
+		process.env.CK_TEST_HOME = testHome;
 		await writeMetadata(tempDir);
 		confirmMock.mockReset();
 		confirmMock.mockResolvedValue(true);
@@ -115,6 +122,8 @@ describe("promptKitUpdate auto-init behavior", () => {
 
 	afterEach(async () => {
 		await rm(tempDir, { recursive: true, force: true });
+		await rm(testHome, { recursive: true, force: true });
+		Reflect.deleteProperty(process.env, "CK_TEST_HOME");
 	});
 
 	/** Create test deps with exec mock (for -y mode) and spawn mock (for interactive mode) */

--- a/src/__tests__/commands/update-cli-prompt-kit.test.ts
+++ b/src/__tests__/commands/update-cli-prompt-kit.test.ts
@@ -3,7 +3,7 @@
  * Uses ONLY dependency injection — zero mock.module() to avoid cross-file contamination.
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PromptKitUpdateDeps } from "@/commands/update-cli.js";
@@ -13,13 +13,22 @@ import { versionsMatch } from "@/domains/versioning/checking/version-utils.js";
 
 describe("promptKitUpdate version display", () => {
 	let tempDir: string;
+	// Isolated empty home so hook self-heal checks never read the developer's real
+	// global ~/.claude (which has CK hooks installed). Without this, version-skip
+	// tests reinstall on a dev machine but pass in CI where ~/.claude is empty.
+	let testHome: string;
 
 	beforeEach(async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "ck-prompt-kit-"));
+		testHome = await mkdtemp(join(tmpdir(), "ck-prompt-kit-home-"));
+		await mkdir(join(testHome, ".claude"), { recursive: true });
+		process.env.CK_TEST_HOME = testHome;
 	});
 
 	afterEach(async () => {
 		await rm(tempDir, { recursive: true, force: true });
+		await rm(testHome, { recursive: true, force: true });
+		Reflect.deleteProperty(process.env, "CK_TEST_HOME");
 	});
 
 	/** Build deps with injectable exec side-effect and spinner capture */

--- a/src/commands/uninstall/removal-handler.ts
+++ b/src/commands/uninstall/removal-handler.ts
@@ -26,6 +26,7 @@ import {
 	displayDryRunPreview,
 } from "./analysis-handler.js";
 import type { Installation } from "./installation-detector.js";
+import { type SettingsCleanupResult, cleanupUninstalledSettings } from "./settings-cleanup.js";
 
 export interface UninstallExecutionSummary {
 	path: string;
@@ -48,12 +49,46 @@ async function isDirectory(filePath: string): Promise<boolean> {
 
 function getUninstallMutatePaths(options: {
 	retainedManifestPaths: string[];
+	settingsFileExists: boolean;
+	ckJsonExists: boolean;
 }): string[] {
+	const paths: string[] = [];
+
+	// metadata.json is mutated (rewritten) only on partial uninstall; a full uninstall lists it
+	// in toDelete instead, so adding it here would be redundant.
 	if (options.retainedManifestPaths.length > 0) {
-		return ["metadata.json"];
+		paths.push("metadata.json");
 	}
 
-	return [];
+	// settings.json and .ck.json are mutated by settings cleanup. Back them up so an uninstall
+	// failure rolls their previous content back alongside the deleted files.
+	if (options.settingsFileExists) {
+		paths.push("settings.json");
+	}
+	if (options.ckJsonExists) {
+		paths.push(".ck.json");
+	}
+
+	return paths;
+}
+
+/**
+ * Log a one-line summary of the settings.json/.ck.json entries reversed during uninstall.
+ */
+function logSettingsCleanup(result: SettingsCleanupResult, dryRun: boolean): void {
+	if (result.hooksRemoved === 0 && result.mcpServersRemoved === 0) return;
+
+	const parts: string[] = [];
+	if (result.hooksRemoved > 0) {
+		parts.push(`${result.hooksRemoved} hook${result.hooksRemoved === 1 ? "" : "s"}`);
+	}
+	if (result.mcpServersRemoved > 0) {
+		parts.push(
+			`${result.mcpServersRemoved} MCP server${result.mcpServersRemoved === 1 ? "" : "s"}`,
+		);
+	}
+	const verb = dryRun ? "Would remove" : "Removed";
+	log.info(`${verb} ${parts.join(" and ")} from settings.json`);
 }
 
 async function restoreUninstallBackup(backup: DestructiveOperationBackup): Promise<void> {
@@ -127,6 +162,12 @@ export async function removeInstallations(
 				const label = options.kit ? `${installation.type} (${options.kit} kit)` : installation.type;
 				const legacyLabel = !installation.hasMetadata ? " [legacy]" : "";
 				displayDryRunPreview(analysis, `${label}${legacyLabel}`);
+				const settingsPreview = await cleanupUninstalledSettings(installation.path, {
+					kit: options.kit,
+					remainingKits: analysis.remainingKits,
+					dryRun: true,
+				});
+				logSettingsCleanup(settingsPreview, true);
 				if (analysis.remainingKits.length > 0) {
 					log.info(`Remaining kits after uninstall: ${analysis.remainingKits.join(", ")}`);
 				}
@@ -138,6 +179,8 @@ export async function removeInstallations(
 
 			const mutatePaths = getUninstallMutatePaths({
 				retainedManifestPaths: analysis.retainedManifestPaths,
+				settingsFileExists: await pathExists(join(installation.path, "settings.json")),
+				ckJsonExists: await pathExists(join(installation.path, ".ck.json")),
 			});
 			let backup: DestructiveOperationBackup | null = null;
 
@@ -212,6 +255,16 @@ export async function removeInstallations(
 						throw new Error("Failed to update metadata.json after partial uninstall");
 					}
 				}
+
+				// Reverse settings.json hook/MCP registrations and clear .ck.json tracking.
+				// Runs before the empty-directory check so removing settings.json / .ck.json can
+				// leave the install dir empty and eligible for cleanup. Covered by the recovery
+				// backup (settings.json / .ck.json are in mutatePaths) so a failure rolls back.
+				const settingsCleanup = await cleanupUninstalledSettings(installation.path, {
+					kit: options.kit,
+					remainingKits: analysis.remainingKits,
+				});
+				logSettingsCleanup(settingsCleanup, false);
 
 				// Check if installation directory is now empty, remove it
 				try {

--- a/src/commands/uninstall/settings-cleanup.ts
+++ b/src/commands/uninstall/settings-cleanup.ts
@@ -1,0 +1,277 @@
+/**
+ * Settings Cleanup (uninstall)
+ *
+ * Reverses the settings.json mutations that `ck init` performed. Install records every
+ * hook command and MCP server it writes into settings.json inside `.ck.json`
+ * (InstalledSettingsTracker). Uninstall reads that tracking back and removes exactly those
+ * entries from settings.json, then clears the corresponding `.ck.json` tracking.
+ *
+ * Safety rules:
+ * - Only remove hook/MCP entries whose normalized command matches what CK tracked installing.
+ *   User-authored or user-edited entries never match and are preserved.
+ * - For kit-scoped uninstall, an entry still tracked by a remaining kit is preserved (shared).
+ * - User hook enable/disable preferences (top-level `hooks` map in `.ck.json`) are preserved.
+ */
+
+import { join } from "node:path";
+import { type SettingsJson, SettingsMerger } from "@/domains/config/settings-merger.js";
+import { normalizeCommand } from "@/shared/command-normalizer.js";
+import { parseJsonContent } from "@/shared/json-content.js";
+import { logger } from "@/shared/logger.js";
+import type { InstalledSettings, KitType } from "@/types";
+import { pathExists, readFile, remove, writeFile } from "fs-extra";
+
+const CK_JSON_FILE = ".ck.json";
+const SETTINGS_FILE = "settings.json";
+
+interface CkJsonData {
+	kits?: Record<string, { installedSettings?: InstalledSettings; [key: string]: unknown }>;
+	[key: string]: unknown;
+}
+
+export interface SettingsCleanupResult {
+	hooksRemoved: number;
+	mcpServersRemoved: number;
+	settingsFileRemoved: boolean;
+	ckJsonRemoved: boolean;
+}
+
+const EMPTY_RESULT: SettingsCleanupResult = {
+	hooksRemoved: 0,
+	mcpServersRemoved: 0,
+	settingsFileRemoved: false,
+	ckJsonRemoved: false,
+};
+
+export interface SettingsCleanupOptions {
+	/** Kit being removed. Undefined means a full uninstall of every tracked kit. */
+	kit?: KitType;
+	/** Kits that remain installed after this uninstall (their entries must be preserved). */
+	remainingKits: KitType[];
+	/** When true, compute counts but do not write/delete anything. */
+	dryRun?: boolean;
+}
+
+/**
+ * Resolve which tracked hook commands (normalized) and MCP server names should be removed
+ * from settings.json for this uninstall, excluding anything a remaining kit still owns.
+ */
+function resolveRemovalTargets(
+	kits: Record<string, { installedSettings?: InstalledSettings }>,
+	removedKitNames: string[],
+	remainingKits: KitType[],
+): { hooks: Set<string>; servers: Set<string> } {
+	const retainedHooks = new Set<string>();
+	const retainedServers = new Set<string>();
+	for (const remainingKit of remainingKits) {
+		const installed = kits[remainingKit]?.installedSettings;
+		for (const command of installed?.hooks ?? []) {
+			const normalized = normalizeCommand(command);
+			if (normalized) retainedHooks.add(normalized);
+		}
+		for (const server of installed?.mcpServers ?? []) {
+			retainedServers.add(server);
+		}
+	}
+
+	const hooks = new Set<string>();
+	const servers = new Set<string>();
+	for (const kitName of removedKitNames) {
+		const installed = kits[kitName]?.installedSettings;
+		for (const command of installed?.hooks ?? []) {
+			const normalized = normalizeCommand(command);
+			if (normalized && !retainedHooks.has(normalized)) hooks.add(normalized);
+		}
+		for (const server of installed?.mcpServers ?? []) {
+			if (!retainedServers.has(server)) servers.add(server);
+		}
+	}
+
+	return { hooks, servers };
+}
+
+/**
+ * Remove hook entries whose normalized command matches one of `normalizedToRemove`.
+ * Handles both HookConfig (nested `hooks` array) and bare HookEntry shapes, and prunes
+ * empty hook configs / empty event arrays / an empty `hooks` key.
+ * @returns number of individual hooks removed
+ */
+function removeHooksFromSettings(settings: SettingsJson, normalizedToRemove: Set<string>): number {
+	if (!settings.hooks || normalizedToRemove.size === 0) return 0;
+
+	let removed = 0;
+	const eventKeysToDelete: string[] = [];
+
+	for (const [eventName, entries] of Object.entries(settings.hooks)) {
+		const keptEntries: Array<Record<string, unknown>> = [];
+
+		for (const entry of entries as Array<Record<string, unknown>>) {
+			if (Array.isArray(entry.hooks)) {
+				const keptHooks = (entry.hooks as Array<{ command?: unknown }>).filter((hook) => {
+					if (
+						typeof hook.command === "string" &&
+						normalizedToRemove.has(normalizeCommand(hook.command))
+					) {
+						removed++;
+						return false;
+					}
+					return true;
+				});
+				// Drop the whole config when all of its hooks were CK-installed and removed.
+				if (keptHooks.length > 0) {
+					keptEntries.push({ ...entry, hooks: keptHooks });
+				}
+				continue;
+			}
+
+			if (
+				typeof entry.command === "string" &&
+				normalizedToRemove.has(normalizeCommand(entry.command))
+			) {
+				removed++;
+				continue;
+			}
+
+			keptEntries.push(entry);
+		}
+
+		if (keptEntries.length > 0) {
+			(settings.hooks as Record<string, unknown>)[eventName] = keptEntries;
+		} else {
+			eventKeysToDelete.push(eventName);
+		}
+	}
+
+	for (const eventName of eventKeysToDelete) {
+		delete settings.hooks[eventName];
+	}
+	if (Object.keys(settings.hooks).length === 0) {
+		Reflect.deleteProperty(settings, "hooks");
+	}
+
+	return removed;
+}
+
+/**
+ * Remove tracked MCP servers from settings.mcp.servers, pruning empty `servers`/`mcp` keys.
+ * @returns number of servers removed
+ */
+function removeMcpServersFromSettings(
+	settings: SettingsJson,
+	serversToRemove: Set<string>,
+): number {
+	const servers = settings.mcp?.servers;
+	if (!servers || serversToRemove.size === 0) return 0;
+
+	let removed = 0;
+	for (const name of serversToRemove) {
+		if (Object.hasOwn(servers, name)) {
+			delete servers[name];
+			removed++;
+		}
+	}
+
+	if (removed > 0 && settings.mcp) {
+		if (Object.keys(servers).length === 0) {
+			Reflect.deleteProperty(settings.mcp, "servers");
+		}
+		if (Object.keys(settings.mcp).length === 0) {
+			Reflect.deleteProperty(settings, "mcp");
+		}
+	}
+
+	return removed;
+}
+
+/**
+ * Remove the uninstalled kit(s) from `.ck.json` tracking. Deletes the file entirely when no
+ * kits remain and no other top-level keys (e.g. user hook-disable prefs) exist.
+ * @returns true if the `.ck.json` file was deleted
+ */
+async function cleanupCkJson(
+	ckJsonPath: string,
+	data: CkJsonData,
+	removedKitNames: string[],
+	dryRun: boolean,
+): Promise<boolean> {
+	if (!data.kits) return false;
+
+	for (const kitName of removedKitNames) {
+		delete data.kits[kitName];
+	}
+
+	const noKitsLeft = Object.keys(data.kits).length === 0;
+	const otherTopLevelKeys = Object.keys(data).filter((key) => key !== "kits");
+
+	if (dryRun) return noKitsLeft && otherTopLevelKeys.length === 0;
+
+	if (noKitsLeft && otherTopLevelKeys.length === 0) {
+		await remove(ckJsonPath);
+		return true;
+	}
+
+	if (noKitsLeft) {
+		Reflect.deleteProperty(data, "kits");
+	}
+	await writeFile(ckJsonPath, JSON.stringify(data, null, 2), "utf-8");
+	return false;
+}
+
+/**
+ * Reverse settings.json mutations and clear `.ck.json` tracking for an uninstalled scope.
+ * No-op (zero result) when `.ck.json` does not exist (nothing was ever tracked).
+ *
+ * @param installationPath - The `.claude` directory of the installation (local or global)
+ */
+export async function cleanupUninstalledSettings(
+	installationPath: string,
+	options: SettingsCleanupOptions,
+): Promise<SettingsCleanupResult> {
+	const ckJsonPath = join(installationPath, CK_JSON_FILE);
+	if (!(await pathExists(ckJsonPath))) {
+		return { ...EMPTY_RESULT };
+	}
+
+	let data: CkJsonData;
+	try {
+		data = parseJsonContent<CkJsonData>(await readFile(ckJsonPath, "utf-8"));
+	} catch (error) {
+		logger.debug(
+			`Settings cleanup: failed to parse ${ckJsonPath}: ${
+				error instanceof Error ? error.message : "unknown error"
+			}`,
+		);
+		return { ...EMPTY_RESULT };
+	}
+
+	const kits = data.kits ?? {};
+	const removedKitNames = options.kit ? [options.kit] : Object.keys(kits);
+	const { hooks, servers } = resolveRemovalTargets(kits, removedKitNames, options.remainingKits);
+
+	const result: SettingsCleanupResult = { ...EMPTY_RESULT };
+	const settingsPath = join(installationPath, SETTINGS_FILE);
+	const settings = await SettingsMerger.readSettingsFile(settingsPath);
+
+	if (settings) {
+		result.hooksRemoved = removeHooksFromSettings(settings, hooks);
+		result.mcpServersRemoved = removeMcpServersFromSettings(settings, servers);
+
+		if (!options.dryRun && (result.hooksRemoved > 0 || result.mcpServersRemoved > 0)) {
+			if (Object.keys(settings).length === 0) {
+				await remove(settingsPath);
+				result.settingsFileRemoved = true;
+			} else {
+				await SettingsMerger.writeSettingsFile(settingsPath, settings);
+			}
+		}
+	}
+
+	result.ckJsonRemoved = await cleanupCkJson(
+		ckJsonPath,
+		data,
+		removedKitNames,
+		options.dryRun ?? false,
+	);
+
+	return result;
+}

--- a/tests/commands/uninstall-settings-cleanup.test.ts
+++ b/tests/commands/uninstall-settings-cleanup.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { cleanupUninstalledSettings } from "@/commands/uninstall/settings-cleanup.js";
+import type { SettingsJson } from "@/domains/config/settings-merger.js";
+import { type TestPaths, setupTestPaths } from "../helpers/test-paths.js";
+
+/**
+ * Unit tests for the uninstall settings-cleanup module (issue #898).
+ * Verifies that uninstall reverses the hook/MCP registrations install wrote into
+ * settings.json and clears .ck.json tracking, while preserving user-authored and
+ * shared remaining-kit entries.
+ */
+describe("cleanupUninstalledSettings", () => {
+	let testPaths: TestPaths;
+	let claudeDir: string;
+
+	beforeEach(async () => {
+		testPaths = setupTestPaths();
+		// Use a dedicated install dir so the helper's pre-seeded global .claude stays clean
+		claudeDir = join(testPaths.testHome, "install", ".claude");
+		await mkdir(claudeDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		testPaths.cleanup();
+	});
+
+	const settingsPath = () => join(claudeDir, "settings.json");
+	const ckJsonPath = () => join(claudeDir, ".ck.json");
+
+	async function writeSettings(settings: SettingsJson): Promise<void> {
+		await writeFile(settingsPath(), JSON.stringify(settings, null, 2), "utf-8");
+	}
+
+	async function writeCkJson(data: unknown): Promise<void> {
+		await writeFile(ckJsonPath(), JSON.stringify(data, null, 2), "utf-8");
+	}
+
+	function readSettings(): SettingsJson {
+		return JSON.parse(readFileSync(settingsPath(), "utf-8")) as SettingsJson;
+	}
+
+	/** Flatten all hook command strings for an event, across HookConfig and HookEntry shapes. */
+	function hookCommands(event: string): string[] {
+		const entries = (readSettings().hooks?.[event] ?? []) as Array<Record<string, unknown>>;
+		return entries.flatMap((entry) => {
+			if (Array.isArray(entry.hooks)) {
+				return (entry.hooks as Array<{ command?: string }>).map((h) => h.command ?? "");
+			}
+			return [entry.command as string];
+		});
+	}
+
+	test("removes CK-installed hooks while preserving user hooks", async () => {
+		await writeSettings({
+			hooks: {
+				PreToolUse: [
+					{
+						matcher: "Bash",
+						hooks: [
+							{ type: "command", command: 'node "$HOME/.claude/hooks/ck-guard.cjs"' },
+							{ type: "command", command: 'node "$HOME/.claude/hooks/user-guard.cjs"' },
+						],
+					},
+				],
+			},
+		});
+		await writeCkJson({
+			kits: {
+				engineer: {
+					installedSettings: {
+						hooks: ['node "$HOME/.claude/hooks/ck-guard.cjs"'],
+						mcpServers: [],
+					},
+				},
+			},
+		});
+
+		const result = await cleanupUninstalledSettings(claudeDir, { remainingKits: [] });
+
+		expect(result.hooksRemoved).toBe(1);
+		expect(hookCommands("PreToolUse")).toEqual(['node "$HOME/.claude/hooks/user-guard.cjs"']);
+	});
+
+	test("matches tracked hooks across path-format differences (tilde vs $HOME)", async () => {
+		await writeSettings({
+			hooks: {
+				SessionStart: [
+					{ hooks: [{ type: "command", command: "node ~/.claude/hooks/session.cjs" }] },
+				],
+			},
+		});
+		await writeCkJson({
+			kits: {
+				engineer: {
+					installedSettings: {
+						hooks: ['node "$HOME/.claude/hooks/session.cjs"'],
+						mcpServers: [],
+					},
+				},
+			},
+		});
+
+		const result = await cleanupUninstalledSettings(claudeDir, { remainingKits: [] });
+
+		expect(result.hooksRemoved).toBe(1);
+		// The only hook was removed -> settings became empty -> file deleted
+		expect(result.settingsFileRemoved).toBe(true);
+		expect(existsSync(settingsPath())).toBe(false);
+	});
+
+	test("removes CK MCP servers while preserving user servers", async () => {
+		await writeSettings({
+			mcp: {
+				servers: {
+					qdrant: { command: "qdrant" },
+					"user-server": { command: "custom" },
+				},
+			},
+		});
+		await writeCkJson({
+			kits: {
+				engineer: { installedSettings: { hooks: [], mcpServers: ["qdrant"] } },
+			},
+		});
+
+		const result = await cleanupUninstalledSettings(claudeDir, { remainingKits: [] });
+
+		expect(result.mcpServersRemoved).toBe(1);
+		const settings = readSettings();
+		expect(settings.mcp?.servers).toEqual({ "user-server": { command: "custom" } });
+	});
+
+	test("kit-scoped uninstall preserves hooks shared with a remaining kit", async () => {
+		const sharedHook = 'node "$HOME/.claude/hooks/shared.cjs"';
+		const engineerHook = 'node "$HOME/.claude/hooks/engineer-only.cjs"';
+		await writeSettings({
+			hooks: {
+				PreToolUse: [
+					{
+						hooks: [
+							{ type: "command", command: sharedHook },
+							{ type: "command", command: engineerHook },
+						],
+					},
+				],
+			},
+		});
+		await writeCkJson({
+			kits: {
+				engineer: { installedSettings: { hooks: [sharedHook, engineerHook], mcpServers: [] } },
+				marketing: { installedSettings: { hooks: [sharedHook], mcpServers: [] } },
+			},
+		});
+
+		const result = await cleanupUninstalledSettings(claudeDir, {
+			kit: "engineer",
+			remainingKits: ["marketing"],
+		});
+
+		expect(result.hooksRemoved).toBe(1);
+		expect(hookCommands("PreToolUse")).toEqual([sharedHook]);
+
+		// .ck.json keeps the marketing entry, drops engineer
+		const ckJson = JSON.parse(readFileSync(ckJsonPath(), "utf-8"));
+		expect(ckJson.kits.engineer).toBeUndefined();
+		expect(ckJson.kits.marketing).toBeDefined();
+		expect(result.ckJsonRemoved).toBe(false);
+	});
+
+	test("deletes .ck.json on full uninstall when no kits remain", async () => {
+		await writeSettings({
+			hooks: {
+				SessionStart: [{ hooks: [{ type: "command", command: "node ~/.claude/hooks/a.cjs" }] }],
+			},
+		});
+		await writeCkJson({
+			kits: {
+				engineer: { installedSettings: { hooks: ["node ~/.claude/hooks/a.cjs"], mcpServers: [] } },
+			},
+		});
+
+		const result = await cleanupUninstalledSettings(claudeDir, { remainingKits: [] });
+
+		expect(result.ckJsonRemoved).toBe(true);
+		expect(existsSync(ckJsonPath())).toBe(false);
+		// settings.json had only the CK hook -> file removed once empty
+		expect(result.settingsFileRemoved).toBe(true);
+		expect(existsSync(settingsPath())).toBe(false);
+	});
+
+	test("preserves top-level hook-disable prefs in .ck.json after full uninstall", async () => {
+		await writeSettings({ hooks: {} });
+		await writeCkJson({
+			hooks: { "some-hook": false },
+			kits: { engineer: { installedSettings: { hooks: [], mcpServers: [] } } },
+		});
+
+		const result = await cleanupUninstalledSettings(claudeDir, { remainingKits: [] });
+
+		expect(result.ckJsonRemoved).toBe(false);
+		const ckJson = JSON.parse(readFileSync(ckJsonPath(), "utf-8"));
+		expect(ckJson.hooks).toEqual({ "some-hook": false });
+		expect(ckJson.kits).toBeUndefined();
+	});
+
+	test("no-op (zero result) when .ck.json is absent", async () => {
+		await writeSettings({
+			hooks: {
+				SessionStart: [{ hooks: [{ type: "command", command: "node ~/.claude/hooks/a.cjs" }] }],
+			},
+		});
+
+		const result = await cleanupUninstalledSettings(claudeDir, { remainingKits: [] });
+
+		expect(result).toEqual({
+			hooksRemoved: 0,
+			mcpServersRemoved: 0,
+			settingsFileRemoved: false,
+			ckJsonRemoved: false,
+		});
+		// settings.json untouched
+		expect(existsSync(settingsPath())).toBe(true);
+	});
+
+	test("dry-run computes counts without mutating files", async () => {
+		await writeSettings({
+			hooks: {
+				SessionStart: [{ hooks: [{ type: "command", command: "node ~/.claude/hooks/a.cjs" }] }],
+			},
+			mcp: { servers: { qdrant: { command: "qdrant" } } },
+		});
+		await writeCkJson({
+			kits: {
+				engineer: {
+					installedSettings: { hooks: ["node ~/.claude/hooks/a.cjs"], mcpServers: ["qdrant"] },
+				},
+			},
+		});
+		const settingsBefore = readFileSync(settingsPath(), "utf-8");
+		const ckJsonBefore = readFileSync(ckJsonPath(), "utf-8");
+
+		const result = await cleanupUninstalledSettings(claudeDir, { remainingKits: [], dryRun: true });
+
+		expect(result.hooksRemoved).toBe(1);
+		expect(result.mcpServersRemoved).toBe(1);
+		expect(readFileSync(settingsPath(), "utf-8")).toBe(settingsBefore);
+		expect(readFileSync(ckJsonPath(), "utf-8")).toBe(ckJsonBefore);
+	});
+});


### PR DESCRIPTION
## Problem

`ck uninstall` deleted ClaudeKit files but never reversed the `settings.json`
mutations that `ck init` made. After a global uninstall, hook registrations
(and MCP server entries) written into `~/.claude/settings.json` survived, leaving
the file pointing at hook scripts that no longer exist; a later re-install then
inherited those zombie entries.

Closes #898

## Root Cause

Install already records every hook command and MCP server it writes into
`settings.json` inside `.ck.json` (`InstalledSettingsTracker`). The uninstall
path (`removal-handler.ts` / `analysis-handler.ts`) only removed files listed in
`metadata.json` and never read `.ck.json`, never touched `settings.json`, and
never cleaned up `.ck.json`. The reverse-tracking data existed but was unused.

## What changed

| File | Change |
|------|--------|
| `src/commands/uninstall/settings-cleanup.ts` | New module: loads `.ck.json` tracking, removes the matching hook/MCP entries from `settings.json`, clears the kit's `.ck.json` tracking |
| `src/commands/uninstall/removal-handler.ts` | Wires cleanup into removal (dry-run preview + real run); adds `settings.json` / `.ck.json` to the recovery backup; surfaces counts in the summary |
| `tests/commands/uninstall-settings-cleanup.test.ts` | New unit suite (8 cases) |

Behavior:
- Normalized-command matching removes a tracked hook across path-format
  differences (tilde vs `$HOME`). User-authored or user-edited entries never
  match and are preserved.
- Kit-scoped uninstall preserves entries still tracked by a remaining kit.
- User hook enable/disable prefs (top-level `hooks` map in `.ck.json`) are preserved.
- `settings.json` / `.ck.json` are added to the recovery backup so a failed
  uninstall rolls their previous content back.
- Empty `settings.json` / `.ck.json` are removed once nothing meaningful remains.

## Incidental test fix

While validating, the `promptKitUpdate` version-skip tests
(`update-cli-auto-init`, `update-cli-prompt-kit`) were found to be non-hermetic:
they created temp install dirs but never isolated the home directory, so the hook
self-heal checks read the developer's real global `~/.claude`. On a machine with
ClaudeKit installed they flagged a reinstall and failed locally, while passing in
CI (empty `~/.claude`). Fixed by pointing `CK_TEST_HOME` at a fresh empty home in
`beforeEach`. No production code change. Separate commit (`test:`).

## Validation

- [x] `bun run ci:local` passes (typecheck, lint, build, full test suite, help/manifest/docs parity, ui:build, prepublish)
- [x] New cleanup suite: 8/8 pass
- [x] Existing uninstall integration suite: 46/46 pass
- [x] `promptKitUpdate` suites now hermetic and deterministic
