### PR TITLE
fix: harden plugin lifecycle convergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,14 @@ ck migrate --agent codex
 Switching modes removes only ClaudeKit-owned plugin or copied-skill state. ClaudeKit
 backs up managed copied files before replacing them, preserves user-modified files, and
 verifies the selected surface before removing CK-owned plugin registrations or cache.
+Normal copies expose skills as `ck:<name>`; the canonical plugin payload keeps bare skill
+names because Claude and Codex apply the `ck` plugin namespace themselves. Plugin staging
+is transactional: a validated replacement is activated with the prior source retained
+until both provider preparations succeed, then committed or rolled back together.
+
+For stored plugin consent, `ck update` repairs unhealthy state even when the Engineer
+version is unchanged. This includes missing, disabled, stale-version, stale-source, and
+orphaned Claude state, plus actionable Codex inspection or lifecycle drift.
 
 > Stable `4.5.2` predates the short-lived plugin-default change. This contract reverses
 > only the affected development prereleases; stable users retain the normal-skills behavior.
@@ -316,7 +324,7 @@ ck doctor --report
 # Auto-fix all fixable issues
 ck doctor --fix
 
-# CI mode: no prompts, exit 1 on failures
+# CI mode: no prompts, exit 1 on failures or actionable warnings
 ck doctor --check-only
 
 # Machine-readable JSON output
@@ -348,7 +356,7 @@ ck doctor --verbose --fix
 
 **Exit Codes:**
 - `0`: All checks pass or issues fixed
-- `1`: Failures detected (only with `--check-only`)
+- `1`: Failures, actionable warnings, or provider inspection errors detected with `--check-only`
 
 > **Note:** `ck diagnose` is deprecated. Use `ck doctor` instead.
 
@@ -383,6 +391,10 @@ ck uninstall --yes        # Non-interactive - skip confirmation (for scripts)
 - Shows paths before deletion
 - Requires confirmation (unless `--yes` flag)
 - Removes ClaudeKit subdirectories (`commands/`, `agents/`, `skills/`, `workflows/`, `hooks/`, `metadata.json`)
+- For global Engineer scope, removes and verifies the owned Claude and Codex plugins and
+  `claudekit` marketplace state. Repeated cleanup is an idempotent no-op; unverifiable or
+  residual provider state prevents a false success result.
+- Local-only and Marketing-only uninstall do not change global Engineer plugin state.
 - **Preserves user configs** like `settings.json`, `settings.local.json`, and `CLAUDE.md`
 
 **Note:** Only removes valid ClaudeKit installations (with metadata.json). Regular `.claude` directories from Claude Desktop are not affected.

--- a/docs/install-mode-contract.md
+++ b/docs/install-mode-contract.md
@@ -92,6 +92,13 @@ Plugin:
 - Cleanup copied skills only after plugin verification.
 - Persist `plugin` so later init/update runs retain the explicit choice.
 
+Skill identifiers:
+
+- Canonical Engineer plugin payloads use bare skill names such as `scout`; Claude and
+  Codex expose them through the plugin namespace as `ck:scout`.
+- Normal copied installs project bare names to `ck:<name>` exactly once, including nested
+  skills, without changing the canonical plugin payload.
+
 ## Duplicate-State Regression
 
 The known bad state is copied Engineer skills at version N plus an enabled
@@ -107,6 +114,11 @@ Repair rules:
 ## Cleanup And Rollback
 
 - No destructive cleanup happens before replacement verification.
+- A replacement marketplace source is built and validated in a temporary directory. The
+  prior stable source remains available until both provider preparations verify.
+- Claude or Codex preparation failure restores the previous stable source and provider
+  registration; successful preparations commit together without temporary or backup
+  residue.
 - Copied files are backed up under `.claude/backups/ck-legacy-<timestamp>` before
   removal.
 - Migration writes a receipt recording source mode, target mode, plugin version,
@@ -136,6 +148,8 @@ Repair rules:
 - Preserves explicit stored `plugin` consent across version updates.
 - Resolves missing, `auto`, invalid, and `legacy` preferences to Normal skills.
 - Does not install or repair plugins merely because a runtime supports them.
+- With stored `plugin` consent, repairs same-version missing, disabled, stale-version,
+  stale-source, orphan-cache, and actionable provider inspection states.
 
 `ck doctor`:
 
@@ -144,6 +158,15 @@ Repair rules:
   Codex plugin state.
 - Warns when preference and live state disagree.
 - Warns when copied skills and plugin state can both expose CK skills.
+- Treats Codex inspection errors as actionable rather than passing the row.
+- With `--check-only`, exits `1` for failures or warnings in text, JSON, and report modes.
+
+`ck uninstall`:
+
+- Global Engineer uninstall removes the owned Claude and Codex plugins, their `claudekit`
+  marketplace state, and stale Claude cache, then verifies absence.
+- Cleanup is idempotent; residual or unverifiable provider state prevents a success result.
+- Local-only and Marketing-only uninstall leave global Engineer plugin state unchanged.
 
 ## Release Boundary
 

--- a/src/__tests__/commands/doctor-exit-semantics.test.ts
+++ b/src/__tests__/commands/doctor-exit-semantics.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { hasActionableDoctorFindings } from "@/commands/doctor.js";
+
+describe("doctor check-only exit semantics", () => {
+	test.each([
+		[{ failed: 0, warnings: 0 }, false],
+		[{ failed: 1, warnings: 0 }, true],
+		[{ failed: 0, warnings: 1 }, true],
+		[{ failed: 1, warnings: 1 }, true],
+	] as const)("maps summary %p to actionable=%p", (summary, expected) => {
+		expect(hasActionableDoctorFindings(summary)).toBe(expected);
+	});
+});

--- a/src/__tests__/commands/update-cli-auto-init.test.ts
+++ b/src/__tests__/commands/update-cli-auto-init.test.ts
@@ -181,6 +181,7 @@ describe("promptKitUpdate auto-init behavior", () => {
 			isCancelFn: isCancelMock,
 			detectInstallModeFn: () => makeInstallModeReport(tempDir, "plugin"),
 			hasTrackedPluginSuppliedLegacyFilesFn: () => false,
+			shouldRefreshClaudePluginFn: () => false,
 			shouldRefreshCodexPluginFn: async () => false,
 			detectCodexPluginStateFn: async () => ({
 				status: "missing",
@@ -358,6 +359,42 @@ describe("promptKitUpdate auto-init behavior", () => {
 		expect(capturedSpawnArgs()).toContain("--restore-ck-hooks");
 		expect(capturedSpawnArgs()).toContain("plugin");
 	});
+
+	test("reinstalls a same-version plugin install when Claude plugin health requires repair", async () => {
+		await writeMetadata(tempDir, "1.0.0", "plugin");
+		const { deps, spawnCount, capturedSpawnArgs } = makeDeps();
+		deps.getLatestReleaseTagFn = async () => "v1.0.0";
+		let seen: unknown;
+		deps.shouldRefreshClaudePluginFn = (_claudeDir, options) => {
+			seen = options;
+			return true;
+		};
+
+		await promptKitUpdate(false, true, deps);
+
+		expect(spawnCount()).toBe(1);
+		expect(capturedSpawnArgs()).toContain("plugin");
+		expect(seen).toMatchObject({
+			expectedVersion: "1.0.0",
+			expectedSource: join(testHome, ".cache", "claude", "ck-plugin-source"),
+		});
+	});
+
+	test.each(["missing", "orphan-cache", "disabled", "stale-version", "stale-source"])(
+		"routes same-version Claude %s health through explicit plugin repair",
+		async () => {
+			await writeMetadata(tempDir, "1.0.0", "plugin");
+			const { deps, spawnCount, capturedSpawnArgs } = makeDeps();
+			deps.getLatestReleaseTagFn = async () => "v1.0.0";
+			deps.shouldRefreshClaudePluginFn = () => true;
+
+			await promptKitUpdate(false, true, deps);
+
+			expect(spawnCount()).toBe(1);
+			expect(capturedSpawnArgs()).toContain("--install-mode");
+			expect(capturedSpawnArgs()).toContain("plugin");
+		},
+	);
 
 	test("cleans Codex config before checking stable plugin source (--yes mode)", async () => {
 		await writeMetadata(tempDir, "1.0.0", "plugin");

--- a/src/__tests__/services/transformers/engineer-legacy-skill-name-projector.test.ts
+++ b/src/__tests__/services/transformers/engineer-legacy-skill-name-projector.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	projectEngineerLegacySkillContent,
+	projectEngineerSkillNamesForInstall,
+} from "@/services/transformers/engineer-legacy-skill-name-projector.js";
+
+const tempDirs: string[] = [];
+
+async function makePayload(): Promise<string> {
+	const root = await mkdtemp(join(tmpdir(), "ck-legacy-skill-projection-"));
+	tempDirs.push(root);
+	return root;
+}
+
+async function writeSkill(root: string, directory: string, content: string): Promise<string> {
+	const skillDir = join(root, ".claude", "skills", directory);
+	await mkdir(skillDir, { recursive: true });
+	const filePath = join(skillDir, "SKILL.md");
+	await writeFile(filePath, content, "utf8");
+	return filePath;
+}
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map((directory) => rm(directory, { recursive: true })));
+});
+
+describe("Engineer legacy skill name projection", () => {
+	test("adds ck: exactly once while preserving all unrelated bytes", () => {
+		const canonical = [
+			"---",
+			'name: "cook" # public command',
+			"description: Keep: punctuation and formatting",
+			"metadata:",
+			"  version: 1",
+			"---",
+			"",
+			"# Body",
+			"Keep this body byte-for-byte.",
+		].join("\r\n");
+
+		const projected = projectEngineerLegacySkillContent(canonical);
+		expect(projected.changed).toBe(true);
+		expect(projected.name).toBe("ck:cook");
+		expect(projected.content).toBe(canonical.replace('name: "cook"', 'name: "ck:cook"'));
+
+		const repeated = projectEngineerLegacySkillContent(projected.content);
+		expect(repeated.changed).toBe(false);
+		expect(repeated.content).toBe(projected.content);
+	});
+
+	test.each([
+		"---\nname: ck:cook\ndescription: Existing\n---\nBody\n",
+		"# Missing frontmatter\nname: cook\n",
+		"---\nname: [invalid\ndescription: Invalid\n---\nBody\n",
+		"---\nname: first\nname: second\n---\nBody\n",
+	])("leaves already-prefixed, missing, or invalid frontmatter unchanged", (content) => {
+		const result = projectEngineerLegacySkillContent(content);
+		expect(result.changed).toBe(false);
+		expect(result.content).toBe(content);
+	});
+
+	test.each(["global", "local"])(
+		"projects the temporary %s Normal-install payload without changing file shape",
+		async () => {
+			const root = await makePayload();
+			const filePath = await writeSkill(
+				root,
+				"cook",
+				"---\nname: cook\ndescription: Cook\n---\n\nBody\n",
+			);
+
+			const result = await projectEngineerSkillNamesForInstall(root, {
+				kitType: "engineer",
+				installMode: "legacy",
+			});
+			expect(result).toEqual({ skillsScanned: 1, skillsProjected: 1 });
+			expect(await readFile(filePath, "utf8")).toContain("name: ck:cook");
+		},
+	);
+
+	test("detects destination name collisions before writing any files", async () => {
+		const root = await makePayload();
+		const barePath = await writeSkill(root, "cook", "---\nname: cook\n---\nBody\n");
+		await writeSkill(root, "cook-alias", "---\nname: ck:cook\n---\nAlias\n");
+
+		await expect(
+			projectEngineerSkillNamesForInstall(root, {
+				kitType: "engineer",
+				installMode: "legacy",
+			}),
+		).rejects.toThrow("name collision");
+		expect(await readFile(barePath, "utf8")).toContain("name: cook\n");
+	});
+
+	test("projects nested Engineer skills and includes them in collision preflight", async () => {
+		const root = await makePayload();
+		const nestedPath = await writeSkill(
+			root,
+			"document-skills/pdf",
+			"---\nname: pdf\ndescription: PDF\n---\nBody\n",
+		);
+
+		const result = await projectEngineerSkillNamesForInstall(root, {
+			kitType: "engineer",
+			installMode: "legacy",
+		});
+
+		expect(result).toEqual({ skillsScanned: 1, skillsProjected: 1 });
+		expect(await readFile(nestedPath, "utf8")).toContain("name: ck:pdf");
+
+		const aliasPath = await writeSkill(root, "pdf-alias", "---\nname: ck:pdf\n---\nAlias\n");
+		await expect(
+			projectEngineerSkillNamesForInstall(root, {
+				kitType: "engineer",
+				installMode: "legacy",
+			}),
+		).rejects.toThrow("name collision");
+		expect(await readFile(aliasPath, "utf8")).toContain("name: ck:pdf");
+	});
+
+	test("skips symlinked skill entries to keep projection inside the payload", async () => {
+		const root = await makePayload();
+		const outsideRoot = await makePayload();
+		const outsideFile = await writeSkill(outsideRoot, "outside", "---\nname: outside\n---\nBody\n");
+		const skillsDir = join(root, ".claude", "skills");
+		await mkdir(skillsDir, { recursive: true });
+		await symlink(join(outsideRoot, ".claude", "skills", "outside"), join(skillsDir, "linked"));
+
+		const result = await projectEngineerSkillNamesForInstall(root, {
+			kitType: "engineer",
+			installMode: "legacy",
+		});
+		expect(result).toEqual({ skillsScanned: 0, skillsProjected: 0 });
+		expect(await readFile(outsideFile, "utf8")).toContain("name: outside\n");
+	});
+
+	test("missing skills directory is a deterministic no-op for plugin staging callers", async () => {
+		const root = await makePayload();
+		expect(
+			await projectEngineerSkillNamesForInstall(root, {
+				kitType: "engineer",
+				installMode: "legacy",
+			}),
+		).toEqual({
+			skillsScanned: 0,
+			skillsProjected: 0,
+		});
+	});
+
+	test.each([
+		{ kitType: "engineer", installMode: "plugin" },
+		{ kitType: "marketing", installMode: "legacy" },
+	])("leaves $kitType $installMode staging byte-for-byte unchanged", async (context) => {
+		const root = await makePayload();
+		const canonical = "---\nname: cook\ndescription: Canonical\n---\nBody\n";
+		const filePath = await writeSkill(root, "cook", canonical);
+
+		expect(await projectEngineerSkillNamesForInstall(root, context)).toEqual({
+			skillsScanned: 0,
+			skillsProjected: 0,
+		});
+		expect(await readFile(filePath, "utf8")).toBe(canonical);
+	});
+});

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -50,7 +50,7 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<void> 
 		const generator = new ReportGenerator();
 		console.log(generator.generateJsonReport(summary));
 		// Use exitCode instead of exit() to allow stdout to flush properly
-		process.exitCode = summary.failed > 0 && checkOnly ? 1 : 0;
+		process.exitCode = checkOnly && hasActionableDoctorFindings(summary) ? 1 : 0;
 		return;
 	}
 
@@ -63,6 +63,9 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<void> 
 		const gistResult = await generator.uploadToGist(textReport);
 		if (gistResult) {
 			logger.info(`Report uploaded: ${gistResult.url}`);
+		}
+		if (checkOnly) {
+			process.exitCode = hasActionableDoctorFindings(summary) ? 1 : 0;
 		}
 		return;
 	}
@@ -80,15 +83,17 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<void> 
 				healSummary.succeeded > 0 ? await createDoctorRunner(runnerOptions).run() : summary;
 			renderer.renderResults(finalSummary);
 
-			if (checkOnly && finalSummary.failed > 0) {
+			if (checkOnly && hasActionableDoctorFindings(finalSummary)) {
 				process.exitCode = 1;
 			}
 
 			if (healSummary.failed > 0) {
 				process.exitCode = 1;
 				outro(`${healSummary.failed} auto-fix attempt(s) failed`);
-			} else if (finalSummary.failed === 0) {
+			} else if (finalSummary.failed === 0 && finalSummary.warnings === 0) {
 				outro(healSummary.succeeded > 0 ? "All fixable issues resolved!" : "All checks passed!");
+			} else if (finalSummary.failed === 0) {
+				outro(`${finalSummary.warnings} warning(s) remain after auto-heal`);
 			} else {
 				outro(`${finalSummary.failed} issue(s) remain after auto-heal`);
 			}
@@ -103,7 +108,7 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<void> 
 	renderer.renderResults(summary);
 
 	// Handle --check-only mode exit code
-	if (checkOnly && summary.failed > 0) {
+	if (checkOnly && hasActionableDoctorFindings(summary)) {
 		process.exitCode = 1;
 	}
 
@@ -126,11 +131,20 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<void> 
 	}
 
 	// Outro
-	if (summary.failed === 0) {
+	if (summary.failed === 0 && summary.warnings === 0) {
 		outro("All checks passed!");
+	} else if (summary.failed === 0) {
+		outro(`${summary.warnings} warning(s) found`);
 	} else {
 		outro(`${summary.failed} issue(s) found`);
 	}
+}
+
+export function hasActionableDoctorFindings(summary: {
+	failed: number;
+	warnings: number;
+}): boolean {
+	return summary.failed > 0 || summary.warnings > 0;
 }
 
 function createDoctorRunner(options: CheckRunnerOptions): CheckRunner {

--- a/src/commands/init/phases/__tests__/plugin-install-handler.test.ts
+++ b/src/commands/init/phases/__tests__/plugin-install-handler.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { existsSync, readFileSync, renameSync } from "node:fs";
+import { chmod, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import {
-	handlePluginInstall,
+	type PluginInstallDeps,
+	handlePluginInstall as handlePluginInstallUnsafe,
 	stagePluginSource,
 } from "@/commands/init/phases/plugin-install-handler.js";
 import type { InitContext } from "@/commands/init/types.js";
@@ -36,18 +37,86 @@ const failedInstallResult: MigrateResult = {
 	receiptPath: null,
 	error: "plugin did not verify after install",
 };
+const noClaudePluginResult: UninstallPluginResult = {
+	uninstalled: false,
+	staleCacheRemoved: false,
+	pluginStillInstalled: false,
+};
+const noCodexPluginResult: RemoveCodexPluginResult = {
+	removed: false,
+	marketplaceRemoved: false,
+	pluginStillInstalled: false,
+};
+
+function handlePluginInstall(
+	ctx: InitContext,
+	overrides: PluginInstallDeps = {},
+): Promise<InitContext> {
+	return handlePluginInstallUnsafe(ctx, {
+		migrate: async () => okResult,
+		installCodex: async () => okCodexResult,
+		uninstallClaudePlugin: async () => noClaudePluginResult,
+		removeCodexPlugin: async () => noCodexPluginResult,
+		persistPreference: async () => {},
+		...overrides,
+	});
+}
 
 describe("handlePluginInstall (init Phase 7.5)", () => {
 	let root: string;
 	let extractDir: string;
 	let claudeDir: string;
 	let stageBase: string;
+	let providerRunnerMarker: string;
+	let originalEnvironment: Record<string, string | undefined>;
 
 	beforeEach(async () => {
 		root = join(tmpdir(), `ck-pih-${Date.now()}-${Math.round(performance.now())}`);
 		extractDir = join(root, "extract");
 		claudeDir = join(root, "claude");
 		stageBase = join(root, "stage");
+		providerRunnerMarker = join(root, "provider-runner-reached");
+		const providerBinDir = join(root, "provider-bin");
+		const isolatedHome = join(root, "guard-home");
+		const isolatedCodexHome = join(root, "guard-codex-home");
+		const isolatedClaudeHome = join(root, "guard-claude-home");
+		originalEnvironment = Object.fromEntries(
+			[
+				"HOME",
+				"CODEX_HOME",
+				"USERPROFILE",
+				"APPDATA",
+				"LOCALAPPDATA",
+				"CLAUDE_CONFIG_DIR",
+				"PATH",
+				"CK_TEST_PROVIDER_MARKER",
+			].map((name) => [name, process.env[name]]),
+		);
+		Object.assign(process.env, {
+			HOME: isolatedHome,
+			CODEX_HOME: isolatedCodexHome,
+			USERPROFILE: isolatedHome,
+			APPDATA: join(isolatedHome, "AppData", "Roaming"),
+			LOCALAPPDATA: join(isolatedHome, "AppData", "Local"),
+			CLAUDE_CONFIG_DIR: isolatedClaudeHome,
+			CK_TEST_PROVIDER_MARKER: providerRunnerMarker,
+			PATH: `${providerBinDir}${delimiter}${process.env.PATH ?? ""}`,
+		});
+		await mkdir(providerBinDir, { recursive: true });
+		for (const executable of ["claude", "codex"]) {
+			const shim = join(providerBinDir, executable);
+			await writeFile(
+				shim,
+				'#!/bin/sh\nprintf "provider-runner-reached" > "$CK_TEST_PROVIDER_MARKER"\nexit 97\n',
+				"utf-8",
+			);
+			await chmod(shim, 0o755);
+			await writeFile(
+				join(providerBinDir, `${executable}.cmd`),
+				'@echo provider-runner-reached>"%CK_TEST_PROVIDER_MARKER%"\r\n@exit /b 97\r\n',
+				"utf-8",
+			);
+		}
 		await mkdir(join(extractDir, ".claude", ".claude-plugin"), { recursive: true });
 		await mkdir(join(extractDir, ".claude", "skills", "cook"), { recursive: true });
 		await writeFile(
@@ -58,7 +127,15 @@ describe("handlePluginInstall (init Phase 7.5)", () => {
 		await mkdir(claudeDir, { recursive: true });
 	});
 	afterEach(async () => {
-		await rm(root, { recursive: true, force: true });
+		try {
+			expect(existsSync(providerRunnerMarker)).toBe(false);
+		} finally {
+			for (const [name, value] of Object.entries(originalEnvironment)) {
+				if (value === undefined) delete process.env[name];
+				else process.env[name] = value;
+			}
+			await rm(root, { recursive: true, force: true });
+		}
 	});
 
 	function ctxOf(
@@ -219,6 +296,114 @@ describe("handlePluginInstall (init Phase 7.5)", () => {
 		).rejects.toThrow("Codex plugin install failed");
 	});
 
+	test("Codex preparation failure leaves Claude legacy cleanup untouched", async () => {
+		let claudeMigrationCalled = false;
+		await expect(
+			handlePluginInstall(ctxOf({ installMode: "plugin" }), {
+				installCodex: async () => ({
+					action: "install-failed",
+					pluginVerified: false,
+					error: "marketplace replacement failed",
+				}),
+				migrate: async () => {
+					claudeMigrationCalled = true;
+					return okResult;
+				},
+				stageBaseDir: stageBase,
+			}),
+		).rejects.toThrow("Codex plugin install failed");
+		expect(claudeMigrationCalled).toBe(false);
+	});
+
+	test("Codex failure after stage activation restores the previous stable source", async () => {
+		await writeStableStage(stageBase);
+
+		await expect(
+			handlePluginInstall(ctxOf({ installMode: "plugin" }), {
+				installCodex: async () => ({
+					action: "install-failed",
+					pluginVerified: false,
+					error: "injected Codex failure",
+				}),
+				stageBaseDir: stageBase,
+			}),
+		).rejects.toThrow("Codex plugin install failed");
+
+		expect(readFileSync(join(stageBase, "last-known-good.txt"), "utf-8")).toBe("stable");
+	});
+
+	test("Claude failure after stage activation restores the previous stable source", async () => {
+		await writeStableStage(stageBase);
+
+		await expect(
+			handlePluginInstall(ctxOf({ installMode: "plugin" }), {
+				installCodex: async () => okCodexResult,
+				migrate: async () => failedInstallResult,
+				stageBaseDir: stageBase,
+			}),
+		).rejects.toThrow("Claude plugin install failed");
+
+		expect(readFileSync(join(stageBase, "last-known-good.txt"), "utf-8")).toBe("stable");
+	});
+
+	test("Claude failure restores stage before rolling back Codex preparation", async () => {
+		await writeStableStage(stageBase);
+		let codexCommitted = false;
+		let codexRolledBack = false;
+
+		await expect(
+			handlePluginInstall(ctxOf({ installMode: "plugin" }), {
+				prepareCodex: async () => ({
+					result: okCodexResult,
+					commit: () => {
+						codexCommitted = true;
+					},
+					rollback: async () => {
+						codexRolledBack = true;
+						expect(readFileSync(join(stageBase, "last-known-good.txt"), "utf-8")).toBe("stable");
+						return { ok: true, detail: "restored Codex" };
+					},
+				}),
+				migrate: async () => failedInstallResult,
+				stageBaseDir: stageBase,
+			}),
+		).rejects.toThrow("Claude plugin install failed");
+
+		expect(codexRolledBack).toBe(true);
+		expect(codexCommitted).toBe(false);
+	});
+
+	test("preference persistence failure happens before Claude migration and restores metadata", async () => {
+		await writeStableStage(stageBase);
+		const metadataPath = join(claudeDir, "metadata.json");
+		const originalMetadata = '{"kits":{"engineer":{"installModePreference":"legacy"}}}\n';
+		await writeFile(metadataPath, originalMetadata, "utf-8");
+		let claudeMigrationCalled = false;
+
+		await expect(
+			handlePluginInstall(ctxOf({ installMode: "plugin" }), {
+				prepareCodex: async () => ({
+					result: okCodexResult,
+					commit: () => {},
+					rollback: async () => ({ ok: true, detail: "restored Codex" }),
+				}),
+				persistPreference: async () => {
+					await writeFile(metadataPath, '{"partial":true}\n', "utf-8");
+					throw new Error("disk full");
+				},
+				migrate: async () => {
+					claudeMigrationCalled = true;
+					return okResult;
+				},
+				stageBaseDir: stageBase,
+			}),
+		).rejects.toThrow("disk full");
+
+		expect(claudeMigrationCalled).toBe(false);
+		expect(readFileSync(metadataPath, "utf-8")).toBe(originalMetadata);
+		expect(readFileSync(join(stageBase, "last-known-good.txt"), "utf-8")).toBe("stable");
+	});
+
 	test("explicit legacy mode removes plugin state and skips plugin migration", async () => {
 		let migrated = false;
 		let codexInstalled = false;
@@ -282,6 +467,36 @@ describe("handlePluginInstall (init Phase 7.5)", () => {
 		).rejects.toThrow("Codex plugin cleanup failed");
 
 		expect(existsSync(stageBase)).toBe(false);
+	});
+
+	test("explicit legacy mode fails on error-only provider cleanup results", async () => {
+		await expect(
+			handlePluginInstall(ctxOf({ installMode: "legacy" }), {
+				uninstallClaudePlugin: async () => ({
+					uninstalled: false,
+					staleCacheRemoved: false,
+					pluginStillInstalled: false,
+					error: "Claude marketplace removal failed",
+				}),
+				removeCodexPlugin: async () => ({
+					removed: false,
+					marketplaceRemoved: false,
+					pluginStillInstalled: false,
+					error: "Codex unavailable; absence cannot be verified",
+				}),
+			}),
+		).rejects.toThrow("Claude marketplace removal failed");
+		await expect(
+			handlePluginInstall(ctxOf({ installMode: "legacy" }), {
+				uninstallClaudePlugin: async () => noClaudePluginResult,
+				removeCodexPlugin: async () => ({
+					removed: false,
+					marketplaceRemoved: false,
+					pluginStillInstalled: false,
+					error: "Codex unavailable; absence cannot be verified",
+				}),
+			}),
+		).rejects.toThrow("Codex unavailable; absence cannot be verified");
 	});
 
 	test("explicit legacy mode fails when Claude plugin cleanup does not verify", async () => {
@@ -388,7 +603,90 @@ describe("stagePluginSource", () => {
 		expect(codexMarketplace.plugins[0].policy.installation).toBe("AVAILABLE");
 	});
 
+	test("preserves the last-known-good stage when payload copy fails", async () => {
+		const base = join(root, "stage");
+		await writeStableStage(base);
+		expect(() =>
+			stagePluginSource(join(root, "extract"), base, {
+				transactionId: "copy-failure",
+				copyDirectory: () => {
+					throw new Error("copy failed");
+				},
+			}),
+		).toThrow("copy failed");
+		expect(readFileSync(join(base, "last-known-good.txt"), "utf-8")).toBe("stable");
+		expectTransactionResidueAbsent(base, "copy-failure");
+	});
+
+	test("preserves the last-known-good stage when validation fails", async () => {
+		const base = join(root, "stage");
+		await writeStableStage(base);
+		expect(() =>
+			stagePluginSource(join(root, "extract"), base, {
+				transactionId: "validation-failure",
+				validateSource: () => {
+					throw new Error("validation failed");
+				},
+			}),
+		).toThrow("validation failed");
+		expect(readFileSync(join(base, "last-known-good.txt"), "utf-8")).toBe("stable");
+		expectTransactionResidueAbsent(base, "validation-failure");
+	});
+
+	test("restores the last-known-good stage when the atomic swap fails", async () => {
+		const base = join(root, "stage");
+		const temporary = `${base}.tmp-swap-failure`;
+		await writeStableStage(base);
+		expect(() =>
+			stagePluginSource(join(root, "extract"), base, {
+				transactionId: "swap-failure",
+				renameDirectory: (source, target) => {
+					if (source === temporary) throw new Error("swap failed");
+					renameSync(source, target);
+				},
+			}),
+		).toThrow("swap failed");
+		expect(readFileSync(join(base, "last-known-good.txt"), "utf-8")).toBe("stable");
+		expectTransactionResidueAbsent(base, "swap-failure");
+	});
+
+	test("restores the last-known-good stage when a completed swap reports failure", async () => {
+		const base = join(root, "stage");
+		const temporary = `${base}.tmp-ambiguous-swap`;
+		await writeStableStage(base);
+		expect(() =>
+			stagePluginSource(join(root, "extract"), base, {
+				transactionId: "ambiguous-swap",
+				renameDirectory: (source, target) => {
+					renameSync(source, target);
+					if (source === temporary) throw new Error("swap outcome unknown");
+				},
+			}),
+		).toThrow("swap outcome unknown");
+		expect(readFileSync(join(base, "last-known-good.txt"), "utf-8")).toBe("stable");
+		expectTransactionResidueAbsent(base, "ambiguous-swap");
+	});
+
+	test("replaces the stable source idempotently without transaction residue", () => {
+		const base = join(root, "stage");
+		stagePluginSource(join(root, "extract"), base, { transactionId: "first" });
+		stagePluginSource(join(root, "extract"), base, { transactionId: "second" });
+		expect(existsSync(join(base, ".claude", ".claude-plugin", "plugin.json"))).toBe(true);
+		expectTransactionResidueAbsent(base, "first");
+		expectTransactionResidueAbsent(base, "second");
+	});
+
 	test("throws when archive has no .claude payload", () => {
 		expect(() => stagePluginSource(join(root, "nonexistent"), join(root, "stage2"))).toThrow();
 	});
 });
+
+async function writeStableStage(base: string): Promise<void> {
+	await mkdir(base, { recursive: true });
+	await writeFile(join(base, "last-known-good.txt"), "stable", "utf-8");
+}
+
+function expectTransactionResidueAbsent(base: string, transactionId: string): void {
+	expect(existsSync(`${base}.tmp-${transactionId}`)).toBe(false);
+	expect(existsSync(`${base}.backup-${transactionId}`)).toBe(false);
+}

--- a/src/commands/init/phases/plugin-install-handler.ts
+++ b/src/commands/init/phases/plugin-install-handler.ts
@@ -1,10 +1,21 @@
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
 import type { InitContext } from "@/commands/init/types.js";
 import {
 	type CodexPluginInstallResult,
+	type CodexPluginPreparation,
+	type InstallCodexPluginOptions,
 	type RemoveCodexPluginResult,
-	installCodexPlugin,
+	prepareCodexPlugin,
 	removeCodexPlugin,
 } from "@/domains/installation/plugin/codex-plugin-installer.js";
 import {
@@ -25,7 +36,9 @@ export interface PluginInstallDeps {
 	/** Injectable for tests; defaults to the real migrate flow. */
 	migrate?: typeof migrateLegacyToPlugin;
 	/** Injectable for tests; defaults to the real Codex plugin install flow. */
-	installCodex?: typeof installCodexPlugin;
+	installCodex?: (options: InstallCodexPluginOptions) => Promise<CodexPluginInstallResult>;
+	/** Transactional Codex preparation. Preferred over installCodex when supplied. */
+	prepareCodex?: typeof prepareCodexPlugin;
 	/** Injectable for tests; defaults to the real Claude plugin removal flow. */
 	uninstallClaudePlugin?: typeof uninstallEnginePlugin;
 	/** Injectable for tests; defaults to the real Codex plugin removal flow. */
@@ -34,6 +47,19 @@ export interface PluginInstallDeps {
 	persistPreference?: typeof updateInstallModePreference;
 	/** Override the staged-source base dir (tests). */
 	stageBaseDir?: string;
+}
+
+export interface PluginStageDeps {
+	transactionId?: string;
+	copyDirectory?: (source: string, target: string) => void;
+	validateSource?: (sourceDir: string) => void;
+	renameDirectory?: (source: string, target: string) => void;
+}
+
+export interface PluginStageTransaction {
+	pluginSourceDir: string;
+	commit: () => void;
+	rollback: () => void;
 }
 
 /**
@@ -54,49 +80,69 @@ export async function handlePluginInstall(
 	}
 
 	const migrate = deps.migrate ?? migrateLegacyToPlugin;
-	const installCodex = deps.installCodex ?? installCodexPlugin;
+	const legacyInstallCodex = deps.installCodex;
+	const prepareCodex =
+		deps.prepareCodex ??
+		(legacyInstallCodex
+			? async (options: InstallCodexPluginOptions): Promise<CodexPluginPreparation> => ({
+					result: await legacyInstallCodex(options),
+					commit: () => {},
+					rollback: async () => ({
+						ok: true,
+						detail: "Injected Codex installer has no transactional state",
+					}),
+				})
+			: prepareCodexPlugin);
 	const uninstallClaude = deps.uninstallClaudePlugin ?? uninstallEnginePlugin;
 	const removeCodex = deps.removeCodexPlugin ?? removeCodexPlugin;
 	const persistPreference = deps.persistPreference ?? updateInstallModePreference;
 
 	if (ctx.options.installMode !== "plugin") {
-		let cleanupError: Error | null = null;
+		const cleanupErrors: string[] = [];
 		try {
 			const result = await uninstallClaude({ claudeDir: ctx.claudeDir });
 			logLegacyPluginCleanup(result);
-			if (result.pluginStillInstalled) {
-				cleanupError = new Error(
-					`Claude plugin cleanup failed while switching to Normal skills: ${
-						result.error ?? "plugin remains registered"
-					}`,
+			if (result.error || result.pluginStillInstalled) {
+				cleanupErrors.push(
+					`Claude plugin cleanup failed while switching to Normal skills: ${result.error ?? "plugin remains registered"}`,
 				);
 			}
 		} catch (err) {
 			logger.verbose(`Claude plugin cleanup skipped: ${(err as Error).message}`);
-			cleanupError = err as Error;
+			cleanupErrors.push(`Claude plugin cleanup failed: ${(err as Error).message}`);
 		}
 		try {
 			const result = await removeCodex();
 			logCodexPluginCleanup(result);
-			if (result.pluginStillInstalled) {
-				cleanupError = new Error(
-					`Codex plugin cleanup failed while switching to Normal skills: ${
-						result.error ?? "plugin remains registered"
-					}`,
+			if (result.error || result.pluginStillInstalled) {
+				cleanupErrors.push(
+					`Codex plugin cleanup failed while switching to Normal skills: ${result.error ?? "plugin remains registered"}`,
 				);
 			}
 		} catch (err) {
 			logger.verbose(`Codex plugin cleanup skipped: ${(err as Error).message}`);
-			cleanupError = err as Error;
+			cleanupErrors.push(`Codex plugin cleanup failed: ${(err as Error).message}`);
 		}
-		if (cleanupError) {
-			throw cleanupError;
+		if (cleanupErrors.length > 0) {
+			throw new Error(cleanupErrors.join("; "));
 		}
 		return ctx;
 	}
 
+	let stageTransaction: PluginStageTransaction | null = null;
+	let codexPreparation: CodexPluginPreparation | null = null;
+	let preferenceSnapshot: Buffer | null | undefined;
 	try {
-		const pluginSourceDir = stagePluginSource(ctx.extractDir, deps.stageBaseDir);
+		stageTransaction = preparePluginSourceTransaction(ctx.extractDir, deps.stageBaseDir);
+		const { pluginSourceDir } = stageTransaction;
+		codexPreparation = await prepareCodex({ pluginSourceDir });
+		const codexResult = codexPreparation.result;
+		logCodexPluginResult(codexResult);
+		if (codexResult.action === "install-failed") {
+			throw new Error(`Codex plugin install failed: ${codexResult.error ?? codexResult.action}`);
+		}
+		preferenceSnapshot = snapshotFile(join(ctx.claudeDir, "metadata.json"));
+		await persistPreference(ctx.claudeDir, "plugin");
 		try {
 			const result = await migrate({ pluginSourceDir, claudeDir: ctx.claudeDir });
 			logPluginResult(result);
@@ -116,27 +162,54 @@ export async function handlePluginInstall(
 				`Claude plugin install skipped (legacy copy retained): ${(err as Error).message}`,
 			);
 		}
-		try {
-			const result = await installCodex({ pluginSourceDir });
-			logCodexPluginResult(result);
-			if (ctx.options.installMode === "plugin" && result.action === "install-failed") {
-				throw new Error(`Codex plugin install failed: ${result.error ?? result.action}`);
-			}
-			await persistPreference(ctx.claudeDir, "plugin");
-		} catch (err) {
-			if (ctx.options.installMode === "plugin") {
-				throw err;
-			}
-			logger.verbose(`Codex plugin install skipped: ${(err as Error).message}`);
-		}
+		stageTransaction.commit();
+		codexPreparation.commit();
 	} catch (err) {
+		const rollbackErrors: string[] = [];
+		if (preferenceSnapshot !== undefined) {
+			try {
+				restoreFile(join(ctx.claudeDir, "metadata.json"), preferenceSnapshot);
+			} catch (rollbackError) {
+				rollbackErrors.push(`preference rollback failed: ${(rollbackError as Error).message}`);
+			}
+		}
+		try {
+			stageTransaction?.rollback();
+		} catch (rollbackError) {
+			rollbackErrors.push(`stage rollback failed: ${(rollbackError as Error).message}`);
+		}
+		if (codexPreparation) {
+			try {
+				const rollback = await codexPreparation.rollback();
+				if (!rollback.ok) rollbackErrors.push(`Codex rollback failed: ${rollback.detail}`);
+			} catch (rollbackError) {
+				rollbackErrors.push(`Codex rollback failed: ${(rollbackError as Error).message}`);
+			}
+		}
+		const failure =
+			rollbackErrors.length > 0
+				? new Error(`${(err as Error).message}; ${rollbackErrors.join("; ")}`)
+				: err;
 		if (ctx.options.installMode === "plugin") {
-			throw err;
+			throw failure;
 		}
 		// Never fail init over the plugin path — the legacy copy from handleMerge stands.
-		logger.verbose(`Plugin staging skipped (legacy copy retained): ${(err as Error).message}`);
+		logger.verbose(`Plugin staging skipped (legacy copy retained): ${(failure as Error).message}`);
 	}
 	return ctx;
+}
+
+function snapshotFile(filePath: string): Buffer | null {
+	return existsSync(filePath) ? readFileSync(filePath) : null;
+}
+
+function restoreFile(filePath: string, content: Buffer | null): void {
+	if (content === null) {
+		rmSync(filePath, { force: true });
+		return;
+	}
+	mkdirSync(dirname(filePath), { recursive: true });
+	writeFileSync(filePath, content);
 }
 
 function logLegacyPluginCleanup(result: UninstallPluginResult): void {
@@ -154,17 +227,111 @@ function logLegacyPluginCleanup(result: UninstallPluginResult): void {
  * one pointing at `./.claude`. A stable path is used so `claude plugin marketplace
  * update` keeps resolving after init.
  */
-export function stagePluginSource(extractDir: string, stageBaseDir?: string): string {
+export function stagePluginSource(
+	extractDir: string,
+	stageBaseDir?: string,
+	deps: PluginStageDeps = {},
+): string {
+	const transaction = preparePluginSourceTransaction(extractDir, stageBaseDir, deps);
+	transaction.commit();
+	return transaction.pluginSourceDir;
+}
+
+export function preparePluginSourceTransaction(
+	extractDir: string,
+	stageBaseDir?: string,
+	deps: PluginStageDeps = {},
+): PluginStageTransaction {
 	const base = stageBaseDir ?? join(PathResolver.getCacheDir(true), "ck-plugin-source");
 	const payloadSrc = join(extractDir, ".claude");
 	if (!existsSync(payloadSrc)) {
 		throw new Error(`plugin payload not found in archive: ${payloadSrc}`);
 	}
+	return preparePluginSourceReplacement(payloadSrc, base, deps);
+}
 
-	rmSync(base, { recursive: true, force: true });
-	mkdirSync(base, { recursive: true });
-	const stagedPayload = join(base, ".claude");
-	cpSync(payloadSrc, stagedPayload, { recursive: true });
+export function replacePluginSourceAtomically(
+	payloadSrc: string,
+	base: string,
+	deps: PluginStageDeps = {},
+): string {
+	const transaction = preparePluginSourceReplacement(payloadSrc, base, deps);
+	transaction.commit();
+	return transaction.pluginSourceDir;
+}
+
+function preparePluginSourceReplacement(
+	payloadSrc: string,
+	base: string,
+	deps: PluginStageDeps = {},
+): PluginStageTransaction {
+	const transactionId = deps.transactionId ?? randomUUID();
+	const temporary = `${base}.tmp-${transactionId}`;
+	const backup = `${base}.backup-${transactionId}`;
+	const copyDirectory =
+		deps.copyDirectory ??
+		((source: string, target: string) => cpSync(source, target, { recursive: true }));
+	const validateSource = deps.validateSource ?? validatePluginSource;
+	const renameDirectory = deps.renameDirectory ?? renameSync;
+	let previousMoved = false;
+	let settled = false;
+
+	rmSync(temporary, { recursive: true, force: true });
+	rmSync(backup, { recursive: true, force: true });
+	try {
+		buildPluginSource(payloadSrc, temporary, copyDirectory);
+		validateSource(temporary);
+		if (existsSync(base)) {
+			renameDirectory(base, backup);
+			previousMoved = true;
+		}
+		renameDirectory(temporary, base);
+		return {
+			pluginSourceDir: base,
+			commit: () => {
+				if (settled) return;
+				settled = true;
+				previousMoved = false;
+				try {
+					rmSync(backup, { recursive: true, force: true });
+					rmSync(temporary, { recursive: true, force: true });
+				} catch (error) {
+					logger.verbose(
+						`Plugin stage transaction residue cleanup skipped: ${(error as Error).message}`,
+					);
+				}
+			},
+			rollback: () => {
+				if (settled) return;
+				settled = true;
+				rmSync(base, { recursive: true, force: true });
+				if (previousMoved && existsSync(backup)) renameDirectory(backup, base);
+				previousMoved = false;
+				rmSync(temporary, { recursive: true, force: true });
+				rmSync(backup, { recursive: true, force: true });
+			},
+		};
+	} catch (error) {
+		if (previousMoved && existsSync(backup)) {
+			rmSync(base, { recursive: true, force: true });
+			renameDirectory(backup, base);
+			previousMoved = false;
+		}
+		throw error;
+	} finally {
+		rmSync(temporary, { recursive: true, force: true });
+		if (!previousMoved && !settled) rmSync(backup, { recursive: true, force: true });
+	}
+}
+
+function buildPluginSource(
+	payloadSrc: string,
+	targetDir: string,
+	copyDirectory: (source: string, target: string) => void,
+): void {
+	mkdirSync(targetDir, { recursive: true });
+	const stagedPayload = join(targetDir, ".claude");
+	copyDirectory(payloadSrc, stagedPayload);
 	ensureCodexPluginManifest(stagedPayload);
 
 	const claudeMarketplace = {
@@ -172,9 +339,9 @@ export function stagePluginSource(extractDir: string, stageBaseDir?: string): st
 		owner: { name: "ClaudeKit" },
 		plugins: [{ name: "ck", source: "./.claude", description: "ClaudeKit Engineer" }],
 	};
-	mkdirSync(join(base, ".claude-plugin"), { recursive: true });
+	mkdirSync(join(targetDir, ".claude-plugin"), { recursive: true });
 	writeFileSync(
-		join(base, ".claude-plugin", "marketplace.json"),
+		join(targetDir, ".claude-plugin", "marketplace.json"),
 		`${JSON.stringify(claudeMarketplace, null, 2)}\n`,
 		"utf-8",
 	);
@@ -191,13 +358,57 @@ export function stagePluginSource(extractDir: string, stageBaseDir?: string): st
 			},
 		],
 	};
-	mkdirSync(join(base, ".agents", "plugins"), { recursive: true });
+	mkdirSync(join(targetDir, ".agents", "plugins"), { recursive: true });
 	writeFileSync(
-		join(base, ".agents", "plugins", "marketplace.json"),
+		join(targetDir, ".agents", "plugins", "marketplace.json"),
 		`${JSON.stringify(codexMarketplace, null, 2)}\n`,
 		"utf-8",
 	);
-	return base;
+}
+
+function validatePluginSource(sourceDir: string): void {
+	const claudeManifest = readRequiredJson(
+		join(sourceDir, ".claude", ".claude-plugin", "plugin.json"),
+		"Claude plugin manifest",
+	);
+	const codexManifest = readRequiredJson(
+		join(sourceDir, ".claude", ".codex-plugin", "plugin.json"),
+		"Codex plugin manifest",
+	);
+	const claudeMarketplace = readRequiredJson(
+		join(sourceDir, ".claude-plugin", "marketplace.json"),
+		"Claude marketplace",
+	);
+	const codexMarketplace = readRequiredJson(
+		join(sourceDir, ".agents", "plugins", "marketplace.json"),
+		"Codex marketplace",
+	);
+	if (claudeManifest.name !== "ck" || codexManifest.name !== "ck") {
+		throw new Error("staged plugin manifests must identify the ck plugin");
+	}
+	if (!marketplaceReferencesPluginSource(claudeMarketplace, false)) {
+		throw new Error("staged Claude marketplace does not reference ./.claude");
+	}
+	if (!marketplaceReferencesPluginSource(codexMarketplace, true)) {
+		throw new Error("staged Codex marketplace does not reference ./.claude");
+	}
+}
+
+function readRequiredJson(filePath: string, label: string): Record<string, unknown> {
+	const parsed = readJsonSafe(filePath);
+	if (!parsed) throw new Error(`${label} is missing or invalid: ${filePath}`);
+	return parsed;
+}
+
+function marketplaceReferencesPluginSource(
+	marketplace: Record<string, unknown>,
+	nestedSource: boolean,
+): boolean {
+	if (!Array.isArray(marketplace.plugins) || marketplace.plugins.length === 0) return false;
+	const plugin = marketplace.plugins[0];
+	if (!isRecord(plugin) || plugin.name !== "ck") return false;
+	if (!nestedSource) return plugin.source === "./.claude";
+	return isRecord(plugin.source) && plugin.source.path === "./.claude";
 }
 
 function ensureCodexPluginManifest(pluginRoot: string): void {

--- a/src/commands/init/phases/transform-handler.ts
+++ b/src/commands/init/phases/transform-handler.ts
@@ -6,6 +6,7 @@
 import { join } from "node:path";
 import { ConfigManager } from "@/domains/config/config-manager.js";
 import { CommandsPrefix } from "@/services/transformers/commands-prefix.js";
+import { projectEngineerSkillNamesForInstall } from "@/services/transformers/engineer-legacy-skill-name-projector.js";
 import {
 	transformFolderPaths,
 	validateFolderOptions,
@@ -36,6 +37,18 @@ export async function handleTransforms(ctx: InitContext): Promise<InitContext> {
 		});
 		logger.success(
 			`Transformed ${transformResult.totalChanges} path(s) in ${transformResult.filesTransformed} file(s)`,
+		);
+	}
+
+	// Native plugin runtimes apply the `ck` namespace to canonical bare skill names.
+	// Normal installs need that namespace projected onto their temporary copied payload.
+	const skillProjection = await projectEngineerSkillNamesForInstall(ctx.extractDir, {
+		kitType: ctx.kitType,
+		installMode: ctx.options.installMode,
+	});
+	if (skillProjection.skillsProjected > 0) {
+		logger.success(
+			`Projected ${skillProjection.skillsProjected} Engineer skill name(s) for Normal installation`,
 		);
 	}
 

--- a/src/commands/uninstall/__tests__/uninstall-command-provider-cleanup.test.ts
+++ b/src/commands/uninstall/__tests__/uninstall-command-provider-cleanup.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { EngineerProviderCleanupResult } from "@/domains/installation/plugin/engineer-provider-cleanup.js";
+import { logger } from "@/shared/logger.js";
+import { type TestPaths, setupTestPaths } from "../../../../tests/helpers/test-paths.js";
+import { uninstallCommand } from "../uninstall-command.js";
+
+const cleanProviders: EngineerProviderCleanupResult = {
+	success: true,
+	changed: true,
+	claude: null,
+	codex: null,
+	errors: [],
+};
+
+describe("uninstallCommand provider cleanup", () => {
+	let paths: TestPaths;
+	let projectDir: string;
+	let originalCwd: string;
+
+	beforeEach(async () => {
+		originalCwd = process.cwd();
+		paths = setupTestPaths();
+		projectDir = join(paths.testHome, "project");
+		await mkdir(join(projectDir, ".claude"), { recursive: true });
+		process.chdir(projectDir);
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		paths.cleanup();
+	});
+
+	async function install(scope: "global" | "local", kit: "engineer" | "marketing") {
+		const claudeDir = scope === "global" ? paths.claudeDir : join(projectDir, ".claude");
+		await mkdir(join(claudeDir, "skills"), { recursive: true });
+		await writeFile(join(claudeDir, "skills", `${kit}.md`), kit);
+		await writeFile(
+			join(claudeDir, "metadata.json"),
+			JSON.stringify({
+				name: kit,
+				version: "1.0.0",
+				installedAt: "2026-07-11T00:00:00.000Z",
+				scope,
+				installedFiles: [`skills/${kit}.md`],
+			}),
+		);
+	}
+
+	function options(overrides: Record<string, unknown> = {}) {
+		return {
+			yes: true,
+			json: false,
+			verbose: false,
+			local: false,
+			global: false,
+			all: false,
+			dryRun: false,
+			forceOverwrite: true,
+			...overrides,
+		};
+	}
+
+	test("global Engineer uninstall cleans both provider plugins", async () => {
+		await install("global", "engineer");
+		let cleanupCalls = 0;
+
+		await uninstallCommand(options({ global: true }), {
+			cleanupEngineerProviderPlugins: async () => {
+				cleanupCalls += 1;
+				return cleanProviders;
+			},
+		});
+
+		expect(cleanupCalls).toBe(1);
+	});
+
+	test("all-scope uninstall cleans providers once", async () => {
+		await install("global", "engineer");
+		await install("local", "engineer");
+		let cleanupCalls = 0;
+
+		await uninstallCommand(options({ all: true }), {
+			cleanupEngineerProviderPlugins: async () => {
+				cleanupCalls += 1;
+				return cleanProviders;
+			},
+		});
+
+		expect(cleanupCalls).toBe(1);
+	});
+
+	test("project-only uninstall preserves global provider state", async () => {
+		await install("local", "engineer");
+		let cleanupCalls = 0;
+
+		await uninstallCommand(options({ local: true }), {
+			cleanupEngineerProviderPlugins: async () => {
+				cleanupCalls += 1;
+				return cleanProviders;
+			},
+		});
+
+		expect(cleanupCalls).toBe(0);
+	});
+
+	test("Marketing-only uninstall preserves Engineer provider state", async () => {
+		await install("global", "marketing");
+		let cleanupCalls = 0;
+
+		await uninstallCommand(options({ global: true, kit: "marketing" }), {
+			cleanupEngineerProviderPlugins: async () => {
+				cleanupCalls += 1;
+				return cleanProviders;
+			},
+		});
+
+		expect(cleanupCalls).toBe(0);
+	});
+
+	test("verification failure prevents a successful command result", async () => {
+		await install("global", "engineer");
+		const exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never);
+		const errorSpy = spyOn(logger, "error").mockImplementation(() => {});
+
+		await uninstallCommand(options({ global: true }), {
+			cleanupEngineerProviderPlugins: async () => ({
+				...cleanProviders,
+				success: false,
+				changed: false,
+				errors: ["Codex plugin remains installed"],
+			}),
+		});
+
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith(
+			"Engineer plugin cleanup incomplete: Codex plugin remains installed",
+		);
+		expect(existsSync(join(paths.claudeDir, "skills", "engineer.md"))).toBe(true);
+		exitSpy.mockRestore();
+		errorSpy.mockRestore();
+	});
+
+	test("repeated uninstall is idempotent", async () => {
+		await install("global", "engineer");
+		let cleanupCalls = 0;
+		const deps = {
+			cleanupEngineerProviderPlugins: async () => {
+				cleanupCalls += 1;
+				return cleanProviders;
+			},
+		};
+
+		await uninstallCommand(options({ global: true }), deps);
+		await uninstallCommand(options({ global: true }), deps);
+
+		expect(cleanupCalls).toBe(2);
+	});
+
+	test("explicit global uninstall removes provider-only state without file metadata", async () => {
+		let cleanupCalls = 0;
+		await uninstallCommand(options({ global: true }), {
+			cleanupEngineerProviderPlugins: async () => {
+				cleanupCalls += 1;
+				return cleanProviders;
+			},
+		});
+
+		expect(cleanupCalls).toBe(1);
+	});
+});

--- a/src/commands/uninstall/uninstall-command.ts
+++ b/src/commands/uninstall/uninstall-command.ts
@@ -4,7 +4,10 @@
  * Main orchestrator for the uninstall command.
  */
 
-import { uninstallEnginePlugin } from "@/domains/installation/plugin/uninstall-plugin.js";
+import {
+	type EngineerProviderCleanupResult,
+	cleanupEngineerProviderPlugins,
+} from "@/domains/installation/plugin/engineer-provider-cleanup.js";
 import { getInstalledKits } from "@/domains/migration/metadata-migration.js";
 import { PromptsManager } from "@/domains/ui/prompts.js";
 import { ManifestWriter } from "@/services/file-operations/manifest-writer.js";
@@ -18,6 +21,23 @@ import { type Installation, detectInstallations } from "./installation-detector.
 import { removeInstallations } from "./removal-handler.js";
 
 const prompts = new PromptsManager();
+
+export interface UninstallCommandDependencies {
+	cleanupEngineerProviderPlugins?: () => Promise<EngineerProviderCleanupResult>;
+}
+
+async function cleanupEngineerProvidersOrThrow(
+	deps: UninstallCommandDependencies,
+): Promise<EngineerProviderCleanupResult> {
+	const cleanupProviders = deps.cleanupEngineerProviderPlugins ?? cleanupEngineerProviderPlugins;
+	const result = await cleanupProviders();
+	if (!result.success) {
+		throw new Error(
+			`Engineer plugin cleanup incomplete: ${result.errors.join("; ") || "verification failed"}`,
+		);
+	}
+	return result;
+}
 
 type UninstallScope = "all" | "local" | "global";
 type KitSelection = KitType | "all";
@@ -169,7 +189,10 @@ async function confirmUninstall(scope: UninstallScope, kitLabel = ""): Promise<b
 	return confirmed === true;
 }
 
-export async function uninstallCommand(options: UninstallCommandOptions): Promise<void> {
+export async function uninstallCommand(
+	options: UninstallCommandOptions,
+	deps: UninstallCommandDependencies = {},
+): Promise<void> {
 	try {
 		await withProcessLock("kit-install", async () => {
 			// 1. Validate options
@@ -180,6 +203,16 @@ export async function uninstallCommand(options: UninstallCommandOptions): Promis
 
 			// 3. Check if any found
 			if (allInstallations.length === 0) {
+				const explicitGlobalEngineerCleanup =
+					(validOptions.global || validOptions.all) &&
+					(validOptions.kit === "engineer" || !validOptions.kit);
+				if (explicitGlobalEngineerCleanup && !validOptions.dryRun) {
+					const pluginResult = await cleanupEngineerProvidersOrThrow(deps);
+					if (pluginResult.changed) {
+						prompts.outro("ClaudeKit Engineer provider plugins removed successfully!");
+						return;
+					}
+				}
 				logger.info("No ClaudeKit installations found.");
 				return;
 			}
@@ -298,7 +331,9 @@ export async function uninstallCommand(options: UninstallCommandOptions): Promis
 					(scope === "global" || scope === "all") &&
 					(kitToRemove === "engineer" || !kitToRemove)
 				) {
-					log.info("A ClaudeKit Engineer plugin install (if present) would also be deregistered.");
+					log.info(
+						"ClaudeKit Engineer plugins in Claude and Codex (if present) would also be removed.",
+					);
 				}
 				prompts.outro("Dry-run complete. No changes were made.");
 				return;
@@ -321,24 +356,19 @@ export async function uninstallCommand(options: UninstallCommandOptions): Promis
 				}
 			}
 
-			// 14. Remove files using manifest
+			// 14. Remove global Engineer provider state before committing file deletion.
+			// A verification failure leaves the copied installation intact and retryable.
+			if ((scope === "global" || scope === "all") && (kitToRemove === "engineer" || !kitToRemove)) {
+				const pluginResult = await cleanupEngineerProvidersOrThrow(deps);
+				if (pluginResult.changed) log.info("Removed ClaudeKit Engineer provider plugins.");
+			}
+
+			// 14.5: remove files using manifest only after provider cleanup verifies.
 			const results = await removeInstallations(installations, {
 				dryRun: false,
 				forceOverwrite: validOptions.forceOverwrite,
 				kit: kitToRemove,
 			});
-
-			// 14.5: also remove the engineer plugin (#691) — non-fatal, no-op if not a plugin install
-			if ((scope === "global" || scope === "all") && (kitToRemove === "engineer" || !kitToRemove)) {
-				try {
-					const pluginResult = await uninstallEnginePlugin();
-					if (pluginResult.uninstalled) {
-						log.info("Removed ClaudeKit Engineer plugin.");
-					}
-				} catch (err) {
-					logger.verbose(`Plugin uninstall skipped: ${(err as Error).message}`);
-				}
-			}
 
 			const hasProtectedFiles = results.some((result) => result.protectedTrackedPaths.length > 0);
 

--- a/src/commands/update/post-update-handler.ts
+++ b/src/commands/update/post-update-handler.ts
@@ -19,6 +19,10 @@ import {
 	repairMissingHookFileReferences,
 } from "@/domains/health-checks/checkers/hook-health-checker.js";
 import {
+	type ClaudePluginHealthOptions,
+	detectClaudePluginHealth,
+} from "@/domains/installation/plugin/claude-plugin-health.js";
+import {
 	type CodexPluginState,
 	type CodexPluginStateOptions,
 	detectCodexPluginState,
@@ -442,6 +446,7 @@ export interface PromptKitUpdateDeps {
 	hasTrackedPluginSuppliedLegacyFilesFn?: (claudeDir: string) => boolean;
 	shouldRefreshCodexPluginFn?: (options?: CodexPluginStateOptions) => Promise<boolean>;
 	detectCodexPluginStateFn?: (options?: CodexPluginStateOptions) => Promise<CodexPluginState>;
+	shouldRefreshClaudePluginFn?: (claudeDir: string, options?: ClaudePluginHealthOptions) => boolean;
 	cleanupStaleCodexConfigEntriesFn?: typeof cleanupStaleCodexConfigEntries;
 	skillsPackageManager?: SkillsPackageManager;
 }
@@ -507,6 +512,10 @@ export async function promptKitUpdate(
 		const detectCodexPluginStateFn =
 			deps?.detectCodexPluginStateFn ??
 			((options?: CodexPluginStateOptions) => detectCodexPluginState(undefined, options));
+		const shouldRefreshClaudePluginFn =
+			deps?.shouldRefreshClaudePluginFn ??
+			((claudeDir: string, options?: ClaudePluginHealthOptions) =>
+				detectClaudePluginHealth(claudeDir, options).shouldRefresh);
 		const cleanupStaleCodexConfigEntriesFn =
 			deps?.cleanupStaleCodexConfigEntriesFn ?? cleanupStaleCodexConfigEntries;
 		const setup = await getSetupFn();
@@ -651,6 +660,17 @@ export async function promptKitUpdate(
 						}
 					}
 					if (installModePreference !== "legacy") {
+						if (
+							shouldRefreshClaudePluginFn(selectedClaudeDir, {
+								expectedVersion: kitVersion,
+								expectedSource: join(PathResolver.getCacheDir(true), "ck-plugin-source"),
+							})
+						) {
+							logger.warning(
+								"Detected Claude Code plugin state requiring refresh; reinstalling global Engineer content",
+							);
+							forceKitReinstall = true;
+						}
 						try {
 							await cleanupStaleCodexConfigEntriesFn({ global: true, provider: "codex" });
 						} catch (error) {

--- a/src/domains/health-checks/__tests__/plugin-install-mode-checker.test.ts
+++ b/src/domains/health-checks/__tests__/plugin-install-mode-checker.test.ts
@@ -172,7 +172,7 @@ describe("PluginInstallModeChecker", () => {
 		});
 
 		expect(r.status).toBe("warn");
-		expect(r.message).toContain("Codex plugin requires refresh");
+		expect(r.message).toContain("Codex plugin requires repair");
 		expect(r.message).toContain("Codex plugin: installed-stale-version, 2.20.1-beta.6");
 	});
 
@@ -224,7 +224,89 @@ describe("PluginInstallModeChecker", () => {
 			expectedVersion: "2.20.1-beta.7",
 			expectedMarketplace: "claudekit",
 		});
-		expect((seen[0] as { expectedSource?: string }).expectedSource).toContain("ck-plugin-source");
+		expect((seen[0] as { expectedSource?: string }).expectedSource).toEndWith(
+			join("ck-plugin-source", ".claude"),
+		);
+	});
+
+	test.each([
+		["unknown", false, false],
+		["missing", false, false],
+		["disabled", true, false],
+		["installed-stale-version", true, true],
+		["installed-stale-source", true, true],
+	] as const)(
+		"plugin preference reports Codex %s as actionable",
+		async (status, installed, refresh) => {
+			await writeMetadata({
+				kits: {
+					engineer: {
+						version: "2.20.1-beta.7",
+						installedAt: "x",
+						installModePreference: "plugin",
+					},
+				},
+			});
+			await writeSettings({ "ck@claudekit": true });
+
+			const r = await single({
+				...codexUnavailable,
+				status,
+				installed,
+				enabled: status !== "disabled" && installed,
+				shouldRefresh: refresh,
+				...(status === "unknown" ? { error: "inspection failed" } : {}),
+			});
+
+			expect(r.status).toBe("warn");
+			expect(r.message).toContain(
+				status === "unknown" ? "Codex plugin inspection failed" : "Codex plugin requires repair",
+			);
+		},
+	);
+
+	test("Codex inspection exception is never reported as pass for plugin preference", async () => {
+		await writeMetadata({
+			kits: {
+				engineer: {
+					version: "2.20.1-beta.7",
+					installedAt: "x",
+					installModePreference: "plugin",
+				},
+			},
+		});
+		await writeSettings({ "ck@claudekit": true });
+
+		const [result] = await new PluginInstallModeChecker(claudeDir, {
+			detectCodexPluginState: async () => {
+				throw new Error("inspection failed");
+			},
+		}).run();
+
+		expect(result.status).toBe("warn");
+		expect(result.message).toContain("inspection failed");
+	});
+
+	test("Codex inspection exception is never reported as pass for Normal preference", async () => {
+		await writeMetadata({
+			kits: {
+				engineer: {
+					version: "2.20.1-beta.7",
+					installedAt: "x",
+					installModePreference: "legacy",
+				},
+			},
+		});
+
+		const [result] = await new PluginInstallModeChecker(claudeDir, {
+			detectCodexPluginState: async () => {
+				throw new Error("inspection failed");
+			},
+		}).run();
+
+		expect(result.status).toBe("warn");
+		expect(result.message).toContain("Codex plugin inspection failed");
+		expect(result.message).toContain("inspection failed");
 	});
 
 	test("warns when legacy preference still has an active Codex plugin", async () => {

--- a/src/domains/health-checks/plugin-install-mode-checker.ts
+++ b/src/domains/health-checks/plugin-install-mode-checker.ts
@@ -74,6 +74,9 @@ export class PluginInstallModeChecker implements Checker {
 				preference === "plugin"
 					? `Install mode: mixed (normal copy + plugin both present). Run \`ck init -g --kit engineer --install-mode plugin\` to repair plugin mode.${suffix}`
 					: `Install mode: mixed (normal copy + plugin both present). Run \`ck init -g --kit engineer --install-mode legacy\` to keep normal skills and remove CK-owned plugin state.${suffix}`;
+		} else if (codexState.status === "unknown") {
+			status = "warn";
+			message = `Install mode: ${displayedMode}; Codex plugin inspection failed. Run \`ck doctor --check-only\` again or verify with \`codex plugin list\`.${suffix}`;
 		} else if (
 			preference === "legacy" &&
 			(r.plugin.installed || r.plugin.staleCache || codexState.installed)
@@ -89,9 +92,9 @@ export class PluginInstallModeChecker implements Checker {
 		) {
 			status = "warn";
 			message = `Install mode: ${displayedMode}, but preference is plugin. Run \`ck init -g --kit engineer --install-mode plugin\`.${suffix}`;
-		} else if (codexState.shouldRefresh && preference !== "legacy") {
+		} else if (preference === "plugin" && isUnhealthyCodexPluginState(codexState)) {
 			status = "warn";
-			message = `Install mode: ${displayedMode}; Codex plugin requires refresh. Run \`ck update\`.${suffix}`;
+			message = `Install mode: ${displayedMode}; Codex plugin requires repair. Run \`ck init -g --kit engineer --install-mode plugin\`.${suffix}`;
 		} else if (r.mode === "fresh") {
 			status = "info";
 			message = `Install mode: fresh (ClaudeKit Engineer not installed). Run \`ck init\` to install.${suffix}`;
@@ -145,8 +148,19 @@ function expectedCodexPluginOptions(claudeDir: string): CodexPluginStateOptions 
 	return {
 		expectedVersion: readEngineerKitVersion(claudeDir),
 		expectedMarketplace: "claudekit",
-		expectedSource: join(PathResolver.getCacheDir(true), "ck-plugin-source"),
+		expectedSource: join(PathResolver.getCacheDir(true), "ck-plugin-source", ".claude"),
 	};
+}
+
+function isUnhealthyCodexPluginState(state: CodexPluginState): boolean {
+	return (
+		state.status === "unknown" ||
+		state.status === "missing" ||
+		state.status === "disabled" ||
+		state.status === "installed-stale-version" ||
+		state.status === "installed-stale-source" ||
+		state.shouldRefresh
+	);
 }
 
 function readEngineerKitVersion(claudeDir: string): string | null {

--- a/src/domains/installation/plugin/__tests__/claude-plugin-health.test.ts
+++ b/src/domains/installation/plugin/__tests__/claude-plugin-health.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectClaudePluginHealth } from "../claude-plugin-health.js";
+
+describe("detectClaudePluginHealth", () => {
+	let claudeDir: string;
+	let expectedSource: string;
+
+	beforeEach(async () => {
+		claudeDir = await mkdtemp(join(tmpdir(), "ck-claude-health-"));
+		expectedSource = join(claudeDir, "source");
+		await mkdir(expectedSource, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(claudeDir, { recursive: true, force: true });
+	});
+
+	async function register(
+		options: {
+			enabled?: boolean;
+			version?: string;
+			source?: string;
+		} = {},
+	): Promise<void> {
+		await writeFile(
+			join(claudeDir, "settings.json"),
+			JSON.stringify({ enabledPlugins: { "ck@claudekit": options.enabled ?? true } }),
+		);
+		await mkdir(
+			join(claudeDir, "plugins", "cache", "claudekit", "ck", options.version ?? "1.0.0"),
+			{ recursive: true },
+		);
+		await mkdir(join(claudeDir, "plugins"), { recursive: true });
+		await writeFile(
+			join(claudeDir, "plugins", "known_marketplaces.json"),
+			JSON.stringify({
+				claudekit: {
+					source: { source: "directory", path: options.source ?? expectedSource },
+					installLocation: options.source ?? expectedSource,
+				},
+			}),
+		);
+	}
+
+	test("reports missing registration", () => {
+		expect(detectClaudePluginHealth(claudeDir).status).toBe("missing");
+	});
+
+	test("reports orphan cache", async () => {
+		await mkdir(join(claudeDir, "plugins", "cache", "claudekit", "ck", "1.0.0"), {
+			recursive: true,
+		});
+		expect(detectClaudePluginHealth(claudeDir).status).toBe("orphan-cache");
+	});
+
+	test("reports disabled registration", async () => {
+		await register({ enabled: false });
+		expect(detectClaudePluginHealth(claudeDir).status).toBe("disabled");
+	});
+
+	test("reports stale version", async () => {
+		await register({ version: "1.0.0" });
+		expect(
+			detectClaudePluginHealth(claudeDir, { expectedVersion: "2.0.0", expectedSource }).status,
+		).toBe("installed-stale-version");
+	});
+
+	test("reports stale source", async () => {
+		await register({ source: join(claudeDir, "old-source") });
+		expect(
+			detectClaudePluginHealth(claudeDir, { expectedVersion: "1.0.0", expectedSource }).status,
+		).toBe("installed-stale-source");
+	});
+
+	test("reports current state with normalized equivalent paths", async () => {
+		await register({ source: join(expectedSource, "..", "source"), version: "v1.0.0" });
+		const health = detectClaudePluginHealth(claudeDir, {
+			expectedVersion: "1.0.0",
+			expectedSource,
+		});
+		expect(health.status).toBe("installed-current");
+		expect(health.shouldRefresh).toBe(false);
+	});
+});

--- a/src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts
+++ b/src/domains/installation/plugin/__tests__/codex-plugin-installer.test.ts
@@ -4,6 +4,7 @@ import {
 	type CodexRunResult,
 	detectCodexPluginState,
 	installCodexPlugin,
+	prepareCodexPlugin,
 	removeCodexPlugin,
 	resolveCodexExecutable,
 	resolveCodexExecutableCandidates,
@@ -74,6 +75,38 @@ describe("CodexPluginInstaller", () => {
 			["plugin", "marketplace", "add", "/tmp/plugin-source"],
 			["plugin", "add", "ck@claudekit"],
 			["plugin", "list", "--json"],
+		]);
+	});
+
+	test("fresh preparation rolls back newly added plugin and marketplace", async () => {
+		const calls: string[][] = [];
+		const installer = new CodexPluginInstaller(async (args) => {
+			calls.push(args);
+			const command = args.join(" ");
+			if (command === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (command === "plugin --help") return ok("plugin marketplace add");
+			if (command === "plugin marketplace add /tmp/source") return ok();
+			if (command === "plugin add ck@claudekit") return ok();
+			if (command === "plugin list --json") {
+				return ok(JSON.stringify({ installed: [{ pluginId: "ck@claudekit", enabled: true }] }));
+			}
+			if (command === "plugin remove ck@claudekit") return ok();
+			if (command === "plugin marketplace remove claudekit") return ok();
+			return fail(`unexpected command: ${command}`);
+		});
+
+		const preparation = await prepareCodexPlugin({
+			pluginSourceDir: "/tmp/source",
+			installer,
+		});
+		expect(preparation.result).toEqual({ action: "installed", pluginVerified: true });
+		await expect(preparation.rollback()).resolves.toEqual({
+			ok: true,
+			detail: "removed newly prepared Codex plugin and marketplace",
+		});
+		expect(calls.slice(-2)).toEqual([
+			["plugin", "remove", "ck@claudekit"],
+			["plugin", "marketplace", "remove", "claudekit"],
 		]);
 	});
 
@@ -163,9 +196,10 @@ other@market  installed, enabled
 		expect(result.error).toContain("bad marketplace");
 	});
 
-	test("replaces stale marketplace source before installing", async () => {
+	test("replaces stale marketplace source even when the plugin is disabled", async () => {
 		const calls: string[][] = [];
 		let addAttempts = 0;
+		let listAttempts = 0;
 		const installer = new CodexPluginInstaller(async (args) => {
 			calls.push(args);
 			if (args.join(" ") === "--version") return ok("codex-cli 0.143.0-alpha.14");
@@ -179,7 +213,22 @@ other@market  installed, enabled
 			if (args.join(" ") === "plugin marketplace remove claudekit") return ok();
 			if (args.join(" ") === "plugin add ck@claudekit") return ok();
 			if (args.join(" ") === "plugin list --json") {
-				return ok(JSON.stringify({ installed: [{ pluginId: "ck@claudekit", enabled: true }] }));
+				listAttempts++;
+				return ok(
+					JSON.stringify({
+						installed: [
+							{
+								pluginId: "ck@claudekit",
+								installed: true,
+								enabled: listAttempts !== 1,
+								source: {
+									source: "local",
+									path: listAttempts === 1 ? "/tmp/old-source/.claude" : "/tmp/source/.claude",
+								},
+							},
+						],
+					}),
+				);
 			}
 			return fail(`unexpected command: ${args.join(" ")}`);
 		});
@@ -191,11 +240,241 @@ other@market  installed, enabled
 			["--version"],
 			["plugin", "--help"],
 			["plugin", "marketplace", "add", "/tmp/source"],
+			["plugin", "list", "--json"],
 			["plugin", "marketplace", "remove", "claudekit"],
 			["plugin", "marketplace", "add", "/tmp/source"],
 			["plugin", "add", "ck@claudekit"],
 			["plugin", "list", "--json"],
 		]);
+	});
+
+	test("keeps a healthy already-registered marketplace without replacement", async () => {
+		const calls: string[][] = [];
+		const installer = new CodexPluginInstaller(async (args) => {
+			calls.push(args);
+			if (args.join(" ") === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (args.join(" ") === "plugin --help") return ok("plugin marketplace add");
+			if (args.join(" ") === "plugin marketplace add /tmp/source") {
+				return fail("marketplace 'claudekit' is already added");
+			}
+			if (args.join(" ") === "plugin add ck@claudekit") return ok();
+			if (args.join(" ") === "plugin list --json") {
+				return ok(
+					JSON.stringify({
+						installed: [
+							{
+								pluginId: "ck@claudekit",
+								installed: true,
+								enabled: true,
+								source: { source: "local", path: "/tmp/source/.claude" },
+							},
+						],
+					}),
+				);
+			}
+			return fail(`unexpected command: ${args.join(" ")}`);
+		});
+
+		await expect(
+			installCodexPlugin({ pluginSourceDir: "/tmp/source", installer }),
+		).resolves.toEqual({ action: "installed", pluginVerified: true });
+		expect(calls).not.toContainEqual(["plugin", "marketplace", "remove", "claudekit"]);
+	});
+
+	test("same-source preparation rollback reloads restored stage content", async () => {
+		const calls: string[][] = [];
+		let marketplaceAdds = 0;
+		const installer = new CodexPluginInstaller(async (args) => {
+			calls.push(args);
+			const command = args.join(" ");
+			if (command === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (command === "plugin --help") return ok("plugin marketplace add");
+			if (command === "plugin marketplace add /tmp/source") {
+				marketplaceAdds++;
+				return marketplaceAdds === 1 ? fail("marketplace 'claudekit' is already added") : ok();
+			}
+			if (command === "plugin list --json") {
+				return ok(
+					JSON.stringify({
+						installed: [
+							{
+								pluginId: "ck@claudekit",
+								installed: true,
+								enabled: true,
+								source: "/tmp/source/.claude",
+							},
+						],
+					}),
+				);
+			}
+			if (command === "plugin add ck@claudekit") return ok();
+			if (command === "plugin remove ck@claudekit") return ok();
+			if (command === "plugin marketplace remove claudekit") return ok();
+			return fail(`unexpected command: ${command}`);
+		});
+
+		const preparation = await prepareCodexPlugin({
+			pluginSourceDir: "/tmp/source",
+			installer,
+		});
+		await expect(preparation.rollback()).resolves.toEqual({
+			ok: true,
+			detail: "reloaded previous Codex marketplace and plugin state",
+		});
+		expect(calls.slice(-4)).toEqual([
+			["plugin", "remove", "ck@claudekit"],
+			["plugin", "marketplace", "remove", "claudekit"],
+			["plugin", "marketplace", "add", "/tmp/source"],
+			["plugin", "add", "ck@claudekit"],
+		]);
+	});
+
+	test("restores stale marketplace and plugin state when replacement fails", async () => {
+		const calls: string[][] = [];
+		let newSourceAttempts = 0;
+		const installer = new CodexPluginInstaller(async (args) => {
+			calls.push(args);
+			if (args.join(" ") === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (args.join(" ") === "plugin --help") return ok("plugin marketplace add");
+			if (args.join(" ") === "plugin marketplace add /tmp/new-source") {
+				newSourceAttempts++;
+				return newSourceAttempts === 1
+					? fail("marketplace 'claudekit' is already added from a different source")
+					: fail("replacement failed");
+			}
+			if (args.join(" ") === "plugin list --json") {
+				return ok(
+					JSON.stringify({
+						installed: [
+							{
+								pluginId: "ck@claudekit",
+								installed: true,
+								enabled: true,
+								source: { source: "local", path: "/tmp/old-source/.claude" },
+							},
+						],
+					}),
+				);
+			}
+			if (args.join(" ") === "plugin marketplace remove claudekit") return ok();
+			if (args.join(" ") === "plugin marketplace add /tmp/old-source") return ok();
+			if (args.join(" ") === "plugin add ck@claudekit") return ok();
+			return fail(`unexpected command: ${args.join(" ")}`);
+		});
+
+		const result = await installCodexPlugin({
+			pluginSourceDir: "/tmp/new-source",
+			installer,
+		});
+		expect(result).toMatchObject({ action: "install-failed", pluginVerified: false });
+		expect(result.error).toContain("replacement failed");
+		expect(result.error).toContain("restored previous marketplace and plugin state");
+		expect(calls).toContainEqual(["plugin", "marketplace", "add", "/tmp/old-source"]);
+		expect(calls).toContainEqual(["plugin", "add", "ck@claudekit"]);
+	});
+
+	test("does not destroy stale registration when its prior source is not recoverable", async () => {
+		const calls: string[][] = [];
+		const installer = new CodexPluginInstaller(async (args) => {
+			calls.push(args);
+			if (args.join(" ") === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (args.join(" ") === "plugin --help") return ok("plugin marketplace add");
+			if (args.join(" ") === "plugin marketplace add /tmp/new-source") {
+				return fail("marketplace 'claudekit' is already added from a different source");
+			}
+			if (args.join(" ") === "plugin list --json") {
+				return ok(
+					JSON.stringify({
+						installed: [
+							{
+								pluginId: "ck@claudekit",
+								installed: true,
+								enabled: true,
+								source: { source: "local", path: ".claude" },
+							},
+						],
+					}),
+				);
+			}
+			return fail(`unexpected command: ${args.join(" ")}`);
+		});
+		const result = await installCodexPlugin({
+			pluginSourceDir: "/tmp/new-source",
+			installer,
+		});
+		expect(result).toMatchObject({ action: "install-failed", pluginVerified: false });
+		expect(result.error).toContain("previous source could not be determined safely");
+		expect(calls).not.toContainEqual(["plugin", "marketplace", "remove", "claudekit"]);
+	});
+
+	test("recovers malformed Codex inspection when add reports a safe previous source", async () => {
+		const calls: string[][] = [];
+		let newSourceAdds = 0;
+		let jsonLists = 0;
+		const installer = new CodexPluginInstaller(async (args) => {
+			calls.push(args);
+			const command = args.join(" ");
+			if (command === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (command === "plugin --help") return ok("plugin marketplace add");
+			if (command === "plugin marketplace add /tmp/new-source") {
+				newSourceAdds++;
+				return newSourceAdds === 1
+					? fail("marketplace already registered; source: /tmp/old-source")
+					: ok();
+			}
+			if (command === "plugin list --json") {
+				jsonLists++;
+				return jsonLists === 1
+					? fail("malformed marketplace state")
+					: ok(
+							JSON.stringify({
+								installed: [
+									{
+										pluginId: "ck@claudekit",
+										installed: true,
+										enabled: true,
+										source: "/tmp/new-source/.claude",
+									},
+								],
+							}),
+						);
+			}
+			if (command === "plugin list") return fail("malformed marketplace state");
+			if (command === "plugin marketplace remove claudekit") return ok();
+			if (command === "plugin add ck@claudekit") return ok();
+			return fail(`unexpected command: ${command}`);
+		});
+
+		await expect(
+			installCodexPlugin({ pluginSourceDir: "/tmp/new-source", installer }),
+		).resolves.toEqual({ action: "installed", pluginVerified: true });
+		expect(calls).toContainEqual(["plugin", "marketplace", "remove", "claudekit"]);
+		expect(calls).toContainEqual(["plugin", "marketplace", "add", "/tmp/new-source"]);
+	});
+
+	test("keeps irrecoverable unknown Codex registration non-destructive and explicit", async () => {
+		const calls: string[][] = [];
+		const installer = new CodexPluginInstaller(async (args) => {
+			calls.push(args);
+			const command = args.join(" ");
+			if (command === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (command === "plugin --help") return ok("plugin marketplace add");
+			if (command === "plugin marketplace add /tmp/new-source") {
+				return fail("marketplace already registered from a different source");
+			}
+			if (command === "plugin list --json" || command === "plugin list") {
+				return fail("malformed marketplace state");
+			}
+			return fail(`unexpected command: ${command}`);
+		});
+
+		const result = await installCodexPlugin({
+			pluginSourceDir: "/tmp/new-source",
+			installer,
+		});
+		expect(result).toMatchObject({ action: "install-failed", pluginVerified: false });
+		expect(result.error).toContain("irrecoverably unknown");
+		expect(calls).not.toContainEqual(["plugin", "marketplace", "remove", "claudekit"]);
 	});
 
 	test("asks update self-heal to refresh only when supported Codex is missing ck", async () => {
@@ -281,6 +560,55 @@ other@market  installed, enabled
 			status: "disabled",
 			shouldRefresh: true,
 		});
+	});
+
+	test("expected Codex source and version cannot pass when inspection omits them", async () => {
+		const stateWith = (entry: Record<string, unknown>) =>
+			new CodexPluginInstaller(async (args) => {
+				if (args.join(" ") === "--version") return ok("codex-cli 0.143.0-alpha.14");
+				if (args.join(" ") === "plugin --help") return ok("plugin marketplace add");
+				if (args.join(" ") === "plugin list --json") {
+					return ok(JSON.stringify({ installed: [{ pluginId: "ck@claudekit", ...entry }] }));
+				}
+				return fail("unexpected");
+			});
+
+		await expect(
+			detectCodexPluginState(
+				stateWith({
+					installed: true,
+					enabled: true,
+					version: "2.20.1",
+					marketplace: "claudekit",
+				}),
+				{ expectedSource: "/expected/.claude" },
+			),
+		).resolves.toMatchObject({ status: "installed-stale-source", shouldRefresh: true });
+
+		await expect(
+			detectCodexPluginState(
+				stateWith({
+					installed: true,
+					enabled: true,
+					marketplace: "claudekit",
+					source: "/expected/.claude",
+				}),
+				{ expectedVersion: "2.20.1", expectedSource: "/expected/.claude" },
+			),
+		).resolves.toMatchObject({ status: "installed-stale-version", shouldRefresh: true });
+
+		await expect(
+			detectCodexPluginState(
+				stateWith({
+					installed: true,
+					enabled: false,
+					version: "2.20.1",
+					marketplace: "claudekit",
+					source: "/old/.claude",
+				}),
+				{ expectedVersion: "2.20.1", expectedSource: "/expected/.claude" },
+			),
+		).resolves.toMatchObject({ status: "installed-stale-source", shouldRefresh: true });
 	});
 
 	test("self-heal refreshes stale Codex versions instead of treating enabled as healthy", async () => {
@@ -401,6 +729,67 @@ other@market  installed, enabled
 		});
 	});
 
+	test("marketplace removal failure prevents verified cleanup success", async () => {
+		const installer = new CodexPluginInstaller(async (args) => {
+			const command = args.join(" ");
+			if (command === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (command === "plugin --help") return ok("plugin marketplace add");
+			if (command === "plugin remove ck@claudekit") return ok();
+			if (command === "plugin marketplace remove claudekit") return fail("registry locked");
+			if (command === "plugin list --json") return ok(JSON.stringify({ installed: [] }));
+			return fail(`unexpected command: ${command}`);
+		});
+
+		await expect(removeCodexPlugin({ installer })).resolves.toMatchObject({
+			removed: true,
+			marketplaceRemoved: false,
+			pluginStillInstalled: false,
+			error: "codex marketplace removal failed: registry locked",
+		});
+	});
+
+	test("repeated cleanup treats an already-absent marketplace as an idempotent no-op", async () => {
+		const installer = new CodexPluginInstaller(async (args) => {
+			const command = args.join(" ");
+			if (command === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (command === "plugin --help") return ok("plugin marketplace add");
+			if (command === "plugin remove ck@claudekit") return fail("plugin not found");
+			if (command === "plugin marketplace remove claudekit") {
+				return fail("marketplace not found");
+			}
+			if (command === "plugin list --json") return ok(JSON.stringify({ installed: [] }));
+			return fail(`unexpected command: ${command}`);
+		});
+
+		await expect(removeCodexPlugin({ installer })).resolves.toMatchObject({
+			removed: false,
+			marketplaceRemoved: false,
+			pluginStillInstalled: false,
+		});
+		expect((await removeCodexPlugin({ installer })).error).toBeUndefined();
+	});
+
+	test("unknown post-removal state is an explicit verification failure", async () => {
+		const installer = new CodexPluginInstaller(async (args) => {
+			const command = args.join(" ");
+			if (command === "--version") return ok("codex-cli 0.143.0-alpha.14");
+			if (command === "plugin --help") return ok("plugin marketplace add");
+			if (command === "plugin remove ck@claudekit") return ok();
+			if (command === "plugin marketplace remove claudekit") return ok();
+			if (command === "plugin list --json" || command === "plugin list") {
+				return fail("inspection failed");
+			}
+			return fail(`unexpected command: ${command}`);
+		});
+
+		await expect(removeCodexPlugin({ installer })).resolves.toMatchObject({
+			removed: true,
+			marketplaceRemoved: true,
+			verificationStatus: "unknown",
+			error: "codex plugin absence could not be verified: inspection failed",
+		});
+	});
+
 	test("skips Codex plugin removal when Codex has no plugin support", async () => {
 		const calls: string[][] = [];
 		const installer = new CodexPluginInstaller(async (args) => {
@@ -413,6 +802,9 @@ other@market  installed, enabled
 		await expect(removeCodexPlugin({ installer })).resolves.toEqual({
 			removed: false,
 			marketplaceRemoved: false,
+			verificationStatus: "plugins-unsupported",
+			error:
+				"Codex plugin commands are unsupported; persisted plugin and marketplace absence cannot be verified",
 		});
 		expect(calls).toEqual([["--version"], ["plugin", "--help"]]);
 	});

--- a/src/domains/installation/plugin/__tests__/engineer-provider-cleanup.test.ts
+++ b/src/domains/installation/plugin/__tests__/engineer-provider-cleanup.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+import type { CodexPluginState } from "../codex-plugin-installer.js";
+import { cleanupEngineerProviderPlugins } from "../engineer-provider-cleanup.js";
+
+function codexState(status: CodexPluginState["status"]): CodexPluginState {
+	const installed = status.startsWith("installed") || status === "disabled";
+	return {
+		status,
+		pluginId: "ck@claudekit",
+		enabled: status === "installed-current",
+		installed,
+		installedVersion: installed ? "1.0.0" : null,
+		expectedVersion: null,
+		marketplace: installed ? "claudekit" : null,
+		expectedMarketplace: null,
+		source: null,
+		expectedSource: null,
+		shouldRefresh: installed,
+	};
+}
+
+const claudeAbsent = {
+	uninstalled: false,
+	staleCacheRemoved: false,
+	pluginStillInstalled: false,
+};
+
+describe("cleanupEngineerProviderPlugins", () => {
+	test("fails before provider calls when a test omits isolation dependencies", async () => {
+		const previousTestHome = process.env.CK_TEST_HOME;
+		process.env.CK_TEST_HOME = "/tmp/ck-provider-cleanup-test";
+		let claudeCalled = false;
+		try {
+			await expect(
+				cleanupEngineerProviderPlugins({
+					uninstallClaudePlugin: async () => {
+						claudeCalled = true;
+						return claudeAbsent;
+					},
+				}),
+			).rejects.toThrow("must inject Claude and Codex cleanup and verification dependencies");
+			expect(claudeCalled).toBe(false);
+		} finally {
+			if (previousTestHome === undefined) Reflect.deleteProperty(process.env, "CK_TEST_HOME");
+			else process.env.CK_TEST_HOME = previousTestHome;
+		}
+	});
+
+	test("attempts and verifies both providers", async () => {
+		const calls: string[] = [];
+		const result = await cleanupEngineerProviderPlugins({
+			uninstallClaudePlugin: async () => {
+				calls.push("claude-cleanup");
+				return { ...claudeAbsent, uninstalled: true };
+			},
+			removeCodexPlugin: async () => {
+				calls.push("codex-cleanup");
+				return { removed: true, marketplaceRemoved: true, pluginStillInstalled: false };
+			},
+			verifyClaudePluginAbsent: () => {
+				calls.push("claude-verify");
+				return true;
+			},
+			readCodexPluginState: async () => {
+				calls.push("codex-verify");
+				return codexState("missing");
+			},
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.changed).toBe(true);
+		expect(calls).toContainAllValues([
+			"claude-cleanup",
+			"codex-cleanup",
+			"claude-verify",
+			"codex-verify",
+		]);
+	});
+
+	test("is idempotent when both providers are already absent", async () => {
+		const deps = {
+			uninstallClaudePlugin: async () => claudeAbsent,
+			removeCodexPlugin: async () => ({
+				removed: false,
+				marketplaceRemoved: false,
+				pluginStillInstalled: false,
+			}),
+			verifyClaudePluginAbsent: () => true,
+			readCodexPluginState: async () => codexState("missing"),
+		};
+
+		const first = await cleanupEngineerProviderPlugins(deps);
+		const second = await cleanupEngineerProviderPlugins(deps);
+		expect(first).toMatchObject({ success: true, changed: false, errors: [] });
+		expect(second).toMatchObject({ success: true, changed: false, errors: [] });
+	});
+
+	test("attempts Codex cleanup after Claude cleanup throws", async () => {
+		let codexAttempted = false;
+		const result = await cleanupEngineerProviderPlugins({
+			uninstallClaudePlugin: async () => {
+				throw new Error("claude failed");
+			},
+			removeCodexPlugin: async () => {
+				codexAttempted = true;
+				return { removed: true, marketplaceRemoved: true, pluginStillInstalled: false };
+			},
+			verifyClaudePluginAbsent: () => true,
+			readCodexPluginState: async () => codexState("missing"),
+		});
+
+		expect(codexAttempted).toBe(true);
+		expect(result.success).toBe(false);
+		expect(result.errors.join(" ")).toContain("Claude plugin cleanup failed");
+	});
+
+	test("reports residual and unknown provider states as failures", async () => {
+		const result = await cleanupEngineerProviderPlugins({
+			uninstallClaudePlugin: async () => ({
+				...claudeAbsent,
+				pluginStillInstalled: true,
+				error: "plugin remains registered",
+			}),
+			removeCodexPlugin: async () => ({
+				removed: false,
+				marketplaceRemoved: false,
+				pluginStillInstalled: false,
+			}),
+			verifyClaudePluginAbsent: () => false,
+			readCodexPluginState: async () => ({
+				...codexState("unknown"),
+				error: "plugin list failed",
+			}),
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.errors.join(" ")).toContain("plugin remains registered");
+		expect(result.errors.join(" ")).toContain("could not verify absence (unknown");
+	});
+
+	test("fails when unavailable provider surfaces cannot verify persisted absence", async () => {
+		for (const status of ["codex-unavailable", "plugins-unsupported"] as const) {
+			const result = await cleanupEngineerProviderPlugins({
+				uninstallClaudePlugin: async () => claudeAbsent,
+				removeCodexPlugin: async () => ({ removed: false, marketplaceRemoved: false }),
+				verifyClaudePluginAbsent: () => true,
+				readCodexPluginState: async () => codexState(status),
+			});
+			expect(result.success).toBe(false);
+			expect(result.errors.join(" ")).toContain(`could not verify absence (${status}`);
+		}
+	});
+});

--- a/src/domains/installation/plugin/__tests__/install-mode-detector.test.ts
+++ b/src/domains/installation/plugin/__tests__/install-mode-detector.test.ts
@@ -80,6 +80,31 @@ describe("install-mode-detector", () => {
 		expect(detectInstallMode(claudeDir).mode).toBe("legacy");
 	});
 
+	test("legacy: deprecated root installedFiles still triggers convergence", async () => {
+		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
+		await writeFile(join(claudeDir, "skills", "cook", "SKILL.md"), "# cook\n", "utf-8");
+		await writeMetadata({
+			name: "claudekit-engineer",
+			version: "2.17.0",
+			installedFiles: ["skills/cook/SKILL.md"],
+		});
+
+		expect(detectLegacyState(claudeDir)).toEqual({ installed: true, version: "2.17.0" });
+		expect(detectInstallMode(claudeDir).mode).toBe("legacy");
+	});
+
+	test("legacy: checksum-less structured records trigger convergence without ownership inference", async () => {
+		await mkdir(join(claudeDir, "skills", "user"), { recursive: true });
+		await writeFile(join(claudeDir, "skills", "user", "SKILL.md"), "# user\n", "utf-8");
+		await writeMetadata({
+			name: "claudekit-engineer",
+			version: "2.17.0",
+			files: [{ path: "skills/user/SKILL.md" }],
+		});
+
+		expect(detectInstallMode(claudeDir).mode).toBe("legacy");
+	});
+
 	test("legacy: metadata without files or engineer kit is NOT legacy", async () => {
 		await writeMetadata({ name: "claudekit-engineer", version: "2.18.0" });
 		expect(detectLegacyState(claudeDir).installed).toBe(false);

--- a/src/domains/installation/plugin/__tests__/migrate-legacy-to-plugin.test.ts
+++ b/src/domains/installation/plugin/__tests__/migrate-legacy-to-plugin.test.ts
@@ -74,9 +74,18 @@ describe("migrateLegacyToPlugin (orchestration)", () => {
 		writeFile(join(claudeDir, "metadata.json"), JSON.stringify(obj), "utf-8");
 	const writeSettings = (enabledPlugins: Record<string, boolean>) =>
 		writeFile(join(claudeDir, "settings.json"), JSON.stringify({ enabledPlugins }), "utf-8");
+	const writeMarketplace = async (source = "/src") => {
+		await mkdir(join(claudeDir, "plugins"), { recursive: true });
+		await writeFile(
+			join(claudeDir, "plugins", "known_marketplaces.json"),
+			JSON.stringify({ claudekit: { installLocation: source } }),
+			"utf-8",
+		);
+	};
 
 	test("already plugin -> noop, no install calls", async () => {
 		await writeSettings({ "ck@claudekit": true });
+		await writeMarketplace();
 		const { installer, calls } = fakeInstaller();
 		let removerCalled = false;
 		const r = await migrateLegacyToPlugin({
@@ -98,6 +107,7 @@ describe("migrateLegacyToPlugin (orchestration)", () => {
 		await mkdir(join(claudeDir, "hooks"), { recursive: true });
 		await writeFile(join(claudeDir, "hooks", "session-init.cjs"), "runtime hook", "utf-8");
 		await writeSettings({ "ck@claudekit": true });
+		await writeMarketplace();
 		await writeMetadata({
 			kits: {
 				engineer: {
@@ -143,6 +153,132 @@ describe("migrateLegacyToPlugin (orchestration)", () => {
 		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
 		await writeFile(join(claudeDir, "skills", "cook", "SKILL.md"), "plugin materialized", "utf-8");
 		expect(detectInstallMode(claudeDir).mode).toBe("plugin");
+	});
+
+	test("plugin-only disabled registration is enabled and refreshed", async () => {
+		await writeSettings({ "ck@claudekit": false });
+		await writeMarketplace();
+		const { installer, calls } = fakeInstaller();
+
+		const result = await migrateLegacyToPlugin({
+			pluginSourceDir: "/src",
+			claudeDir,
+			installer,
+			now: TS,
+		});
+
+		expect(result.pluginVerified).toBe(true);
+		expect(calls).toContainEqual(["plugin", "enable", "ck@claudekit"]);
+		expect(calls).toContainEqual(["plugin", "update", "ck@claudekit"]);
+	});
+
+	test("plugin-only stale marketplace source is refreshed", async () => {
+		await writeSettings({ "ck@claudekit": true });
+		await writeMarketplace("/old-source");
+		const { installer, calls } = fakeInstaller();
+
+		const result = await migrateLegacyToPlugin({
+			pluginSourceDir: "/src",
+			claudeDir,
+			installer,
+			now: TS,
+		});
+
+		expect(result.pluginVerified).toBe(true);
+		expect(calls).toContainEqual(["plugin", "marketplace", "remove", "claudekit"]);
+		expect(calls).toContainEqual(["plugin", "marketplace", "add", "/src"]);
+		expect(calls).toContainEqual(["plugin", "update", "ck@claudekit"]);
+	});
+
+	test("plugin-only stale version is refreshed from the staged manifest", async () => {
+		const stagedSource = join(claudeDir, "staged-source");
+		await mkdir(join(stagedSource, ".claude", ".claude-plugin"), { recursive: true });
+		await writeFile(
+			join(stagedSource, ".claude", ".claude-plugin", "plugin.json"),
+			JSON.stringify({ name: "ck", version: "2.20.1" }),
+			"utf-8",
+		);
+		await mkdir(join(claudeDir, "plugins", "cache", "claudekit", "ck", "2.19.0"), {
+			recursive: true,
+		});
+		await writeSettings({ "ck@claudekit": true });
+		await writeMarketplace(stagedSource);
+		const { installer, calls } = fakeInstaller();
+
+		const result = await migrateLegacyToPlugin({
+			pluginSourceDir: stagedSource,
+			claudeDir,
+			installer,
+			now: TS,
+		});
+
+		expect(result.pluginVerified).toBe(true);
+		expect(calls).toContainEqual(["plugin", "update", "ck@claudekit"]);
+	});
+
+	test("malformed Claude marketplace replacement failure restores registration bytes", async () => {
+		await writeSettings({ "ck@claudekit": true });
+		await mkdir(join(claudeDir, "plugins"), { recursive: true });
+		const registryPath = join(claudeDir, "plugins", "known_marketplaces.json");
+		await writeFile(registryPath, "{malformed", "utf-8");
+		const { installer, calls } = fakeInstaller({
+			marketplaceAddOk: false,
+			marketplaceUpdateOk: false,
+		});
+
+		const result = await migrateLegacyToPlugin({
+			pluginSourceDir: "/src",
+			claudeDir,
+			installer,
+			now: TS,
+		});
+
+		expect(result.action).toBe("install-failed");
+		expect(readFileSync(registryPath, "utf-8")).toBe("{malformed");
+		expect(calls).toContainEqual(["plugin", "marketplace", "remove", "claudekit"]);
+	});
+
+	test("recovers malformed Claude marketplace registration to the staged source", async () => {
+		await writeSettings({ "ck@claudekit": true });
+		await mkdir(join(claudeDir, "plugins"), { recursive: true });
+		const registryPath = join(claudeDir, "plugins", "known_marketplaces.json");
+		await writeFile(registryPath, "{malformed", "utf-8");
+		const calls: string[][] = [];
+		const installer = new PluginInstaller(async (args) => {
+			calls.push(args);
+			const command = args.join(" ");
+			if (command === "--version") return ok("2.1.178");
+			if (command === "plugin --help") return ok("Manage marketplaces");
+			if (command === "plugin marketplace remove claudekit") {
+				await writeFile(registryPath, "{}\n", "utf-8");
+				return ok("");
+			}
+			if (command === "plugin marketplace add /src") {
+				await writeFile(
+					registryPath,
+					JSON.stringify({ claudekit: { installLocation: "/src" } }),
+					"utf-8",
+				);
+				return ok("");
+			}
+			if (command === "plugin update ck@claudekit") return ok("");
+			if (command === "plugin list") return ok("ck@claudekit Status: enabled");
+			return ok("");
+		});
+
+		const result = await migrateLegacyToPlugin({
+			pluginSourceDir: "/src",
+			claudeDir,
+			installer,
+			now: TS,
+		});
+
+		expect(result.pluginVerified).toBe(true);
+		expect(JSON.parse(readFileSync(registryPath, "utf-8"))).toEqual({
+			claudekit: { installLocation: "/src" },
+		});
+		expect(calls).toContainEqual(["plugin", "marketplace", "remove", "claudekit"]);
+		expect(calls).toContainEqual(["plugin", "marketplace", "add", "/src"]);
 	});
 
 	test("cc without plugin support -> skipped (caller falls back to legacy copy)", async () => {
@@ -222,6 +358,70 @@ describe("migrateLegacyToPlugin (orchestration)", () => {
 		const receipt = JSON.parse(readFileSync(r.receiptPath as string, "utf-8"));
 		expect(receipt[0].fromMode).toBe("legacy");
 		expect(receipt[0].toMode).toBe("plugin");
+	});
+
+	test("late receipt failure restores removed legacy files and metadata", async () => {
+		const legacyFile = join(claudeDir, "skills", "cook", "SKILL.md");
+		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
+		await writeFile(legacyFile, "legacy skill", "utf-8");
+		const metadata = {
+			kits: {
+				engineer: {
+					version: "2.19.0",
+					installedAt: "x",
+					files: [{ path: "skills/cook/SKILL.md", ownership: "ck" }],
+				},
+			},
+		};
+		await writeMetadata(metadata);
+		const { installer } = fakeInstaller();
+
+		const result = await migrateLegacyToPlugin({
+			pluginSourceDir: "/staged/kit",
+			claudeDir,
+			installer,
+			now: TS,
+			writeReceiptFn: () => {
+				throw new Error("disk full");
+			},
+		});
+
+		expect(result).toMatchObject({
+			action: "install-failed",
+			pluginVerified: false,
+			error: "plugin migration transaction failed: disk full",
+		});
+		expect(readFileSync(legacyFile, "utf-8")).toBe("legacy skill");
+		expect(JSON.parse(readFileSync(join(claudeDir, "metadata.json"), "utf-8"))).toEqual(metadata);
+		expect(existsSync(join(claudeDir, ".ck-migration-log.json"))).toBe(false);
+	});
+
+	test("deprecated string installedFiles converge without deleting their payload", async () => {
+		const legacyFile = join(claudeDir, "skills", "cook", "SKILL.md");
+		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
+		await writeFile(legacyFile, "historical content", "utf-8");
+		await writeMetadata({
+			name: "engineer",
+			version: "2.18.0",
+			installedFiles: ["skills/cook/SKILL.md"],
+		});
+		const { installer } = fakeInstaller();
+
+		const result = await migrateLegacyToPlugin({
+			pluginSourceDir: "/src",
+			claudeDir,
+			installer,
+			now: TS,
+		});
+
+		expect(result.action).toBe("migrated-from-legacy");
+		expect(existsSync(legacyFile)).toBe(true);
+		const metadata = JSON.parse(readFileSync(join(claudeDir, "metadata.json"), "utf-8"));
+		expect(metadata.installedFiles).toEqual([]);
+		await writeSettings({ "ck@claudekit": true });
+		await writeMarketplace();
+		expect(detectInstallMode(claudeDir).mode).toBe("plugin");
+		expect(detectInstallMode(claudeDir).legacy.installed).toBe(false);
 	});
 
 	test("mixed already-installed plugin refreshes plugin and still cleans legacy skills", async () => {
@@ -319,6 +519,42 @@ describe("defaultLegacyRemover", () => {
 		expect(existsSync(join(claudeDir, "skills", "mine", "SKILL.md"))).toBe(true); // user preserved
 		expect(existsSync(join(backupDir, "skills", "cook", "SKILL.md"))).toBe(true); // backed up
 		expect(existsSync(join(backupDir, "agents", "planner.md"))).toBe(true); // backed up
+	});
+
+	test("legacy root installedFiles are evidence only and never deletion authority", async () => {
+		await writeFile(join(claudeDir, "skills", "cook", "SKILL.md"), "historical", "utf-8");
+		await writeFile(
+			join(claudeDir, "metadata.json"),
+			JSON.stringify({ installedFiles: ["skills/cook/SKILL.md"] }),
+			"utf-8",
+		);
+
+		const removed = defaultLegacyRemover(claudeDir, backupDir);
+
+		expect(removed).toEqual([]);
+		expect(existsSync(join(claudeDir, "skills", "cook", "SKILL.md"))).toBe(true);
+	});
+
+	test("checksum-less records stay while explicitly CK-owned records can be removed", async () => {
+		await writeFile(join(claudeDir, "skills", "cook", "SKILL.md"), "unknown", "utf-8");
+		await mkdir(join(claudeDir, "skills", "safe"), { recursive: true });
+		await writeFile(join(claudeDir, "skills", "safe", "SKILL.md"), "safe", "utf-8");
+		await writeFile(
+			join(claudeDir, "metadata.json"),
+			JSON.stringify({
+				files: [
+					{ path: "skills/cook/SKILL.md" },
+					{ path: "skills/safe/SKILL.md", ownership: "ck" },
+				],
+			}),
+			"utf-8",
+		);
+
+		const removed = defaultLegacyRemover(claudeDir, backupDir);
+
+		expect(removed).toEqual(["skills/safe/SKILL.md"]);
+		expect(existsSync(join(claudeDir, "skills", "cook", "SKILL.md"))).toBe(true);
+		expect(existsSync(join(claudeDir, "skills", "safe", "SKILL.md"))).toBe(false);
 	});
 
 	test("removes unmodified plugin-supplied files marked user-owned by manifestless installs", async () => {

--- a/src/domains/installation/plugin/claude-plugin-health.ts
+++ b/src/domains/installation/plugin/claude-plugin-health.ts
@@ -1,0 +1,87 @@
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { join, normalize, resolve } from "node:path";
+import { versionsMatch } from "@/domains/versioning/checking/version-utils.js";
+import { detectPluginState } from "./install-mode-detector.js";
+
+export type ClaudePluginHealthStatus =
+	| "missing"
+	| "orphan-cache"
+	| "disabled"
+	| "installed-stale-version"
+	| "installed-stale-source"
+	| "installed-current";
+
+export interface ClaudePluginHealthOptions {
+	expectedVersion?: string | null;
+	expectedSource?: string | null;
+}
+
+export interface ClaudePluginHealth {
+	status: ClaudePluginHealthStatus;
+	shouldRefresh: boolean;
+	installedVersion: string | null;
+	source: string | null;
+}
+
+export function detectClaudePluginHealth(
+	claudeDir: string,
+	options: ClaudePluginHealthOptions = {},
+): ClaudePluginHealth {
+	const state = detectPluginState(claudeDir);
+	const source = readMarketplaceSource(claudeDir, state.marketplace ?? "claudekit");
+	const base = { installedVersion: state.version, source };
+
+	if (!state.installed) {
+		return {
+			...base,
+			status: state.staleCache ? "orphan-cache" : "missing",
+			shouldRefresh: true,
+		};
+	}
+	if (!state.enabled) return { ...base, status: "disabled", shouldRefresh: true };
+	if (
+		options.expectedVersion &&
+		(!state.version || !versionsMatch(state.version, options.expectedVersion))
+	) {
+		return { ...base, status: "installed-stale-version", shouldRefresh: true };
+	}
+	if (options.expectedSource && (!source || !pathsMatch(source, options.expectedSource))) {
+		return { ...base, status: "installed-stale-source", shouldRefresh: true };
+	}
+	return { ...base, status: "installed-current", shouldRefresh: false };
+}
+
+function readMarketplaceSource(claudeDir: string, marketplace: string): string | null {
+	try {
+		const parsed = JSON.parse(
+			readFileSync(join(claudeDir, "plugins", "known_marketplaces.json"), "utf-8"),
+		);
+		if (!isRecord(parsed)) return null;
+		const entry = isRecord(parsed[marketplace])
+			? parsed[marketplace]
+			: isRecord(parsed.marketplaces) && isRecord(parsed.marketplaces[marketplace])
+				? parsed.marketplaces[marketplace]
+				: null;
+		if (!entry) return null;
+		if (typeof entry.installLocation === "string") return entry.installLocation;
+		if (isRecord(entry.source) && typeof entry.source.path === "string") return entry.source.path;
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+function pathsMatch(actual: string, expected: string): boolean {
+	return canonicalPath(actual) === canonicalPath(expected);
+}
+
+function canonicalPath(pathValue: string): string {
+	const absolute = resolve(pathValue);
+	const resolved = existsSync(absolute) ? realpathSync(absolute) : absolute;
+	const normalized = normalize(resolved);
+	return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/domains/installation/plugin/codex-plugin-installer.ts
+++ b/src/domains/installation/plugin/codex-plugin-installer.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { existsSync, realpathSync } from "node:fs";
-import { normalize, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, normalize, resolve } from "node:path";
 import { promisify } from "node:util";
 import {
 	CK_MARKETPLACE_NAME,
@@ -137,10 +137,22 @@ export interface CodexPluginInstallResult {
 	error?: string;
 }
 
+export interface CodexPluginRollbackResult {
+	ok: boolean;
+	detail: string;
+}
+
+export interface CodexPluginPreparation {
+	result: CodexPluginInstallResult;
+	commit(): void;
+	rollback(): Promise<CodexPluginRollbackResult>;
+}
+
 export interface RemoveCodexPluginResult {
 	removed: boolean;
 	marketplaceRemoved: boolean;
 	pluginStillInstalled?: boolean;
+	verificationStatus?: CodexPluginStatus;
 	error?: string;
 }
 
@@ -245,26 +257,28 @@ function classifyCodexPluginEntry(
 	options: CodexPluginStateOptions = {},
 ): CodexPluginState {
 	if (!entry) return createState("missing", null, options);
-	if (!entry.enabled || !entry.installed) return createState("disabled", entry, options);
+	if (!entry.installed) return createState("disabled", entry, options);
 
 	const expectedMarketplace = options.expectedMarketplace ?? CK_MARKETPLACE_NAME;
-	if (entry.marketplace && entry.marketplace !== expectedMarketplace) {
+	if (
+		options.expectedMarketplace &&
+		(!entry.marketplace || entry.marketplace !== expectedMarketplace)
+	) {
 		return createState("installed-stale-source", entry, options);
 	}
 	if (
 		options.expectedSource &&
-		entry.source &&
-		!pluginSourceMatches(entry.source, options.expectedSource)
+		(!entry.source || !pluginSourceMatches(entry.source, options.expectedSource))
 	) {
 		return createState("installed-stale-source", entry, options);
 	}
 	if (
 		options.expectedVersion &&
-		entry.version &&
-		!versionsMatch(entry.version, options.expectedVersion)
+		(!entry.version || !versionsMatch(entry.version, options.expectedVersion))
 	) {
 		return createState("installed-stale-version", entry, options);
 	}
+	if (!entry.enabled) return createState("disabled", entry, options);
 
 	return createState("installed-current", entry, options);
 }
@@ -419,66 +433,220 @@ async function detectCodexPluginListState(
 export async function installCodexPlugin(
 	opts: InstallCodexPluginOptions,
 ): Promise<CodexPluginInstallResult> {
+	const preparation = await prepareCodexPlugin(opts);
+	preparation.commit();
+	return preparation.result;
+}
+
+export async function prepareCodexPlugin(
+	opts: InstallCodexPluginOptions,
+): Promise<CodexPluginPreparation> {
 	const installer = opts.installer ?? new CodexPluginInstaller(undefined, opts.codexHome);
 
 	if (!(await installer.isCodexAvailable()) || !(await installer.isPluginSupported())) {
-		return { action: "skipped-codex-unsupported", pluginVerified: false };
+		return inertPreparation({ action: "skipped-codex-unsupported", pluginVerified: false });
 	}
 
 	const added = await addOrReplaceMarketplace(installer, opts.pluginSourceDir);
 	if (!added.ok) {
-		return {
+		return inertPreparation({
 			action: "install-failed",
 			pluginVerified: false,
 			error: added.error,
-		};
+		});
 	}
 
 	const installed = await installer.add();
 	if (!installed.ok) {
-		return {
+		const rollback = added.rollback ? await added.rollback() : null;
+		return inertPreparation({
 			action: "install-failed",
 			pluginVerified: false,
-			error: `codex plugin add failed: ${installed.stderr.trim()}`,
-		};
+			error: appendRollback(`codex plugin add failed: ${installed.stderr.trim()}`, rollback),
+		});
 	}
 
 	const verified = await installer.verifyInstalled();
 	if (!verified) {
-		return {
+		const rollback = added.rollback ? await added.rollback() : null;
+		return inertPreparation({
 			action: "install-failed",
 			pluginVerified: false,
-			error: "codex plugin did not verify after install",
-		};
+			error: appendRollback("codex plugin did not verify after install", rollback),
+		});
 	}
+	return activePreparation(
+		{ action: "installed", pluginVerified: true },
+		added.rollback ?? (async () => "no Codex marketplace change required"),
+	);
+}
 
-	return { action: "installed", pluginVerified: true };
+function inertPreparation(result: CodexPluginInstallResult): CodexPluginPreparation {
+	return {
+		result,
+		commit: () => {},
+		rollback: async () => ({ ok: true, detail: "Codex preparation already settled" }),
+	};
+}
+
+function activePreparation(
+	result: CodexPluginInstallResult,
+	rollbackAction: () => Promise<string>,
+): CodexPluginPreparation {
+	let active = true;
+	return {
+		result,
+		commit: () => {
+			active = false;
+		},
+		rollback: async () => {
+			if (!active) return { ok: true, detail: "Codex preparation already committed" };
+			active = false;
+			const detail = await rollbackAction();
+			return { ok: !/failed/i.test(detail), detail };
+		},
+	};
 }
 
 async function addOrReplaceMarketplace(
 	installer: CodexPluginInstaller,
 	pluginSourceDir: string,
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<{ ok: true; rollback?: () => Promise<string> } | { ok: false; error: string }> {
 	const added = await installer.marketplaceAdd(pluginSourceDir);
-	if (added.ok) return { ok: true };
+	if (added.ok) {
+		return {
+			ok: true,
+			rollback: () => removePreparedMarketplace(installer),
+		};
+	}
 
 	const error = added.stderr.trim();
-	if (!isReplaceableMarketplaceAddFailure(error)) {
+	if (!isMarketplaceAlreadyRegistered(error)) {
 		return { ok: false, error: `codex marketplace add failed: ${error}` };
 	}
 
-	await installer.marketplaceRemove(CK_MARKETPLACE_NAME);
+	const previousState = await detectCodexPluginListState(installer, {
+		expectedSource: join(pluginSourceDir, ".claude"),
+	});
+	const recoveredMarketplaceSource = marketplaceSourceFromAddError(error);
+	if (previousState.status === "unknown" && !recoveredMarketplaceSource) {
+		return {
+			ok: false,
+			error: `codex marketplace refresh skipped: registration is irrecoverably unknown because no safe previous source was reported (${previousState.error ?? error})`,
+		};
+	}
+	if (previousState.installed && previousState.status !== "installed-stale-source") {
+		return {
+			ok: true,
+			rollback: () => reloadMarketplaceAndPlugin(installer, pluginSourceDir),
+		};
+	}
+	const isStaleSource =
+		previousState.status === "installed-stale-source" ||
+		(previousState.status === "unknown" && recoveredMarketplaceSource !== null) ||
+		hasDifferentMarketplaceSource(error);
+	if (!isStaleSource) {
+		return {
+			ok: true,
+			rollback: () => reloadMarketplaceAndPlugin(installer, pluginSourceDir),
+		};
+	}
+
+	const previousMarketplaceSource =
+		marketplaceRootFromPluginSource(previousState.source) ?? recoveredMarketplaceSource;
+	if (!previousMarketplaceSource) {
+		return {
+			ok: false,
+			error: `codex marketplace refresh skipped: previous source could not be determined safely (${error})`,
+		};
+	}
+	const removed = await installer.marketplaceRemove(CK_MARKETPLACE_NAME);
+	if (!removed.ok) {
+		return {
+			ok: false,
+			error: `codex marketplace remove failed: ${removed.stderr.trim() || error}`,
+		};
+	}
 	const readded = await installer.marketplaceAdd(pluginSourceDir);
-	if (readded.ok) return { ok: true };
+	const rollback = async (): Promise<string> => {
+		await installer.marketplaceRemove(CK_MARKETPLACE_NAME);
+		const restored = await installer.marketplaceAdd(previousMarketplaceSource);
+		if (!restored.ok) {
+			return `rollback failed: ${restored.stderr.trim() || "previous marketplace could not be restored"}`;
+		}
+		if (previousState.installed || previousState.status === "unknown") {
+			const pluginRestored = await installer.add();
+			if (!pluginRestored.ok) {
+				return `marketplace restored but plugin rollback failed: ${pluginRestored.stderr.trim()}`;
+			}
+		}
+		return "restored previous marketplace and plugin state";
+	};
+	if (readded.ok) return { ok: true, rollback };
+
+	const rollbackDetail = await rollback();
 
 	return {
 		ok: false,
-		error: `codex marketplace refresh failed: ${readded.stderr.trim() || error}`,
+		error: `codex marketplace refresh failed: ${readded.stderr.trim() || error}; ${rollbackDetail}`,
 	};
 }
 
-function isReplaceableMarketplaceAddFailure(error: string): boolean {
+async function removePreparedMarketplace(installer: CodexPluginInstaller): Promise<string> {
+	const removedPlugin = await installer.remove();
+	const removedMarketplace = await installer.marketplaceRemove(CK_MARKETPLACE_NAME);
+	return removedPlugin.ok && removedMarketplace.ok
+		? "removed newly prepared Codex plugin and marketplace"
+		: `Codex rollback failed: ${removedPlugin.stderr.trim() || removedMarketplace.stderr.trim() || "cleanup did not verify"}`;
+}
+
+async function reloadMarketplaceAndPlugin(
+	installer: CodexPluginInstaller,
+	source: string,
+): Promise<string> {
+	await installer.remove();
+	const removedMarketplace = await installer.marketplaceRemove(CK_MARKETPLACE_NAME);
+	if (!removedMarketplace.ok) {
+		return `Codex rollback failed: ${removedMarketplace.stderr.trim() || "marketplace removal failed"}`;
+	}
+	const restoredMarketplace = await installer.marketplaceAdd(source);
+	if (!restoredMarketplace.ok) {
+		return `Codex rollback failed: ${restoredMarketplace.stderr.trim() || "marketplace restore failed"}`;
+	}
+	const restoredPlugin = await installer.add();
+	return restoredPlugin.ok
+		? "reloaded previous Codex marketplace and plugin state"
+		: `Codex rollback failed: ${restoredPlugin.stderr.trim() || "plugin restore failed"}`;
+}
+
+function isMarketplaceAlreadyRegistered(error: string): boolean {
 	return /\balready\b/i.test(error) && /\bmarketplace\b/i.test(error);
+}
+
+function hasDifferentMarketplaceSource(error: string): boolean {
+	return /\bdifferent\s+source\b/i.test(error);
+}
+
+function marketplaceRootFromPluginSource(source: string | null): string | null {
+	if (!source) return null;
+	const trimmed = source.trim();
+	if (!trimmed || /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return null;
+	const normalized = normalize(trimmed);
+	if (!isAbsolute(normalized)) return null;
+	return basename(normalized) === ".claude" ? dirname(normalized) : normalized;
+}
+
+function marketplaceSourceFromAddError(error: string): string | null {
+	const unixPath = error.match(/(?:from|source(?:\s+is)?)[\s:=]+["']?(\/[^"'\r\n;]+)/i)?.[1];
+	const windowsPath = error.match(
+		/(?:from|source(?:\s+is)?)[\s:=]+["']?([A-Za-z]:[\\/][^"'\r\n;]+)/i,
+	)?.[1];
+	const candidate = (windowsPath ?? unixPath)?.trim().replace(/[),.]+$/, "") ?? null;
+	return marketplaceRootFromPluginSource(candidate);
+}
+
+function appendRollback(error: string, rollback: string | null): string {
+	return rollback ? `${error}; ${rollback}` : error;
 }
 
 export async function removeCodexPlugin(
@@ -486,21 +654,51 @@ export async function removeCodexPlugin(
 ): Promise<RemoveCodexPluginResult> {
 	const installer = opts.installer ?? new CodexPluginInstaller(undefined, opts.codexHome);
 
-	if (!(await installer.isCodexAvailable()) || !(await installer.isPluginSupported())) {
-		return { removed: false, marketplaceRemoved: false };
+	if (!(await installer.isCodexAvailable())) {
+		return {
+			removed: false,
+			marketplaceRemoved: false,
+			verificationStatus: "codex-unavailable",
+			error: "Codex is unavailable; persisted plugin and marketplace absence cannot be verified",
+		};
+	}
+	if (!(await installer.isPluginSupported())) {
+		return {
+			removed: false,
+			marketplaceRemoved: false,
+			verificationStatus: "plugins-unsupported",
+			error:
+				"Codex plugin commands are unsupported; persisted plugin and marketplace absence cannot be verified",
+		};
 	}
 
 	const removed = await installer.remove();
 	const marketplaceRemoved = await installer.marketplaceRemove();
 	const state = await detectCodexPluginListState(installer);
+	const errors: string[] = [];
+	if (!marketplaceRemoved.ok && !isAlreadyAbsentMarketplace(marketplaceRemoved.stderr)) {
+		errors.push(
+			`codex marketplace removal failed: ${marketplaceRemoved.stderr.trim() || "command did not succeed"}`,
+		);
+	}
+	if (state.status === "unknown") {
+		errors.push(
+			`codex plugin absence could not be verified: ${state.error ?? "inspection failed"}`,
+		);
+	} else if (state.installed) {
+		errors.push(`codex plugin still installed after removal (${state.status})`);
+	}
 	return {
 		removed: removed.ok,
 		marketplaceRemoved: marketplaceRemoved.ok,
 		pluginStillInstalled: state.installed,
-		...(state.installed
-			? { error: `codex plugin still installed after removal (${state.status})` }
-			: {}),
+		...(state.status === "unknown" ? { verificationStatus: state.status } : {}),
+		...(errors.length > 0 ? { error: errors.join("; ") } : {}),
 	};
+}
+
+function isAlreadyAbsentMarketplace(error: string): boolean {
+	return /\bnot\s+found\b|\bdoes\s+not\s+exist\b|\bnot\s+registered\b/i.test(error);
 }
 
 export async function shouldRefreshCodexPlugin(

--- a/src/domains/installation/plugin/engineer-provider-cleanup.ts
+++ b/src/domains/installation/plugin/engineer-provider-cleanup.ts
@@ -1,0 +1,118 @@
+import { PathResolver } from "@/shared/path-resolver.js";
+import {
+	type CodexPluginState,
+	detectCodexPluginState,
+	removeCodexPlugin,
+} from "./codex-plugin-installer.js";
+import { detectPluginState } from "./install-mode-detector.js";
+import { type UninstallPluginResult, uninstallEnginePlugin } from "./uninstall-plugin.js";
+
+export interface EngineerProviderCleanupResult {
+	success: boolean;
+	changed: boolean;
+	claude: UninstallPluginResult | null;
+	codex: Awaited<ReturnType<typeof removeCodexPlugin>> | null;
+	errors: string[];
+}
+
+export interface EngineerProviderCleanupDependencies {
+	uninstallClaudePlugin?: () => Promise<UninstallPluginResult>;
+	removeCodexPlugin?: () => Promise<Awaited<ReturnType<typeof removeCodexPlugin>>>;
+	verifyClaudePluginAbsent?: () => boolean;
+	readCodexPluginState?: () => Promise<CodexPluginState>;
+}
+
+function codexAbsenceIsVerifiable(state: CodexPluginState): boolean {
+	return state.status === "missing";
+}
+
+/**
+ * Remove the Engineer plugin from both supported providers.
+ *
+ * Each provider is attempted independently so one failure cannot strand the
+ * other provider. Only ClaudeKit's fixed plugin and marketplace identifiers
+ * are touched by the provider-specific cleanup functions.
+ */
+export async function cleanupEngineerProviderPlugins(
+	deps: EngineerProviderCleanupDependencies = {},
+): Promise<EngineerProviderCleanupResult> {
+	if (
+		process.env.CK_TEST_HOME &&
+		(!deps.uninstallClaudePlugin ||
+			!deps.removeCodexPlugin ||
+			!deps.verifyClaudePluginAbsent ||
+			!deps.readCodexPluginState)
+	) {
+		throw new Error(
+			"Provider cleanup tests must inject Claude and Codex cleanup and verification dependencies",
+		);
+	}
+
+	const uninstallClaude = deps.uninstallClaudePlugin ?? (() => uninstallEnginePlugin());
+	const uninstallCodex = deps.removeCodexPlugin ?? (() => removeCodexPlugin());
+	const verifyClaudeAbsent =
+		deps.verifyClaudePluginAbsent ??
+		(() => {
+			const state = detectPluginState(PathResolver.getGlobalKitDir());
+			return !state.installed && !state.staleCache;
+		});
+	const readCodexState = deps.readCodexPluginState ?? (() => detectCodexPluginState());
+
+	const [claudeAttempt, codexAttempt] = await Promise.allSettled([
+		uninstallClaude(),
+		uninstallCodex(),
+	]);
+	const errors: string[] = [];
+	const claude = claudeAttempt.status === "fulfilled" ? claudeAttempt.value : null;
+	const codex = codexAttempt.status === "fulfilled" ? codexAttempt.value : null;
+
+	if (claudeAttempt.status === "rejected") {
+		errors.push(`Claude plugin cleanup failed: ${String(claudeAttempt.reason)}`);
+	} else if (claudeAttempt.value.error || claudeAttempt.value.pluginStillInstalled) {
+		errors.push(
+			`Claude plugin cleanup failed: ${claudeAttempt.value.error ?? "plugin is still installed"}`,
+		);
+	}
+
+	if (codexAttempt.status === "rejected") {
+		errors.push(`Codex plugin cleanup failed: ${String(codexAttempt.reason)}`);
+	} else if (codexAttempt.value.error || codexAttempt.value.pluginStillInstalled) {
+		errors.push(
+			`Codex plugin cleanup failed: ${codexAttempt.value.error ?? "plugin is still installed"}`,
+		);
+	}
+
+	if (claudeAttempt.status === "fulfilled") {
+		try {
+			if (!verifyClaudeAbsent()) errors.push("Claude plugin cleanup could not verify absence");
+		} catch (error) {
+			errors.push(`Claude plugin cleanup verification failed: ${String(error)}`);
+		}
+	}
+
+	if (codexAttempt.status === "fulfilled") {
+		try {
+			const state = await readCodexState();
+			if (!codexAbsenceIsVerifiable(state)) {
+				errors.push(
+					`Codex plugin cleanup could not verify absence (${state.status}${state.error ? `: ${state.error}` : ""})`,
+				);
+			}
+		} catch (error) {
+			errors.push(`Codex plugin cleanup verification failed: ${String(error)}`);
+		}
+	}
+
+	return {
+		success: errors.length === 0,
+		changed: Boolean(
+			claude?.uninstalled ||
+				claude?.staleCacheRemoved ||
+				codex?.removed ||
+				codex?.marketplaceRemoved,
+		),
+		claude,
+		codex,
+		errors,
+	};
+}

--- a/src/domains/installation/plugin/historical-metadata-files.ts
+++ b/src/domains/installation/plugin/historical-metadata-files.ts
@@ -1,0 +1,55 @@
+export type HistoricalFileOwnership = "ck" | "ck-modified" | "user" | "unknown";
+
+export interface HistoricalTrackedFile {
+	path: string;
+	ownership: HistoricalFileOwnership;
+	checksum?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeOwnership(value: unknown): HistoricalFileOwnership {
+	if (value === "ck" || value === "ck-modified" || value === "user") return value;
+	return "unknown";
+}
+
+/**
+ * Read every historical Engineer file-list shape without inferring destructive
+ * ownership. Old `installedFiles` entries prove that a copied install exists,
+ * but they do not carry enough evidence to authorize deleting user content.
+ */
+export function collectEngineerHistoricalFiles(metadata: unknown): HistoricalTrackedFile[] {
+	if (!isRecord(metadata)) return [];
+
+	const tracked: HistoricalTrackedFile[] = [];
+	const push = (files: unknown) => {
+		if (!Array.isArray(files)) return;
+		for (const file of files) {
+			if (typeof file === "string") {
+				tracked.push({ path: file, ownership: "unknown" });
+				continue;
+			}
+			if (!isRecord(file) || typeof file.path !== "string") continue;
+			tracked.push({
+				path: file.path,
+				ownership: normalizeOwnership(file.ownership),
+				...(typeof file.checksum === "string" ? { checksum: file.checksum } : {}),
+			});
+		}
+	};
+
+	if (isRecord(metadata.kits)) {
+		const engineer = metadata.kits.engineer;
+		if (isRecord(engineer)) {
+			push(engineer.files);
+			push(engineer.installedFiles);
+		}
+		return tracked;
+	}
+
+	push(metadata.files);
+	push(metadata.installedFiles);
+	return tracked;
+}

--- a/src/domains/installation/plugin/install-mode-detector.ts
+++ b/src/domains/installation/plugin/install-mode-detector.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { PathResolver } from "@/shared/path-resolver.js";
 import { compareVersions } from "compare-versions";
+import { collectEngineerHistoricalFiles } from "./historical-metadata-files.js";
 
 /**
  * Install-mode detection for the ClaudeKit Engineer kit.
@@ -253,7 +254,7 @@ export function hasTrackedPluginSuppliedLegacyFiles(
 	const metadata = readJsonSafe(join(claudeDir, "metadata.json"));
 	if (!isRecord(metadata)) return false;
 
-	for (const file of collectTrackedFiles(metadata)) {
+	for (const file of collectEngineerHistoricalFiles(metadata)) {
 		const resolvedPath = resolveSafePluginSuppliedLegacyPath(claudeDir, file.path);
 		if (!resolvedPath || !existsSync(resolvedPath)) continue;
 		if (file.ownership === "user" && !checksumMatches(resolvedPath, file.checksum)) continue;
@@ -261,38 +262,6 @@ export function hasTrackedPluginSuppliedLegacyFiles(
 	}
 
 	return false;
-}
-
-interface TrackedFile {
-	path: string;
-	ownership: "ck" | "ck-modified" | "user";
-	checksum?: string;
-}
-
-function collectTrackedFiles(metadata: Record<string, unknown>): TrackedFile[] {
-	const tracked: TrackedFile[] = [];
-	const push = (files: unknown) => {
-		if (!Array.isArray(files)) return;
-		for (const file of files) {
-			if (!isRecord(file) || typeof file.path !== "string") continue;
-			const ownership =
-				file.ownership === "user" || file.ownership === "ck-modified" ? file.ownership : "ck";
-			tracked.push({
-				path: file.path,
-				ownership,
-				checksum: typeof file.checksum === "string" ? file.checksum : undefined,
-			});
-		}
-	};
-
-	if (isRecord(metadata.kits)) {
-		const engineer = metadata.kits[ENGINEER_KIT_KEY];
-		if (isRecord(engineer)) push(engineer.files);
-	} else {
-		push(metadata.files);
-	}
-
-	return tracked;
 }
 
 function resolveSafePluginSuppliedLegacyPath(claudeDir: string, pathValue: string): string | null {

--- a/src/domains/installation/plugin/migrate-legacy-to-plugin.ts
+++ b/src/domains/installation/plugin/migrate-legacy-to-plugin.ts
@@ -9,6 +9,11 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
+import { detectClaudePluginHealth } from "@/domains/installation/plugin/claude-plugin-health.js";
+import {
+	type HistoricalTrackedFile,
+	collectEngineerHistoricalFiles,
+} from "@/domains/installation/plugin/historical-metadata-files.js";
 import {
 	ENGINEER_KIT_KEY,
 	type InstallMode,
@@ -57,6 +62,8 @@ export interface MigrateOptions {
 	removeLegacy?: LegacyRemover;
 	/** ISO timestamp; injected in tests, runtime passes new Date().toISOString(). */
 	now?: string;
+	/** Failure injection for the final receipt write. */
+	writeReceiptFn?: typeof writeReceipt;
 }
 
 export async function migrateLegacyToPlugin(opts: MigrateOptions): Promise<MigrateResult> {
@@ -66,12 +73,20 @@ export async function migrateLegacyToPlugin(opts: MigrateOptions): Promise<Migra
 	const ts = opts.now ?? new Date().toISOString();
 
 	const before = detectInstallMode(claudeDir);
+	let forceMarketplaceReplacement = false;
 
-	// Already plugin-only (no legacy copy left): nothing to do. "verified" reflects
-	// the detector's enable state, not an unconditional true.
+	// Plugin-only installs still need repair when disabled, stale, or registered
+	// against a previous staged source. Only a fully current install is a no-op.
 	if (before.mode === "plugin") {
-		prunePluginSuppliedLegacyFilesFromMetadata(claudeDir);
-		return base("noop-already-plugin", before.mode, before.plugin.enabled);
+		const health = detectClaudePluginHealth(claudeDir, {
+			expectedVersion: readExpectedPluginVersion(opts.pluginSourceDir),
+			expectedSource: opts.pluginSourceDir,
+		});
+		if (!health.shouldRefresh) {
+			prunePluginSuppliedLegacyFilesFromMetadata(claudeDir);
+			return base("noop-already-plugin", before.mode, true);
+		}
+		forceMarketplaceReplacement = health.status === "installed-stale-source";
 	}
 
 	// Older Claude Code without plugin support: return a precise result so explicit
@@ -83,8 +98,14 @@ export async function migrateLegacyToPlugin(opts: MigrateOptions): Promise<Migra
 	// Non-destructive: register/refresh marketplace + install/update + verify. Surface
 	// command failures early before removing the legacy copy.
 	const prepared = before.plugin.installed
-		? await refreshExistingPlugin(installer, opts.pluginSourceDir, before.plugin.enabled)
-		: await installPlugin(installer, opts.pluginSourceDir);
+		? await refreshExistingPlugin(
+				installer,
+				opts.pluginSourceDir,
+				before.plugin.enabled,
+				claudeDir,
+				forceMarketplaceReplacement,
+			)
+		: await installPlugin(installer, opts.pluginSourceDir, claudeDir);
 	if (!prepared.ok) {
 		return {
 			...base("install-failed", before.mode, false),
@@ -93,33 +114,51 @@ export async function migrateLegacyToPlugin(opts: MigrateOptions): Promise<Migra
 	}
 	const verified = await installer.verifyInstalled();
 	if (!verified) {
-		// Nothing destructive happened yet, so there is nothing to roll back.
+		prepared.rollback?.();
 		return {
 			...base("install-failed", before.mode, false),
 			error: "plugin did not verify after install",
 		};
 	}
 
-	// Destructive step runs ONLY after a verified install.
+	// Destructive file cleanup, metadata pruning, and receipt writing are one local
+	// transaction. Any late filesystem error restores copied files, metadata, the
+	// previous receipt, and the prior Claude registration.
 	let backupDir: string | null = null;
 	let removedPaths: string[] = [];
-	if (before.legacy.installed) {
-		backupDir = join(claudeDir, "backups", `ck-legacy-${ts.replace(/[:.]/g, "-")}`);
-		mkdirSync(backupDir, { recursive: true });
-		removedPaths = removeLegacy(claudeDir, backupDir);
-		prunePluginSuppliedLegacyFilesFromMetadata(claudeDir, removedPaths);
-	}
+	const metadataPath = join(claudeDir, "metadata.json");
+	const receiptFile = join(claudeDir, ".ck-migration-log.json");
+	const metadataSnapshot = snapshotFile(metadataPath);
+	const receiptSnapshot = snapshotFile(receiptFile);
+	let receiptPath: string;
+	try {
+		if (before.legacy.installed) {
+			backupDir = join(claudeDir, "backups", `ck-legacy-${ts.replace(/[:.]/g, "-")}`);
+			mkdirSync(backupDir, { recursive: true });
+			removedPaths = removeLegacy(claudeDir, backupDir);
+			prunePluginSuppliedLegacyFilesFromMetadata(claudeDir, removedPaths);
+		}
 
-	// Record the version that is now installed (post-install), not the pre-install one.
-	const installedVersion = detectPluginState(claudeDir).version;
-	const receiptPath = writeReceipt(claudeDir, {
-		fromMode: before.mode,
-		toMode: "plugin",
-		pluginVersion: installedVersion,
-		backupDir,
-		removedPaths,
-		timestamp: ts,
-	});
+		// Record the version that is now installed (post-install), not the pre-install one.
+		const installedVersion = detectPluginState(claudeDir).version;
+		receiptPath = (opts.writeReceiptFn ?? writeReceipt)(claudeDir, {
+			fromMode: before.mode,
+			toMode: "plugin",
+			pluginVersion: installedVersion,
+			backupDir,
+			removedPaths,
+			timestamp: ts,
+		});
+	} catch (error) {
+		if (backupDir) restoreLegacyBackup(claudeDir, backupDir, removedPaths);
+		restoreFile(metadataPath, metadataSnapshot);
+		restoreFile(receiptFile, receiptSnapshot);
+		prepared.rollback?.();
+		return {
+			...base("install-failed", before.mode, false),
+			error: `plugin migration transaction failed: ${(error as Error).message}`,
+		};
+	}
 
 	return {
 		action: before.legacy.installed ? "migrated-from-legacy" : "installed-fresh",
@@ -129,6 +168,11 @@ export async function migrateLegacyToPlugin(opts: MigrateOptions): Promise<Migra
 		removedPaths,
 		receiptPath,
 	};
+}
+
+function readExpectedPluginVersion(pluginSourceDir: string): string | null {
+	const manifest = readJsonSafe(join(pluginSourceDir, ".claude", ".claude-plugin", "plugin.json"));
+	return isRecord(manifest) && typeof manifest.version === "string" ? manifest.version : null;
 }
 
 function base(
@@ -156,7 +200,7 @@ const LEGACY_SENTINEL_FILENAMES = new Set([".gitignore"]);
  */
 export function defaultLegacyRemover(claudeDir: string, backupDir: string): string[] {
 	const meta = readJsonSafe(join(claudeDir, "metadata.json"));
-	const files = collectTrackedFiles(meta);
+	const files = collectEngineerHistoricalFiles(meta);
 	const removed: string[] = [];
 	for (const file of files) {
 		const legacyPath = resolveSafePluginSuppliedLegacyPath(claudeDir, file.path);
@@ -174,10 +218,24 @@ export function defaultLegacyRemover(claudeDir: string, backupDir: string): stri
 function backupAndRemove(backupDir: string, relativePath: string, abs: string): boolean {
 	const backupTarget = resolveSafeChildPath(backupDir, relativePath);
 	if (!backupTarget) return false;
-	mkdirSync(dirname(backupTarget), { recursive: true });
-	cpSync(abs, backupTarget, { recursive: true });
-	rmSync(abs, { recursive: true, force: true });
-	return true;
+	try {
+		mkdirSync(dirname(backupTarget), { recursive: true });
+		cpSync(abs, backupTarget, { recursive: true });
+		rmSync(abs, { recursive: true, force: true });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function restoreLegacyBackup(claudeDir: string, backupDir: string, removedPaths: string[]): void {
+	for (const pathValue of removedPaths) {
+		const source = resolveSafeChildPath(backupDir, pathValue);
+		const target = resolveSafeChildPath(claudeDir, pathValue);
+		if (!source || !target || !existsSync(source)) continue;
+		mkdirSync(dirname(target), { recursive: true });
+		cpSync(source, target, { recursive: true });
+	}
 }
 
 function removeOrphanLegacySentinels(
@@ -266,10 +324,9 @@ function directoryContainsOnlySentinels(dir: string): boolean {
 	return true;
 }
 
-function isSafeToRemovePluginSuppliedLegacyFile(file: TrackedFile, abs: string): boolean {
-	if (file.ownership !== "user") {
-		return true;
-	}
+function isSafeToRemovePluginSuppliedLegacyFile(file: HistoricalTrackedFile, abs: string): boolean {
+	if (file.ownership === "ck") return true;
+	if (file.ownership !== "user") return false;
 
 	// Offline/local kit installs can lack release-manifest.json, so files are
 	// tracked as user-owned even though the installer just copied them. Remove
@@ -341,42 +398,6 @@ function compareLegacyPaths(a: string, b: string): number {
 	return 0;
 }
 
-interface TrackedFile {
-	path: string;
-	ownership: "ck" | "ck-modified" | "user";
-	checksum?: string;
-}
-
-function collectTrackedFiles(meta: unknown): TrackedFile[] {
-	if (!isRecord(meta)) return [];
-	const out: TrackedFile[] = [];
-	const push = (arr: unknown) => {
-		if (!Array.isArray(arr)) return;
-		for (const f of arr) {
-			if (isRecord(f) && typeof f.path === "string") {
-				const ownership =
-					f.ownership === "user" || f.ownership === "ck-modified" ? f.ownership : "ck";
-				out.push({
-					path: f.path,
-					ownership,
-					checksum: typeof f.checksum === "string" ? f.checksum : undefined,
-				});
-			}
-		}
-	};
-	// Engineer-scoped ONLY: this migration must never touch other kits' files.
-	if (isRecord(meta.kits)) {
-		// Multi-kit format: only the engineer kit's tracked files.
-		const engineer = (meta.kits as Record<string, unknown>)[ENGINEER_KIT_KEY];
-		if (isRecord(engineer)) push(engineer.files);
-	} else {
-		// Legacy single-kit format (no kits{}): root files belong to the only installed
-		// kit, and migration is gated to the engineer kit by the caller.
-		push(meta.files);
-	}
-	return out;
-}
-
 function prunePluginSuppliedLegacyFilesFromMetadata(
 	claudeDir: string,
 	removedPaths?: string[],
@@ -393,6 +414,13 @@ function prunePluginSuppliedLegacyFilesFromMetadata(
 	const pruneFiles = (files: unknown): unknown => {
 		if (!Array.isArray(files)) return files;
 		const pruned = files.filter((file) => {
+			if (typeof file === "string") {
+				const normalizedPath = normalizeComparableLegacyPath(file);
+				return !(
+					isPluginSuppliedLegacyPath(normalizedPath) &&
+					resolveSafePluginSuppliedLegacyPath(claudeDir, normalizedPath) !== null
+				);
+			}
 			if (!isRecord(file) || typeof file.path !== "string") return true;
 			const normalizedPath = normalizeComparableLegacyPath(file.path);
 			const resolvedPath = resolveSafePluginSuppliedLegacyPath(claudeDir, normalizedPath);
@@ -410,6 +438,7 @@ function prunePluginSuppliedLegacyFilesFromMetadata(
 		const engineer = (meta.kits as Record<string, unknown>)[ENGINEER_KIT_KEY];
 		if (isRecord(engineer)) {
 			engineer.files = pruneFiles(engineer.files);
+			engineer.installedFiles = pruneFiles(engineer.installedFiles);
 		}
 	} else {
 		meta.files = pruneFiles(meta.files);
@@ -454,54 +483,145 @@ function readJsonSafe(filePath: string): unknown {
 	}
 }
 
+function snapshotFile(filePath: string): Buffer | null {
+	return existsSync(filePath) ? readFileSync(filePath) : null;
+}
+
+function restoreFile(filePath: string, content: Buffer | null): void {
+	if (content === null) {
+		rmSync(filePath, { force: true });
+		return;
+	}
+	mkdirSync(dirname(filePath), { recursive: true });
+	writeFileSync(filePath, content);
+}
+
 interface PluginPrepareResult {
 	ok: boolean;
 	error?: string;
+	rollback?: () => void;
 }
 
 async function installPlugin(
 	installer: PluginInstaller,
 	pluginSourceDir: string,
+	claudeDir: string,
 ): Promise<PluginPrepareResult> {
-	const added = await installer.marketplaceAdd(pluginSourceDir);
-	if (!added.ok) {
-		return { ok: false, error: `marketplace add failed: ${added.stderr.trim()}` };
-	}
+	const marketplace = await prepareClaudeMarketplace(installer, pluginSourceDir, claudeDir);
+	if (!marketplace.ok) return marketplace;
 	const installed = await installer.install("user");
 	if (!installed.ok) {
+		marketplace.rollback?.();
 		return { ok: false, error: `plugin install failed: ${installed.stderr.trim()}` };
 	}
-	return { ok: true };
+	return { ok: true, rollback: marketplace.rollback };
 }
 
 async function refreshExistingPlugin(
 	installer: PluginInstaller,
 	pluginSourceDir: string,
 	enabled: boolean,
+	claudeDir: string,
+	forceMarketplaceReplacement = false,
 ): Promise<PluginPrepareResult> {
-	const added = await installer.marketplaceAdd(pluginSourceDir);
-	if (!added.ok) {
-		const updatedMarketplace = await installer.marketplaceUpdate();
-		if (!updatedMarketplace.ok) {
-			return {
-				ok: false,
-				error: `marketplace refresh failed: ${updatedMarketplace.stderr.trim() || added.stderr.trim()}`,
-			};
-		}
-	}
+	const marketplace = await prepareClaudeMarketplace(
+		installer,
+		pluginSourceDir,
+		claudeDir,
+		forceMarketplaceReplacement,
+	);
+	if (!marketplace.ok) return marketplace;
 
 	if (!enabled) {
 		const enabledResult = await installer.enable();
 		if (!enabledResult.ok) {
+			marketplace.rollback?.();
 			return { ok: false, error: `plugin enable failed: ${enabledResult.stderr.trim()}` };
 		}
 	}
 
 	const updated = await installer.update();
 	if (!updated.ok) {
+		marketplace.rollback?.();
 		return { ok: false, error: `plugin update failed: ${updated.stderr.trim()}` };
 	}
-	return { ok: true };
+	return { ok: true, rollback: marketplace.rollback };
+}
+
+interface ClaudeRegistrationSnapshot {
+	files: Array<{ path: string; content: Buffer | null }>;
+}
+
+async function prepareClaudeMarketplace(
+	installer: PluginInstaller,
+	pluginSourceDir: string,
+	claudeDir: string,
+	forceReplacement = false,
+): Promise<PluginPrepareResult> {
+	const snapshot = snapshotClaudeRegistration(claudeDir);
+	const rollback = () => restoreClaudeRegistration(snapshot);
+	if (forceReplacement) {
+		const removed = await installer.marketplaceRemove();
+		if (!removed.ok) {
+			rollback();
+			return {
+				ok: false,
+				error: `marketplace replacement failed: ${removed.stderr.trim()}`,
+			};
+		}
+		const replaced = await installer.marketplaceAdd(pluginSourceDir);
+		if (replaced.ok) return { ok: true, rollback };
+		rollback();
+		return {
+			ok: false,
+			error: `marketplace replacement failed: ${replaced.stderr.trim()}; restored previous registration`,
+		};
+	}
+	const added = await installer.marketplaceAdd(pluginSourceDir);
+	if (added.ok) return { ok: true, rollback };
+
+	const updated = await installer.marketplaceUpdate();
+	if (updated.ok) return { ok: true, rollback };
+
+	const removed = await installer.marketplaceRemove();
+	if (!removed.ok) {
+		rollback();
+		return {
+			ok: false,
+			error: `marketplace replacement failed: ${removed.stderr.trim() || updated.stderr.trim() || added.stderr.trim()}`,
+		};
+	}
+	const replaced = await installer.marketplaceAdd(pluginSourceDir);
+	if (replaced.ok) return { ok: true, rollback };
+
+	rollback();
+	return {
+		ok: false,
+		error: `marketplace replacement failed: ${replaced.stderr.trim() || updated.stderr.trim() || added.stderr.trim()}; restored previous registration`,
+	};
+}
+
+function snapshotClaudeRegistration(claudeDir: string): ClaudeRegistrationSnapshot {
+	return {
+		files: [
+			join(claudeDir, "plugins", "known_marketplaces.json"),
+			join(claudeDir, "settings.json"),
+		].map((path) => ({
+			path,
+			content: existsSync(path) ? readFileSync(path) : null,
+		})),
+	};
+}
+
+function restoreClaudeRegistration(snapshot: ClaudeRegistrationSnapshot): void {
+	for (const file of snapshot.files) {
+		if (file.content === null) {
+			rmSync(file.path, { force: true });
+			continue;
+		}
+		mkdirSync(dirname(file.path), { recursive: true });
+		writeFileSync(file.path, file.content);
+	}
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/services/transformers/engineer-legacy-skill-name-projector.ts
+++ b/src/services/transformers/engineer-legacy-skill-name-projector.ts
@@ -1,0 +1,164 @@
+import type { Dirent } from "node:fs";
+import { lstat, readFile, readdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const SKILL_NAME_PREFIX = "ck:";
+const SAFE_SKILL_NAME = /^[a-zA-Z0-9][a-zA-Z0-9._:-]*$/;
+const FRONTMATTER = /^(\uFEFF?---[ \t]*\r?\n)([\s\S]*?)(\r?\n---[ \t]*(?:\r?\n|$))/;
+const NAME_LINE = /^([ \t]*name[ \t]*:[ \t]*)(.*)$/gm;
+
+export interface EngineerLegacySkillProjectionResult {
+	skillsScanned: number;
+	skillsProjected: number;
+}
+
+export interface EngineerSkillProjectionContext {
+	kitType?: string;
+	installMode: string;
+}
+
+interface Projection {
+	content: string;
+	name?: string;
+	changed: boolean;
+}
+
+function projectNameValue(
+	rawValue: string,
+): { value: string; name: string; changed: boolean } | null {
+	const valueMatch = rawValue.match(
+		/^([ \t]*)(?:(["'])([a-zA-Z0-9][a-zA-Z0-9._:-]*)\2|([a-zA-Z0-9][a-zA-Z0-9._:-]*))([ \t]*(?:#.*)?)$/,
+	);
+	if (!valueMatch) return null;
+
+	const [, leadingWhitespace, quote = "", quotedName, plainName, suffix] = valueMatch;
+	const name = quotedName ?? plainName;
+	if (!name || !SAFE_SKILL_NAME.test(name)) return null;
+
+	const projectedName = name.startsWith(SKILL_NAME_PREFIX) ? name : `${SKILL_NAME_PREFIX}${name}`;
+
+	return {
+		value: `${leadingWhitespace}${quote}${projectedName}${quote}${suffix}`,
+		name: projectedName,
+		changed: projectedName !== name,
+	};
+}
+
+/**
+ * Project a canonical Engineer skill name onto a Normal-install destination copy.
+ *
+ * The replacement is intentionally surgical: only a single scalar `name:` field
+ * in valid leading YAML frontmatter is changed. All other bytes remain intact.
+ */
+export function projectEngineerLegacySkillContent(content: string): Projection {
+	const frontmatterMatch = content.match(FRONTMATTER);
+	if (!frontmatterMatch) return { content, changed: false };
+
+	const frontmatterBody = frontmatterMatch[2];
+	const nameLines = [...frontmatterBody.matchAll(NAME_LINE)];
+	if (nameLines.length !== 1) return { content, changed: false };
+
+	const nameLine = nameLines[0];
+	const projected = projectNameValue(nameLine[2]);
+	if (!projected) return { content, changed: false };
+
+	const lineStart = nameLine.index ?? 0;
+	const valueStart = lineStart + nameLine[1].length;
+	const projectedFrontmatter =
+		frontmatterBody.slice(0, valueStart) +
+		projected.value +
+		frontmatterBody.slice(valueStart + nameLine[2].length);
+
+	return {
+		content:
+			frontmatterMatch[1] +
+			projectedFrontmatter +
+			frontmatterMatch[3] +
+			content.slice(frontmatterMatch[0].length),
+		name: projected.name,
+		changed: projected.changed,
+	};
+}
+
+/**
+ * Rewrite only the temporary Engineer payload used by legacy/Normal installs.
+ * Symlinked skill directories and files are skipped to keep traversal bounded.
+ */
+async function projectEngineerLegacySkillNames(
+	extractDir: string,
+): Promise<EngineerLegacySkillProjectionResult> {
+	const skillsDir = join(extractDir, ".claude", "skills");
+	let skillFiles: string[];
+	try {
+		skillFiles = await collectSkillFiles(skillsDir);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			return { skillsScanned: 0, skillsProjected: 0 };
+		}
+		throw error;
+	}
+
+	const projections: Array<{ filePath: string; projection: Projection }> = [];
+	const projectedNames = new Map<string, string>();
+	let skillsScanned = 0;
+
+	for (const filePath of skillFiles) {
+		let fileStats;
+		try {
+			fileStats = await lstat(filePath);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+			throw error;
+		}
+		if (!fileStats.isFile() || fileStats.isSymbolicLink()) continue;
+
+		skillsScanned += 1;
+		const projection = projectEngineerLegacySkillContent(await readFile(filePath, "utf8"));
+		if (projection.name) {
+			const previousPath = projectedNames.get(projection.name);
+			if (previousPath) {
+				throw new Error(
+					`Engineer skill name collision after Normal-install projection: ${projection.name} (${previousPath}, ${filePath})`,
+				);
+			}
+			projectedNames.set(projection.name, filePath);
+		}
+		if (projection.changed) projections.push({ filePath, projection });
+	}
+
+	for (const { filePath, projection } of projections) {
+		await writeFile(filePath, projection.content, "utf8");
+	}
+
+	return { skillsScanned, skillsProjected: projections.length };
+}
+
+async function collectSkillFiles(directory: string): Promise<string[]> {
+	const entries: Dirent<string>[] = await readdir(directory, { withFileTypes: true });
+	const skillFiles: string[] = [];
+	for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+		if (entry.isSymbolicLink()) continue;
+		const entryPath = join(directory, entry.name);
+		if (entry.isDirectory()) {
+			skillFiles.push(...(await collectSkillFiles(entryPath)));
+		} else if (entry.isFile() && entry.name === "SKILL.md") {
+			skillFiles.push(entryPath);
+		}
+	}
+	return skillFiles;
+}
+
+/**
+ * Apply the compatibility projection only for Engineer Normal installations.
+ * Plugin staging and other kits return before reading or writing the payload.
+ */
+export async function projectEngineerSkillNamesForInstall(
+	extractDir: string,
+	context: EngineerSkillProjectionContext,
+): Promise<EngineerLegacySkillProjectionResult> {
+	if (context.kitType !== "engineer" || context.installMode === "plugin") {
+		return { skillsScanned: 0, skillsProjected: 0 };
+	}
+
+	return projectEngineerLegacySkillNames(extractDir);
+}

--- a/tests/commands/uninstall.test.ts
+++ b/tests/commands/uninstall.test.ts
@@ -8,6 +8,14 @@ import { logger } from "@/shared/logger.js";
 import type { Metadata } from "@/types";
 import { type TestPaths, setupTestPaths } from "../helpers/test-paths.js";
 
+const isolatedProviderCleanup = async () => ({
+	success: true,
+	changed: false,
+	claude: null,
+	codex: null,
+	errors: [],
+});
+
 describe("uninstall command integration", () => {
 	let testPaths: TestPaths;
 	let testProjectDir: string;
@@ -1257,16 +1265,19 @@ describe("uninstall command integration", () => {
 
 			// This will only work if the global path is properly detected
 			// For now, we test the local flag worked
-			await uninstallCommand({
-				yes: true,
-				json: false,
-				verbose: false,
-				local: false,
-				global: true,
-				all: false,
-				dryRun: false,
-				forceOverwrite: false,
-			});
+			await uninstallCommand(
+				{
+					yes: true,
+					json: false,
+					verbose: false,
+					local: false,
+					global: true,
+					all: false,
+					dryRun: false,
+					forceOverwrite: false,
+				},
+				{ cleanupEngineerProviderPlugins: isolatedProviderCleanup },
+			);
 
 			// Verify local was NOT removed
 			expect(existsSync(join(testLocalClaudeDir, "commands", "test.md"))).toBe(true);
@@ -1291,16 +1302,19 @@ describe("uninstall command integration", () => {
 
 			const { uninstallCommand } = await import("../../src/commands/uninstall/index.js");
 
-			await uninstallCommand({
-				yes: true,
-				json: false,
-				verbose: false,
-				local: true,
-				global: true,
-				all: false,
-				dryRun: false,
-				forceOverwrite: false,
-			});
+			await uninstallCommand(
+				{
+					yes: true,
+					json: false,
+					verbose: false,
+					local: true,
+					global: true,
+					all: false,
+					dryRun: false,
+					forceOverwrite: false,
+				},
+				{ cleanupEngineerProviderPlugins: isolatedProviderCleanup },
+			);
 
 			// Verify local was removed
 			expect(existsSync(join(testLocalClaudeDir, "commands", "test.md"))).toBe(false);
@@ -1326,16 +1340,19 @@ describe("uninstall command integration", () => {
 			const { uninstallCommand } = await import("../../src/commands/uninstall/index.js");
 
 			// Using --all flag (equivalent to --local --global)
-			await uninstallCommand({
-				yes: true,
-				json: false,
-				verbose: false,
-				local: false,
-				global: false,
-				all: true,
-				dryRun: false,
-				forceOverwrite: false,
-			});
+			await uninstallCommand(
+				{
+					yes: true,
+					json: false,
+					verbose: false,
+					local: false,
+					global: false,
+					all: true,
+					dryRun: false,
+					forceOverwrite: false,
+				},
+				{ cleanupEngineerProviderPlugins: isolatedProviderCleanup },
+			);
 
 			// Verify local was removed
 			expect(existsSync(join(testLocalClaudeDir, "commands", "test.md"))).toBe(false);

--- a/tests/integration/helpers/fake-plugin-providers.ts
+++ b/tests/integration/helpers/fake-plugin-providers.ts
@@ -1,0 +1,237 @@
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+export interface FakeProviderState {
+	marketplaceSource: string | null;
+	installed: boolean;
+	enabled: boolean;
+	version: string | null;
+	failPluginAddOnce?: boolean;
+}
+
+export interface FakePluginProviderHarness {
+	root: string;
+	claudeDir: string;
+	codexHome: string;
+	extractDir: string;
+	stageDir: string;
+	userFile: string;
+	readClaudeState(): FakeProviderState;
+	readCodexState(): FakeProviderState;
+	writeClaudeState(state: Partial<FakeProviderState>): void;
+	writeCodexState(state: Partial<FakeProviderState>): void;
+	cleanup(): void;
+}
+
+const ENV_KEYS = [
+	"HOME",
+	"USERPROFILE",
+	"CK_TEST_HOME",
+	"CLAUDE_CONFIG_DIR",
+	"CODEX_HOME",
+	"APPDATA",
+	"LOCALAPPDATA",
+	"XDG_CACHE_HOME",
+	"PATH",
+] as const;
+
+const FAKE_CLAUDE = String.raw`#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const config = process.env.CLAUDE_CONFIG_DIR;
+const statePath = path.join(config, "fake-claude-provider.json");
+const args = process.argv.slice(2);
+const read = (file, fallback) => { try { return JSON.parse(fs.readFileSync(file, "utf8")); } catch { return fallback; } };
+const state = read(statePath, { marketplaceSource: null, installed: false, enabled: false, version: null });
+const save = () => { fs.mkdirSync(config, { recursive: true }); fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n"); };
+const settingsPath = path.join(config, "settings.json");
+const syncSettings = () => {
+  const settings = read(settingsPath, {}); settings.enabledPlugins = settings.enabledPlugins || {};
+  if (state.installed) settings.enabledPlugins["ck@claudekit"] = state.enabled;
+  else delete settings.enabledPlugins["ck@claudekit"];
+  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
+};
+const syncMarketplace = () => {
+  const file = path.join(config, "plugins", "known_marketplaces.json"); fs.mkdirSync(path.dirname(file), { recursive: true });
+  const known = read(file, {}); if (state.marketplaceSource) known.claudekit = { installLocation: state.marketplaceSource }; else delete known.claudekit;
+  fs.writeFileSync(file, JSON.stringify(known, null, 2) + "\n");
+};
+const currentVersion = () => { try { return JSON.parse(fs.readFileSync(path.join(state.marketplaceSource, ".claude", ".claude-plugin", "plugin.json"), "utf8")).version; } catch { return "0.0.0"; } };
+const cache = () => { if (state.version) fs.mkdirSync(path.join(config, "plugins", "cache", "claudekit", "ck", state.version), { recursive: true }); };
+const ok = (text = "") => { if (text) process.stdout.write(text + "\n"); save(); process.exit(0); };
+const fail = (text) => { save(); process.stderr.write(text + "\n"); process.exit(1); };
+if (args[0] === "--version") ok("2.1.0");
+if (args[0] === "plugin" && args[1] === "--help") ok("plugin marketplace install update uninstall");
+if (args[1] === "marketplace" && args[2] === "add") {
+  const source = args[3]; if (state.marketplaceSource && state.marketplaceSource !== source) fail("marketplace already registered from different source");
+  state.marketplaceSource = source; syncMarketplace(); ok();
+}
+if (args[1] === "marketplace" && args[2] === "update") fail("marketplace source cannot update in place");
+if (args[1] === "marketplace" && args[2] === "remove") { state.marketplaceSource = null; syncMarketplace(); ok(); }
+if (args[1] === "install") { state.installed = true; state.enabled = true; state.version = currentVersion(); syncSettings(); cache(); ok(); }
+if (args[1] === "enable") { state.installed = true; state.enabled = true; syncSettings(); ok(); }
+if (args[1] === "update") { state.installed = true; state.version = currentVersion(); syncSettings(); cache(); ok(); }
+if (args[1] === "uninstall") { state.installed = false; state.enabled = false; syncSettings(); ok(); }
+if (args[1] === "list") ok(state.installed ? "ck@claudekit\n  " + (state.enabled ? "enabled" : "disabled") + "\n" : "No plugins installed");
+fail("unsupported fake claude command: " + args.join(" "));
+`;
+
+const FAKE_CODEX = String.raw`#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const home = process.env.CODEX_HOME;
+const statePath = path.join(home, "fake-codex-provider.json");
+const args = process.argv.slice(2);
+const read = (file, fallback) => { try { return JSON.parse(fs.readFileSync(file, "utf8")); } catch { return fallback; } };
+const state = read(statePath, { marketplaceSource: null, installed: false, enabled: false, version: null });
+const save = () => { fs.mkdirSync(home, { recursive: true }); fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n"); };
+const currentVersion = () => { try { return JSON.parse(fs.readFileSync(path.join(state.marketplaceSource, ".claude", ".codex-plugin", "plugin.json"), "utf8")).version; } catch { return "0.0.0"; } };
+const entry = () => ({ pluginId: "ck@claudekit", installed: state.installed, enabled: state.enabled, version: state.version, marketplace: "claudekit", source: state.marketplaceSource ? path.join(state.marketplaceSource, ".claude") : null });
+const ok = (text = "") => { if (text) process.stdout.write(text + "\n"); save(); process.exit(0); };
+const fail = (text) => { save(); process.stderr.write(text + "\n"); process.exit(1); };
+if (args[0] === "--version") ok("codex 1.0.0");
+if (args[0] === "plugin" && args[1] === "--help") ok("plugin marketplace add remove list");
+if (args[1] === "marketplace" && args[2] === "add") {
+  const source = args[3]; if (state.marketplaceSource && state.marketplaceSource !== source) fail("marketplace already registered from different source");
+  state.marketplaceSource = source; ok();
+}
+if (args[1] === "marketplace" && args[2] === "remove") { if (!state.marketplaceSource) fail("marketplace not found"); state.marketplaceSource = null; ok(); }
+if (args[1] === "add") {
+  if (state.failPluginAddOnce) { state.failPluginAddOnce = false; fail("injected plugin add failure"); }
+  state.installed = true; state.enabled = true; state.version = currentVersion(); ok();
+}
+if (args[1] === "remove") { if (!state.installed) fail("plugin not found"); state.installed = false; state.enabled = false; ok(); }
+if (args[1] === "list" && args[2] === "--json") ok(JSON.stringify(state.installed ? [entry()] : []));
+if (args[1] === "list") ok(state.installed ? "ck@claudekit installed " + (state.enabled ? "enabled " : "disabled ") + (state.version || "") : "No plugins installed");
+fail("unsupported fake codex command: " + args.join(" "));
+`;
+
+function readState(path: string): FakeProviderState {
+	return JSON.parse(readFileSync(path, "utf8")) as FakeProviderState;
+}
+
+function mergeState(path: string, patch: Partial<FakeProviderState>): FakeProviderState {
+	let current: FakeProviderState = {
+		marketplaceSource: null,
+		installed: false,
+		enabled: false,
+		version: null,
+	};
+	try {
+		current = readState(path);
+	} catch {}
+	const next = { ...current, ...patch };
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+	return next;
+}
+
+function syncClaudeFilesystem(claudeDir: string, state: FakeProviderState): void {
+	const settingsPath = join(claudeDir, "settings.json");
+	let settings: Record<string, unknown> = {};
+	try {
+		settings = JSON.parse(readFileSync(settingsPath, "utf8")) as Record<string, unknown>;
+	} catch {}
+	const enabledPlugins =
+		typeof settings.enabledPlugins === "object" && settings.enabledPlugins !== null
+			? (settings.enabledPlugins as Record<string, boolean>)
+			: {};
+	const otherPlugins = Object.fromEntries(
+		Object.entries(enabledPlugins).filter(([name]) => name !== "ck@claudekit"),
+	);
+	settings.enabledPlugins = state.installed
+		? { ...otherPlugins, "ck@claudekit": state.enabled }
+		: otherPlugins;
+	writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf8");
+
+	const marketplacePath = join(claudeDir, "plugins", "known_marketplaces.json");
+	mkdirSync(dirname(marketplacePath), { recursive: true });
+	const marketplaces: Record<string, unknown> = {};
+	if (state.marketplaceSource) {
+		marketplaces.claudekit = { installLocation: state.marketplaceSource };
+	}
+	writeFileSync(marketplacePath, `${JSON.stringify(marketplaces, null, 2)}\n`, "utf8");
+
+	if (state.version) {
+		mkdirSync(join(claudeDir, "plugins", "cache", "claudekit", "ck", state.version), {
+			recursive: true,
+		});
+	}
+}
+
+export function createFakePluginProviderHarness(): FakePluginProviderHarness {
+	const root = mkdtempSync(join(tmpdir(), "ck-plugin-lifecycle-"));
+	const claudeDir = join(root, ".claude");
+	const codexHome = join(root, ".codex");
+	const extractDir = join(root, "extract");
+	const stageDir = join(root, ".cache", "claude", "ck-plugin-source");
+	const binDir = join(root, "bin");
+	const userFile = join(claudeDir, "skills", "personal", "SKILL.md");
+	const previousEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+	for (const directory of [claudeDir, codexHome, binDir, join(extractDir, ".claude")]) {
+		mkdirSync(directory, { recursive: true });
+	}
+	for (const key of ["HOME", "USERPROFILE", "CK_TEST_HOME"] as const) process.env[key] = root;
+	process.env.CLAUDE_CONFIG_DIR = claudeDir;
+	process.env.CODEX_HOME = codexHome;
+	process.env.APPDATA = join(root, "AppData", "Roaming");
+	process.env.LOCALAPPDATA = join(root, "AppData", "Local");
+	process.env.XDG_CACHE_HOME = join(root, ".cache");
+	process.env.PATH = `${binDir}:${previousEnv.PATH ?? ""}`;
+
+	writeFileSync(join(binDir, "claude"), FAKE_CLAUDE, "utf8");
+	writeFileSync(join(binDir, "codex"), FAKE_CODEX, "utf8");
+	chmodSync(join(binDir, "claude"), 0o755);
+	chmodSync(join(binDir, "codex"), 0o755);
+
+	mkdirSync(join(extractDir, ".claude", ".claude-plugin"), { recursive: true });
+	writeFileSync(
+		join(extractDir, ".claude", ".claude-plugin", "plugin.json"),
+		`${JSON.stringify({ name: "ck", version: "2.20.1" })}\n`,
+		"utf8",
+	);
+	mkdirSync(join(extractDir, ".claude", ".codex-plugin"), { recursive: true });
+	writeFileSync(
+		join(extractDir, ".claude", ".codex-plugin", "plugin.json"),
+		`${JSON.stringify({ name: "ck", version: "2.20.1" })}\n`,
+		"utf8",
+	);
+	mkdirSync(join(extractDir, ".claude", "skills", "cook"), { recursive: true });
+	writeFileSync(
+		join(extractDir, ".claude", "skills", "cook", "SKILL.md"),
+		"---\nname: cook\n---\nBody\n",
+		"utf8",
+	);
+	mkdirSync(dirname(userFile), { recursive: true });
+	writeFileSync(userFile, "user-owned content\n", "utf8");
+
+	const claudeStatePath = join(claudeDir, "fake-claude-provider.json");
+	const codexStatePath = join(codexHome, "fake-codex-provider.json");
+
+	return {
+		root,
+		claudeDir,
+		codexHome,
+		extractDir,
+		stageDir,
+		userFile,
+		readClaudeState: () => readState(claudeStatePath),
+		readCodexState: () => readState(codexStatePath),
+		writeClaudeState: (state) => {
+			syncClaudeFilesystem(claudeDir, mergeState(claudeStatePath, state));
+		},
+		writeCodexState: (state) => {
+			mergeState(codexStatePath, state);
+		},
+		cleanup: () => {
+			for (const key of ENV_KEYS) {
+				const previous = previousEnv[key];
+				if (previous === undefined) delete process.env[key];
+				else process.env[key] = previous;
+			}
+			rmSync(root, { recursive: true, force: true });
+		},
+	};
+}

--- a/tests/integration/plugin-install-e2e.test.ts
+++ b/tests/integration/plugin-install-e2e.test.ts
@@ -1,15 +1,39 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { stagePluginSource } from "@/commands/init/phases/plugin-install-handler.js";
+import { dirname, join } from "node:path";
+import {
+	handlePluginInstall,
+	replacePluginSourceAtomically,
+	stagePluginSource,
+} from "@/commands/init/phases/plugin-install-handler.js";
+import type { InitContext } from "@/commands/init/types.js";
+import { uninstallCommand } from "@/commands/uninstall/uninstall-command.js";
+import { promptKitUpdate } from "@/commands/update/post-update-handler.js";
+import { PluginInstallModeChecker } from "@/domains/health-checks/plugin-install-mode-checker.js";
 import {
 	CodexPluginInstaller,
+	detectCodexPluginState,
 	installCodexPlugin,
+	removeCodexPlugin,
 } from "@/domains/installation/plugin/codex-plugin-installer.js";
+import { cleanupEngineerProviderPlugins } from "@/domains/installation/plugin/engineer-provider-cleanup.js";
 import { detectInstallMode } from "@/domains/installation/plugin/install-mode-detector.js";
 import { migrateLegacyToPlugin } from "@/domains/installation/plugin/migrate-legacy-to-plugin.js";
+import { uninstallEnginePlugin } from "@/domains/installation/plugin/uninstall-plugin.js";
+import {
+	type FakePluginProviderHarness,
+	createFakePluginProviderHarness,
+} from "./helpers/fake-plugin-providers.js";
 
 /**
  * Real end-to-end migration check (#693). Exercises the actual install path:
@@ -47,6 +71,300 @@ function commandWorks(command: string, args: string[], match?: RegExp): boolean 
 		return false;
 	}
 }
+
+describe("plugin lifecycle e2e (isolated fake providers)", () => {
+	let harness: FakePluginProviderHarness;
+
+	beforeEach(() => {
+		harness = createFakePluginProviderHarness();
+		writeMetadata([], "legacy");
+	});
+
+	afterEach(() => {
+		harness.cleanup();
+	});
+
+	function writeMetadata(
+		files: Array<{ path: string; ownership?: "ck" | "user" }> = [],
+		installModePreference: "legacy" | "plugin" = "plugin",
+	): void {
+		writeFileSync(
+			join(harness.claudeDir, "metadata.json"),
+			`${JSON.stringify(
+				{
+					kits: {
+						engineer: {
+							version: "2.20.1",
+							installedAt: "2026-07-11T12:00:00.000Z",
+							installModePreference,
+							files: files.map((file) => ({
+								...file,
+								checksum: "0".repeat(64),
+								installedVersion: "2.20.1",
+							})),
+						},
+					},
+				},
+				null,
+				2,
+			)}\n`,
+			"utf8",
+		);
+	}
+
+	function context(installMode: "plugin" | "legacy"): InitContext {
+		return {
+			kitType: "engineer",
+			extractDir: harness.extractDir,
+			claudeDir: harness.claudeDir,
+			options: { global: true, installMode },
+		} as unknown as InitContext;
+	}
+
+	async function explicitPluginOptIn(): Promise<void> {
+		await handlePluginInstall(context("plugin"), { stageBaseDir: harness.stageDir });
+	}
+
+	test("fresh explicit opt-in reaches current provider state and healthy doctor output", async () => {
+		await explicitPluginOptIn();
+
+		const claude = detectInstallMode(harness.claudeDir);
+		expect(claude.mode).toBe("plugin");
+		expect(claude.plugin).toMatchObject({ enabled: true, version: "2.20.1" });
+		const codex = await detectCodexPluginState(undefined, {
+			expectedVersion: "2.20.1",
+			expectedSource: join(harness.stageDir, ".claude"),
+		});
+		expect(codex.status).toBe("installed-current");
+		expect(harness.readClaudeState().marketplaceSource).toBe(harness.stageDir);
+		expect(harness.readCodexState().marketplaceSource).toBe(harness.stageDir);
+
+		const doctor = await new PluginInstallModeChecker(harness.claudeDir).run();
+		expect(doctor[0]).toMatchObject({ status: "pass" });
+		expect(doctor[0].message).toContain("Codex plugin: installed-current");
+		expect(readFileSync(harness.userFile, "utf8")).toBe("user-owned content\n");
+	});
+
+	test("same-version unhealthy update routes through promptKitUpdate and repairs both providers", async () => {
+		await explicitPluginOptIn();
+		rmSync(join(harness.claudeDir, "plugins", "cache", "claudekit", "ck"), {
+			recursive: true,
+			force: true,
+		});
+		harness.writeClaudeState({ installed: true, enabled: false, version: "1.0.0" });
+		harness.writeCodexState({
+			marketplaceSource: harness.stageDir,
+			installed: true,
+			enabled: false,
+			version: "1.0.0",
+		});
+		let spawnCalls = 0;
+
+		await promptKitUpdate(false, true, {
+			getSetupFn: async () => ({
+				global: {
+					path: harness.claudeDir,
+					metadata: { kits: { engineer: { version: "2.20.1" } } },
+					components: {
+						commands: 0,
+						hooks: 0,
+						skills: 0,
+						workflows: 0,
+						settings: 0,
+					},
+				},
+				project: {
+					path: "",
+					metadata: null,
+					components: {
+						commands: 0,
+						hooks: 0,
+						skills: 0,
+						workflows: 0,
+						settings: 0,
+					},
+				},
+			}),
+			spawnInitFn: async (args) => {
+				spawnCalls += 1;
+				expect(args).toContain("--install-mode");
+				expect(args).toContain("plugin");
+				await handlePluginInstall(context("plugin"), { stageBaseDir: harness.stageDir });
+				return 0;
+			},
+			loadFullConfigFn: async () => ({ config: { updatePipeline: {} } }),
+		});
+
+		expect(spawnCalls).toBe(1);
+		expect(detectInstallMode(harness.claudeDir).plugin).toMatchObject({
+			enabled: true,
+			version: "2.20.1",
+		});
+		expect(
+			(
+				await detectCodexPluginState(undefined, {
+					expectedVersion: "2.20.1",
+					expectedSource: join(harness.stageDir, ".claude"),
+				})
+			).status,
+		).toBe("installed-current");
+	});
+
+	test("mixed, disabled, stale, and wrong-source providers converge without user data loss", async () => {
+		await explicitPluginOptIn();
+		const legacyFile = join(harness.claudeDir, "skills", "legacy-ck", "SKILL.md");
+		mkdirSync(dirname(legacyFile), { recursive: true });
+		writeFileSync(legacyFile, "CK-owned legacy content\n", "utf8");
+		writeMetadata(
+			[
+				{ path: "skills/legacy-ck/SKILL.md", ownership: "ck" },
+				{ path: "skills/personal/SKILL.md", ownership: "user" },
+			],
+			"plugin",
+		);
+		rmSync(join(harness.claudeDir, "plugins", "cache", "claudekit", "ck"), {
+			recursive: true,
+			force: true,
+		});
+		harness.writeClaudeState({
+			marketplaceSource: join(harness.root, "old-claude-source"),
+			installed: true,
+			enabled: false,
+			version: "1.0.0",
+		});
+		harness.writeCodexState({
+			marketplaceSource: join(harness.root, "old-codex-source"),
+			installed: true,
+			enabled: true,
+			version: "1.0.0",
+		});
+		expect(detectInstallMode(harness.claudeDir).mode).toBe("mixed");
+		expect(
+			(
+				await detectCodexPluginState(undefined, {
+					expectedSource: join(harness.stageDir, ".claude"),
+				})
+			).status,
+		).toBe("installed-stale-source");
+
+		const codexRepair = await installCodexPlugin({ pluginSourceDir: harness.stageDir });
+		expect(codexRepair).toEqual({ action: "installed", pluginVerified: true });
+		expect(harness.readCodexState()).toMatchObject({
+			marketplaceSource: harness.stageDir,
+			enabled: true,
+			version: "2.20.1",
+		});
+		const claudeRepair = await migrateLegacyToPlugin({
+			pluginSourceDir: harness.stageDir,
+			claudeDir: harness.claudeDir,
+			now: "2026-07-11T12:00:00.000Z",
+		});
+		expect(claudeRepair.action).toBe("migrated-from-legacy");
+		expect(claudeRepair.pluginVerified).toBe(true);
+		expect(existsSync(legacyFile)).toBe(false);
+		expect(readFileSync(harness.userFile, "utf8")).toBe("user-owned content\n");
+		expect(harness.readClaudeState()).toMatchObject({
+			marketplaceSource: harness.stageDir,
+			enabled: true,
+			version: "2.20.1",
+		});
+		expect(harness.readCodexState()).toMatchObject({
+			marketplaceSource: harness.stageDir,
+			enabled: true,
+			version: "2.20.1",
+		});
+		expect((await new PluginInstallModeChecker(harness.claudeDir).run())[0].status).toBe("pass");
+	});
+
+	test("global uninstall command removes both providers and repeated command remains a no-op", async () => {
+		await explicitPluginOptIn();
+		writeMetadata([{ path: "skills/personal/SKILL.md", ownership: "user" }], "plugin");
+		const cleanupResults: Array<Awaited<ReturnType<typeof cleanupEngineerProviderPlugins>>> = [];
+		const cleanupProviders = async () => {
+			const result = await cleanupEngineerProviderPlugins({
+				uninstallClaudePlugin: () => uninstallEnginePlugin({ claudeDir: harness.claudeDir }),
+				removeCodexPlugin: () => removeCodexPlugin({ codexHome: harness.codexHome }),
+				verifyClaudePluginAbsent: () => !detectInstallMode(harness.claudeDir).plugin.installed,
+				readCodexPluginState: () => detectCodexPluginState(),
+			});
+			cleanupResults.push(result);
+			return result;
+		};
+		const options = {
+			yes: true,
+			json: false,
+			verbose: false,
+			local: false,
+			global: true,
+			all: false,
+			dryRun: false,
+			forceOverwrite: false,
+			kit: "engineer" as const,
+		};
+
+		await uninstallCommand(options, { cleanupEngineerProviderPlugins: cleanupProviders });
+
+		expect(detectInstallMode(harness.claudeDir).plugin.installed).toBe(false);
+		expect((await detectCodexPluginState()).status).toBe("missing");
+		expect(readFileSync(harness.userFile, "utf8")).toBe("user-owned content\n");
+
+		await uninstallCommand(options, { cleanupEngineerProviderPlugins: cleanupProviders });
+		expect(detectInstallMode(harness.claudeDir).plugin.installed).toBe(false);
+		expect((await detectCodexPluginState()).status).toBe("missing");
+		expect(cleanupResults.map((result) => result.changed)).toEqual([true, false]);
+	});
+
+	test("staging and provider failures restore the previous stable source and registration", async () => {
+		await explicitPluginOptIn();
+		const claudeBefore = harness.readClaudeState();
+		const stableMarker = join(harness.stageDir, "stable-marker.txt");
+		writeFileSync(stableMarker, "stable\n", "utf8");
+		let renameCount = 0;
+
+		expect(() =>
+			replacePluginSourceAtomically(join(harness.extractDir, ".claude"), harness.stageDir, {
+				transactionId: "injected-failure",
+				renameDirectory: (source, target) => {
+					renameCount += 1;
+					if (renameCount === 2) throw new Error("injected activation failure");
+					renameSync(source, target);
+				},
+			}),
+		).toThrow("injected activation failure");
+		expect(readFileSync(stableMarker, "utf8")).toBe("stable\n");
+
+		const oldSource = join(harness.root, "old-codex-source");
+		mkdirSync(join(oldSource, ".claude", ".codex-plugin"), { recursive: true });
+		writeFileSync(
+			join(oldSource, ".claude", ".codex-plugin", "plugin.json"),
+			`${JSON.stringify({ name: "ck", version: "1.0.0" })}\n`,
+			"utf8",
+		);
+		harness.writeCodexState({
+			marketplaceSource: oldSource,
+			installed: true,
+			enabled: true,
+			version: "1.0.0",
+			failPluginAddOnce: true,
+		});
+
+		const failed = await installCodexPlugin({ pluginSourceDir: harness.stageDir });
+		expect(failed.action).toBe("install-failed");
+		expect(failed.error).toContain("restored previous marketplace and plugin state");
+		expect(harness.readCodexState()).toMatchObject({
+			marketplaceSource: oldSource,
+			installed: true,
+			enabled: true,
+			version: "1.0.0",
+		});
+		expect(harness.readClaudeState()).toEqual(claudeBefore);
+		expect(detectInstallMode(harness.claudeDir).plugin).toMatchObject({
+			enabled: true,
+			version: "2.20.1",
+		});
+		expect(readFileSync(harness.userFile, "utf8")).toBe("user-owned content\n");
+	});
+});
 
 describeOrSkip("plugin install e2e (real claude binary, sandboxed)", () => {
 	let sandbox: string; // CLAUDE_CONFIG_DIR


### PR DESCRIPTION
## Summary
- preserve Normal install as the default while honoring explicit persisted plugin opt-in
- make Claude and Codex plugin install, repair, migration, doctor, and uninstall flows transactional and retry-safe
- project Engineer skill names for Normal installs without changing plugin payload namespaces
- isolate provider tests and add full lifecycle coverage for fresh install, update, repair, uninstall, rollback, and idempotency

## Validation
- `bun run ci:local` (5,269 passed, 65 optional skips, 0 failed)
- UI Vitest: 153 passed
- real Claude/Codex provider canaries in sandbox: 7 passed; host plugin state unchanged
- final Stage 2 code review: no blockers

## Docs impact
Major. CLI contract docs updated here; corresponding public documentation PR follows.

Closes #913
Closes #914
Closes #915
Closes #916
Closes #917
Closes #918
Closes #919
Closes #920