### PR TITLE
fix: ck init --yes re-onboards missing hook files instead of skipping on version match

### DIFF
--- a/src/__tests__/commands/init/phases/selection-handler-version-skip.test.ts
+++ b/src/__tests__/commands/init/phases/selection-handler-version-skip.test.ts
@@ -43,6 +43,20 @@ describe("selection-handler version skip (structural)", () => {
 		expect(earlyExitBlock).toContain("cancelled: true");
 	});
 
+	it("checks for missing registered hook files before skipping (issue #900)", () => {
+		expect(earlyExitBlock).toContain("countMissingHookFileReferencesForClaudeDir(claudeDir)");
+		expect(earlyExitBlock).toContain("missingHookFiles > 0");
+	});
+
+	it("guards the skip return behind the missing-hooks check (not version match alone)", () => {
+		// The skip's success log must come AFTER the missing-hooks check, i.e. live in the
+		// else branch so a broken install re-onboards instead of skipping.
+		const missingIdx = earlyExitBlock.indexOf("missingHookFiles > 0");
+		const skipIdx = earlyExitBlock.indexOf("skipping reinstall");
+		expect(missingIdx).toBeGreaterThan(-1);
+		expect(missingIdx).toBeLessThan(skipIdx);
+	});
+
 	it("catches metadata read errors with verbose logging", () => {
 		expect(earlyExitBlock).toContain("catch");
 		expect(earlyExitBlock).toContain("logger.verbose");

--- a/src/__tests__/commands/update-cli-auto-init.test.ts
+++ b/src/__tests__/commands/update-cli-auto-init.test.ts
@@ -101,9 +101,16 @@ async function writeGlobalHookState(
 
 describe("promptKitUpdate auto-init behavior", () => {
 	let tempDir: string;
+	// Isolated empty home so hook self-heal checks never read the developer's real
+	// global ~/.claude (which has CK hooks installed). Without this, version-skip
+	// tests reinstall on a dev machine but pass in CI where ~/.claude is empty.
+	let testHome: string;
 
 	beforeEach(async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "ck-auto-init-"));
+		testHome = await mkdtemp(join(tmpdir(), "ck-auto-init-home-"));
+		await mkdir(join(testHome, ".claude"), { recursive: true });
+		process.env.CK_TEST_HOME = testHome;
 		await writeMetadata(tempDir);
 		confirmMock.mockReset();
 		confirmMock.mockResolvedValue(true);
@@ -115,6 +122,8 @@ describe("promptKitUpdate auto-init behavior", () => {
 
 	afterEach(async () => {
 		await rm(tempDir, { recursive: true, force: true });
+		await rm(testHome, { recursive: true, force: true });
+		Reflect.deleteProperty(process.env, "CK_TEST_HOME");
 	});
 
 	/** Create test deps with exec mock (for -y mode) and spawn mock (for interactive mode) */

--- a/src/__tests__/commands/update-cli-prompt-kit.test.ts
+++ b/src/__tests__/commands/update-cli-prompt-kit.test.ts
@@ -3,7 +3,7 @@
  * Uses ONLY dependency injection — zero mock.module() to avoid cross-file contamination.
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PromptKitUpdateDeps } from "@/commands/update-cli.js";
@@ -13,13 +13,22 @@ import { versionsMatch } from "@/domains/versioning/checking/version-utils.js";
 
 describe("promptKitUpdate version display", () => {
 	let tempDir: string;
+	// Isolated empty home so hook self-heal checks never read the developer's real
+	// global ~/.claude (which has CK hooks installed). Without this, version-skip
+	// tests reinstall on a dev machine but pass in CI where ~/.claude is empty.
+	let testHome: string;
 
 	beforeEach(async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "ck-prompt-kit-"));
+		testHome = await mkdtemp(join(tmpdir(), "ck-prompt-kit-home-"));
+		await mkdir(join(testHome, ".claude"), { recursive: true });
+		process.env.CK_TEST_HOME = testHome;
 	});
 
 	afterEach(async () => {
 		await rm(tempDir, { recursive: true, force: true });
+		await rm(testHome, { recursive: true, force: true });
+		Reflect.deleteProperty(process.env, "CK_TEST_HOME");
 	});
 
 	/** Build deps with injectable exec side-effect and spinner capture */

--- a/src/__tests__/domains/health-checks/checkers/hook-health-checker-missing-refs-scoped.test.ts
+++ b/src/__tests__/domains/health-checks/checkers/hook-health-checker-missing-refs-scoped.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { countMissingHookFileReferencesForClaudeDir } from "@/domains/health-checks/checkers/hook-health-checker.js";
+
+/**
+ * Unit tests for countMissingHookFileReferencesForClaudeDir (issue #900).
+ * Scoped, install-specific count of registered hook commands whose script file is
+ * missing from THIS install's hooks/ dir — drives the init version-skip integrity check.
+ */
+describe("countMissingHookFileReferencesForClaudeDir", () => {
+	let projectRoot: string;
+	let claudeDir: string;
+	let hooksDir: string;
+
+	beforeEach(async () => {
+		projectRoot = await mkdtemp(join(tmpdir(), "ck-missing-refs-"));
+		claudeDir = join(projectRoot, ".claude");
+		hooksDir = join(claudeDir, "hooks");
+		await mkdir(hooksDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(projectRoot, { recursive: true, force: true });
+	});
+
+	// Hook command rooted at $CLAUDE_PROJECT_DIR so it resolves under claudeDir/hooks
+	// via the helper's default projectRoot (= dirname(claudeDir) = projectRoot).
+	const hookCmd = (name: string) => `node "$CLAUDE_PROJECT_DIR/.claude/hooks/${name}.cjs"`;
+
+	async function writeSettings(hooks: Record<string, unknown>, fileName = "settings.json") {
+		await writeFile(join(claudeDir, fileName), JSON.stringify({ hooks }, null, 2), "utf-8");
+	}
+
+	async function createHookScript(name: string) {
+		await writeFile(join(hooksDir, `${name}.cjs`), "// stub\n", "utf-8");
+	}
+
+	test("counts a registered hook whose script is missing on disk", async () => {
+		await writeSettings({
+			SessionStart: [{ hooks: [{ type: "command", command: hookCmd("session-init") }] }],
+		});
+		// session-init.cjs intentionally not created
+		await expect(countMissingHookFileReferencesForClaudeDir(claudeDir)).resolves.toBe(1);
+	});
+
+	test("returns 0 when every referenced script exists", async () => {
+		await writeSettings({
+			SessionStart: [{ hooks: [{ type: "command", command: hookCmd("session-init") }] }],
+			Stop: [{ hooks: [{ type: "command", command: hookCmd("session-state") }] }],
+		});
+		await createHookScript("session-init");
+		await createHookScript("session-state");
+		await expect(countMissingHookFileReferencesForClaudeDir(claudeDir)).resolves.toBe(0);
+	});
+
+	test("counts across multiple events and only the missing ones", async () => {
+		await writeSettings({
+			SessionStart: [{ hooks: [{ type: "command", command: hookCmd("session-init") }] }],
+			Stop: [{ hooks: [{ type: "command", command: hookCmd("session-state") }] }],
+			PreToolUse: [{ hooks: [{ type: "command", command: hookCmd("descriptive-name") }] }],
+		});
+		await createHookScript("session-init"); // present; other two missing
+		await expect(countMissingHookFileReferencesForClaudeDir(claudeDir)).resolves.toBe(2);
+	});
+
+	test("also scans settings.local.json", async () => {
+		await writeSettings(
+			{ Stop: [{ hooks: [{ type: "command", command: hookCmd("local-only") }] }] },
+			"settings.local.json",
+		);
+		await expect(countMissingHookFileReferencesForClaudeDir(claudeDir)).resolves.toBe(1);
+	});
+
+	test("ignores a missing reference outside the install hooks/ dir", async () => {
+		// Points at .claude/custom/* (not hooks/) — a reinstall could not restore it, so it must
+		// NOT permanently disable the version-skip optimization.
+		await writeSettings({
+			Stop: [
+				{
+					hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.claude/custom/x.cjs"' }],
+				},
+			],
+		});
+		await expect(countMissingHookFileReferencesForClaudeDir(claudeDir)).resolves.toBe(0);
+	});
+
+	test("returns 0 when no settings.json exists", async () => {
+		await expect(countMissingHookFileReferencesForClaudeDir(claudeDir)).resolves.toBe(0);
+	});
+});

--- a/src/commands/init/phases/selection-handler.ts
+++ b/src/commands/init/phases/selection-handler.ts
@@ -9,6 +9,7 @@ import { ConfigManager } from "@/domains/config/config-manager.js";
 import { GitHubClient } from "@/domains/github/github-client.js";
 import { detectAccessibleKits } from "@/domains/github/kit-access-checker.js";
 import { runPreflightChecks } from "@/domains/github/preflight-checker.js";
+import { countMissingHookFileReferencesForClaudeDir } from "@/domains/health-checks/checkers/hook-health-checker.js";
 import { handleFreshInstallation } from "@/domains/installation/fresh-installer.js";
 import { repairLegacyWindowsGlobalKitDir } from "@/domains/installation/global-kit-legacy-repair.js";
 import { versionsMatch } from "@/domains/versioning/checking/version-utils.js";
@@ -528,10 +529,21 @@ export async function handleSelection(ctx: InitContext): Promise<InitContext> {
 			const existingMetadata = await readManifest(claudeDir);
 			const installedKitVersion = existingMetadata?.kits?.[kitType]?.version;
 			if (installedKitVersion && versionsMatch(installedKitVersion, releaseTag)) {
-				logger.success(
-					`Already at latest version (${kitType}@${installedKitVersion}), skipping reinstall`,
-				);
-				return { ...ctx, cancelled: true };
+				// Version match alone is not enough: a prior broken state (e.g. a buggy uninstall
+				// or partial install) can leave registered hooks in settings.json pointing at
+				// .cjs files that no longer exist on disk. Skipping here would leave those hooks
+				// erroring on every event. Re-onboard the missing files instead of skipping.
+				const missingHookFiles = await countMissingHookFileReferencesForClaudeDir(claudeDir);
+				if (missingHookFiles > 0) {
+					logger.warning(
+						`Detected ${missingHookFiles} registered hook(s) whose script is missing on disk; reinstalling to restore them`,
+					);
+				} else {
+					logger.success(
+						`Already at latest version (${kitType}@${installedKitVersion}), skipping reinstall`,
+					);
+					return { ...ctx, cancelled: true };
+				}
 			}
 		} catch (error) {
 			logger.verbose(

--- a/src/domains/health-checks/checkers/hook-health-checker.ts
+++ b/src/domains/health-checks/checkers/hook-health-checker.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import { type SettingsJson, SettingsMerger } from "@/domains/config/settings-merger.js";
 import { isLegacyDescriptiveNamePrompt } from "@/domains/installation/merger/zombie-wirings-pruner.js";
 import { CLAUDEKIT_CLI_NPM_PACKAGE_NAME } from "@/shared/claudekit-constants.js";
@@ -1337,6 +1337,41 @@ export async function countMissingHookFileReferences(projectDir = process.cwd())
 		const settings = await SettingsMerger.readSettingsFile(settingsFile.path);
 		if (!settings) continue;
 		count += collectMissingHookReferences(settings, settingsFile, projectDir).length;
+	}
+	return count;
+}
+
+/**
+ * Count CK-registered hook commands in ONE install's settings.json (+ settings.local.json)
+ * whose target script file is missing on disk.
+ *
+ * Unlike {@link countMissingHookFileReferences} (which unions project + global settings for
+ * `ck doctor`), this is scoped to a single install directory so an install/skip decision is not
+ * influenced by unrelated project or global hooks elsewhere on the machine.
+ *
+ * @param claudeDir Absolute path to the install's `.claude` directory (e.g. `~/.claude` for global).
+ * @param projectRoot Directory used to resolve `$CLAUDE_PROJECT_DIR` / bare `.claude/` tokens in
+ *        hook commands; defaults to the parent of `claudeDir`. `$HOME`-rooted global hooks ignore it.
+ */
+export async function countMissingHookFileReferencesForClaudeDir(
+	claudeDir: string,
+	projectRoot: string = dirname(claudeDir),
+): Promise<number> {
+	const hooksDirPrefix = `${resolve(claudeDir, "hooks")}${sep}`;
+	let count = 0;
+	for (const fileName of ["settings.json", "settings.local.json"]) {
+		const filePath = resolve(claudeDir, fileName);
+		if (!existsSync(filePath)) continue;
+		const settings = await SettingsMerger.readSettingsFile(filePath);
+		if (!settings) continue;
+		const descriptor: ClaudeSettingsFile = { path: filePath, label: fileName, root: "$HOME" };
+		// Only count missing scripts that live in THIS install's hooks/ dir — those are the
+		// kit-managed files a reinstall can restore. A hook pointing at a missing file elsewhere
+		// (e.g. a user's own absolute path) is ignored so the version-skip optimization is not
+		// permanently disabled by an unrelated broken reference a reinstall could not fix.
+		count += collectMissingHookReferences(settings, descriptor, projectRoot).filter((finding) =>
+			finding.resolvedPath.startsWith(hooksDirPrefix),
+		).length;
 	}
 	return count;
 }


### PR DESCRIPTION
## Problem

`ck init -g --kit engineer --yes` short-circuits with "Already at latest version
(...), skipping reinstall" on version equality alone, with **no on-disk integrity
check**. If a prior broken state (e.g. the buggy uninstall in #898/#899, or a
partial install) left hooks registered in `settings.json` pointing at `.cjs`
files that no longer exist, init skips and the hooks error on every event (incl.
Stop) until the user manually runs `ck init --force`.

Reproduced live: a broken install had 13 registered hooks pointing at missing
scripts; `ck init -g --kit engineer --beta --yes` skipped reinstall — only
`--force` repaired it.

Closes #900

## Root Cause

The update pipeline (`promptKitUpdate`) already self-heals missing hooks
(`countMissingHookFileReferences` / `countMissingCkHookRegistrations` → force
reinstall), but the plain `ck init --yes` version-skip early-exit in
`selection-handler.ts` never ran any such check.

## What changed

| File | Change |
|------|--------|
| `src/domains/health-checks/checkers/hook-health-checker.ts` | New `countMissingHookFileReferencesForClaudeDir(claudeDir)` — install-scoped count of registered hook commands whose script is missing |
| `src/commands/init/phases/selection-handler.ts` | Version-skip now checks for missing registered-hook files first; re-onboards instead of skipping when any are missing |
| tests | New unit suite for the helper (6 cases) + structural guards on the skip block |

Design notes:
- The helper is **install-scoped** (not the project+global union `ck doctor`
  uses) and limited to scripts under `<claudeDir>/hooks/`. So a global `ck init`
  isn't influenced by an unrelated project's hooks, and a hook pointing at a
  missing file *outside* the kit's `hooks/` dir (which a reinstall couldn't
  restore anyway) won't permanently disable the version-skip optimization.
- `ck doctor` already flags missing hook file references via
  `checkHookFileReferences`, so no doctor change is needed.

## Note on commits

Includes a cherry-picked `test:` commit (`CK_TEST_HOME` isolation for
`promptKitUpdate` tests) shared with #899 — required for the local gate to pass
deterministically until #899 merges. Identical content; dedups on merge.

## Validation

- [x] `bun run ci:local` passes (typecheck, lint, build, full suite, parity, ui:build, prepublish)
- [x] New helper suite: 6/6 pass
- [x] Version-skip structural suite: 12/12 pass
