### PR TITLE
feat(init): support explicit Engineer install modes

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -1,6 +1,6 @@
 {
 	"version": "4.5.0-dev.7",
-	"generatedAt": "2026-06-29T17:20:27.008Z",
+	"generatedAt": "2026-06-30T16:03:20.406Z",
 	"commands": {
 		"agents": {
 			"name": "agents",
@@ -1096,6 +1096,10 @@
 						{
 							"flags": "--sync",
 							"description": "Sync config files from upstream with interactive hunk-by-hunk merge"
+						},
+						{
+							"flags": "--install-mode <mode>",
+							"description": "Engineer global install mode: auto, plugin, or legacy (default: auto)"
 						},
 						{
 							"flags": "--archive <path>",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -612,6 +612,7 @@ Initialize or update ClaudeKit project (with interactive version selection)
 | `-y, --yes` | Non-interactive mode with sensible defaults (kit: engineer, dir: ., version: latest) | — |
 | `--use-git` | Use git clone instead of GitHub API (uses SSH/HTTPS credentials) | — |
 | `--sync` | Sync config files from upstream with interactive hunk-by-hunk merge | — |
+| `--install-mode <mode>` | Engineer global install mode: auto, plugin, or legacy (default: auto) | — |
 | `--archive <path>` | Use local archive file instead of downloading (zip/tar.gz) | — |
 | `--kit-path <path>` | Use local kit directory instead of downloading | — |
 | `--dir <directory>` | Target directory to initialize/update | `.` |
@@ -1075,4 +1076,4 @@ Watch GitHub issues and auto-respond with AI analysis
 - `ck watch --interval 60000` — Poll every 60 seconds instead of default 30s
 
 
-<!-- generated: 2026-06-15T17:47:28.452Z -->
+<!-- generated: 2026-06-30T16:03:20.133Z -->

--- a/src/__tests__/commands/init/phases/sync-handler-deletions.test.ts
+++ b/src/__tests__/commands/init/phases/sync-handler-deletions.test.ts
@@ -59,6 +59,7 @@ function createSyncContext(overrides: {
 			prefix: true,
 			sync: true,
 			useGit: false,
+			installMode: "auto",
 		},
 		prompts: overrides.prompts as unknown as InitContext["prompts"],
 		explicitDir: true,

--- a/src/__tests__/commands/update-cli-prompt-kit.test.ts
+++ b/src/__tests__/commands/update-cli-prompt-kit.test.ts
@@ -35,12 +35,17 @@ describe("promptKitUpdate version display", () => {
 	function makeDeps(opts?: {
 		sideEffect?: () => void | Promise<void>;
 		latestTag?: string | null;
+		installMode?: InstallModeReport["mode"];
+		hasTrackedPluginSuppliedLegacyFiles?: boolean;
 	}) {
 		const stopCalls: string[] = [];
+		const execCommands: string[] = [];
+		const hasLegacyInstall = opts?.installMode === "legacy" || opts?.installMode === "mixed";
 		let execCalled = false;
 		const deps: PromptKitUpdateDeps = {
-			execAsyncFn: async () => {
+			execAsyncFn: async (command) => {
 				execCalled = true;
+				execCommands.push(command);
 				if (opts?.sideEffect) await opts.sideEffect();
 				return { stdout: "", stderr: "" };
 			},
@@ -65,7 +70,7 @@ describe("promptKitUpdate version display", () => {
 			loadFullConfigFn: async () => ({ config: { updatePipeline: undefined } }),
 			detectInstallModeFn: () =>
 				({
-					mode: "plugin",
+					mode: opts?.installMode ?? "plugin",
 					claudeDir: tempDir,
 					plugin: {
 						installed: true,
@@ -74,12 +79,16 @@ describe("promptKitUpdate version display", () => {
 						marketplace: "claudekit",
 						staleCache: false,
 					},
-					legacy: { installed: false, version: null },
+					legacy: {
+						installed: hasLegacyInstall,
+						version: hasLegacyInstall ? "1.0.0" : null,
+					},
 				}) satisfies InstallModeReport,
-			hasTrackedPluginSuppliedLegacyFilesFn: () => false,
+			hasTrackedPluginSuppliedLegacyFilesFn: () =>
+				opts?.hasTrackedPluginSuppliedLegacyFiles ?? false,
 			shouldRefreshCodexPluginFn: async () => false,
 		};
-		return { deps, stopCalls, wasExecCalled: () => execCalled };
+		return { deps, stopCalls, execCommands, wasExecCalled: () => execCalled };
 	}
 
 	it("shows version transition when kit version changed after init", async () => {
@@ -148,6 +157,28 @@ describe("promptKitUpdate version display", () => {
 
 		await promptKitUpdate(false, true, depsWithPrefix.deps);
 		expect(depsWithPrefix.wasExecCalled()).toBe(false);
+	});
+
+	it("runs kit init for mixed plugin installs with tracked legacy skills even when version matches", async () => {
+		await writeFile(
+			join(tempDir, "metadata.json"),
+			JSON.stringify({
+				version: "1.0.0",
+				kits: { engineer: { version: "1.0.0", installedAt: "2025-01-01T00:00:00Z" } },
+			}),
+		);
+
+		const { deps, execCommands, wasExecCalled } = makeDeps({
+			latestTag: "v1.0.0",
+			installMode: "mixed",
+			hasTrackedPluginSuppliedLegacyFiles: true,
+		});
+
+		await promptKitUpdate(false, true, deps);
+
+		expect(wasExecCalled()).toBe(true);
+		expect(execCommands[0]).toContain("ck init -g --kit engineer --yes");
+		expect(execCommands[0]).toContain("--restore-ck-hooks");
 	});
 
 	it("proceeds normally when latest tag fetch fails (returns null)", async () => {

--- a/src/__tests__/domains/installation/setup-wizard.test.ts
+++ b/src/__tests__/domains/installation/setup-wizard.test.ts
@@ -75,6 +75,18 @@ describe("checkRequiredKeysExist", () => {
 		expect(result.missing).toEqual([]);
 	});
 
+	test("normalizes hidden copy-paste characters from provider values in .env", async () => {
+		const envPath = join(tempDir, ".env");
+		await writeFile(envPath, `GEMINI_API_KEY=\u200B ${VALID_GEMINI_KEY}\uFEFF`);
+
+		const result = await checkRequiredKeysExist(envPath);
+
+		expect(result.envExists).toBe(true);
+		expect(result.allPresent).toBe(true);
+		expect(result.missing).toEqual([]);
+		expect(result.configuredProviders).toEqual(["google"]);
+	});
+
 	test("returns allPresent: true when OPENROUTER_API_KEY exists", async () => {
 		const envPath = join(tempDir, ".env");
 		await writeFile(envPath, `OPENROUTER_API_KEY=${VALID_OPENROUTER_KEY}`);
@@ -212,6 +224,13 @@ describe("checkRequiredKeysExist", () => {
 describe("image provider helpers", () => {
 	test("Gemini validation accepts AI Studio keys with copy-paste whitespace", () => {
 		const pasted = `\n ${VALID_GEMINI_KEY}\r\n`;
+
+		expect(normalizeApiKeyInput(pasted)).toBe(VALID_GEMINI_KEY);
+		expect(validateApiKey(pasted, VALIDATION_PATTERNS.GEMINI_API_KEY)).toBe(true);
+	});
+
+	test("Gemini validation accepts keys with hidden leading characters before whitespace", () => {
+		const pasted = `\u200B ${VALID_GEMINI_KEY}`;
 
 		expect(normalizeApiKeyInput(pasted)).toBe(VALID_GEMINI_KEY);
 		expect(validateApiKey(pasted, VALIDATION_PATTERNS.GEMINI_API_KEY)).toBe(true);

--- a/src/__tests__/domains/installation/setup-wizard.test.ts
+++ b/src/__tests__/domains/installation/setup-wizard.test.ts
@@ -3,6 +3,11 @@ import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	VALIDATION_PATTERNS,
+	normalizeApiKeyInput,
+	validateApiKey,
+} from "@/domains/config/config-validator.js";
+import {
 	REQUIRED_ENV_KEYS,
 	checkRequiredKeysExist,
 	getConfiguredImageProviders,
@@ -205,6 +210,13 @@ describe("checkRequiredKeysExist", () => {
 });
 
 describe("image provider helpers", () => {
+	test("Gemini validation accepts AI Studio keys with copy-paste whitespace", () => {
+		const pasted = `\n ${VALID_GEMINI_KEY}\r\n`;
+
+		expect(normalizeApiKeyInput(pasted)).toBe(VALID_GEMINI_KEY);
+		expect(validateApiKey(pasted, VALIDATION_PATTERNS.GEMINI_API_KEY)).toBe(true);
+	});
+
 	test("getConfiguredImageProviders returns all configured provider paths", () => {
 		expect(
 			getConfiguredImageProviders({

--- a/src/cli/command-registry.ts
+++ b/src/cli/command-registry.ts
@@ -116,6 +116,10 @@ export function registerCommands(cli: ReturnType<typeof cac>): void {
 		.option("--plans-dir <name>", "Custom plans folder name (default: plans)")
 		.option("-y, --yes", "Non-interactive mode with sensible defaults (skip all prompts)")
 		.option("--sync", "Sync config files from upstream with interactive hunk-by-hunk merge")
+		.option(
+			"--install-mode <mode>",
+			"Engineer global install mode: auto, plugin, or legacy (default: auto)",
+		)
 		.option("--use-git", "Use git clone instead of GitHub API (uses SSH/HTTPS credentials)")
 		.option("--archive <path>", "Use local archive file instead of downloading (zip/tar.gz)")
 		.option("--kit-path <path>", "Use local kit directory instead of downloading")

--- a/src/commands/init/init-command.ts
+++ b/src/commands/init/init-command.ts
@@ -134,6 +134,7 @@ function createInitContext(rawOptions: UpdateCommandOptions, prompts: PromptsMan
 		prefix: false,
 		sync: false,
 		useGit: false,
+		installMode: "auto",
 	};
 
 	return {

--- a/src/commands/init/phases/__tests__/plugin-install-handler.test.ts
+++ b/src/commands/init/phases/__tests__/plugin-install-handler.test.ts
@@ -158,6 +158,7 @@ describe("handlePluginInstall (init Phase 7.5)", () => {
 		const uninstallResult: UninstallPluginResult = {
 			uninstalled: true,
 			staleCacheRemoved: true,
+			pluginStillInstalled: false,
 		};
 		const removeCodexResult: RemoveCodexPluginResult = {
 			removed: true,
@@ -188,6 +189,30 @@ describe("handlePluginInstall (init Phase 7.5)", () => {
 		expect(codexInstalled).toBe(false);
 		expect(claudeUninstalls).toEqual([claudeDir]);
 		expect(codexRemovals).toEqual(["codex"]);
+		expect(existsSync(stageBase)).toBe(false);
+	});
+
+	test("explicit legacy mode fails when Claude plugin cleanup does not verify", async () => {
+		let codexRemoved = false;
+		const uninstallResult: UninstallPluginResult = {
+			uninstalled: true,
+			staleCacheRemoved: false,
+			pluginStillInstalled: true,
+			error: "plugin remains registered after cleanup",
+		};
+
+		await expect(
+			handlePluginInstall(ctxOf({ installMode: "legacy" }), {
+				uninstallClaudePlugin: async () => uninstallResult,
+				removeCodexPlugin: async () => {
+					codexRemoved = true;
+					return { removed: true, marketplaceRemoved: true };
+				},
+				stageBaseDir: stageBase,
+			}),
+		).rejects.toThrow("Claude plugin cleanup failed");
+
+		expect(codexRemoved).toBe(true);
 		expect(existsSync(stageBase)).toBe(false);
 	});
 

--- a/src/commands/init/phases/__tests__/plugin-install-handler.test.ts
+++ b/src/commands/init/phases/__tests__/plugin-install-handler.test.ts
@@ -8,8 +8,12 @@ import {
 	stagePluginSource,
 } from "@/commands/init/phases/plugin-install-handler.js";
 import type { InitContext } from "@/commands/init/types.js";
-import type { CodexPluginInstallResult } from "@/domains/installation/plugin/codex-plugin-installer.js";
+import type {
+	CodexPluginInstallResult,
+	RemoveCodexPluginResult,
+} from "@/domains/installation/plugin/codex-plugin-installer.js";
 import type { MigrateResult } from "@/domains/installation/plugin/migrate-legacy-to-plugin.js";
+import type { UninstallPluginResult } from "@/domains/installation/plugin/uninstall-plugin.js";
 
 const okResult: MigrateResult = {
 	action: "installed-fresh",
@@ -22,6 +26,15 @@ const okResult: MigrateResult = {
 const okCodexResult: CodexPluginInstallResult = {
 	action: "installed",
 	pluginVerified: true,
+};
+const failedInstallResult: MigrateResult = {
+	action: "install-failed",
+	modeBefore: "legacy",
+	pluginVerified: false,
+	backupDir: null,
+	removedPaths: [],
+	receiptPath: null,
+	error: "plugin did not verify after install",
 };
 
 describe("handlePluginInstall (init Phase 7.5)", () => {
@@ -48,10 +61,12 @@ describe("handlePluginInstall (init Phase 7.5)", () => {
 		await rm(root, { recursive: true, force: true });
 	});
 
-	function ctxOf(over: Partial<{ kitType: string; global: boolean }> = {}): InitContext {
+	function ctxOf(
+		over: Partial<{ kitType: string; global: boolean; installMode: string }> = {},
+	): InitContext {
 		return {
 			kitType: over.kitType ?? "engineer",
-			options: { global: over.global ?? true },
+			options: { global: over.global ?? true, installMode: over.installMode ?? "auto" },
 			extractDir,
 			claudeDir,
 		} as unknown as InitContext;
@@ -104,6 +119,76 @@ describe("handlePluginInstall (init Phase 7.5)", () => {
 		expect(existsSync(join(stageBase, ".claude", ".codex-plugin", "plugin.json"))).toBe(true);
 		expect(existsSync(join(stageBase, ".claude-plugin", "marketplace.json"))).toBe(true);
 		expect(existsSync(join(stageBase, ".agents", "plugins", "marketplace.json"))).toBe(true);
+	});
+
+	test("explicit plugin mode stages source and installs Claude and Codex plugins", async () => {
+		const calls: string[] = [];
+		const codexCalls: string[] = [];
+		await handlePluginInstall(ctxOf({ installMode: "plugin" }), {
+			migrate: async (o) => {
+				calls.push(o.pluginSourceDir);
+				return okResult;
+			},
+			installCodex: async (o) => {
+				codexCalls.push(o.pluginSourceDir);
+				return okCodexResult;
+			},
+			stageBaseDir: stageBase,
+		});
+
+		expect(calls).toEqual([stageBase]);
+		expect(codexCalls).toEqual([stageBase]);
+	});
+
+	test("explicit plugin mode fails instead of silently keeping legacy when migration fails", async () => {
+		await expect(
+			handlePluginInstall(ctxOf({ installMode: "plugin" }), {
+				migrate: async () => failedInstallResult,
+				installCodex: async () => okCodexResult,
+				stageBaseDir: stageBase,
+			}),
+		).rejects.toThrow("Claude plugin install failed");
+	});
+
+	test("explicit legacy mode removes plugin state and skips plugin migration", async () => {
+		let migrated = false;
+		let codexInstalled = false;
+		const claudeUninstalls: string[] = [];
+		const codexRemovals: string[] = [];
+		const uninstallResult: UninstallPluginResult = {
+			uninstalled: true,
+			staleCacheRemoved: true,
+		};
+		const removeCodexResult: RemoveCodexPluginResult = {
+			removed: true,
+			marketplaceRemoved: true,
+		};
+
+		await handlePluginInstall(ctxOf({ installMode: "legacy" }), {
+			migrate: async () => {
+				migrated = true;
+				return okResult;
+			},
+			installCodex: async () => {
+				codexInstalled = true;
+				return okCodexResult;
+			},
+			uninstallClaudePlugin: async (o) => {
+				claudeUninstalls.push(o?.claudeDir ?? "");
+				return uninstallResult;
+			},
+			removeCodexPlugin: async () => {
+				codexRemovals.push("codex");
+				return removeCodexResult;
+			},
+			stageBaseDir: stageBase,
+		});
+
+		expect(migrated).toBe(false);
+		expect(codexInstalled).toBe(false);
+		expect(claudeUninstalls).toEqual([claudeDir]);
+		expect(codexRemovals).toEqual(["codex"]);
+		expect(existsSync(stageBase)).toBe(false);
 	});
 
 	test("migrate throwing never fails init (legacy copy retained)", async () => {

--- a/src/commands/init/phases/options-resolver.ts
+++ b/src/commands/init/phases/options-resolver.ts
@@ -45,6 +45,7 @@ export async function resolveOptions(ctx: InitContext): Promise<InitContext> {
 		useGit: parsed.useGit ?? false,
 		archive: parsed.archive,
 		kitPath: parsed.kitPath,
+		installMode: parsed.installMode ?? "auto",
 	};
 
 	// Set global flag for ConfigManager

--- a/src/commands/init/phases/plugin-install-handler.ts
+++ b/src/commands/init/phases/plugin-install-handler.ts
@@ -57,17 +57,29 @@ export async function handlePluginInstall(
 	const removeCodex = deps.removeCodexPlugin ?? removeCodexPlugin;
 
 	if (ctx.options.installMode === "legacy") {
+		let cleanupError: Error | null = null;
 		try {
 			const result = await uninstallClaude({ claudeDir: ctx.claudeDir });
 			logLegacyPluginCleanup(result);
+			if (result.pluginStillInstalled) {
+				cleanupError = new Error(
+					`Claude plugin cleanup failed for legacy install mode: ${
+						result.error ?? "plugin remains registered"
+					}`,
+				);
+			}
 		} catch (err) {
 			logger.verbose(`Claude plugin cleanup skipped: ${(err as Error).message}`);
+			cleanupError = err as Error;
 		}
 		try {
 			const result = await removeCodex();
 			logCodexPluginCleanup(result);
 		} catch (err) {
 			logger.verbose(`Codex plugin cleanup skipped: ${(err as Error).message}`);
+		}
+		if (cleanupError) {
+			throw cleanupError;
 		}
 		return ctx;
 	}

--- a/src/commands/init/phases/plugin-install-handler.ts
+++ b/src/commands/init/phases/plugin-install-handler.ts
@@ -3,12 +3,18 @@ import { join } from "node:path";
 import type { InitContext } from "@/commands/init/types.js";
 import {
 	type CodexPluginInstallResult,
+	type RemoveCodexPluginResult,
 	installCodexPlugin,
+	removeCodexPlugin,
 } from "@/domains/installation/plugin/codex-plugin-installer.js";
 import {
 	type MigrateResult,
 	migrateLegacyToPlugin,
 } from "@/domains/installation/plugin/migrate-legacy-to-plugin.js";
+import {
+	type UninstallPluginResult,
+	uninstallEnginePlugin,
+} from "@/domains/installation/plugin/uninstall-plugin.js";
 import { logger } from "@/shared/logger.js";
 import { PathResolver } from "@/shared/path-resolver.js";
 
@@ -19,6 +25,10 @@ export interface PluginInstallDeps {
 	migrate?: typeof migrateLegacyToPlugin;
 	/** Injectable for tests; defaults to the real Codex plugin install flow. */
 	installCodex?: typeof installCodexPlugin;
+	/** Injectable for tests; defaults to the real Claude plugin removal flow. */
+	uninstallClaudePlugin?: typeof uninstallEnginePlugin;
+	/** Injectable for tests; defaults to the real Codex plugin removal flow. */
+	removeCodexPlugin?: typeof removeCodexPlugin;
 	/** Override the staged-source base dir (tests). */
 	stageBaseDir?: string;
 }
@@ -43,12 +53,37 @@ export async function handlePluginInstall(
 
 	const migrate = deps.migrate ?? migrateLegacyToPlugin;
 	const installCodex = deps.installCodex ?? installCodexPlugin;
+	const uninstallClaude = deps.uninstallClaudePlugin ?? uninstallEnginePlugin;
+	const removeCodex = deps.removeCodexPlugin ?? removeCodexPlugin;
+
+	if (ctx.options.installMode === "legacy") {
+		try {
+			const result = await uninstallClaude({ claudeDir: ctx.claudeDir });
+			logLegacyPluginCleanup(result);
+		} catch (err) {
+			logger.verbose(`Claude plugin cleanup skipped: ${(err as Error).message}`);
+		}
+		try {
+			const result = await removeCodex();
+			logCodexPluginCleanup(result);
+		} catch (err) {
+			logger.verbose(`Codex plugin cleanup skipped: ${(err as Error).message}`);
+		}
+		return ctx;
+	}
+
 	try {
 		const pluginSourceDir = stagePluginSource(ctx.extractDir, deps.stageBaseDir);
 		try {
 			const result = await migrate({ pluginSourceDir, claudeDir: ctx.claudeDir });
 			logPluginResult(result);
+			if (ctx.options.installMode === "plugin" && !result.pluginVerified) {
+				throw new Error(`Claude plugin install failed: ${result.error ?? result.action}`);
+			}
 		} catch (err) {
+			if (ctx.options.installMode === "plugin") {
+				throw err;
+			}
 			logger.verbose(
 				`Claude plugin install skipped (legacy copy retained): ${(err as Error).message}`,
 			);
@@ -60,10 +95,21 @@ export async function handlePluginInstall(
 			logger.verbose(`Codex plugin install skipped: ${(err as Error).message}`);
 		}
 	} catch (err) {
+		if (ctx.options.installMode === "plugin") {
+			throw err;
+		}
 		// Never fail init over the plugin path — the legacy copy from handleMerge stands.
 		logger.verbose(`Plugin staging skipped (legacy copy retained): ${(err as Error).message}`);
 	}
 	return ctx;
+}
+
+function logLegacyPluginCleanup(result: UninstallPluginResult): void {
+	if (result.uninstalled || result.staleCacheRemoved) {
+		logger.info("Removed ClaudeKit Engineer plugin state for legacy install mode.");
+	} else {
+		logger.verbose("No ClaudeKit Engineer Claude plugin state found for legacy install mode.");
+	}
 }
 
 /**
@@ -213,5 +259,13 @@ function logCodexPluginResult(result: CodexPluginInstallResult): void {
 		case "install-failed":
 			logger.verbose(`Codex plugin install did not verify. ${result.error ?? ""}`);
 			break;
+	}
+}
+
+function logCodexPluginCleanup(result: RemoveCodexPluginResult): void {
+	if (result.removed || result.marketplaceRemoved) {
+		logger.info("Removed ClaudeKit Engineer Codex plugin state for legacy install mode.");
+	} else {
+		logger.verbose("No ClaudeKit Engineer Codex plugin state found for legacy install mode.");
 	}
 }

--- a/src/commands/init/types.ts
+++ b/src/commands/init/types.ts
@@ -41,6 +41,7 @@ export interface ValidatedOptions {
 	useGit: boolean;
 	archive?: string;
 	kitPath?: string;
+	installMode: "auto" | "plugin" | "legacy";
 }
 
 /**

--- a/src/commands/setup/phases/kit-selection.ts
+++ b/src/commands/setup/phases/kit-selection.ts
@@ -64,6 +64,7 @@ export async function handleKitSelection(ctx: SetupContext): Promise<SetupContex
 			refresh: false,
 			sync: false,
 			useGit: false,
+			installMode: "auto",
 			verbose: false,
 			json: false,
 		});

--- a/src/domains/config/config-validator.ts
+++ b/src/domains/config/config-validator.ts
@@ -12,9 +12,13 @@ export const VALIDATION_PATTERNS = {
 	TELEGRAM_BOT_TOKEN: /^\d+:[A-Za-z0-9_-]{35}$/,
 };
 
+export function normalizeApiKeyInput(value: string): string {
+	return value.trim().replace(/\u200B|\u200C|\u200D|\uFEFF/g, "");
+}
+
 /**
  * Validate an API key or configuration value against a pattern
  */
 export function validateApiKey(value: string, pattern: RegExp): boolean {
-	return pattern.test(value);
+	return pattern.test(normalizeApiKeyInput(value));
 }

--- a/src/domains/config/config-validator.ts
+++ b/src/domains/config/config-validator.ts
@@ -13,7 +13,7 @@ export const VALIDATION_PATTERNS = {
 };
 
 export function normalizeApiKeyInput(value: string): string {
-	return value.trim().replace(/\u200B|\u200C|\u200D|\uFEFF/g, "");
+	return value.replace(/\u200B|\u200C|\u200D|\uFEFF/g, "").trim();
 }
 
 /**

--- a/src/domains/help/commands/init-command-help.ts
+++ b/src/domains/help/commands/init-command-help.ts
@@ -39,6 +39,10 @@ export const initCommandHelp: CommandHelp = {
 					description: "Sync config files from upstream with interactive hunk-by-hunk merge",
 				},
 				{
+					flags: "--install-mode <mode>",
+					description: "Engineer global install mode: auto, plugin, or legacy (default: auto)",
+				},
+				{
 					flags: "--archive <path>",
 					description: "Use local archive file instead of downloading (zip/tar.gz)",
 				},

--- a/src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts
+++ b/src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts
@@ -5,6 +5,7 @@ import {
 	installCodexPlugin,
 	removeCodexPlugin,
 	resolveCodexExecutable,
+	resolveCodexExecutableCandidates,
 	shouldRefreshCodexPlugin,
 	shouldRunCodexInShell,
 } from "@/domains/installation/plugin/codex-plugin-installer.js";
@@ -23,6 +24,17 @@ describe("CodexPluginInstaller", () => {
 		expect(shouldRunCodexInShell("win32")).toBe(false);
 		expect(resolveCodexExecutable("linux")).toBe("codex");
 		expect(shouldRunCodexInShell("linux")).toBe(false);
+	});
+
+	test("falls back to the Windows codex.cmd shim without shell mode", () => {
+		expect(resolveCodexExecutableCandidates("win32")).toEqual([
+			{ command: "codex", argsPrefix: [] },
+			{ command: "cmd.exe", argsPrefix: ["/d", "/s", "/c", "codex.cmd"] },
+		]);
+		expect(resolveCodexExecutableCandidates("linux")).toEqual([
+			{ command: "codex", argsPrefix: [] },
+		]);
+		expect(shouldRunCodexInShell("win32")).toBe(false);
 	});
 
 	test("installs ck@claudekit through a local marketplace", async () => {

--- a/src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts
+++ b/src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts
@@ -3,6 +3,7 @@ import {
 	CodexPluginInstaller,
 	type CodexRunResult,
 	installCodexPlugin,
+	removeCodexPlugin,
 	resolveCodexExecutable,
 	shouldRefreshCodexPlugin,
 	shouldRunCodexInShell,
@@ -115,5 +116,44 @@ describe("CodexPluginInstaller", () => {
 			return fail("unexpected");
 		});
 		await expect(shouldRefreshCodexPlugin(missing)).resolves.toBe(true);
+	});
+
+	test("removes ck@claudekit and the marketplace when Codex plugins are supported", async () => {
+		const calls: string[][] = [];
+		const installer = new CodexPluginInstaller(async (args) => {
+			calls.push(args);
+			if (args.join(" ") === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (args.join(" ") === "plugin --help") return ok("plugin marketplace add");
+			if (args.join(" ") === "plugin remove ck@claudekit") return ok();
+			if (args.join(" ") === "plugin marketplace remove claudekit") return ok();
+			return fail(`unexpected command: ${args.join(" ")}`);
+		});
+
+		await expect(removeCodexPlugin({ installer })).resolves.toEqual({
+			removed: true,
+			marketplaceRemoved: true,
+		});
+		expect(calls).toEqual([
+			["--version"],
+			["plugin", "--help"],
+			["plugin", "remove", "ck@claudekit"],
+			["plugin", "marketplace", "remove", "claudekit"],
+		]);
+	});
+
+	test("skips Codex plugin removal when Codex has no plugin support", async () => {
+		const calls: string[][] = [];
+		const installer = new CodexPluginInstaller(async (args) => {
+			calls.push(args);
+			if (args.join(" ") === "--version") return ok("codex-cli 0.142.0");
+			if (args.join(" ") === "plugin --help") return fail("unknown command");
+			return fail("should not remove");
+		});
+
+		await expect(removeCodexPlugin({ installer })).resolves.toEqual({
+			removed: false,
+			marketplaceRemoved: false,
+		});
+		expect(calls).toEqual([["--version"], ["plugin", "--help"]]);
 	});
 });

--- a/src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts
+++ b/src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts
@@ -18,9 +18,9 @@ function fail(stderr = "failed"): CodexRunResult {
 }
 
 describe("CodexPluginInstaller", () => {
-	test("uses the Windows command shim through a shell", () => {
-		expect(resolveCodexExecutable("win32")).toBe("codex.cmd");
-		expect(shouldRunCodexInShell("win32")).toBe(true);
+	test("resolves Codex without a shell on Windows", () => {
+		expect(resolveCodexExecutable("win32")).toBe("codex");
+		expect(shouldRunCodexInShell("win32")).toBe(false);
 		expect(resolveCodexExecutable("linux")).toBe("codex");
 		expect(shouldRunCodexInShell("linux")).toBe(false);
 	});
@@ -62,6 +62,62 @@ describe("CodexPluginInstaller", () => {
 			["plugin", "add", "ck@claudekit"],
 			["plugin", "list", "--json"],
 		]);
+	});
+
+	test("verifies installed plugin from current Codex text list output when JSON is unsupported", async () => {
+		const calls: string[][] = [];
+		const installer = new CodexPluginInstaller(async (args) => {
+			calls.push(args);
+			if (args.join(" ") === "--version") return ok("codex-cli 0.135.0");
+			if (args.join(" ") === "plugin --help") return ok("plugin marketplace add");
+			if (args.join(" ") === "plugin marketplace add /tmp/plugin-source") return ok();
+			if (args.join(" ") === "plugin add ck@claudekit") return ok();
+			if (args.join(" ") === "plugin list --json") {
+				return fail("error: unexpected argument '--json' found");
+			}
+			if (args.join(" ") === "plugin list") {
+				return ok(`Marketplace \`claudekit\`
+
+PLUGIN        STATUS              VERSION        PATH
+ck@claudekit  installed, enabled  2.20.1-beta.6  C:\\\\Users\\\\kaidu\\\\.codex\\\\plugins\\\\ck
+`);
+			}
+			return fail(`unexpected command: ${args.join(" ")}`);
+		});
+
+		const result = await installCodexPlugin({
+			pluginSourceDir: "/tmp/plugin-source",
+			installer,
+		});
+
+		expect(result).toEqual({ action: "installed", pluginVerified: true });
+		expect(calls).toEqual([
+			["--version"],
+			["plugin", "--help"],
+			["plugin", "marketplace", "add", "/tmp/plugin-source"],
+			["plugin", "add", "ck@claudekit"],
+			["plugin", "list", "--json"],
+			["plugin", "list"],
+		]);
+	});
+
+	test("does not verify text list output unless ck is installed and enabled", async () => {
+		const installer = new CodexPluginInstaller(async (args) => {
+			if (args.join(" ") === "--version") return ok("codex-cli 0.135.0");
+			if (args.join(" ") === "plugin --help") return ok("plugin marketplace add");
+			if (args.join(" ") === "plugin list --json") {
+				return fail("error: unexpected argument '--json' found");
+			}
+			if (args.join(" ") === "plugin list") {
+				return ok(`PLUGIN        STATUS
+ck@claudekit  installed, disabled
+other@market  installed, enabled
+`);
+			}
+			return fail("unexpected");
+		});
+
+		await expect(shouldRefreshCodexPlugin(installer)).resolves.toBe(true);
 	});
 
 	test("skips when Codex lacks plugin support", async () => {

--- a/src/domains/installation/plugin/__tests__/install-mode-detector.test.ts
+++ b/src/domains/installation/plugin/__tests__/install-mode-detector.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -11,6 +12,10 @@ import {
 	resolveInstalledPluginCacheRoot,
 	resolveInstalledPluginCacheSubpath,
 } from "@/domains/installation/plugin/install-mode-detector.js";
+
+function sha256(content: string): string {
+	return createHash("sha256").update(content).digest("hex");
+}
 
 describe("install-mode-detector", () => {
 	let claudeDir: string;
@@ -168,6 +173,63 @@ describe("install-mode-detector", () => {
 		});
 
 		expect(hasTrackedPluginSuppliedLegacyFiles(claudeDir)).toBe(true);
+	});
+
+	test("detects unmodified user-owned plugin payloads from manifestless installs", async () => {
+		const skillContent = "# cook\n";
+		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
+		await writeFile(join(claudeDir, "skills", "cook", "SKILL.md"), skillContent, "utf-8");
+		await writeMetadata({
+			kits: {
+				engineer: {
+					version: "local",
+					files: [
+						{
+							path: "skills/cook/SKILL.md",
+							ownership: "user",
+							checksum: sha256(skillContent),
+						},
+					],
+				},
+			},
+		});
+
+		expect(hasTrackedPluginSuppliedLegacyFiles(claudeDir)).toBe(true);
+	});
+
+	test("ignores modified user-owned plugin payloads from manifestless installs", async () => {
+		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
+		await writeFile(join(claudeDir, "skills", "cook", "SKILL.md"), "# edited\n", "utf-8");
+		await writeMetadata({
+			kits: {
+				engineer: {
+					version: "local",
+					files: [
+						{
+							path: "skills/cook/SKILL.md",
+							ownership: "user",
+							checksum: sha256("# original\n"),
+						},
+					],
+				},
+			},
+		});
+
+		expect(hasTrackedPluginSuppliedLegacyFiles(claudeDir)).toBe(false);
+	});
+
+	test("ignores unsafe tracked plugin payload paths", async () => {
+		await writeFile(join(claudeDir, "settings.json"), "settings", "utf-8");
+		await writeMetadata({
+			kits: {
+				engineer: {
+					version: "2.19.0",
+					files: [{ path: "skills/../settings.json", ownership: "ck" }],
+				},
+			},
+		});
+
+		expect(hasTrackedPluginSuppliedLegacyFiles(claudeDir)).toBe(false);
 	});
 
 	test("ignores mixed installs after plugin-supplied legacy files are gone", async () => {

--- a/src/domains/installation/plugin/__tests__/migrate-legacy-to-plugin.test.ts
+++ b/src/domains/installation/plugin/__tests__/migrate-legacy-to-plugin.test.ts
@@ -196,15 +196,20 @@ describe("migrateLegacyToPlugin (orchestration)", () => {
 describe("defaultLegacyRemover", () => {
 	let claudeDir: string;
 	let backupDir: string;
+	let extraCleanupPaths: string[];
 	beforeEach(async () => {
 		claudeDir = join(tmpdir(), `ck-rm-${Date.now()}-${Math.round(performance.now())}`);
 		backupDir = join(claudeDir, "backup");
+		extraCleanupPaths = [];
 		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
 		await mkdir(join(claudeDir, "skills", "mine"), { recursive: true });
 		await mkdir(backupDir, { recursive: true });
 	});
 	afterEach(async () => {
 		await rm(claudeDir, { recursive: true, force: true });
+		for (const cleanupPath of extraCleanupPaths) {
+			await rm(cleanupPath, { recursive: true, force: true });
+		}
 	});
 
 	test("removes ck-owned files, backs them up, preserves user-owned", async () => {
@@ -377,6 +382,55 @@ describe("defaultLegacyRemover", () => {
 		expect(removed).toEqual([]);
 		expect(existsSync(join(claudeDir, "skills", "cook", "SKILL.md"))).toBe(true);
 		expect(existsSync(join(backupDir, "skills", "cook", "SKILL.md"))).toBe(false);
+	});
+
+	test("does not remove metadata paths that escape the Claude directory", async () => {
+		const outsideName = `ck-outside-${Date.now()}-${Math.round(performance.now())}.txt`;
+		const outsidePath = join(claudeDir, "..", outsideName);
+		extraCleanupPaths.push(outsidePath);
+		await writeFile(outsidePath, "outside", "utf-8");
+		await writeFile(
+			join(claudeDir, "metadata.json"),
+			JSON.stringify({
+				kits: {
+					engineer: {
+						version: "2.19.0",
+						installedAt: "x",
+						files: [{ path: `skills/../../${outsideName}`, ownership: "ck" }],
+					},
+				},
+			}),
+			"utf-8",
+		);
+
+		const removed = defaultLegacyRemover(claudeDir, backupDir);
+
+		expect(removed).toEqual([]);
+		expect(existsSync(outsidePath)).toBe(true);
+		expect(existsSync(join(backupDir, outsideName))).toBe(false);
+	});
+
+	test("does not remove paths that resolve outside plugin-supplied legacy roots", async () => {
+		await writeFile(join(claudeDir, "settings.json"), "settings", "utf-8");
+		await writeFile(
+			join(claudeDir, "metadata.json"),
+			JSON.stringify({
+				kits: {
+					engineer: {
+						version: "2.19.0",
+						installedAt: "x",
+						files: [{ path: "skills/../settings.json", ownership: "ck" }],
+					},
+				},
+			}),
+			"utf-8",
+		);
+
+		const removed = defaultLegacyRemover(claudeDir, backupDir);
+
+		expect(removed).toEqual([]);
+		expect(existsSync(join(claudeDir, "settings.json"))).toBe(true);
+		expect(existsSync(join(backupDir, "settings.json"))).toBe(false);
 	});
 
 	test("preserves runtime files that the plugin format does not supply yet", async () => {

--- a/src/domains/installation/plugin/__tests__/migrate-legacy-to-plugin.test.ts
+++ b/src/domains/installation/plugin/__tests__/migrate-legacy-to-plugin.test.ts
@@ -21,7 +21,16 @@ function ok(stdout: string, success = true): ClaudeRunResult {
 
 /** Fake installer scripted by command; records argv. */
 function fakeInstaller(
-	opts: { claudeAvailable?: boolean; pluginSupported?: boolean; verified?: boolean } = {},
+	opts: {
+		claudeAvailable?: boolean;
+		pluginSupported?: boolean;
+		verified?: boolean;
+		installOk?: boolean;
+		updateOk?: boolean;
+		marketplaceAddOk?: boolean;
+		marketplaceUpdateOk?: boolean;
+		enableOk?: boolean;
+	} = {},
 ) {
 	const calls: string[][] = [];
 	const runner: ClaudeRunner = async (args) => {
@@ -32,6 +41,13 @@ function fakeInstaller(
 			return ok(opts.pluginSupported !== false ? "Manage marketplaces" : "no plugins");
 		if (a === "plugin list")
 			return ok(opts.verified !== false ? "ck@claudekit Status: enabled" : "No plugins installed.");
+		if (a === "plugin marketplace add /src" || a === "plugin marketplace add /staged/kit")
+			return ok("", opts.marketplaceAddOk !== false);
+		if (a === "plugin marketplace update claudekit")
+			return ok("", opts.marketplaceUpdateOk !== false);
+		if (a === "plugin install ck@claudekit --scope user") return ok("", opts.installOk !== false);
+		if (a === "plugin update ck") return ok("", opts.updateOk !== false);
+		if (a === "plugin enable ck") return ok("", opts.enableOk !== false);
 		return ok("");
 	};
 	return { installer: new PluginInstaller(runner), calls };
@@ -139,6 +155,36 @@ describe("migrateLegacyToPlugin (orchestration)", () => {
 		const receipt = JSON.parse(readFileSync(r.receiptPath as string, "utf-8"));
 		expect(receipt[0].fromMode).toBe("legacy");
 		expect(receipt[0].toMode).toBe("plugin");
+	});
+
+	test("mixed already-installed plugin refreshes plugin and still cleans legacy skills", async () => {
+		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
+		await writeFile(join(claudeDir, "skills", "cook", "SKILL.md"), "legacy skill", "utf-8");
+		await writeSettings({ "ck@claudekit": true });
+		await writeMetadata({
+			kits: {
+				engineer: {
+					version: "2.19.0",
+					installedAt: "x",
+					files: [{ path: "skills/cook/SKILL.md", ownership: "ck" }],
+				},
+			},
+		});
+		const { installer, calls } = fakeInstaller({ installOk: false, marketplaceAddOk: false });
+
+		const r = await migrateLegacyToPlugin({
+			pluginSourceDir: "/src",
+			claudeDir,
+			installer,
+			now: TS,
+		});
+
+		expect(r.action).toBe("migrated-from-legacy");
+		expect(r.removedPaths).toEqual(["skills/cook/SKILL.md"]);
+		expect(existsSync(join(claudeDir, "skills", "cook", "SKILL.md"))).toBe(false);
+		expect(calls).toContainEqual(["plugin", "marketplace", "update", "claudekit"]);
+		expect(calls).toContainEqual(["plugin", "update", "ck"]);
+		expect(calls).not.toContainEqual(["plugin", "install", "ck@claudekit", "--scope", "user"]);
 	});
 });
 

--- a/src/domains/installation/plugin/__tests__/migrate-legacy-to-plugin.test.ts
+++ b/src/domains/installation/plugin/__tests__/migrate-legacy-to-plugin.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -17,6 +18,10 @@ const TS = "2026-06-16T00:00:00.000Z";
 
 function ok(stdout: string, success = true): ClaudeRunResult {
 	return { ok: success, stdout, stderr: "", code: success ? 0 : 1 };
+}
+
+function sha256(content: string): string {
+	return createHash("sha256").update(content).digest("hex");
 }
 
 /** Fake installer scripted by command; records argv. */
@@ -233,6 +238,145 @@ describe("defaultLegacyRemover", () => {
 		expect(existsSync(join(claudeDir, "skills", "mine", "SKILL.md"))).toBe(true); // user preserved
 		expect(existsSync(join(backupDir, "skills", "cook", "SKILL.md"))).toBe(true); // backed up
 		expect(existsSync(join(backupDir, "agents", "planner.md"))).toBe(true); // backed up
+	});
+
+	test("removes unmodified plugin-supplied files marked user-owned by manifestless installs", async () => {
+		const skillContent = "offline skill";
+		const agentContent = "offline agent";
+		await writeFile(join(claudeDir, "skills", "cook", "SKILL.md"), skillContent, "utf-8");
+		await mkdir(join(claudeDir, "agents"), { recursive: true });
+		await writeFile(join(claudeDir, "agents", "planner.md"), agentContent, "utf-8");
+		await writeFile(
+			join(claudeDir, "metadata.json"),
+			JSON.stringify({
+				kits: {
+					engineer: {
+						version: "local",
+						installedAt: "x",
+						files: [
+							{
+								path: "skills/cook/SKILL.md",
+								ownership: "user",
+								checksum: sha256(skillContent),
+							},
+							{
+								path: "agents/planner.md",
+								ownership: "user",
+								checksum: sha256(agentContent),
+							},
+						],
+					},
+				},
+			}),
+			"utf-8",
+		);
+
+		const removed = defaultLegacyRemover(claudeDir, backupDir);
+
+		expect(removed).toEqual(["skills/cook/SKILL.md", "agents/planner.md"]);
+		expect(existsSync(join(claudeDir, "skills", "cook", "SKILL.md"))).toBe(false);
+		expect(existsSync(join(claudeDir, "agents", "planner.md"))).toBe(false);
+		expect(existsSync(join(backupDir, "skills", "cook", "SKILL.md"))).toBe(true);
+		expect(existsSync(join(backupDir, "agents", "planner.md"))).toBe(true);
+	});
+
+	test("removes orphaned legacy sentinels after plugin-supplied files are removed", async () => {
+		await mkdir(join(claudeDir, "skills", "cook", "scripts"), { recursive: true });
+		await writeFile(join(claudeDir, "skills", ".gitignore"), "sentinel", "utf-8");
+		await writeFile(
+			join(claudeDir, "skills", "cook", "scripts", ".gitignore"),
+			"sentinel",
+			"utf-8",
+		);
+		await writeFile(join(claudeDir, "skills", "cook", "SKILL.md"), "ck skill", "utf-8");
+		await writeFile(join(claudeDir, "skills", "cook", "scripts", "tool.js"), "tool", "utf-8");
+		await writeFile(
+			join(claudeDir, "metadata.json"),
+			JSON.stringify({
+				kits: {
+					engineer: {
+						version: "2.19.0",
+						installedAt: "x",
+						files: [
+							{ path: "skills/cook/SKILL.md", ownership: "ck" },
+							{ path: "skills/cook/scripts/tool.js", ownership: "ck" },
+						],
+					},
+				},
+			}),
+			"utf-8",
+		);
+
+		const removed = defaultLegacyRemover(claudeDir, backupDir);
+
+		expect(removed).toEqual([
+			"skills/cook/SKILL.md",
+			"skills/cook/scripts/tool.js",
+			"skills/.gitignore",
+			"skills/cook/scripts/.gitignore",
+		]);
+		expect(existsSync(join(claudeDir, "skills", ".gitignore"))).toBe(false);
+		expect(existsSync(join(claudeDir, "skills", "cook", "scripts", ".gitignore"))).toBe(false);
+		expect(existsSync(join(backupDir, "skills", ".gitignore"))).toBe(true);
+		expect(existsSync(join(backupDir, "skills", "cook", "scripts", ".gitignore"))).toBe(true);
+	});
+
+	test("preserves legacy sentinels when user content remains in the same subtree", async () => {
+		await writeFile(join(claudeDir, "skills", ".gitignore"), "sentinel", "utf-8");
+		await writeFile(join(claudeDir, "skills", "cook", "SKILL.md"), "ck skill", "utf-8");
+		await writeFile(join(claudeDir, "skills", "mine", "SKILL.md"), "user skill", "utf-8");
+		await writeFile(
+			join(claudeDir, "metadata.json"),
+			JSON.stringify({
+				kits: {
+					engineer: {
+						version: "2.19.0",
+						installedAt: "x",
+						files: [
+							{ path: "skills/cook/SKILL.md", ownership: "ck" },
+							{ path: "skills/mine/SKILL.md", ownership: "user" },
+						],
+					},
+				},
+			}),
+			"utf-8",
+		);
+
+		const removed = defaultLegacyRemover(claudeDir, backupDir);
+
+		expect(removed).toEqual(["skills/cook/SKILL.md"]);
+		expect(existsSync(join(claudeDir, "skills", ".gitignore"))).toBe(true);
+		expect(existsSync(join(claudeDir, "skills", "mine", "SKILL.md"))).toBe(true);
+		expect(existsSync(join(backupDir, "skills", ".gitignore"))).toBe(false);
+	});
+
+	test("preserves modified user-owned plugin-supplied files", async () => {
+		await writeFile(join(claudeDir, "skills", "cook", "SKILL.md"), "edited skill", "utf-8");
+		await writeFile(
+			join(claudeDir, "metadata.json"),
+			JSON.stringify({
+				kits: {
+					engineer: {
+						version: "local",
+						installedAt: "x",
+						files: [
+							{
+								path: "skills/cook/SKILL.md",
+								ownership: "user",
+								checksum: sha256("original skill"),
+							},
+						],
+					},
+				},
+			}),
+			"utf-8",
+		);
+
+		const removed = defaultLegacyRemover(claudeDir, backupDir);
+
+		expect(removed).toEqual([]);
+		expect(existsSync(join(claudeDir, "skills", "cook", "SKILL.md"))).toBe(true);
+		expect(existsSync(join(backupDir, "skills", "cook", "SKILL.md"))).toBe(false);
 	});
 
 	test("preserves runtime files that the plugin format does not supply yet", async () => {

--- a/src/domains/installation/plugin/__tests__/uninstall-plugin.test.ts
+++ b/src/domains/installation/plugin/__tests__/uninstall-plugin.test.ts
@@ -10,10 +10,11 @@ import {
 } from "@/domains/installation/plugin/plugin-installer.js";
 import { uninstallEnginePlugin } from "@/domains/installation/plugin/uninstall-plugin.js";
 
-function recordingInstaller() {
+function recordingInstaller(onCall?: (args: string[]) => Promise<void> | void) {
 	const calls: string[][] = [];
 	const runner: ClaudeRunner = async (args): Promise<ClaudeRunResult> => {
 		calls.push(args);
+		await onCall?.(args);
 		return { ok: true, stdout: "", stderr: "", code: 0 };
 	};
 	return { installer: new PluginInstaller(runner), calls };
@@ -38,12 +39,18 @@ describe("uninstallEnginePlugin", () => {
 			"utf-8",
 		);
 		await mkdir(join(cacheDir(), "v1"), { recursive: true });
-		const { installer, calls } = recordingInstaller();
+		const { installer, calls } = recordingInstaller(async (args) => {
+			if (args.join(" ") === "plugin uninstall ck") {
+				await writeFile(join(claudeDir, "settings.json"), JSON.stringify({ enabledPlugins: {} }));
+			}
+		});
 
 		const r = await uninstallEnginePlugin({ claudeDir, installer });
 
 		expect(r.uninstalled).toBe(true);
 		expect(r.staleCacheRemoved).toBe(true);
+		expect(r.pluginStillInstalled).toBe(false);
+		expect(r.error).toBeUndefined();
 		expect(calls).toContainEqual(["plugin", "uninstall", "ck"]);
 		expect(calls).toContainEqual(["plugin", "marketplace", "remove", "claudekit"]);
 		expect(existsSync(cacheDir())).toBe(false);
@@ -52,7 +59,12 @@ describe("uninstallEnginePlugin", () => {
 	test("nothing installed: no-op, no claude calls", async () => {
 		const { installer, calls } = recordingInstaller();
 		const r = await uninstallEnginePlugin({ claudeDir, installer });
-		expect(r).toEqual({ uninstalled: false, staleCacheRemoved: false });
+		expect(r).toEqual({
+			uninstalled: false,
+			staleCacheRemoved: false,
+			pluginStillInstalled: false,
+			error: undefined,
+		});
 		expect(calls).toHaveLength(0);
 	});
 
@@ -62,7 +74,23 @@ describe("uninstallEnginePlugin", () => {
 		const r = await uninstallEnginePlugin({ claudeDir, installer });
 		expect(r.uninstalled).toBe(false);
 		expect(r.staleCacheRemoved).toBe(true);
+		expect(r.pluginStillInstalled).toBe(false);
 		expect(calls).toHaveLength(0); // not registered -> no uninstall command
 		expect(existsSync(cacheDir())).toBe(false);
+	});
+
+	test("reports when the plugin remains registered after cleanup commands", async () => {
+		await writeFile(
+			join(claudeDir, "settings.json"),
+			JSON.stringify({ enabledPlugins: { "ck@claudekit": true } }),
+			"utf-8",
+		);
+		const { installer } = recordingInstaller();
+
+		const r = await uninstallEnginePlugin({ claudeDir, installer });
+
+		expect(r.uninstalled).toBe(true);
+		expect(r.pluginStillInstalled).toBe(true);
+		expect(r.error).toContain("plugin remains registered");
 	});
 });

--- a/src/domains/installation/plugin/codex-plugin-installer.ts
+++ b/src/domains/installation/plugin/codex-plugin-installer.ts
@@ -23,6 +23,11 @@ export interface CodexRunOptions {
 
 export type CodexRunner = (args: string[], opts?: CodexRunOptions) => Promise<CodexRunResult>;
 
+export interface CodexExecutableCandidate {
+	command: string;
+	argsPrefix: string[];
+}
+
 export function resolveCodexExecutable(_platformName: NodeJS.Platform = process.platform): string {
 	return "codex";
 }
@@ -31,32 +36,64 @@ export function shouldRunCodexInShell(_platformName: NodeJS.Platform = process.p
 	return false;
 }
 
+export function resolveCodexExecutableCandidates(
+	platformName: NodeJS.Platform = process.platform,
+): CodexExecutableCandidate[] {
+	if (platformName === "win32") {
+		return [
+			{ command: "codex", argsPrefix: [] },
+			{ command: "cmd.exe", argsPrefix: ["/d", "/s", "/c", "codex.cmd"] },
+		];
+	}
+	return [{ command: resolveCodexExecutable(platformName), argsPrefix: [] }];
+}
+
 export const defaultCodexRunner: CodexRunner = async (args, opts) => {
 	const env = { ...process.env };
 	if (opts?.codexHome) env.CODEX_HOME = opts.codexHome;
-	try {
-		const { stdout, stderr } = await execFileAsync(resolveCodexExecutable(), args, {
-			env,
-			shell: shouldRunCodexInShell(),
-			timeout: opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-			maxBuffer: 10 * 1024 * 1024,
-		});
-		return { ok: true, stdout: String(stdout), stderr: String(stderr), code: 0 };
-	} catch (err) {
-		const e = err as {
-			stdout?: string | Buffer;
-			stderr?: string | Buffer;
-			code?: number;
-			message?: string;
-		};
-		return {
-			ok: false,
-			stdout: e.stdout ? String(e.stdout) : "",
-			stderr: e.stderr ? String(e.stderr) : (e.message ?? ""),
-			code: typeof e.code === "number" ? e.code : null,
-		};
+
+	let lastError: unknown = null;
+	const candidates = resolveCodexExecutableCandidates();
+	for (const [index, candidate] of candidates.entries()) {
+		try {
+			const { stdout, stderr } = await execFileAsync(
+				candidate.command,
+				[...candidate.argsPrefix, ...args],
+				{
+					env,
+					shell: shouldRunCodexInShell(),
+					timeout: opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+					maxBuffer: 10 * 1024 * 1024,
+				},
+			);
+			return { ok: true, stdout: String(stdout), stderr: String(stderr), code: 0 };
+		} catch (err) {
+			lastError = err;
+			if (index < candidates.length - 1 && isSpawnResolutionError(err)) {
+				continue;
+			}
+			break;
+		}
 	}
+
+	const e = lastError as {
+		stdout?: string | Buffer;
+		stderr?: string | Buffer;
+		code?: number | string;
+		message?: string;
+	};
+	return {
+		ok: false,
+		stdout: e?.stdout ? String(e.stdout) : "",
+		stderr: e?.stderr ? String(e.stderr) : (e?.message ?? ""),
+		code: typeof e?.code === "number" ? e.code : null,
+	};
 };
+
+function isSpawnResolutionError(err: unknown): boolean {
+	const code = (err as { code?: unknown })?.code;
+	return code === "ENOENT" || code === "EACCES" || code === "EINVAL";
+}
 
 export type CodexPluginInstallAction = "installed" | "skipped-codex-unsupported" | "install-failed";
 

--- a/src/domains/installation/plugin/codex-plugin-installer.ts
+++ b/src/domains/installation/plugin/codex-plugin-installer.ts
@@ -23,12 +23,12 @@ export interface CodexRunOptions {
 
 export type CodexRunner = (args: string[], opts?: CodexRunOptions) => Promise<CodexRunResult>;
 
-export function resolveCodexExecutable(platformName: NodeJS.Platform = process.platform): string {
-	return platformName === "win32" ? "codex.cmd" : "codex";
+export function resolveCodexExecutable(_platformName: NodeJS.Platform = process.platform): string {
+	return "codex";
 }
 
-export function shouldRunCodexInShell(platformName: NodeJS.Platform = process.platform): boolean {
-	return platformName === "win32";
+export function shouldRunCodexInShell(_platformName: NodeJS.Platform = process.platform): boolean {
+	return false;
 }
 
 export const defaultCodexRunner: CodexRunner = async (args, opts) => {
@@ -117,9 +117,16 @@ export class CodexPluginInstaller {
 		return this.run(["plugin", "list", "--json"], this.opts(15_000));
 	}
 
+	async listText(): Promise<CodexRunResult> {
+		return this.run(["plugin", "list"], this.opts(15_000));
+	}
+
 	async verifyInstalled(): Promise<boolean> {
 		const r = await this.listJson();
-		if (!r.ok) return false;
+		if (!r.ok) {
+			const text = await this.listText();
+			return text.ok && parseTextPluginList(text.stdout + text.stderr);
+		}
 		try {
 			const parsed = JSON.parse(r.stdout) as {
 				installed?: Array<{ pluginId?: string; enabled?: boolean; installed?: boolean }>;
@@ -131,9 +138,19 @@ export class CodexPluginInstaller {
 					plugin.enabled === true,
 			);
 		} catch {
-			return false;
+			const text = await this.listText();
+			return text.ok && parseTextPluginList(text.stdout + text.stderr);
 		}
 	}
+}
+
+function parseTextPluginList(output: string): boolean {
+	const pluginId = `${CK_PLUGIN_NAME}@${CK_MARKETPLACE_NAME}`.replace(
+		/[.*+?^${}()|[\]\\]/g,
+		"\\$&",
+	);
+	const row = new RegExp(`^\\s*${pluginId}\\s+.*\\binstalled\\b.*\\benabled\\b`, "im");
+	return row.test(output);
 }
 
 export async function installCodexPlugin(

--- a/src/domains/installation/plugin/codex-plugin-installer.ts
+++ b/src/domains/installation/plugin/codex-plugin-installer.ts
@@ -66,6 +66,11 @@ export interface CodexPluginInstallResult {
 	error?: string;
 }
 
+export interface RemoveCodexPluginResult {
+	removed: boolean;
+	marketplaceRemoved: boolean;
+}
+
 export interface InstallCodexPluginOptions {
 	/** Staged kit dir containing .agents/plugins/marketplace.json. */
 	pluginSourceDir: string;
@@ -96,8 +101,16 @@ export class CodexPluginInstaller {
 		return this.run(["plugin", "marketplace", "add", source], this.opts());
 	}
 
+	async marketplaceRemove(name: string = CK_MARKETPLACE_NAME): Promise<CodexRunResult> {
+		return this.run(["plugin", "marketplace", "remove", name], this.opts());
+	}
+
 	async add(): Promise<CodexRunResult> {
 		return this.run(["plugin", "add", `${CK_PLUGIN_NAME}@${CK_MARKETPLACE_NAME}`], this.opts());
+	}
+
+	async remove(): Promise<CodexRunResult> {
+		return this.run(["plugin", "remove", `${CK_PLUGIN_NAME}@${CK_MARKETPLACE_NAME}`], this.opts());
 	}
 
 	async listJson(): Promise<CodexRunResult> {
@@ -160,6 +173,23 @@ export async function installCodexPlugin(
 	}
 
 	return { action: "installed", pluginVerified: true };
+}
+
+export async function removeCodexPlugin(
+	opts: { installer?: CodexPluginInstaller; codexHome?: string } = {},
+): Promise<RemoveCodexPluginResult> {
+	const installer = opts.installer ?? new CodexPluginInstaller(undefined, opts.codexHome);
+
+	if (!(await installer.isCodexAvailable()) || !(await installer.isPluginSupported())) {
+		return { removed: false, marketplaceRemoved: false };
+	}
+
+	const removed = await installer.remove();
+	const marketplaceRemoved = await installer.marketplaceRemove();
+	return {
+		removed: removed.ok,
+		marketplaceRemoved: marketplaceRemoved.ok,
+	};
 }
 
 export async function shouldRefreshCodexPlugin(

--- a/src/domains/installation/plugin/install-mode-detector.ts
+++ b/src/domains/installation/plugin/install-mode-detector.ts
@@ -1,5 +1,6 @@
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative, resolve } from "node:path";
 import { PathResolver } from "@/shared/path-resolver.js";
 
 /**
@@ -225,12 +226,10 @@ export function hasTrackedPluginSuppliedLegacyFiles(
 	if (!isRecord(metadata)) return false;
 
 	for (const file of collectTrackedFiles(metadata)) {
-		if (file.ownership === "user") continue;
-		const normalized = file.path.replace(/\\/g, "/").replace(/^\.claude\//, "");
-		if (!PLUGIN_SUPPLIED_LEGACY_PREFIXES.some((prefix) => normalized.startsWith(prefix))) {
-			continue;
-		}
-		if (existsSync(join(claudeDir, normalized))) return true;
+		const resolvedPath = resolveSafePluginSuppliedLegacyPath(claudeDir, file.path);
+		if (!resolvedPath || !existsSync(resolvedPath)) continue;
+		if (file.ownership === "user" && !checksumMatches(resolvedPath, file.checksum)) continue;
+		return true;
 	}
 
 	return false;
@@ -239,6 +238,7 @@ export function hasTrackedPluginSuppliedLegacyFiles(
 interface TrackedFile {
 	path: string;
 	ownership: "ck" | "ck-modified" | "user";
+	checksum?: string;
 }
 
 function collectTrackedFiles(metadata: Record<string, unknown>): TrackedFile[] {
@@ -249,7 +249,11 @@ function collectTrackedFiles(metadata: Record<string, unknown>): TrackedFile[] {
 			if (!isRecord(file) || typeof file.path !== "string") continue;
 			const ownership =
 				file.ownership === "user" || file.ownership === "ck-modified" ? file.ownership : "ck";
-			tracked.push({ path: file.path, ownership });
+			tracked.push({
+				path: file.path,
+				ownership,
+				checksum: typeof file.checksum === "string" ? file.checksum : undefined,
+			});
 		}
 	};
 
@@ -261,6 +265,56 @@ function collectTrackedFiles(metadata: Record<string, unknown>): TrackedFile[] {
 	}
 
 	return tracked;
+}
+
+function resolveSafePluginSuppliedLegacyPath(claudeDir: string, pathValue: string): string | null {
+	const normalized = normalizeLegacyPath(pathValue).replace(/^\.\/+/, "");
+	if (!isPluginSuppliedLegacyPath(normalized)) return null;
+	const safe = resolveSafeChildPath(claudeDir, normalized);
+	if (!safe) return null;
+
+	const relativePath = normalizeLegacyPath(relative(resolve(claudeDir), safe));
+	if (!isPluginSuppliedLegacyPath(relativePath)) return null;
+	return safe;
+}
+
+function resolveSafeChildPath(baseDir: string, pathValue: string): string | null {
+	const normalized = normalizeLegacyPath(pathValue);
+	if (!normalized || hasPathTraversal(normalized) || isAbsoluteLike(normalized)) return null;
+
+	const resolvedBase = resolve(baseDir);
+	const resolvedTarget = resolve(resolvedBase, normalized);
+	const relativePath = normalizeLegacyPath(relative(resolvedBase, resolvedTarget));
+	if (!relativePath || relativePath === ".." || relativePath.startsWith("../")) return null;
+	if (isAbsoluteLike(relativePath)) return null;
+	return resolvedTarget;
+}
+
+function isPluginSuppliedLegacyPath(pathValue: string): boolean {
+	const normalized = normalizeLegacyPath(pathValue).replace(/^\.claude\//, "");
+	return PLUGIN_SUPPLIED_LEGACY_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+function checksumMatches(filePath: string, expected?: string): boolean {
+	if (!expected || !/^[a-f0-9]{64}$/i.test(expected)) return false;
+	try {
+		const actual = createHash("sha256").update(readFileSync(filePath)).digest("hex");
+		return actual.toLowerCase() === expected.toLowerCase();
+	} catch {
+		return false;
+	}
+}
+
+function hasPathTraversal(pathValue: string): boolean {
+	return pathValue.split("/").some((segment) => segment === "..");
+}
+
+function isAbsoluteLike(pathValue: string): boolean {
+	return pathValue.startsWith("/") || pathValue.startsWith("//") || /^[A-Za-z]:/.test(pathValue);
+}
+
+function normalizeLegacyPath(pathValue: string): string {
+	return pathValue.replace(/\\/g, "/");
 }
 
 function safeReaddir(dir: string): string[] {

--- a/src/domains/installation/plugin/migrate-legacy-to-plugin.ts
+++ b/src/domains/installation/plugin/migrate-legacy-to-plugin.ts
@@ -69,20 +69,15 @@ export async function migrateLegacyToPlugin(opts: MigrateOptions): Promise<Migra
 		return base("skipped-cc-unsupported", before.mode, false);
 	}
 
-	// Non-destructive: register marketplace + install + verify. Surface command
-	// failures early (before the destructive step) instead of relying on verify alone.
-	const added = await installer.marketplaceAdd(opts.pluginSourceDir);
-	if (!added.ok) {
+	// Non-destructive: register/refresh marketplace + install/update + verify. Surface
+	// command failures early before removing the legacy copy.
+	const prepared = before.plugin.installed
+		? await refreshExistingPlugin(installer, opts.pluginSourceDir, before.plugin.enabled)
+		: await installPlugin(installer, opts.pluginSourceDir);
+	if (!prepared.ok) {
 		return {
 			...base("install-failed", before.mode, false),
-			error: `marketplace add failed: ${added.stderr.trim()}`,
-		};
-	}
-	const installed = await installer.install("user");
-	if (!installed.ok) {
-		return {
-			...base("install-failed", before.mode, false),
-			error: `plugin install failed: ${installed.stderr.trim()}`,
+			error: prepared.error,
 		};
 	}
 	const verified = await installer.verifyInstalled();
@@ -226,6 +221,56 @@ function readJsonSafe(filePath: string): unknown {
 	} catch {
 		return null;
 	}
+}
+
+interface PluginPrepareResult {
+	ok: boolean;
+	error?: string;
+}
+
+async function installPlugin(
+	installer: PluginInstaller,
+	pluginSourceDir: string,
+): Promise<PluginPrepareResult> {
+	const added = await installer.marketplaceAdd(pluginSourceDir);
+	if (!added.ok) {
+		return { ok: false, error: `marketplace add failed: ${added.stderr.trim()}` };
+	}
+	const installed = await installer.install("user");
+	if (!installed.ok) {
+		return { ok: false, error: `plugin install failed: ${installed.stderr.trim()}` };
+	}
+	return { ok: true };
+}
+
+async function refreshExistingPlugin(
+	installer: PluginInstaller,
+	pluginSourceDir: string,
+	enabled: boolean,
+): Promise<PluginPrepareResult> {
+	const added = await installer.marketplaceAdd(pluginSourceDir);
+	if (!added.ok) {
+		const updatedMarketplace = await installer.marketplaceUpdate();
+		if (!updatedMarketplace.ok) {
+			return {
+				ok: false,
+				error: `marketplace refresh failed: ${updatedMarketplace.stderr.trim() || added.stderr.trim()}`,
+			};
+		}
+	}
+
+	if (!enabled) {
+		const enabledResult = await installer.enable();
+		if (!enabledResult.ok) {
+			return { ok: false, error: `plugin enable failed: ${enabledResult.stderr.trim()}` };
+		}
+	}
+
+	const updated = await installer.update();
+	if (!updated.ok) {
+		return { ok: false, error: `plugin update failed: ${updated.stderr.trim()}` };
+	}
+	return { ok: true };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/domains/installation/plugin/migrate-legacy-to-plugin.ts
+++ b/src/domains/installation/plugin/migrate-legacy-to-plugin.ts
@@ -8,7 +8,7 @@ import {
 	rmSync,
 	writeFileSync,
 } from "node:fs";
-import { dirname, join, relative } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import {
 	ENGINEER_KIT_KEY,
 	type InstallMode,
@@ -156,23 +156,25 @@ export function defaultLegacyRemover(claudeDir: string, backupDir: string): stri
 	const files = collectTrackedFiles(meta);
 	const removed: string[] = [];
 	for (const file of files) {
-		if (!isPluginSuppliedLegacyPath(file.path)) continue;
-		const abs = join(claudeDir, file.path);
-		if (!existsSync(abs)) continue;
-		if (!isSafeToRemovePluginSuppliedLegacyFile(file, abs)) continue;
+		const legacyPath = resolveSafePluginSuppliedLegacyPath(claudeDir, file.path);
+		if (!legacyPath) continue;
+		if (!existsSync(legacyPath.absolutePath)) continue;
+		if (!isSafeToRemovePluginSuppliedLegacyFile(file, legacyPath.absolutePath)) continue;
 		// Back up before removing.
-		backupAndRemove(backupDir, file.path, abs);
-		removed.push(file.path);
+		if (!backupAndRemove(backupDir, legacyPath.relativePath, legacyPath.absolutePath)) continue;
+		removed.push(legacyPath.relativePath);
 	}
 	removed.push(...removeOrphanLegacySentinels(claudeDir, backupDir, removed));
 	return removed;
 }
 
-function backupAndRemove(backupDir: string, relativePath: string, abs: string): void {
-	const backupTarget = join(backupDir, relativePath);
+function backupAndRemove(backupDir: string, relativePath: string, abs: string): boolean {
+	const backupTarget = resolveSafeChildPath(backupDir, relativePath);
+	if (!backupTarget) return false;
 	mkdirSync(dirname(backupTarget), { recursive: true });
 	cpSync(abs, backupTarget, { recursive: true });
 	rmSync(abs, { recursive: true, force: true });
+	return true;
 }
 
 function removeOrphanLegacySentinels(
@@ -196,7 +198,7 @@ function removeOrphanLegacySentinels(
 		for (const sentinelAbs of findLegacySentinels(rootAbs)) {
 			const sentinelPath = normalizeLegacyPath(relative(claudeDir, sentinelAbs));
 			if (!isSafeToRemoveLegacySentinel(sentinelPath, sentinelAbs, normalizedRemoved)) continue;
-			backupAndRemove(backupDir, sentinelPath, sentinelAbs);
+			if (!backupAndRemove(backupDir, sentinelPath, sentinelAbs)) continue;
 			removed.push(sentinelPath);
 		}
 	}
@@ -285,6 +287,40 @@ function checksumMatches(filePath: string, expected?: string): boolean {
 function isPluginSuppliedLegacyPath(pathValue: string): boolean {
 	const normalized = normalizeLegacyPath(pathValue).replace(/^\.claude\//, "");
 	return PLUGIN_SUPPLIED_LEGACY_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+function resolveSafePluginSuppliedLegacyPath(
+	claudeDir: string,
+	pathValue: string,
+): { absolutePath: string; relativePath: string } | null {
+	const normalized = normalizeLegacyPath(pathValue).replace(/^\.\/+/, "");
+	if (!isPluginSuppliedLegacyPath(normalized)) return null;
+	const safe = resolveSafeChildPath(claudeDir, normalized);
+	if (!safe) return null;
+
+	const relativePath = normalizeLegacyPath(relative(resolve(claudeDir), safe));
+	if (!isPluginSuppliedLegacyPath(relativePath)) return null;
+	return { absolutePath: safe, relativePath };
+}
+
+function resolveSafeChildPath(baseDir: string, pathValue: string): string | null {
+	const normalized = normalizeLegacyPath(pathValue);
+	if (!normalized || hasPathTraversal(normalized) || isAbsoluteLike(normalized)) return null;
+
+	const resolvedBase = resolve(baseDir);
+	const resolvedTarget = resolve(resolvedBase, normalized);
+	const relativePath = normalizeLegacyPath(relative(resolvedBase, resolvedTarget));
+	if (!relativePath || relativePath === ".." || relativePath.startsWith("../")) return null;
+	if (isAbsoluteLike(relativePath)) return null;
+	return resolvedTarget;
+}
+
+function hasPathTraversal(pathValue: string): boolean {
+	return pathValue.split("/").some((segment) => segment === "..");
+}
+
+function isAbsoluteLike(pathValue: string): boolean {
+	return pathValue.startsWith("/") || pathValue.startsWith("//") || /^[A-Za-z]:/.test(pathValue);
 }
 
 function normalizeLegacyPath(pathValue: string): string {

--- a/src/domains/installation/plugin/migrate-legacy-to-plugin.ts
+++ b/src/domains/installation/plugin/migrate-legacy-to-plugin.ts
@@ -1,5 +1,14 @@
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { createHash } from "node:crypto";
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join, relative } from "node:path";
 import {
 	ENGINEER_KIT_KEY,
 	type InstallMode,
@@ -135,6 +144,7 @@ function base(
 }
 
 const PLUGIN_SUPPLIED_LEGACY_PREFIXES = ["agents/", "skills/"];
+const LEGACY_SENTINEL_FILENAMES = new Set([".gitignore"]);
 
 /**
  * Default legacy remover: backs up and removes ck-owned engineer kit files that
@@ -146,28 +156,145 @@ export function defaultLegacyRemover(claudeDir: string, backupDir: string): stri
 	const files = collectTrackedFiles(meta);
 	const removed: string[] = [];
 	for (const file of files) {
-		if (file.ownership === "user") continue; // never delete user-owned content
 		if (!isPluginSuppliedLegacyPath(file.path)) continue;
 		const abs = join(claudeDir, file.path);
 		if (!existsSync(abs)) continue;
+		if (!isSafeToRemovePluginSuppliedLegacyFile(file, abs)) continue;
 		// Back up before removing.
-		const backupTarget = join(backupDir, file.path);
-		mkdirSync(dirname(backupTarget), { recursive: true });
-		cpSync(abs, backupTarget, { recursive: true });
-		rmSync(abs, { recursive: true, force: true });
+		backupAndRemove(backupDir, file.path, abs);
 		removed.push(file.path);
+	}
+	removed.push(...removeOrphanLegacySentinels(claudeDir, backupDir, removed));
+	return removed;
+}
+
+function backupAndRemove(backupDir: string, relativePath: string, abs: string): void {
+	const backupTarget = join(backupDir, relativePath);
+	mkdirSync(dirname(backupTarget), { recursive: true });
+	cpSync(abs, backupTarget, { recursive: true });
+	rmSync(abs, { recursive: true, force: true });
+}
+
+function removeOrphanLegacySentinels(
+	claudeDir: string,
+	backupDir: string,
+	removedTrackedPaths: string[],
+): string[] {
+	const normalizedRemoved = removedTrackedPaths.map(normalizeLegacyPath);
+	const rootsToSweep = new Set<string>();
+	for (const pathValue of normalizedRemoved) {
+		const [root] = pathValue.split("/");
+		if (root && PLUGIN_SUPPLIED_LEGACY_PREFIXES.includes(`${root}/`)) {
+			rootsToSweep.add(root);
+		}
+	}
+
+	const removed: string[] = [];
+	for (const root of rootsToSweep) {
+		const rootAbs = join(claudeDir, root);
+		if (!existsSync(rootAbs)) continue;
+		for (const sentinelAbs of findLegacySentinels(rootAbs)) {
+			const sentinelPath = normalizeLegacyPath(relative(claudeDir, sentinelAbs));
+			if (!isSafeToRemoveLegacySentinel(sentinelPath, sentinelAbs, normalizedRemoved)) continue;
+			backupAndRemove(backupDir, sentinelPath, sentinelAbs);
+			removed.push(sentinelPath);
+		}
 	}
 	return removed;
 }
 
+function findLegacySentinels(dir: string): string[] {
+	const out: string[] = [];
+	let entries;
+	try {
+		entries = readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return out;
+	}
+
+	for (const entry of entries) {
+		const abs = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			out.push(...findLegacySentinels(abs));
+		} else if (entry.isFile() && LEGACY_SENTINEL_FILENAMES.has(entry.name)) {
+			out.push(abs);
+		}
+	}
+	return out;
+}
+
+function isSafeToRemoveLegacySentinel(
+	sentinelPath: string,
+	sentinelAbs: string,
+	removedTrackedPaths: string[],
+): boolean {
+	if (!isPluginSuppliedLegacyPath(sentinelPath)) return false;
+	if (!LEGACY_SENTINEL_FILENAMES.has(sentinelPath.split("/").pop() ?? "")) return false;
+
+	const sentinelDir = dirname(sentinelPath).replace(/\\/g, "/");
+	if (!removedTrackedPaths.some((removedPath) => removedPath.startsWith(`${sentinelDir}/`))) {
+		return false;
+	}
+
+	return directoryContainsOnlySentinels(dirname(sentinelAbs));
+}
+
+function directoryContainsOnlySentinels(dir: string): boolean {
+	let entries;
+	try {
+		entries = readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return false;
+	}
+
+	for (const entry of entries) {
+		const abs = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (!directoryContainsOnlySentinels(abs)) return false;
+		} else if (!entry.isFile() || !LEGACY_SENTINEL_FILENAMES.has(entry.name)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function isSafeToRemovePluginSuppliedLegacyFile(file: TrackedFile, abs: string): boolean {
+	if (file.ownership !== "user") {
+		return true;
+	}
+
+	// Offline/local kit installs can lack release-manifest.json, so files are
+	// tracked as user-owned even though the installer just copied them. Remove
+	// only when the tracked checksum still matches disk; edited or untracked
+	// user files stay protected.
+	return checksumMatches(abs, file.checksum);
+}
+
+function checksumMatches(filePath: string, expected?: string): boolean {
+	if (!expected || !/^[a-f0-9]{64}$/i.test(expected)) {
+		return false;
+	}
+	try {
+		const actual = createHash("sha256").update(readFileSync(filePath)).digest("hex");
+		return actual.toLowerCase() === expected.toLowerCase();
+	} catch {
+		return false;
+	}
+}
+
 function isPluginSuppliedLegacyPath(pathValue: string): boolean {
-	const normalized = pathValue.replace(/\\/g, "/").replace(/^\.claude\//, "");
+	const normalized = normalizeLegacyPath(pathValue).replace(/^\.claude\//, "");
 	return PLUGIN_SUPPLIED_LEGACY_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+function normalizeLegacyPath(pathValue: string): string {
+	return pathValue.replace(/\\/g, "/");
 }
 
 interface TrackedFile {
 	path: string;
 	ownership: "ck" | "ck-modified" | "user";
+	checksum?: string;
 }
 
 function collectTrackedFiles(meta: unknown): TrackedFile[] {
@@ -179,7 +306,11 @@ function collectTrackedFiles(meta: unknown): TrackedFile[] {
 			if (isRecord(f) && typeof f.path === "string") {
 				const ownership =
 					f.ownership === "user" || f.ownership === "ck-modified" ? f.ownership : "ck";
-				out.push({ path: f.path, ownership });
+				out.push({
+					path: f.path,
+					ownership,
+					checksum: typeof f.checksum === "string" ? f.checksum : undefined,
+				});
 			}
 		}
 	};

--- a/src/domains/installation/plugin/migrate-legacy-to-plugin.ts
+++ b/src/domains/installation/plugin/migrate-legacy-to-plugin.ts
@@ -192,10 +192,13 @@ function removeOrphanLegacySentinels(
 	}
 
 	const removed: string[] = [];
-	for (const root of rootsToSweep) {
+	for (const root of [...rootsToSweep].sort(compareLegacyPaths)) {
 		const rootAbs = join(claudeDir, root);
 		if (!existsSync(rootAbs)) continue;
-		for (const sentinelAbs of findLegacySentinels(rootAbs)) {
+		const sentinels = findLegacySentinels(rootAbs).sort((a, b) =>
+			compareLegacyPaths(relative(claudeDir, a), relative(claudeDir, b)),
+		);
+		for (const sentinelAbs of sentinels) {
 			const sentinelPath = normalizeLegacyPath(relative(claudeDir, sentinelAbs));
 			if (!isSafeToRemoveLegacySentinel(sentinelPath, sentinelAbs, normalizedRemoved)) continue;
 			if (!backupAndRemove(backupDir, sentinelPath, sentinelAbs)) continue;
@@ -214,7 +217,7 @@ function findLegacySentinels(dir: string): string[] {
 		return out;
 	}
 
-	for (const entry of entries) {
+	for (const entry of entries.sort((a, b) => compareLegacyPaths(a.name, b.name))) {
 		const abs = join(dir, entry.name);
 		if (entry.isDirectory()) {
 			out.push(...findLegacySentinels(abs));
@@ -325,6 +328,14 @@ function isAbsoluteLike(pathValue: string): boolean {
 
 function normalizeLegacyPath(pathValue: string): string {
 	return pathValue.replace(/\\/g, "/");
+}
+
+function compareLegacyPaths(a: string, b: string): number {
+	const normalizedA = normalizeLegacyPath(a);
+	const normalizedB = normalizeLegacyPath(b);
+	if (normalizedA < normalizedB) return -1;
+	if (normalizedA > normalizedB) return 1;
+	return 0;
 }
 
 interface TrackedFile {

--- a/src/domains/installation/plugin/uninstall-plugin.ts
+++ b/src/domains/installation/plugin/uninstall-plugin.ts
@@ -11,6 +11,8 @@ import { PathResolver } from "@/shared/path-resolver.js";
 export interface UninstallPluginResult {
 	uninstalled: boolean;
 	staleCacheRemoved: boolean;
+	pluginStillInstalled: boolean;
+	error?: string;
 }
 
 export interface UninstallPluginOptions {
@@ -32,10 +34,22 @@ export async function uninstallEnginePlugin(
 	const state = detectPluginState(claudeDir);
 
 	let uninstalled = false;
+	const errors: string[] = [];
 	if (state.installed) {
-		await installer.uninstall();
-		await installer.marketplaceRemove(state.marketplace ?? CK_MARKETPLACE_NAME);
-		uninstalled = true;
+		const removed = await installer.uninstall();
+		if (removed.ok) {
+			uninstalled = true;
+		} else {
+			errors.push(`plugin uninstall failed: ${removed.stderr.trim() || "unknown error"}`);
+		}
+		const marketplaceRemoved = await installer.marketplaceRemove(
+			state.marketplace ?? CK_MARKETPLACE_NAME,
+		);
+		if (!marketplaceRemoved.ok) {
+			errors.push(
+				`marketplace remove failed: ${marketplaceRemoved.stderr.trim() || "unknown error"}`,
+			);
+		}
 	}
 
 	// Purge cache payload (covers both a registered uninstall and an orphaned stale cache).
@@ -47,5 +61,15 @@ export async function uninstallEnginePlugin(
 		staleCacheRemoved = true;
 	}
 
-	return { uninstalled, staleCacheRemoved };
+	const pluginStillInstalled = state.installed ? detectPluginState(claudeDir).installed : false;
+	if (pluginStillInstalled) {
+		errors.push("plugin remains registered after cleanup");
+	}
+
+	return {
+		uninstalled,
+		staleCacheRemoved,
+		pluginStillInstalled,
+		error: errors.length > 0 ? errors.join("; ") : undefined,
+	};
 }

--- a/src/domains/installation/setup-wizard.ts
+++ b/src/domains/installation/setup-wizard.ts
@@ -242,7 +242,8 @@ async function parseEnvFile(path: string): Promise<Record<string, string>> {
 					value = value.slice(1, -1);
 				}
 				// Trim final value to handle whitespace-only values like `KEY=" "`
-				env[key.trim()] = value.trim();
+				const normalizedKey = key.trim();
+				env[normalizedKey] = normalizeParsedEnvValue(normalizedKey, value);
 			}
 		}
 
@@ -251,6 +252,19 @@ async function parseEnvFile(path: string): Promise<Record<string, string>> {
 		logger.debug(`Failed to parse .env file at ${path}: ${error}`);
 		return {};
 	}
+}
+
+function normalizeParsedEnvValue(key: string, value: string): string {
+	const trimmed = value.trim();
+	if (
+		key === "GEMINI_API_KEY" ||
+		key.startsWith("GEMINI_API_KEY_") ||
+		key === "OPENROUTER_API_KEY" ||
+		key === "MINIMAX_API_KEY"
+	) {
+		return normalizeApiKeyInput(trimmed);
+	}
+	return trimmed;
 }
 
 /**

--- a/src/domains/installation/setup-wizard.ts
+++ b/src/domains/installation/setup-wizard.ts
@@ -1,6 +1,10 @@
 import { join } from "node:path";
 import { generateEnvFile } from "@/domains/config/config-generator.js";
-import { VALIDATION_PATTERNS, validateApiKey } from "@/domains/config/config-validator.js";
+import {
+	VALIDATION_PATTERNS,
+	normalizeApiKeyInput,
+	validateApiKey,
+} from "@/domains/config/config-validator.js";
 import { logger } from "@/shared/logger.js";
 import { PathResolver } from "@/shared/path-resolver.js";
 import * as clack from "@clack/prompts";
@@ -343,8 +347,9 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<boole
 		}
 
 		// Type guard: after isCancel check, result is string
-		if (typeof result === "string" && result) {
-			values[config.key] = result;
+		if (typeof result === "string") {
+			const normalized = normalizeApiKeyInput(result);
+			if (normalized) values[config.key] = normalized;
 		}
 	}
 
@@ -451,7 +456,7 @@ async function promptForAdditionalGeminiKeys(primaryKey: string): Promise<string
 				// Empty = done adding keys
 				if (!value) return;
 				// Trim whitespace (handles copy-paste issues)
-				const trimmed = value.trim();
+				const trimmed = normalizeApiKeyInput(value);
 				if (!trimmed) return;
 				// Validate format
 				if (!validateApiKey(trimmed, VALIDATION_PATTERNS.GEMINI_API_KEY)) {
@@ -471,13 +476,13 @@ async function promptForAdditionalGeminiKeys(primaryKey: string): Promise<string
 		}
 
 		// Empty string means done
-		if (!result || result.trim() === "") {
+		const normalized = typeof result === "string" ? normalizeApiKeyInput(result) : "";
+		if (!normalized) {
 			break;
 		}
 
-		const trimmedKey = result.trim();
-		additionalKeys.push(trimmedKey);
-		allKeys.add(trimmedKey);
+		additionalKeys.push(normalized);
+		allKeys.add(normalized);
 		keyNumber++;
 	}
 

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -90,6 +90,7 @@ export const UpdateCommandOptionsSchema = z
 		useGit: z.boolean().default(false), // Use git clone instead of API download
 		archive: z.string().optional(), // Local archive file path (zip/tar.gz)
 		kitPath: z.string().optional(), // Local kit directory path
+		installMode: z.enum(["auto", "plugin", "legacy"]).default("auto"), // Engineer global install shape
 	})
 	.merge(GlobalOutputOptionsSchema);
 export type UpdateCommandOptions = z.infer<typeof UpdateCommandOptionsSchema>;


### PR DESCRIPTION
## Summary
- add `ck init --install-mode auto|plugin|legacy` so users can choose strict plugin, legacy straight-skill, or existing auto behavior
- make legacy installs remove Claude/Codex plugin state, and make strict plugin installs fail when Claude plugin migration does not verify
- refresh Codex plugin install/removal handling plus generated CLI help/docs surfaces
- normalize pasted Gemini API keys before validation and storage in setup prompts

## Validation
- `bun test src/domains/installation/plugin/__tests__/install-mode-detector.test.ts src/domains/installation/plugin/__tests__/migrate-legacy-to-plugin.test.ts src/domains/installation/plugin/__tests__/uninstall-plugin.test.ts src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts src/commands/init/phases/__tests__/plugin-install-handler.test.ts src/__tests__/commands/update-cli-prompt-kit.test.ts src/__tests__/domains/installation/setup-wizard.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run help:check-parity`
- `bun run manifest:generate`
- `bun run docs:generate`
- pre-commit quality gate on both commits
- pre-push quality gate before branch publish

Fixes claudekit/claudekit-engineer#849
