### PR TITLE
hotfix: keep dashboard global migrate source scoped

### DIFF
--- a/src/__tests__/domains/web-server/routes/migration-routes.test.ts
+++ b/src/__tests__/domains/web-server/routes/migration-routes.test.ts
@@ -997,6 +997,137 @@ describe.serial("migration reconcile route", () => {
 		expect(emptyLike.status).toBe(200);
 	});
 
+	test("reconcile uses global Claude source discovery when global migration is requested", async () => {
+		getCommandSourcePathMock.mockReturnValueOnce("/tmp/global-claude/commands");
+		discoverCommandsMock.mockResolvedValueOnce([
+			{
+				name: "ck/build",
+				displayName: "CK Build",
+				description: "",
+				type: "command",
+				sourcePath: "/tmp/global-claude/commands/ck/build.md",
+				frontmatter: {},
+				body: "# CK Build\n",
+			},
+		]);
+
+		const res = await testFetch(
+			`${ctx.baseUrl}/api/migrate/reconcile?providers=opencode&agents=false&commands=true&skills=false&config=false&rules=false&hooks=false&global=true`,
+		);
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			plan: { meta: { global?: boolean; items: { commands: string[] } } };
+		};
+		expect(getCommandSourcePathMock).toHaveBeenCalledWith(true);
+		expect(body.plan.meta.global).toBe(true);
+		expect(body.plan.meta.items.commands).toEqual(["ck/build"]);
+	});
+
+	test("install discovery uses global Claude source discovery when global migration is requested", async () => {
+		getCommandSourcePathMock.mockReturnValueOnce("/tmp/global-claude/commands");
+		discoverCommandsMock.mockResolvedValueOnce([
+			{
+				name: "ck/build",
+				displayName: "CK Build",
+				description: "",
+				type: "command",
+				sourcePath: "/tmp/global-claude/commands/ck/build.md",
+				frontmatter: {},
+				body: "# CK Build\n",
+			},
+		]);
+
+		const res = await testFetch(
+			`${ctx.baseUrl}/api/migrate/install-discovery?providers=opencode&agents=false&commands=true&skills=false&config=false&rules=false&hooks=false&global=true`,
+		);
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			candidates: Array<{ item: string; sourcePath: string; global: boolean }>;
+		};
+		expect(getCommandSourcePathMock).toHaveBeenCalledWith(true);
+		expect(body.candidates).toEqual([
+			expect.objectContaining({
+				item: "ck/build",
+				sourcePath: "/tmp/global-claude/commands/ck/build.md",
+				global: true,
+			}),
+		]);
+	});
+
+	test("plan execution re-discovers global Claude source when plan meta is global", async () => {
+		getCommandSourcePathMock.mockReturnValueOnce("/tmp/global-claude/commands");
+		discoverCommandsMock.mockResolvedValueOnce([
+			{
+				name: "ck/build",
+				displayName: "CK Build",
+				description: "",
+				type: "command",
+				sourcePath: "/tmp/global-claude/commands/ck/build.md",
+				frontmatter: {},
+				body: "# CK Build\n",
+			},
+		]);
+		installPortableItemsMock.mockImplementationOnce(async (items, providers, type, options) => {
+			expect(type).toBe("command");
+			expect(options).toEqual({ global: true });
+			expect(items.map((item) => (item as { name: string }).name)).toEqual(["ck/build"]);
+			return [
+				{
+					provider: providers[0] as PortableInstallBatch[number]["provider"],
+					providerDisplayName: "OpenCode",
+					success: true,
+					path: "/tmp/opencode/commands/ck/build.md",
+					itemName: "ck/build",
+				},
+			];
+		});
+
+		const plan = {
+			actions: [
+				{
+					action: "install",
+					item: "ck/build",
+					type: "command",
+					provider: "opencode",
+					global: true,
+					targetPath: "/tmp/opencode/commands/ck/build.md",
+					reason: "Install global command",
+				},
+			],
+			summary: { install: 1, update: 0, skip: 0, conflict: 0, delete: 0 },
+			hasConflicts: false,
+			meta: {
+				include: {
+					agents: false,
+					commands: true,
+					skills: false,
+					config: false,
+					rules: false,
+					hooks: false,
+				},
+				providers: ["opencode"],
+				global: true,
+				items: { commands: ["ck/build"] },
+			},
+		};
+
+		const res = await testFetch(`${ctx.baseUrl}/api/migrate/execute`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ plan, resolutions: {} }),
+		});
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			counts: { installed: number; skipped: number; failed: number };
+		};
+		expect(getCommandSourcePathMock).toHaveBeenCalledWith(true);
+		expect(installPortableItemsMock).toHaveBeenCalledTimes(1);
+		expect(body.counts).toEqual({ installed: 1, skipped: 0, failed: 0 });
+	});
+
 	test("reconcile plan keeps project-scoped Codex command actions project-local", async () => {
 		getCommandSourcePathMock.mockReturnValueOnce("/tmp/commands");
 		discoverCommandsMock.mockResolvedValueOnce([

--- a/src/domains/web-server/routes/migration-routes.ts
+++ b/src/domains/web-server/routes/migration-routes.ts
@@ -694,6 +694,7 @@ function getPlanMeta(plan: z.infer<typeof RECONCILE_PLAN_SCHEMA>): {
 	include?: unknown;
 	providers?: unknown;
 	source?: unknown;
+	global?: unknown;
 	items?: unknown;
 } | null {
 	const rawMeta = (plan as { meta?: unknown }).meta;
@@ -702,6 +703,7 @@ function getPlanMeta(plan: z.infer<typeof RECONCILE_PLAN_SCHEMA>): {
 		include?: unknown;
 		providers?: unknown;
 		source?: unknown;
+		global?: unknown;
 		items?: unknown;
 	};
 }
@@ -799,6 +801,17 @@ function getConfigSourceFromPlan(plan: z.infer<typeof RECONCILE_PLAN_SCHEMA>): s
 	}
 	const parsed = parseConfigSource(meta.source);
 	return parsed.ok ? parsed.value : undefined;
+}
+
+function getGlobalOnlyFromPlan(plan: z.infer<typeof RECONCILE_PLAN_SCHEMA>): boolean {
+	const meta = getPlanMeta(plan);
+	const parsedGlobal = parseBooleanLike(meta?.global);
+	if (parsedGlobal.ok && parsedGlobal.value !== undefined) {
+		return parsedGlobal.value;
+	}
+
+	const actionScopes = new Set(plan.actions.map((action) => action.global));
+	return actionScopes.size === 1 && actionScopes.has(true);
 }
 
 function getPlanItemsByType(
@@ -1335,7 +1348,7 @@ export function registerMigrationRoutes(app: Express, deps?: MigrationRouteDeps)
 			}
 
 			// 1. Discover source items
-			const discovered = await discoverMigrationItems(include, configSource);
+			const discovered = await discoverMigrationItems(include, configSource, globalParam);
 
 			// 2. Build source item states with checksums
 			const sourceItems: SourceItemState[] = [];
@@ -1511,6 +1524,7 @@ export function registerMigrationRoutes(app: Express, deps?: MigrationRouteDeps)
 					include,
 					providers: selectedProviders,
 					source: configSource,
+					global: globalParam,
 					mode: reconcileMode,
 					items: {
 						agents: discovered.agents.map((item) => item.name),
@@ -1579,7 +1593,7 @@ export function registerMigrationRoutes(app: Express, deps?: MigrationRouteDeps)
 			const configSource = sourceParsed.value;
 
 			// Discover source items (no reconcile, no checksum computation)
-			const discovered = await discoverMigrationItems(include, configSource);
+			const discovered = await discoverMigrationItems(include, configSource, globalParam);
 
 			// Cross-reference registry for alreadyInstalled detection
 			const registry = await registryDeps.readPortableRegistry();
@@ -1789,7 +1803,12 @@ export function registerMigrationRoutes(app: Express, deps?: MigrationRouteDeps)
 				// Re-discover source items to get file content for installation
 				const includeFromPlan = getIncludeFromPlan(plan);
 				const configSourceFromPlan = getConfigSourceFromPlan(plan);
-				const discovered = await discoverMigrationItems(includeFromPlan, configSourceFromPlan);
+				const globalOnlyFromPlan = getGlobalOnlyFromPlan(plan);
+				const discovered = await discoverMigrationItems(
+					includeFromPlan,
+					configSourceFromPlan,
+					globalOnlyFromPlan,
+				);
 
 				const agentByName = new Map(discovered.agents.map((item) => [item.name, item]));
 				const commandByName = new Map(discovered.commands.map((item) => [item.name, item]));
@@ -2098,9 +2117,9 @@ export function registerMigrationRoutes(app: Express, deps?: MigrationRouteDeps)
 					}
 				}
 				try {
-					const agentSrc = getAgentSourcePath();
-					const cmdSrc = getCommandSourcePath();
-					const skillSrc = getSkillSourcePath();
+					const agentSrc = getAgentSourcePath(globalOnlyFromPlan);
+					const cmdSrc = getCommandSourcePath(globalOnlyFromPlan);
+					const skillSrc = getSkillSourcePath(globalOnlyFromPlan);
 					const kitRoot =
 						(agentSrc ? resolve(agentSrc, "..") : null) ??
 						(cmdSrc ? resolve(cmdSrc, "..") : null) ??


### PR DESCRIPTION
## Summary
- keep dashboard reconcile and install-discovery source lookup global when `global=true`
- persist `plan.meta.global` so dashboard plan execution re-discovers the same global Claude source
- add regression coverage for OpenCode global command migration avoiding project `.claude/commands/opsx` leakage

## Validation
- `bun test src/__tests__/domains/web-server/routes/migration-routes.test.ts`
- `bun test src/__tests__/commands/update-cli-migrate-step.test.ts src/__tests__/domains/web-server/routes/migration-routes.test.ts`
- `bun test src/commands/migrate/__tests__/migrate-global-source.integration.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun test` (4,980 pass / 54 skip / 0 fail)
- `bun run test:e2e` (21 passed)
- local black-box canary: CLI `ck migrate -g --agent opencode --only-commands --yes` + dashboard API reconcile/install/execute migrated only global `ck/build`, not project `opsx/apply`
- Linux LXC `ck-linux-e2e` via tmux: install/build + focused tests (67 pass / 0 fail) + same CLI/dashboard API canary (`LINUX_OPENCODE_MIGRATE_CANARY_OK`)
- Windows `i9-bootcamp`: install/build + focused tests (67 pass / 0 fail) + same CLI/dashboard API canary (`WINDOWS_OPENCODE_MIGRATE_CANARY_OK`)
- pre-push local CI parity: typecheck, lint, build, serialized test suite (4,975 pass / 59 skip / 0 fail), help parity, manifest/docs drift, UI build, packaged CLI verification, UI vitest (153 pass)

## Docs impact
Docs impact: none
Action: no update needed — bug fix preserves existing `--global` migration semantics; no CLI/API surface or documented workflow changed

## Release impact
Patch hotfix.
