### PR TITLE
fix: repair codex plugin update self-heal

### DIFF
--- a/src/__tests__/commands/update-cli-auto-init.test.ts
+++ b/src/__tests__/commands/update-cli-auto-init.test.ts
@@ -182,6 +182,7 @@ describe("promptKitUpdate auto-init behavior", () => {
 			detectInstallModeFn: () => makeInstallModeReport(tempDir, "plugin"),
 			hasTrackedPluginSuppliedLegacyFilesFn: () => false,
 			shouldRefreshCodexPluginFn: async () => false,
+			cleanupStaleCodexConfigEntriesFn: async () => [],
 		};
 		return {
 			deps,
@@ -332,6 +333,31 @@ describe("promptKitUpdate auto-init behavior", () => {
 		expect(capturedSpawnArgs()).toContain("engineer");
 		expect(capturedSpawnArgs()).toContain("--yes");
 		expect(capturedSpawnArgs()).toContain("--restore-ck-hooks");
+	});
+
+	test("cleans Codex config before checking stable plugin source (--yes mode)", async () => {
+		const { deps, spawnCount, capturedSpawnArgs } = makeDeps();
+		deps.getLatestReleaseTagFn = async () => "v1.0.0";
+		let cleanupRan = false;
+		let refreshOptions: unknown;
+		deps.cleanupStaleCodexConfigEntriesFn = async () => {
+			cleanupRan = true;
+			return ["fullstack_developer"];
+		};
+		deps.shouldRefreshCodexPluginFn = async (options) => {
+			expect(cleanupRan).toBe(true);
+			refreshOptions = options;
+			return true;
+		};
+
+		await promptKitUpdate(false, true, deps);
+
+		expect(spawnCount()).toBe(1);
+		expect(capturedSpawnArgs()).toContain("--restore-ck-hooks");
+		expect(refreshOptions).toMatchObject({
+			expectedVersion: "1.0.0",
+			expectedSource: join(testHome, ".cache", "claude", "ck-plugin-source", ".claude"),
+		});
 	});
 
 	test("reinstalls latest legacy global engineer kit to migrate plugin format (--yes mode)", async () => {

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -11,6 +11,7 @@ import { readdir } from "node:fs/promises";
 import { builtinModules } from "node:module";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
+import { cleanupStaleCodexConfigEntries } from "@/commands/portable/codex-toml-installer.js";
 import { CkConfigManager } from "@/domains/config/ck-config-manager.js";
 import {
 	countMissingHookFileReferences,
@@ -32,6 +33,7 @@ import { versionsMatch } from "@/domains/versioning/checking/version-utils.js";
 import { getClaudeKitSetup } from "@/services/file-operations/claudekit-scanner.js";
 import { parseJsonContent } from "@/shared/json-content.js";
 import { logger } from "@/shared/logger.js";
+import { PathResolver } from "@/shared/path-resolver.js";
 import { confirm, isCancel, log, spinner } from "@/shared/safe-prompts.js";
 import {
 	AVAILABLE_KITS,
@@ -423,6 +425,7 @@ export interface PromptKitUpdateDeps {
 	detectInstallModeFn?: (claudeDir: string) => InstallModeReport;
 	hasTrackedPluginSuppliedLegacyFilesFn?: (claudeDir: string) => boolean;
 	shouldRefreshCodexPluginFn?: (options?: CodexPluginStateOptions) => Promise<boolean>;
+	cleanupStaleCodexConfigEntriesFn?: typeof cleanupStaleCodexConfigEntries;
 }
 
 async function findMissingHookDependencies(claudeDir: string): Promise<string[]> {
@@ -482,6 +485,8 @@ export async function promptKitUpdate(
 		const shouldRefreshCodexPluginFn =
 			deps?.shouldRefreshCodexPluginFn ??
 			((options?: CodexPluginStateOptions) => shouldRefreshCodexPlugin(undefined, options));
+		const cleanupStaleCodexConfigEntriesFn =
+			deps?.cleanupStaleCodexConfigEntriesFn ?? cleanupStaleCodexConfigEntries;
 		const setup = await getSetupFn();
 		const hasLocal = !!setup.project.metadata;
 		const hasGlobal = !!setup.global.metadata;
@@ -617,14 +622,27 @@ export async function promptKitUpdate(
 							forceKitReinstall = true;
 						}
 					}
-					if (
-						installModePreference !== "legacy" &&
-						(await shouldRefreshCodexPluginFn({ expectedVersion: kitVersion }))
-					) {
-						logger.warning(
-							"Detected Codex ClaudeKit plugin state requiring refresh; reinstalling global Engineer content",
-						);
-						forceKitReinstall = true;
+					if (installModePreference !== "legacy") {
+						try {
+							await cleanupStaleCodexConfigEntriesFn({ global: true, provider: "codex" });
+						} catch (error) {
+							logger.verbose(
+								`Codex config self-heal skipped: ${
+									error instanceof Error ? error.message : "unknown"
+								}`,
+							);
+						}
+						if (
+							await shouldRefreshCodexPluginFn({
+								expectedVersion: kitVersion,
+								expectedSource: join(PathResolver.getCacheDir(true), "ck-plugin-source", ".claude"),
+							})
+						) {
+							logger.warning(
+								"Detected Codex ClaudeKit plugin state requiring refresh; reinstalling global Engineer content",
+							);
+							forceKitReinstall = true;
+						}
 					}
 				}
 			} catch (error) {

--- a/src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts
+++ b/src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts
@@ -368,6 +368,39 @@ other@market  installed, enabled
 		});
 	});
 
+	test("treats equivalent local source paths as current", async () => {
+		const installer = new CodexPluginInstaller(async (args) => {
+			if (args.join(" ") === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (args.join(" ") === "plugin --help") return ok("plugin marketplace add");
+			if (args.join(" ") === "plugin list --json") {
+				return ok(
+					JSON.stringify({
+						installed: [
+							{
+								pluginId: "ck@claudekit",
+								installed: true,
+								enabled: true,
+								version: "2.20.1-beta.7",
+								marketplace: "claudekit",
+								source: { source: "local", path: "/tmp/ck-plugin-source/.claude" },
+							},
+						],
+					}),
+				);
+			}
+			return fail("unexpected");
+		});
+
+		await expect(
+			detectCodexPluginState(installer, {
+				expectedSource: "/tmp/../tmp/ck-plugin-source/.claude",
+			}),
+		).resolves.toMatchObject({
+			status: "installed-current",
+			shouldRefresh: false,
+		});
+	});
+
 	test("skips Codex plugin removal when Codex has no plugin support", async () => {
 		const calls: string[][] = [];
 		const installer = new CodexPluginInstaller(async (args) => {

--- a/src/domains/installation/plugin/codex-plugin-installer.ts
+++ b/src/domains/installation/plugin/codex-plugin-installer.ts
@@ -1,4 +1,6 @@
 import { execFile } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
+import { normalize, resolve } from "node:path";
 import { promisify } from "node:util";
 import {
 	CK_MARKETPLACE_NAME,
@@ -249,7 +251,11 @@ function classifyCodexPluginEntry(
 	if (entry.marketplace && entry.marketplace !== expectedMarketplace) {
 		return createState("installed-stale-source", entry, options);
 	}
-	if (options.expectedSource && entry.source && entry.source !== options.expectedSource) {
+	if (
+		options.expectedSource &&
+		entry.source &&
+		!pluginSourceMatches(entry.source, options.expectedSource)
+	) {
 		return createState("installed-stale-source", entry, options);
 	}
 	if (
@@ -261,6 +267,28 @@ function classifyCodexPluginEntry(
 	}
 
 	return createState("installed-current", entry, options);
+}
+
+function pluginSourceMatches(actual: string, expected: string): boolean {
+	if (actual === expected) return true;
+
+	const normalizedActual = normalizeLocalSourcePath(actual);
+	const normalizedExpected = normalizeLocalSourcePath(expected);
+	return (
+		normalizedActual !== null &&
+		normalizedExpected !== null &&
+		normalizedActual === normalizedExpected
+	);
+}
+
+function normalizeLocalSourcePath(value: string): string | null {
+	const trimmed = value.trim();
+	if (!trimmed || /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return null;
+
+	const resolved = resolve(trimmed);
+	const canonical = existsSync(resolved) ? realpathSync.native(resolved) : resolved;
+	const normalized = normalize(canonical);
+	return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
 
 function parseTextPluginList(output: string): CodexPluginListEntry | null {


### PR DESCRIPTION
## Summary
- repair stale/malformed Codex config before update self-heal checks plugin state
- refresh ck@claudekit when the registered marketplace source drifts from the stable cache path
- normalize local plugin source paths before comparing them

## Validation
- bun test src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts src/commands/portable/__tests__/codex-config-cleanup.test.ts src/__tests__/commands/update-cli-auto-init.test.ts
- bun run typecheck
- bun run build
- bunx biome check src/commands/update/post-update-handler.ts src/domains/installation/plugin/codex-plugin-installer.ts src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts src/__tests__/commands/update-cli-auto-init.test.ts
- pre-push gate rerun passed after one unrelated timeout passed on direct rerun

## Docs impact
None. Internal update self-heal; no user-facing command, setup, or docs contract changes.