### PR TITLE
fix: repair codex hook migration self-heal

### DIFF
--- a/src/commands/migrate/__tests__/migrate-global-source.integration.test.ts
+++ b/src/commands/migrate/__tests__/migrate-global-source.integration.test.ts
@@ -49,7 +49,7 @@ function seedClaudeDir(
 
 function seedInstalledPluginCache(
 	home: string,
-	types: Array<"agents" | "skills">,
+	types: Array<"agents" | "skills" | "hooks">,
 	version = "v2.20.0",
 ): string {
 	const claudeDir = join(home, ".claude");
@@ -64,7 +64,56 @@ function seedInstalledPluginCache(
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(join(dir, ".keep"), "");
 	}
+	if (types.includes("hooks")) {
+		writeFileSync(
+			join(cacheRoot, "settings.json"),
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Read",
+							hooks: [{ type: "command", command: 'node "$HOME/.claude/hooks/privacy-block.cjs"' }],
+						},
+					],
+				},
+			}),
+		);
+	}
 	return cacheRoot;
+}
+
+function seedConfiguredPluginSource(home: string): string {
+	const claudeDir = join(home, ".claude");
+	const sourceRoot = join(home, ".cache", "claude", "ck-plugin-source");
+	const pluginClaudeRoot = join(sourceRoot, ".claude");
+	mkdirSync(join(pluginClaudeRoot, "hooks"), { recursive: true });
+	writeFileSync(join(pluginClaudeRoot, "hooks", ".keep"), "");
+	writeFileSync(
+		join(pluginClaudeRoot, "settings.json"),
+		JSON.stringify({
+			hooks: {
+				PreToolUse: [
+					{
+						matcher: "Read",
+						hooks: [{ type: "command", command: 'node "$HOME/.claude/hooks/privacy-block.cjs"' }],
+					},
+				],
+			},
+		}),
+	);
+	mkdirSync(claudeDir, { recursive: true });
+	writeFileSync(
+		join(claudeDir, "settings.json"),
+		JSON.stringify({
+			enabledPlugins: { "ck@claudekit": true },
+			extraKnownMarketplaces: {
+				claudekit: {
+					source: { source: "directory", path: sourceRoot },
+				},
+			},
+		}),
+	);
+	return pluginClaudeRoot;
 }
 
 function seedSandbox(opts: {
@@ -305,6 +354,31 @@ describe("ck migrate -g: SOURCE scope (issue #803)", () => {
 
 		expect(getAgentSourcePath()).toBe(join(pluginRoot, "agents"));
 		expect(getSkillSourcePath()).toBe(join(pluginRoot, "skills"));
+	});
+
+	it("T11: globalOnly=true resolves hooks from plugin cache when hook settings are plugin-owned", () => {
+		const sb = seedSandbox({
+			homeTypes: ["commands", "rules"],
+			cwdTypes: [],
+		});
+		const pluginRoot = seedInstalledPluginCache(sb.home, ["hooks"]);
+		activate(sb);
+
+		expect(getHooksSourcePath(true)).toBe(join(pluginRoot, "hooks"));
+		expect(getHooksSourcePath()).toBe(join(pluginRoot, "hooks"));
+	});
+
+	it("T12: configured marketplace source wins over installed plugin cache for hooks", () => {
+		const sb = seedSandbox({
+			homeTypes: ["commands", "rules"],
+			cwdTypes: [],
+		});
+		seedInstalledPluginCache(sb.home, ["hooks"], "v2.19.0");
+		const pluginClaudeRoot = seedConfiguredPluginSource(sb.home);
+		activate(sb);
+
+		expect(getHooksSourcePath(true)).toBe(join(pluginClaudeRoot, "hooks"));
+		expect(getHooksSourcePath()).toBe(join(pluginClaudeRoot, "hooks"));
 	});
 });
 

--- a/src/commands/migrate/migrate-command.ts
+++ b/src/commands/migrate/migrate-command.ts
@@ -6,7 +6,7 @@
 import { existsSync } from "node:fs";
 import { readFile, rm, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { handleDeletions } from "../../domains/installation/deletion-handler.js";
@@ -617,6 +617,29 @@ function createSkippedPathMigrationCleanupResult(action: ReconcileAction): Porta
 		skipped: true,
 		skipReason: "Legacy path cleanup skipped because no successful replacement write was recorded",
 	};
+}
+
+function resolveHookTargetPath(
+	item: PortableItem,
+	provider: ProviderType,
+	global: boolean,
+): string | null {
+	const pathConfig = providers[provider].hooks;
+	if (!pathConfig) return null;
+	const basePath = global ? pathConfig.globalPath : pathConfig.projectPath;
+	if (!basePath) return null;
+
+	const converted = convertItem(item, pathConfig.format, provider, { global });
+	if (converted.error) return null;
+
+	const targetPath =
+		pathConfig.writeStrategy === "single-file" ? basePath : join(basePath, converted.filename);
+	const resolvedTarget = resolve(targetPath).replace(/\\/g, "/");
+	const resolvedBase = resolve(basePath).replace(/\\/g, "/").replace(/\/+$/, "");
+	if (resolvedTarget !== resolvedBase && !resolvedTarget.startsWith(`${resolvedBase}/`)) {
+		return null;
+	}
+	return targetPath;
 }
 
 /**
@@ -1231,24 +1254,34 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		const progressSink = createMigrateProgressSink(writeTasks.length + plannedDeleteActions.length);
 		const writtenPaths = new Set<string>();
 		type WriteTask = (typeof writeTasks)[number];
+		const recordHookTargetForSettings = (
+			provider: ProviderType,
+			global: boolean,
+			targetPath: string,
+		) => {
+			if (targetPath.length === 0 || !existsSync(targetPath)) return;
+			const resolvedPath = resolve(targetPath);
+			const entry = successfulHookFiles.get(provider) ?? {
+				files: [],
+				global,
+			};
+			const hookFile = basename(targetPath);
+			if (!entry.files.includes(hookFile)) entry.files.push(hookFile);
+			successfulHookFiles.set(provider, entry);
+
+			const absExisting = successfulHookAbsPaths.get(provider) ?? [];
+			if (!absExisting.includes(resolvedPath)) {
+				absExisting.push(resolvedPath);
+				successfulHookAbsPaths.set(provider, absExisting);
+			}
+		};
 		const recordSuccessfulWrites = (task: WriteTask, taskResults: PortableInstallResult[]) => {
-			for (const result of taskResults.filter((entry) => entry.success && !entry.skipped)) {
-				if (result.path.length > 0) {
+			for (const result of taskResults.filter((entry) => entry.success)) {
+				if (!result.skipped && result.path.length > 0) {
 					writtenPaths.add(resolve(result.path));
 				}
 				if (task.type === "hooks") {
-					const existing = successfulHookFiles.get(task.provider) ?? {
-						files: [],
-						global: task.global,
-					};
-					existing.files.push(basename(result.path));
-					successfulHookFiles.set(task.provider, existing);
-					// Track absolute paths for Codex wrapper generation
-					if (result.path.length > 0) {
-						const absExisting = successfulHookAbsPaths.get(task.provider) ?? [];
-						absExisting.push(resolve(result.path));
-						successfulHookAbsPaths.set(task.provider, absExisting);
-					}
+					recordHookTargetForSettings(task.provider, task.global, result.path);
 				}
 			}
 		};
@@ -1301,6 +1334,17 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 			allResults.push(...taskResults);
 			recordSuccessfulWrites(task, taskResults);
 			progressSink.tick(progressLabelForType(task.type));
+		}
+
+		if (hooksSource && effectiveHookItems.length > 0) {
+			for (const provider of selectedProviders) {
+				if (!getProvidersSupporting("hooks").includes(provider)) continue;
+				const global = resolvePortableTypeGlobal(provider, "hooks", installGlobally);
+				for (const item of effectiveHookItems) {
+					const targetPath = resolveHookTargetPath(item, provider, global);
+					if (targetPath) recordHookTargetForSettings(provider, global, targetPath);
+				}
+			}
 		}
 
 		// Ensure opencode.json has a `model` — migrated agents inherit from global
@@ -1375,12 +1419,17 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 		// After all actions executed, merge hooks into target settings.json per provider
 		for (const [hooksProvider, entry] of successfulHookFiles) {
 			if (entry.files.length === 0) continue;
+			const sourceSettingsPath = hooksSource
+				? join(dirname(hooksSource), "settings.json")
+				: undefined;
 			const mergeResult = await migrateHooksSettings({
 				sourceProvider: "claude-code",
 				targetProvider: hooksProvider,
 				installedHookFiles: entry.files,
 				installedHookAbsolutePaths: successfulHookAbsPaths.get(hooksProvider),
 				global: entry.global,
+				sourceSettingsPath,
+				sourceHooksDir: hooksSource ?? undefined,
 			});
 			appendMigrationWarningMessages(postProgressWarnings, mergeResult.warnings);
 			if (mergeResult.success && mergeResult.hooksRegistered > 0) {

--- a/src/commands/portable/__tests__/codex-hook-compat-integration.test.ts
+++ b/src/commands/portable/__tests__/codex-hook-compat-integration.test.ts
@@ -348,28 +348,10 @@ describe("codex hook compat integration — upgrade from previous ck migrate", (
 		};
 		// New SessionStart from source should be added
 		expect(written.hooks.SessionStart).toBeDefined();
-		// L10 — The legacy SubagentStart entry in the pre-populated hooks.json must be absent
-		// in the result. The new migration must not preserve unsupported events even if they
-		// appeared in a pre-existing hooks.json. (ck-managed entries are replaced on migration;
-		// unknown user entries are preserved as-is by deduplicateMerge — but SubagentStart is
-		// not a valid Codex event so Codex ignores it, and our pipeline never writes it.)
-		//
-		// Note: the pre-existing SubagentStart entry in this test was written raw (simulating
-		// a stale CK-managed entry). After migration, deduplicateMerge preserves existing keys
-		// not overwritten by new hooks. SubagentStart is NOT emitted by the new migration
-		// (it's unsupported per capability table), so it SURVIVES in hooks.json from the
-		// pre-existing content. The important assertion is that we did NOT add new SubagentStart
-		// entries — hooksRegistered only counts CK-converted hooks, not pre-existing stale ones.
-		//
-		// For CK-managed entries (identified by _origin field in future), removal is tracked
-		// as a separate cleanup step. This test documents the current behavior.
+		// Stale CK-managed unsupported events are pruned on rerun, then the new migration
+		// adds only supported Codex hook events.
 		const subagentEntries = (written.hooks.SubagentStart as Array<unknown> | undefined) ?? [];
-		// The old direct-copied entry from the pre-populated hooks.json is preserved by
-		// deduplicateMerge (unknown user content). But our new pipeline added 0 SubagentStart
-		// entries — so count must not INCREASE beyond what was there before migration.
-		expect(subagentEntries.length).toBe(1); // Pre-existing stale entry: preserved as-is
-		// Explicitly: no additional SubagentStart from the new migration run
-		// (result.hooksRegistered does not count SubagentStart — it was filtered out)
+		expect(subagentEntries.length).toBe(0);
 	}, 10000);
 
 	it("upgrade: repeat migration does not duplicate entries (idempotent)", async () => {

--- a/src/commands/portable/__tests__/hooks-settings-merger.test.ts
+++ b/src/commands/portable/__tests__/hooks-settings-merger.test.ts
@@ -395,6 +395,76 @@ describe("mergeHooksIntoSettings", () => {
 		expect(commands).not.toContain(staleCommand);
 		expect(commands).toContain(liveCommand);
 	});
+
+	it("prunes generated Codex wrappers whose original hook target is missing", async () => {
+		const ckHooksDir = join(testDir, ".codex", "hooks");
+		await Bun.write(join(ckHooksDir, ".keep"), "");
+		const path = join(testDir, "merge-codex-missing-original.json");
+		const wrapperPath = join(ckHooksDir, "1234abcd-privacy-block.cjs");
+		const missingOriginal = join(ckHooksDir, "privacy-block.cjs");
+		const wrapperCommand = `node "${wrapperPath}"`;
+		writeFileSync(wrapperPath, `const ORIGINAL_HOOK = ${JSON.stringify(missingOriginal)};\n`);
+
+		writeFileSync(
+			path,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Read",
+							hooks: [{ type: "command", command: wrapperCommand }],
+						},
+					],
+				},
+			}),
+		);
+
+		await mergeHooksIntoSettings(path, {}, { targetProvider: "codex", targetHooksDir: ckHooksDir });
+
+		const content = JSON.parse(await Bun.file(path).text());
+		expect(content.hooks.PreToolUse).toBeUndefined();
+	});
+
+	it("prunes direct Claude hook commands from Codex settings on rerun", async () => {
+		const ckHooksDir = join(testDir, ".codex", "hooks");
+		await Bun.write(join(ckHooksDir, ".keep"), "");
+		const path = join(testDir, "merge-codex-foreign-claude-hook.json");
+		const wrapperPath = join(ckHooksDir, "abcd1234-privacy-block.cjs");
+		const rawClaudeCommand = 'node "$HOME/.claude/hooks/privacy-block.cjs"';
+		const wrapperCommand = `node "${wrapperPath}"`;
+		writeFileSync(wrapperPath, "process.exit(0);\n");
+		writeFileSync(
+			path,
+			JSON.stringify({
+				hooks: {
+					PreToolUse: [
+						{
+							matcher: "Read",
+							hooks: [{ type: "command", command: rawClaudeCommand }],
+						},
+					],
+				},
+			}),
+		);
+
+		await mergeHooksIntoSettings(
+			path,
+			{
+				PreToolUse: [
+					{
+						matcher: "Read",
+						hooks: [{ type: "command", command: wrapperCommand }],
+					},
+				],
+			},
+			{ targetProvider: "codex", targetHooksDir: ckHooksDir },
+		);
+
+		const content = JSON.parse(await Bun.file(path).text());
+		const commands = content.hooks.PreToolUse[0].hooks.map((h: { command: string }) => h.command);
+		expect(commands).not.toContain(rawClaudeCommand);
+		expect(commands).toContain(wrapperCommand);
+	});
 });
 
 describe("migrateHooksSettings", () => {
@@ -461,6 +531,55 @@ describe("migrateHooksSettings", () => {
 			expect(result.status).toBe("registered");
 			expect(result.success).toBe(true);
 			expect(result.hooksRegistered).toBe(1);
+		} finally {
+			process.chdir(originalCwd);
+			rmSync(tempBase, { recursive: true, force: true });
+		}
+	});
+
+	it("reads hook registrations from an explicit source settings path", async () => {
+		const tempBase = mkdtempSync(join(tmpdir(), "hooks-source-override-"));
+		const originalCwd = process.cwd();
+		try {
+			process.chdir(tempBase);
+			const sourceRoot = join(tempBase, "plugin-source", ".claude");
+			const sourceHooksDir = join(sourceRoot, "hooks");
+			mkdirSync(sourceHooksDir, { recursive: true });
+			writeFileSync(join(sourceHooksDir, "plugin-hook.cjs"), "// hook");
+			writeFileSync(
+				join(sourceRoot, "settings.json"),
+				JSON.stringify({
+					hooks: {
+						PreToolUse: [
+							{
+								matcher: "Read",
+								hooks: [
+									{
+										type: "command",
+										command: 'node ".claude/hooks/plugin-hook.cjs"',
+									},
+								],
+							},
+						],
+					},
+				}),
+			);
+
+			const result = await migrateHooksSettings({
+				sourceProvider: "claude-code",
+				targetProvider: "gemini-cli",
+				installedHookFiles: ["plugin-hook.cjs"],
+				global: false,
+				sourceSettingsPath: join(sourceRoot, "settings.json"),
+				sourceHooksDir,
+			});
+
+			expect(result.status).toBe("registered");
+			expect(result.sourceSettingsPath).toBe(join(sourceRoot, "settings.json"));
+			const target = JSON.parse(await Bun.file(join(tempBase, ".gemini", "settings.json")).text());
+			const command = target.hooks.BeforeTool[0].hooks[0].command;
+			expect(command).toContain(".gemini/hooks/plugin-hook.cjs");
+			expect(command).not.toContain("plugin-source/.claude/hooks");
 		} finally {
 			process.chdir(originalCwd);
 			rmSync(tempBase, { recursive: true, force: true });

--- a/src/commands/portable/config-discovery.ts
+++ b/src/commands/portable/config-discovery.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { cp, mkdir, readFile, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
+import { resolveInstalledPluginCacheSubpath } from "@/domains/installation/plugin/install-mode-detector.js";
 import {
 	findExistingProjectConfigPath,
 	findExistingProjectLayoutPath,
@@ -219,6 +220,54 @@ export function getRulesSourcePath(globalOnly = false): string {
 	return findExistingProjectLayoutPath(process.cwd(), "rules") ?? globalPath;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isClaudeKitPluginEnabled(settings: unknown): boolean {
+	if (!isRecord(settings)) return false;
+	const enabledPlugins = settings.enabledPlugins;
+	if (Array.isArray(enabledPlugins)) {
+		return enabledPlugins.includes("ck@claudekit");
+	}
+	return isRecord(enabledPlugins) && enabledPlugins["ck@claudekit"] === true;
+}
+
+function readJsonSafe(filePath: string): unknown | null {
+	try {
+		return JSON.parse(readFileSync(filePath, "utf-8"));
+	} catch {
+		return null;
+	}
+}
+
+function resolveConfiguredClaudeKitPluginSourceSubpath(relativePath: string): string | null {
+	const claudeDir = join(homedir(), ".claude");
+	const settings = readJsonSafe(join(claudeDir, "settings.json"));
+	if (!isClaudeKitPluginEnabled(settings) || !isRecord(settings)) return null;
+
+	const marketplaces = settings.extraKnownMarketplaces;
+	const claudekit = isRecord(marketplaces) ? marketplaces.claudekit : null;
+	const source = isRecord(claudekit) ? claudekit.source : null;
+	const sourcePath = isRecord(source) && typeof source.path === "string" ? source.path : null;
+	if (!sourcePath) return null;
+
+	const candidates = [join(sourcePath, ".claude", relativePath), join(sourcePath, relativePath)];
+	return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+function hasAdjacentSettings(sourceDir: string): boolean {
+	return existsSync(join(dirname(sourceDir), "settings.json"));
+}
+
+function resolveClaudeKitPluginHooksSourcePath(): string | null {
+	const candidates = [
+		resolveConfiguredClaudeKitPluginSourceSubpath("hooks"),
+		resolveInstalledPluginCacheSubpath("hooks", join(homedir(), ".claude")),
+	].filter((path): path is string => typeof path === "string");
+	return candidates.find((candidate) => hasAdjacentSettings(candidate)) ?? null;
+}
+
 /**
  * Get default hooks source path.
  *
@@ -227,8 +276,10 @@ export function getRulesSourcePath(globalOnly = false): string {
  */
 export function getHooksSourcePath(globalOnly = false): string {
 	const globalPath = join(homedir(), ".claude", "hooks");
-	if (globalOnly) return globalPath;
-	return findExistingProjectLayoutPath(process.cwd(), "hooks") ?? globalPath;
+	const pluginPath = resolveClaudeKitPluginHooksSourcePath();
+	const globalCandidate = pluginPath ?? globalPath;
+	if (globalOnly) return globalCandidate;
+	return findExistingProjectLayoutPath(process.cwd(), "hooks") ?? globalCandidate;
 }
 
 /** Discover CLAUDE.md config file */

--- a/src/commands/portable/hooks-settings-merger.ts
+++ b/src/commands/portable/hooks-settings-merger.ts
@@ -4,10 +4,10 @@
  *
  * Used by `ck migrate` to auto-register hooks after copying hook files.
  */
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, dirname, extname, join, resolve } from "node:path";
+import { basename, dirname, extname, isAbsolute, join, resolve } from "node:path";
 import type { CodexCapabilities } from "./codex-capabilities.js";
 import { detectCodexCapabilities } from "./codex-capabilities.js";
 import { ensureCodexHooksFeatureFlag } from "./codex-features-flag.js";
@@ -65,6 +65,17 @@ export interface MigrateHooksSettingsOptions {
 	installedHookFiles: string[];
 	global: boolean;
 	/**
+	 * Optional settings.json override adjacent to the actual hook source tree.
+	 * Plugin installs can source hook files from a staged/cache tree while the
+	 * default global Claude settings no longer contains plugin-owned hooks.
+	 */
+	sourceSettingsPath?: string;
+	/**
+	 * Optional hooks directory override used for command path rewriting.
+	 * Should match the directory that supplied installedHookFiles.
+	 */
+	sourceHooksDir?: string;
+	/**
 	 * For codex target: absolute paths to the original installed .cjs hook scripts.
 	 * Used to generate wrapper scripts. If omitted when target=codex, wrapper
 	 * generation is skipped and commands are rewritten via path substitution only.
@@ -99,10 +110,37 @@ interface MergeHooksOptions {
 
 const CODEX_WRAPPABLE_HOOK_EXTENSIONS = new Set([".js", ".cjs", ".mjs", ".ts"]);
 
+function resolveSettingsPath(pathValue: string, isGlobal: boolean): string {
+	if (isGlobal || isAbsolute(pathValue)) return pathValue;
+	return join(process.cwd(), pathValue);
+}
+
 function isCodexWrappableHookPath(filePath: string): boolean {
 	return (
 		hookAssetBasename(filePath) !== "node-hook-runner.sh" &&
 		CODEX_WRAPPABLE_HOOK_EXTENSIONS.has(extname(filePath).toLowerCase())
+	);
+}
+
+function collectSourceHookDirs(
+	sourceHooksDirOverride: string | undefined,
+	providerSourceHooksDir: string,
+): string[] {
+	const dirs = [sourceHooksDirOverride, providerSourceHooksDir].filter(
+		(value): value is string => typeof value === "string" && value.length > 0,
+	);
+	return Array.from(new Set(dirs));
+}
+
+function rewriteHookPathsFromSourceDirs(
+	hooks: HooksSection,
+	sourceHooksDirs: string[],
+	targetHooksDir: string,
+): HooksSection {
+	return sourceHooksDirs.reduce(
+		(currentHooks, sourceHooksDir) =>
+			rewriteHookPaths(currentHooks, sourceHooksDir, targetHooksDir),
+		hooks,
 	);
 }
 
@@ -405,9 +443,10 @@ function pruneIncompatibleHookRegistrations(
 			const keptHooks = group.hooks.filter((entry) => {
 				const refs = extractHookReferencesFromCommand(entry.command);
 				const targetOwned = commandTargetsHookDir(entry.command, targetHooksDir);
+				const foreignCkOwned = commandTargetsForeignCkHookDir(entry.command, targetHooksDir);
 				const incompatible =
 					!isCodexSupportedHookEvent(event) || refs.some((ref) => isExcludedHookAsset(ref));
-				if (targetOwned && incompatible) {
+				if (foreignCkOwned || (targetOwned && incompatible)) {
 					hooksPruned += 1;
 					return false;
 				}
@@ -480,6 +519,23 @@ function commandTargetsHookDir(command: string, targetHooksDir: string): boolean
 	);
 }
 
+function commandTargetsForeignCkHookDir(command: string, targetHooksDir: string): boolean {
+	const normalizedCommand = command.replace(/\\/g, "/");
+	const normalizedDir = targetHooksDir.replace(/\\/g, "/").replace(/\/+$/, "");
+	const targetTokens = [
+		`${normalizedDir}/`,
+		"$HOME/.codex/hooks/",
+		"~/.codex/hooks/",
+		".codex/hooks/",
+	];
+	if (targetTokens.some((token) => normalizedCommand.includes(token))) return false;
+	return (
+		normalizedCommand.includes("$HOME/.claude/hooks/") ||
+		normalizedCommand.includes("~/.claude/hooks/") ||
+		normalizedCommand.includes(".claude/hooks/")
+	);
+}
+
 /**
  * True if the absolute path looks like a CK-managed hook install location.
  * We only self-heal ck-owned entries to avoid silently dropping a user's
@@ -494,6 +550,29 @@ function isCkManagedHookPath(absPath: string): boolean {
 		normalized.includes("/.codex/hooks/") ||
 		normalized.includes("/.gemini/hooks/")
 	);
+}
+
+function readCodexWrapperOriginalHookPath(wrapperPath: string): string | null {
+	try {
+		const content = readFileSync(wrapperPath, "utf8");
+		const match = content.match(
+			/const\s+ORIGINAL_HOOK\s*=\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')/,
+		);
+		if (!match) return null;
+		const literal = match[1];
+		if (literal.startsWith('"')) {
+			return JSON.parse(literal) as string;
+		}
+		return literal.slice(1, -1).replace(/\\'/g, "'").replace(/\\\\/g, "\\");
+	} catch {
+		return null;
+	}
+}
+
+function codexWrapperReferencesMissingOriginal(wrapperPath: string): boolean {
+	const originalPath = readCodexWrapperOriginalHookPath(wrapperPath);
+	if (!originalPath || !isCkManagedHookPath(originalPath)) return false;
+	return !existsSync(originalPath);
 }
 
 /**
@@ -544,7 +623,7 @@ function pruneStaleFileHooks(existing: HooksSection): HooksSection {
 				const ckPaths = paths.filter(isCkManagedHookPath);
 				if (ckPaths.length === 0) return true; // No CK-managed reference — keep
 				// Hook is stale iff every CK-managed reference is missing.
-				return ckPaths.some((p) => existsSync(p));
+				return ckPaths.some((p) => existsSync(p) && !codexWrapperReferencesMissingOriginal(p));
 			});
 			if (survivingHooks.length > 0) {
 				prunedGroups.push({ ...group, hooks: survivingHooks });
@@ -639,9 +718,11 @@ export async function migrateHooksSettings(
 	}
 
 	// Resolve settings.json paths
-	const sourceSettingsPath = isGlobal
-		? sourceConfig.settingsJsonPath?.globalPath
-		: sourceConfig.settingsJsonPath?.projectPath;
+	const sourceSettingsPath =
+		options.sourceSettingsPath ??
+		(isGlobal
+			? sourceConfig.settingsJsonPath?.globalPath
+			: sourceConfig.settingsJsonPath?.projectPath);
 	const targetSettingsPath = isGlobal
 		? targetConfig.settingsJsonPath?.globalPath
 		: targetConfig.settingsJsonPath?.projectPath;
@@ -671,9 +752,7 @@ export async function migrateHooksSettings(
 	}
 
 	// For project-level, resolve relative to cwd
-	const resolvedSourcePath = isGlobal
-		? sourceSettingsPath
-		: join(process.cwd(), sourceSettingsPath);
+	const resolvedSourcePath = resolveSettingsPath(sourceSettingsPath, isGlobal);
 	const resolvedTargetPath = isGlobal
 		? targetSettingsPath
 		: join(process.cwd(), targetSettingsPath);
@@ -730,9 +809,10 @@ export async function migrateHooksSettings(
 	}
 
 	// Resolve hooks directories for path rewriting
-	const sourceHooksDir = isGlobal
+	const providerSourceHooksDir = isGlobal
 		? (sourceConfig.hooks?.globalPath ?? "")
 		: (sourceConfig.hooks?.projectPath ?? "");
+	const sourceHooksDirs = collectSourceHookDirs(options.sourceHooksDir, providerSourceHooksDir);
 	const targetHooksDir = isGlobal
 		? (targetConfig.hooks?.globalPath ?? "")
 		: (targetConfig.hooks?.projectPath ?? "");
@@ -743,7 +823,7 @@ export async function migrateHooksSettings(
 		targetProvider,
 		warnings,
 	});
-	const rewritten = rewriteHookPaths(filtered, sourceHooksDir, targetHooksDir);
+	const rewritten = rewriteHookPathsFromSourceDirs(filtered, sourceHooksDirs, targetHooksDir);
 	const eventMapped = mapHookEventsForProvider(rewritten, targetProvider);
 
 	// Count hooks being registered
@@ -856,9 +936,11 @@ async function migrateHooksSettingsForCodex(
 	const capabilities: CodexCapabilities = await detectCodexCapabilities();
 
 	// Resolve settings paths
-	const sourceSettingsPath = isGlobal
-		? sourceConfig.settingsJsonPath.globalPath
-		: sourceConfig.settingsJsonPath.projectPath;
+	const sourceSettingsPath =
+		options.sourceSettingsPath ??
+		(isGlobal
+			? sourceConfig.settingsJsonPath.globalPath
+			: sourceConfig.settingsJsonPath.projectPath);
 	const targetSettingsPath = isGlobal
 		? (codexConfig.settingsJsonPath?.globalPath ?? null)
 		: (codexConfig.settingsJsonPath?.projectPath ?? null);
@@ -875,9 +957,7 @@ async function migrateHooksSettingsForCodex(
 		};
 	}
 
-	const resolvedSourcePath = isGlobal
-		? sourceSettingsPath
-		: join(process.cwd(), sourceSettingsPath);
+	const resolvedSourcePath = resolveSettingsPath(sourceSettingsPath, isGlobal);
 	const resolvedTargetPath = isGlobal
 		? targetSettingsPath
 		: join(process.cwd(), targetSettingsPath);
@@ -943,9 +1023,14 @@ async function migrateHooksSettingsForCodex(
 		? (codexConfig.hooks?.globalPath ?? "")
 		: (codexConfig.hooks?.projectPath ?? "");
 
-	const sourceHooksDir = isGlobal
+	const providerSourceHooksDir = isGlobal
 		? (sourceConfig.hooks?.globalPath ?? "")
 		: (sourceConfig.hooks?.projectPath ?? "");
+	const sourceHooksDir = options.sourceHooksDir ?? providerSourceHooksDir;
+	const sourceHookCommandDirs = collectSourceHookDirs(
+		options.sourceHooksDir,
+		providerSourceHooksDir,
+	);
 
 	// If caller provided absolute paths, generate wrappers; otherwise fall back to path rewrite.
 	// commandSubstitutions maps each original absolute hook path → its hash-prefixed wrapper path.
@@ -977,11 +1062,11 @@ async function migrateHooksSettingsForCodex(
 					addKey(join(targetHooksDir, base));
 					addKey(`./${join(targetHooksDir, base)}`);
 				}
-				if (sourceHooksDir) {
-					const sourceAbs = join(resolve(sourceHooksDir), base);
+				for (const commandSourceHooksDir of sourceHookCommandDirs) {
+					const sourceAbs = join(resolve(commandSourceHooksDir), base);
 					addKey(sourceAbs);
-					addKey(join(sourceHooksDir, base));
-					addKey(`./${join(sourceHooksDir, base)}`);
+					addKey(join(commandSourceHooksDir, base));
+					addKey(`./${join(commandSourceHooksDir, base)}`);
 					// macOS: `/var` is a symlink to `/private/var`. Tmp paths and user
 					// paths can appear in either form. Add both so includes() matches.
 					if (sourceAbs.startsWith("/private/")) {
@@ -997,7 +1082,8 @@ async function migrateHooksSettingsForCodex(
 	// Step 6: Convert hooks through Codex compatibility transformer
 	// Guard: if sourceHooksDir is empty, skip path rewrite to avoid catastrophic replacement
 	// where rewriteCommandPath would replace every "/" in commands with the target path.
-	if (!sourceHooksDir) {
+	const pathRewriteSourceDir = providerSourceHooksDir || sourceHooksDir;
+	if (!pathRewriteSourceDir) {
 		// Return the filtered hooks converted without path rewriting
 		const convertedNoRewrite = convertClaudeHooksToCodex(
 			filtered,
@@ -1049,7 +1135,7 @@ async function migrateHooksSettingsForCodex(
 	// Global-scope migrations pass undefined → no behavior change.
 	const effectiveTargetDir = targetHooksDir || sourceHooksDir;
 	const converted = convertClaudeHooksToCodex(filtered, capabilities, {
-		sourceDir: sourceHooksDir,
+		sourceDir: pathRewriteSourceDir,
 		targetDir: effectiveTargetDir,
 		commandSubstitutions: commandSubstitutions.size > 0 ? commandSubstitutions : undefined,
 		projectDir,


### PR DESCRIPTION
## Summary

- resolve global hook migration from the ClaudeKit plugin source/cache when hook settings are plugin-owned
- run Codex hook registration merge even when hook files are already present and skipped, so reruns can self-heal broken hooks.json
- prune broken Codex wrapper entries whose ORIGINAL_HOOK target is missing, plus direct Claude hook commands in Codex hooks.json

## Validation

- `bun test src/commands/portable/__tests__/codex-hook-compat-integration.test.ts src/commands/portable/__tests__/hooks-settings-merger.test.ts src/commands/migrate/__tests__/migrate-global-source.integration.test.ts`
- `bunx biome check src/commands/portable/hooks-settings-merger.ts src/commands/migrate/migrate-command.ts src/commands/portable/config-discovery.ts src/commands/portable/__tests__/hooks-settings-merger.test.ts src/commands/migrate/__tests__/migrate-global-source.integration.test.ts src/commands/portable/__tests__/codex-hook-compat-integration.test.ts`
- `bun test` (`5112 pass`, `58 skip`, `0 fail`)
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- pre-push local CI parity gate passed, including package verification and UI vitest suite
- repaired local `~/.codex` with `bun run src/index.ts migrate --agent codex --global --yes --hooks --install`; verified scout/privacy wrappers exit 0 and `hooks.json` contains 0 raw `.claude/hooks` commands

Docs impact: none. This repairs internal migration/self-heal behavior without changing user-facing commands or documented setup.

Release impact: patch bugfix for Codex hook migration installs that can leave generated wrappers pointing at missing originals.
