### PR TITLE
fix: close plugin lifecycle audit gaps

### DIFF
--- a/src/domains/installation/plugin/__tests__/engineer-provider-cleanup.test.ts
+++ b/src/domains/installation/plugin/__tests__/engineer-provider-cleanup.test.ts
@@ -77,6 +77,25 @@ describe("cleanupEngineerProviderPlugins", () => {
 		]);
 	});
 
+	test("counts Claude marketplace-only cleanup as a provider change", async () => {
+		const result = await cleanupEngineerProviderPlugins({
+			uninstallClaudePlugin: async () => ({
+				...claudeAbsent,
+				marketplaceRemoved: true,
+				marketplaceStillRegistered: false,
+			}),
+			removeCodexPlugin: async () => ({
+				removed: false,
+				marketplaceRemoved: false,
+				pluginStillInstalled: false,
+			}),
+			verifyClaudePluginAbsent: () => true,
+			readCodexPluginState: async () => codexState("missing"),
+		});
+
+		expect(result).toMatchObject({ success: true, changed: true, errors: [] });
+	});
+
 	test("is idempotent when both providers are already absent", async () => {
 		const deps = {
 			uninstallClaudePlugin: async () => claudeAbsent,

--- a/src/domains/installation/plugin/__tests__/historical-metadata-files.test.ts
+++ b/src/domains/installation/plugin/__tests__/historical-metadata-files.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { collectEngineerHistoricalFiles } from "@/domains/installation/plugin/historical-metadata-files.js";
+
+describe("collectEngineerHistoricalFiles", () => {
+	test("uses only nested Engineer records when multiple kits exist", () => {
+		const result = collectEngineerHistoricalFiles({
+			files: [
+				{ path: "skills/root-only/SKILL.md", ownership: "ck" },
+				{ path: "skills/shared/SKILL.md", ownership: "user" },
+			],
+			installedFiles: ["agents/root-agent.md", "skills/shared/SKILL.md"],
+			kits: {
+				engineer: {
+					files: [
+						{ path: "skills/shared/SKILL.md", ownership: "ck" },
+						{ path: "skills/nested-only/SKILL.md", ownership: "ck-modified" },
+					],
+					installedFiles: ["agents/nested-agent.md", "agents/root-agent.md"],
+				},
+				marketing: {
+					files: [{ path: "skills/marketing/SKILL.md", ownership: "ck" }],
+					installedFiles: ["agents/marketing.md"],
+				},
+			},
+		});
+
+		expect(result).toEqual([
+			{ path: "skills/shared/SKILL.md", ownership: "ck" },
+			{ path: "skills/nested-only/SKILL.md", ownership: "ck-modified" },
+			{ path: "agents/nested-agent.md", ownership: "unknown" },
+			{ path: "agents/root-agent.md", ownership: "unknown" },
+		]);
+	});
+
+	test("merges transitional root records only when Engineer is the sole kit", () => {
+		const result = collectEngineerHistoricalFiles({
+			files: [
+				{ path: "skills/root-only/SKILL.md", ownership: "ck" },
+				{ path: "skills/shared/SKILL.md", ownership: "user" },
+			],
+			installedFiles: ["agents/root-agent.md"],
+			kits: {
+				engineer: {
+					files: [{ path: "skills/shared/SKILL.md", ownership: "ck" }],
+				},
+			},
+		});
+
+		expect(result).toEqual([
+			{ path: "skills/shared/SKILL.md", ownership: "ck" },
+			{ path: "skills/root-only/SKILL.md", ownership: "ck" },
+			{ path: "agents/root-agent.md", ownership: "unknown" },
+		]);
+	});
+
+	test("does not attribute transitional root records to Engineer when only another kit exists", () => {
+		const result = collectEngineerHistoricalFiles({
+			files: [{ path: "skills/marketing/SKILL.md", ownership: "ck" }],
+			installedFiles: ["agents/marketing.md"],
+			kits: {
+				marketing: {
+					files: [{ path: "skills/marketing/SKILL.md", ownership: "ck" }],
+				},
+			},
+		});
+
+		expect(result).toEqual([]);
+	});
+});

--- a/src/domains/installation/plugin/__tests__/install-mode-detector.test.ts
+++ b/src/domains/installation/plugin/__tests__/install-mode-detector.test.ts
@@ -214,6 +214,35 @@ describe("install-mode-detector", () => {
 		expect(detectInstallMode(claudeDir).mode).toBe("fresh");
 	});
 
+	test("plugin: ck from an unrelated marketplace is not ClaudeKit-owned state", async () => {
+		await writeSettings({ "ck@community": true });
+		await makePluginCache("community", "9.9.9");
+
+		expect(detectPluginState(claudeDir)).toEqual({
+			installed: false,
+			enabled: false,
+			version: null,
+			marketplace: null,
+			staleCache: false,
+		});
+		expect(detectInstallMode(claudeDir).mode).toBe("fresh");
+		expect(resolveInstalledPluginCacheRoot(claudeDir)).toBeNull();
+	});
+
+	test("plugin: unrelated ck cache does not mask the official ClaudeKit cache", async () => {
+		await writeSettings({ "ck@community": true, "ck@claudekit": true });
+		await makePluginCache("community", "9.9.9");
+		await makePluginCache("claudekit", "2.20.1");
+
+		expect(detectPluginState(claudeDir)).toEqual({
+			installed: true,
+			enabled: true,
+			version: "2.20.1",
+			marketplace: "claudekit",
+			staleCache: false,
+		});
+	});
+
 	test("mixed: legacy payload AND plugin registration present", async () => {
 		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
 		await writeFile(join(claudeDir, "skills", "cook", "SKILL.md"), "# cook\n", "utf-8");

--- a/src/domains/installation/plugin/__tests__/migrate-legacy-to-plugin.test.ts
+++ b/src/domains/installation/plugin/__tests__/migrate-legacy-to-plugin.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { existsSync, readFileSync, rmSync, symlinkSync } from "node:fs";
+import { mkdir, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { detectInstallMode } from "@/domains/installation/plugin/install-mode-detector.js";
@@ -396,10 +396,265 @@ describe("migrateLegacyToPlugin (orchestration)", () => {
 		expect(existsSync(join(claudeDir, ".ck-migration-log.json"))).toBe(false);
 	});
 
-	test("deprecated string installedFiles converge without deleting their payload", async () => {
+	test("rejects a preexisting symlinked backup root before removing legacy files", async () => {
 		const legacyFile = join(claudeDir, "skills", "cook", "SKILL.md");
+		const outsideBackup = join(
+			tmpdir(),
+			`ck-outside-backup-${Date.now()}-${Math.round(performance.now())}`,
+		);
 		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
+		await mkdir(outsideBackup, { recursive: true });
+		await writeFile(legacyFile, "legacy skill", "utf-8");
+		await writeMetadata({
+			kits: {
+				engineer: {
+					version: "2.19.0",
+					files: [{ path: "skills/cook/SKILL.md", ownership: "ck" }],
+				},
+			},
+		});
+		await symlink(outsideBackup, join(claudeDir, "backups"), "dir");
+		const { installer } = fakeInstaller();
+
+		const result = await migrateLegacyToPlugin({
+			pluginSourceDir: "/staged/kit",
+			claudeDir,
+			installer,
+			now: TS,
+		});
+
+		expect(result.action).toBe("install-failed");
+		expect(result.error).toContain("unsafe backup directory");
+		expect(readFileSync(legacyFile, "utf-8")).toBe("legacy skill");
+		expect(await readdir(outsideBackup)).toEqual([]);
+		await rm(outsideBackup, { recursive: true, force: true });
+	});
+
+	test("reports incomplete rollback when a receipt failure introduces a target symlink", async () => {
+		const legacyFile = join(claudeDir, "skills", "cook", "SKILL.md");
+		const outsideFile = join(
+			tmpdir(),
+			`ck-rollback-outside-${Date.now()}-${Math.round(performance.now())}.md`,
+		);
+		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
+		await writeFile(legacyFile, "legacy skill", "utf-8");
+		await writeFile(outsideFile, "outside stays", "utf-8");
+		await writeMetadata({
+			kits: {
+				engineer: {
+					version: "2.19.0",
+					files: [{ path: "skills/cook/SKILL.md", ownership: "ck" }],
+				},
+			},
+		});
+		const { installer } = fakeInstaller();
+
+		const result = await migrateLegacyToPlugin({
+			pluginSourceDir: "/staged/kit",
+			claudeDir,
+			installer,
+			now: TS,
+			writeReceiptFn: () => {
+				symlinkSync(outsideFile, legacyFile);
+				throw new Error("disk full");
+			},
+		});
+
+		expect(result.action).toBe("install-failed");
+		expect(result.error).toContain("rollback incomplete");
+		expect(result.error).toContain("skills/cook/SKILL.md");
+		expect(result.backupDir).not.toBeNull();
+		expect(existsSync(join(result.backupDir as string, "skills", "cook", "SKILL.md"))).toBe(true);
+		expect(readFileSync(outsideFile, "utf-8")).toBe("outside stays");
+		await rm(outsideFile, { force: true });
+	});
+
+	test("never restores metadata through a symlink introduced during receipt failure", async () => {
+		const legacyFile = join(claudeDir, "skills", "cook", "SKILL.md");
+		const metadataPath = join(claudeDir, "metadata.json");
+		const outsideFile = join(
+			tmpdir(),
+			`ck-metadata-restore-outside-${Date.now()}-${Math.round(performance.now())}.json`,
+		);
+		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
+		await writeFile(legacyFile, "legacy skill", "utf-8");
+		await writeFile(outsideFile, "outside metadata stays", "utf-8");
+		await writeMetadata({
+			kits: {
+				engineer: {
+					version: "2.19.0",
+					files: [{ path: "skills/cook/SKILL.md", ownership: "ck" }],
+				},
+			},
+		});
+		const { installer } = fakeInstaller();
+
+		const result = await migrateLegacyToPlugin({
+			pluginSourceDir: "/staged/kit",
+			claudeDir,
+			installer,
+			now: TS,
+			writeReceiptFn: () => {
+				rmSync(metadataPath, { force: true });
+				symlinkSync(outsideFile, metadataPath);
+				throw new Error("disk full");
+			},
+		});
+
+		expect(result.error).toContain("rollback incomplete");
+		expect(result.error).toContain("metadata.json: unsafe restore target");
+		expect(readFileSync(outsideFile, "utf-8")).toBe("outside metadata stays");
+		expect(result.backupDir).not.toBeNull();
+		await rm(outsideFile, { force: true });
+	});
+
+	test("never restores a receipt snapshot through a replacement symlink", async () => {
+		const legacyFile = join(claudeDir, "skills", "cook", "SKILL.md");
+		const receiptPath = join(claudeDir, ".ck-migration-log.json");
+		const outsideFile = join(
+			tmpdir(),
+			`ck-receipt-restore-outside-${Date.now()}-${Math.round(performance.now())}.json`,
+		);
+		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
+		await writeFile(legacyFile, "legacy skill", "utf-8");
+		await writeFile(receiptPath, '[{"prior":true}]\n', "utf-8");
+		await writeFile(outsideFile, "outside receipt stays", "utf-8");
+		await writeMetadata({
+			kits: {
+				engineer: {
+					version: "2.19.0",
+					files: [{ path: "skills/cook/SKILL.md", ownership: "ck" }],
+				},
+			},
+		});
+		const { installer } = fakeInstaller();
+
+		const result = await migrateLegacyToPlugin({
+			pluginSourceDir: "/staged/kit",
+			claudeDir,
+			installer,
+			now: TS,
+			writeReceiptFn: () => {
+				rmSync(receiptPath, { force: true });
+				symlinkSync(outsideFile, receiptPath);
+				throw new Error("disk full");
+			},
+		});
+
+		expect(result.error).toContain("rollback incomplete");
+		expect(result.error).toContain(".ck-migration-log.json: unsafe restore target");
+		expect(readFileSync(outsideFile, "utf-8")).toBe("outside receipt stays");
+		await rm(outsideFile, { force: true });
+	});
+
+	test("never restores Claude provider settings through a replacement symlink", async () => {
+		const legacyFile = join(claudeDir, "skills", "cook", "SKILL.md");
+		const settingsPath = join(claudeDir, "settings.json");
+		const outsideFile = join(
+			tmpdir(),
+			`ck-settings-restore-outside-${Date.now()}-${Math.round(performance.now())}.json`,
+		);
+		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
+		await writeFile(legacyFile, "legacy skill", "utf-8");
+		await writeFile(settingsPath, JSON.stringify({ enabledPlugins: {} }), "utf-8");
+		await writeFile(outsideFile, "outside settings stay", "utf-8");
+		await writeMetadata({
+			kits: {
+				engineer: {
+					version: "2.19.0",
+					files: [{ path: "skills/cook/SKILL.md", ownership: "ck" }],
+				},
+			},
+		});
+		const { installer } = fakeInstaller();
+
+		const result = await migrateLegacyToPlugin({
+			pluginSourceDir: "/staged/kit",
+			claudeDir,
+			installer,
+			now: TS,
+			writeReceiptFn: () => {
+				rmSync(settingsPath, { force: true });
+				symlinkSync(outsideFile, settingsPath);
+				throw new Error("disk full");
+			},
+		});
+
+		expect(result.error).toContain("rollback incomplete");
+		expect(result.error).toContain("settings.json: unsafe restore target");
+		expect(readFileSync(outsideFile, "utf-8")).toBe("outside settings stay");
+		await rm(outsideFile, { force: true });
+	});
+
+	test("same-version deprecated installedFiles converge when bytes match staged plugin payload", async () => {
+		const legacyFile = join(claudeDir, "skills", "cook", "SKILL.md");
+		const legacyAgent = join(claudeDir, "agents", "planner.md");
+		const pluginSourceDir = join(claudeDir, "staged-source");
+		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
+		await mkdir(join(claudeDir, "agents"), { recursive: true });
+		await mkdir(join(pluginSourceDir, ".claude", "skills", "cook"), { recursive: true });
+		await mkdir(join(pluginSourceDir, ".claude", "agents"), { recursive: true });
+		await mkdir(join(pluginSourceDir, ".claude", ".claude-plugin"), { recursive: true });
 		await writeFile(legacyFile, "historical content", "utf-8");
+		await writeFile(legacyAgent, "historical agent", "utf-8");
+		await writeFile(
+			join(pluginSourceDir, ".claude", "skills", "cook", "SKILL.md"),
+			"historical content",
+			"utf-8",
+		);
+		await writeFile(
+			join(pluginSourceDir, ".claude", "agents", "planner.md"),
+			"historical agent",
+			"utf-8",
+		);
+		await writeFile(
+			join(pluginSourceDir, ".claude", ".claude-plugin", "plugin.json"),
+			JSON.stringify({ name: "ck", version: "2.18.0" }),
+			"utf-8",
+		);
+		await writeMetadata({
+			name: "engineer",
+			version: "2.18.0",
+			installedFiles: ["skills/cook/SKILL.md", "agents/planner.md"],
+		});
+		const { installer } = fakeInstaller();
+
+		const result = await migrateLegacyToPlugin({
+			pluginSourceDir,
+			claudeDir,
+			installer,
+			now: TS,
+		});
+
+		expect(result.action).toBe("migrated-from-legacy");
+		expect(result.removedPaths).toEqual(["skills/cook/SKILL.md", "agents/planner.md"]);
+		expect(existsSync(legacyFile)).toBe(false);
+		expect(existsSync(legacyAgent)).toBe(false);
+		expect(
+			readFileSync(join(result.backupDir as string, "skills", "cook", "SKILL.md"), "utf-8"),
+		).toBe("historical content");
+		expect(readFileSync(join(result.backupDir as string, "agents", "planner.md"), "utf-8")).toBe(
+			"historical agent",
+		);
+		const metadata = JSON.parse(readFileSync(join(claudeDir, "metadata.json"), "utf-8"));
+		expect(metadata.installedFiles).toEqual([]);
+		await writeSettings({ "ck@claudekit": true });
+		await writeMarketplace(pluginSourceDir);
+		expect(detectInstallMode(claudeDir).mode).toBe("plugin");
+		expect(detectInstallMode(claudeDir).legacy.installed).toBe(false);
+	});
+
+	test("mismatched deprecated installedFiles content stays mixed and actionable", async () => {
+		const legacyFile = join(claudeDir, "skills", "cook", "SKILL.md");
+		const pluginSourceDir = join(claudeDir, "staged-source");
+		await mkdir(join(claudeDir, "skills", "cook"), { recursive: true });
+		await mkdir(join(pluginSourceDir, ".claude", "skills", "cook"), { recursive: true });
+		await writeFile(legacyFile, "user edited content", "utf-8");
+		await writeFile(
+			join(pluginSourceDir, ".claude", "skills", "cook", "SKILL.md"),
+			"staged plugin content",
+			"utf-8",
+		);
 		await writeMetadata({
 			name: "engineer",
 			version: "2.18.0",
@@ -408,20 +663,113 @@ describe("migrateLegacyToPlugin (orchestration)", () => {
 		const { installer } = fakeInstaller();
 
 		const result = await migrateLegacyToPlugin({
-			pluginSourceDir: "/src",
+			pluginSourceDir,
 			claudeDir,
 			installer,
 			now: TS,
 		});
 
 		expect(result.action).toBe("migrated-from-legacy");
-		expect(existsSync(legacyFile)).toBe(true);
+		expect(result.removedPaths).toEqual([]);
+		expect(readFileSync(legacyFile, "utf-8")).toBe("user edited content");
 		const metadata = JSON.parse(readFileSync(join(claudeDir, "metadata.json"), "utf-8"));
-		expect(metadata.installedFiles).toEqual([]);
+		expect(metadata.installedFiles).toEqual(["skills/cook/SKILL.md"]);
 		await writeSettings({ "ck@claudekit": true });
-		await writeMarketplace();
-		expect(detectInstallMode(claudeDir).mode).toBe("plugin");
-		expect(detectInstallMode(claudeDir).legacy.installed).toBe(false);
+		await writeMarketplace(pluginSourceDir);
+		expect(detectInstallMode(claudeDir).mode).toBe("mixed");
+		expect(detectInstallMode(claudeDir).legacy.installed).toBe(true);
+	});
+
+	test("multi-kit migration prunes nested Engineer records without touching ambiguous root records", async () => {
+		const liveNested = join(claudeDir, "skills", "live-nested", "SKILL.md");
+		const liveRoot = join(claudeDir, "agents", "live-root.md");
+		await mkdir(join(claudeDir, "skills", "live-nested"), { recursive: true });
+		await mkdir(join(claudeDir, "agents"), { recursive: true });
+		await writeFile(liveNested, "live nested", "utf-8");
+		await writeFile(liveRoot, "live root", "utf-8");
+		await writeMetadata({
+			files: [
+				{ path: "agents/live-root.md", ownership: "ck" },
+				{ path: "agents/removed-root.md", ownership: "ck" },
+			],
+			installedFiles: ["agents/live-root.md", "agents/removed-root.md"],
+			kits: {
+				engineer: {
+					files: [
+						{ path: "skills/live-nested/SKILL.md", ownership: "ck" },
+						{ path: "skills/removed-nested/SKILL.md", ownership: "ck" },
+					],
+					installedFiles: ["skills/live-nested/SKILL.md", "skills/removed-nested/SKILL.md"],
+				},
+				marketing: {
+					files: [{ path: "skills/marketing/SKILL.md", ownership: "ck" }],
+				},
+			},
+		});
+		const { installer } = fakeInstaller();
+
+		const result = await migrateLegacyToPlugin({
+			pluginSourceDir: "/src",
+			claudeDir,
+			installer,
+			removeLegacy: () => ["skills/removed-nested/SKILL.md"],
+			now: TS,
+		});
+
+		expect(result.action).toBe("migrated-from-legacy");
+		const metadata = JSON.parse(readFileSync(join(claudeDir, "metadata.json"), "utf-8"));
+		expect(metadata.kits.engineer.files).toEqual([
+			{ path: "skills/live-nested/SKILL.md", ownership: "ck" },
+		]);
+		expect(metadata.kits.engineer.installedFiles).toEqual(["skills/live-nested/SKILL.md"]);
+		expect(metadata.files).toEqual([
+			{ path: "agents/live-root.md", ownership: "ck" },
+			{ path: "agents/removed-root.md", ownership: "ck" },
+		]);
+		expect(metadata.installedFiles).toEqual(["agents/live-root.md", "agents/removed-root.md"]);
+		expect(metadata.kits.marketing.files).toEqual([
+			{ path: "skills/marketing/SKILL.md", ownership: "ck" },
+		]);
+		expect(readFileSync(liveNested, "utf-8")).toBe("live nested");
+		expect(readFileSync(liveRoot, "utf-8")).toBe("live root");
+	});
+
+	test("sole-Engineer migration prunes both nested and transitional root records", async () => {
+		await mkdir(join(claudeDir, "skills", "live"), { recursive: true });
+		await mkdir(join(claudeDir, "agents"), { recursive: true });
+		await writeFile(join(claudeDir, "skills", "live", "SKILL.md"), "live", "utf-8");
+		await writeFile(join(claudeDir, "agents", "live.md"), "live", "utf-8");
+		await writeMetadata({
+			files: [
+				{ path: "agents/live.md", ownership: "ck" },
+				{ path: "agents/removed.md", ownership: "ck" },
+			],
+			installedFiles: ["agents/live.md", "agents/removed.md"],
+			kits: {
+				engineer: {
+					files: [
+						{ path: "skills/live/SKILL.md", ownership: "ck" },
+						{ path: "skills/removed/SKILL.md", ownership: "ck" },
+					],
+				},
+			},
+		});
+		const { installer } = fakeInstaller();
+
+		await migrateLegacyToPlugin({
+			pluginSourceDir: "/src",
+			claudeDir,
+			installer,
+			removeLegacy: () => ["skills/removed/SKILL.md", "agents/removed.md"],
+			now: TS,
+		});
+
+		const metadata = JSON.parse(readFileSync(join(claudeDir, "metadata.json"), "utf-8"));
+		expect(metadata.kits.engineer.files).toEqual([
+			{ path: "skills/live/SKILL.md", ownership: "ck" },
+		]);
+		expect(metadata.files).toEqual([{ path: "agents/live.md", ownership: "ck" }]);
+		expect(metadata.installedFiles).toEqual(["agents/live.md"]);
 	});
 
 	test("mixed already-installed plugin refreshes plugin and still cleans legacy skills", async () => {
@@ -521,7 +869,91 @@ describe("defaultLegacyRemover", () => {
 		expect(existsSync(join(backupDir, "agents", "planner.md"))).toBe(true); // backed up
 	});
 
-	test("legacy root installedFiles are evidence only and never deletion authority", async () => {
+	for (const ownership of ["ck", "user", "unknown"] as const) {
+		test(`preserves ${ownership}-owned files reached through a symlink component`, async () => {
+			const outsideDir = join(
+				tmpdir(),
+				`ck-rm-outside-${ownership}-${Date.now()}-${Math.round(performance.now())}`,
+			);
+			extraCleanupPaths.push(outsideDir);
+			await mkdir(outsideDir, { recursive: true });
+			await writeFile(join(outsideDir, "SKILL.md"), "outside content", "utf-8");
+			await symlink(outsideDir, join(claudeDir, "skills", "linked"), "dir");
+			const tracked = {
+				path: "skills/linked/SKILL.md",
+				ownership,
+				...(ownership === "user" ? { checksum: sha256("outside content") } : {}),
+			};
+			await writeFile(
+				join(claudeDir, "metadata.json"),
+				JSON.stringify({ kits: { engineer: { files: [tracked] } } }),
+				"utf-8",
+			);
+			const pluginSourceDir = join(claudeDir, "staged-source");
+			if (ownership === "unknown") {
+				await mkdir(join(pluginSourceDir, ".claude", "skills", "linked"), { recursive: true });
+				await writeFile(
+					join(pluginSourceDir, ".claude", "skills", "linked", "SKILL.md"),
+					"outside content",
+					"utf-8",
+				);
+			}
+
+			const removed = defaultLegacyRemover(claudeDir, backupDir, pluginSourceDir);
+
+			expect(removed).toEqual([]);
+			expect(readFileSync(join(outsideDir, "SKILL.md"), "utf-8")).toBe("outside content");
+			expect(existsSync(join(backupDir, "skills", "linked", "SKILL.md"))).toBe(false);
+		});
+	}
+
+	test("rejects unknown ownership proof reached through a staged-source symlink", async () => {
+		const outsideDir = join(
+			tmpdir(),
+			`ck-rm-staged-outside-${Date.now()}-${Math.round(performance.now())}`,
+		);
+		extraCleanupPaths.push(outsideDir);
+		await mkdir(outsideDir, { recursive: true });
+		await writeFile(join(outsideDir, "SKILL.md"), "matching content", "utf-8");
+		await writeFile(join(claudeDir, "skills", "cook", "SKILL.md"), "matching content", "utf-8");
+		await writeFile(
+			join(claudeDir, "metadata.json"),
+			JSON.stringify({ installedFiles: ["skills/cook/SKILL.md"] }),
+			"utf-8",
+		);
+		const pluginSourceDir = join(claudeDir, "staged-source");
+		await mkdir(join(pluginSourceDir, ".claude", "skills"), { recursive: true });
+		await symlink(outsideDir, join(pluginSourceDir, ".claude", "skills", "cook"), "dir");
+
+		const removed = defaultLegacyRemover(claudeDir, backupDir, pluginSourceDir);
+
+		expect(removed).toEqual([]);
+		expect(readFileSync(join(claudeDir, "skills", "cook", "SKILL.md"), "utf-8")).toBe(
+			"matching content",
+		);
+		expect(readFileSync(join(outsideDir, "SKILL.md"), "utf-8")).toBe("matching content");
+	});
+
+	test("preserves a structured CK-owned directory and all untracked descendants", async () => {
+		await writeFile(join(claudeDir, "skills", "cook", "SKILL.md"), "tracked", "utf-8");
+		await writeFile(join(claudeDir, "skills", "cook", "notes.txt"), "untracked", "utf-8");
+		await writeFile(
+			join(claudeDir, "metadata.json"),
+			JSON.stringify({
+				kits: { engineer: { files: [{ path: "skills/cook", ownership: "ck" }] } },
+			}),
+			"utf-8",
+		);
+
+		const removed = defaultLegacyRemover(claudeDir, backupDir);
+
+		expect(removed).toEqual([]);
+		expect(readFileSync(join(claudeDir, "skills", "cook", "SKILL.md"), "utf-8")).toBe("tracked");
+		expect(readFileSync(join(claudeDir, "skills", "cook", "notes.txt"), "utf-8")).toBe("untracked");
+		expect(existsSync(join(backupDir, "skills", "cook"))).toBe(false);
+	});
+
+	test("legacy root installedFiles require exact staged plugin bytes before deletion", async () => {
 		await writeFile(join(claudeDir, "skills", "cook", "SKILL.md"), "historical", "utf-8");
 		await writeFile(
 			join(claudeDir, "metadata.json"),
@@ -529,10 +961,58 @@ describe("defaultLegacyRemover", () => {
 			"utf-8",
 		);
 
-		const removed = defaultLegacyRemover(claudeDir, backupDir);
+		const removedWithoutSource = defaultLegacyRemover(claudeDir, backupDir);
+
+		expect(removedWithoutSource).toEqual([]);
+		expect(existsSync(join(claudeDir, "skills", "cook", "SKILL.md"))).toBe(true);
+
+		const pluginSourceDir = join(claudeDir, "staged-source");
+		await mkdir(join(pluginSourceDir, ".claude", "skills", "cook"), { recursive: true });
+		await writeFile(
+			join(pluginSourceDir, ".claude", "skills", "cook", "SKILL.md"),
+			"historical",
+			"utf-8",
+		);
+
+		const removedWithProof = defaultLegacyRemover(claudeDir, backupDir, pluginSourceDir);
+
+		expect(removedWithProof).toEqual(["skills/cook/SKILL.md"]);
+		expect(existsSync(join(claudeDir, "skills", "cook", "SKILL.md"))).toBe(false);
+		expect(readFileSync(join(backupDir, "skills", "cook", "SKILL.md"), "utf-8")).toBe("historical");
+	});
+
+	test("historical proof never authorizes runtime or untracked file deletion", async () => {
+		const pluginSourceDir = join(claudeDir, "staged-source");
+		await mkdir(join(claudeDir, "hooks"), { recursive: true });
+		await mkdir(join(pluginSourceDir, ".claude", "hooks"), { recursive: true });
+		await mkdir(join(pluginSourceDir, ".claude", "skills", "mine"), { recursive: true });
+		await writeFile(join(claudeDir, "hooks", "session-init.cjs"), "same runtime", "utf-8");
+		await writeFile(
+			join(pluginSourceDir, ".claude", "hooks", "session-init.cjs"),
+			"same runtime",
+			"utf-8",
+		);
+		await writeFile(join(claudeDir, "skills", "mine", "SKILL.md"), "same untracked", "utf-8");
+		await writeFile(
+			join(pluginSourceDir, ".claude", "skills", "mine", "SKILL.md"),
+			"same untracked",
+			"utf-8",
+		);
+		await writeFile(
+			join(claudeDir, "metadata.json"),
+			JSON.stringify({ installedFiles: ["hooks/session-init.cjs"] }),
+			"utf-8",
+		);
+
+		const removed = defaultLegacyRemover(claudeDir, backupDir, pluginSourceDir);
 
 		expect(removed).toEqual([]);
-		expect(existsSync(join(claudeDir, "skills", "cook", "SKILL.md"))).toBe(true);
+		expect(readFileSync(join(claudeDir, "hooks", "session-init.cjs"), "utf-8")).toBe(
+			"same runtime",
+		);
+		expect(readFileSync(join(claudeDir, "skills", "mine", "SKILL.md"), "utf-8")).toBe(
+			"same untracked",
+		);
 	});
 
 	test("checksum-less records stay while explicitly CK-owned records can be removed", async () => {

--- a/src/domains/installation/plugin/__tests__/uninstall-plugin.test.ts
+++ b/src/domains/installation/plugin/__tests__/uninstall-plugin.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -10,12 +10,14 @@ import {
 } from "@/domains/installation/plugin/plugin-installer.js";
 import { uninstallEnginePlugin } from "@/domains/installation/plugin/uninstall-plugin.js";
 
-function recordingInstaller(onCall?: (args: string[]) => Promise<void> | void) {
+function recordingInstaller(
+	onCall?: (args: string[]) => Promise<ClaudeRunResult | undefined> | ClaudeRunResult | undefined,
+) {
 	const calls: string[][] = [];
 	const runner: ClaudeRunner = async (args): Promise<ClaudeRunResult> => {
 		calls.push(args);
-		await onCall?.(args);
-		return { ok: true, stdout: "", stderr: "", code: 0 };
+		const result = await onCall?.(args);
+		return result ?? { ok: true, stdout: "", stderr: "", code: 0 };
 	};
 	return { installer: new PluginInstaller(runner), calls };
 }
@@ -31,6 +33,12 @@ describe("uninstallEnginePlugin", () => {
 	});
 
 	const cacheDir = () => join(claudeDir, "plugins", "cache", "claudekit", "ck");
+	const registryPath = () => join(claudeDir, "plugins", "known_marketplaces.json");
+
+	async function writeRegistry(registry: unknown): Promise<void> {
+		await mkdir(join(claudeDir, "plugins"), { recursive: true });
+		await writeFile(registryPath(), JSON.stringify(registry), "utf-8");
+	}
 
 	test("registered plugin: uninstalls, removes marketplace, purges cache", async () => {
 		await writeFile(
@@ -39,17 +47,26 @@ describe("uninstallEnginePlugin", () => {
 			"utf-8",
 		);
 		await mkdir(join(cacheDir(), "v1"), { recursive: true });
+		await writeRegistry({
+			claudekit: { source: { source: "directory", path: "/tmp/claudekit" } },
+		});
 		const { installer, calls } = recordingInstaller(async (args) => {
 			if (args.join(" ") === "plugin uninstall ck") {
 				await writeFile(join(claudeDir, "settings.json"), JSON.stringify({ enabledPlugins: {} }));
 			}
+			if (args.join(" ") === "plugin marketplace remove claudekit") {
+				await writeRegistry({});
+			}
+			return undefined;
 		});
 
 		const r = await uninstallEnginePlugin({ claudeDir, installer });
 
 		expect(r.uninstalled).toBe(true);
 		expect(r.staleCacheRemoved).toBe(true);
+		expect(r.marketplaceRemoved).toBe(true);
 		expect(r.pluginStillInstalled).toBe(false);
+		expect(r.marketplaceStillRegistered).toBe(false);
 		expect(r.error).toBeUndefined();
 		expect(calls).toContainEqual(["plugin", "uninstall", "ck"]);
 		expect(calls).toContainEqual(["plugin", "marketplace", "remove", "claudekit"]);
@@ -62,7 +79,9 @@ describe("uninstallEnginePlugin", () => {
 		expect(r).toEqual({
 			uninstalled: false,
 			staleCacheRemoved: false,
+			marketplaceRemoved: false,
 			pluginStillInstalled: false,
+			marketplaceStillRegistered: false,
 			error: undefined,
 		});
 		expect(calls).toHaveLength(0);
@@ -92,5 +111,136 @@ describe("uninstallEnginePlugin", () => {
 		expect(r.uninstalled).toBe(true);
 		expect(r.pluginStillInstalled).toBe(true);
 		expect(r.error).toContain("plugin remains registered");
+	});
+
+	test("marketplace-only registry is removed while unrelated entries are preserved", async () => {
+		const unrelated = { source: { source: "github", repo: "example/community" } };
+		await writeRegistry({
+			claudekit: { source: { source: "directory", path: "/tmp/claudekit" } },
+			community: unrelated,
+		});
+		const { installer, calls } = recordingInstaller(async (args) => {
+			if (args.join(" ") === "plugin marketplace remove claudekit") {
+				await writeRegistry({ community: unrelated });
+			}
+			return undefined;
+		});
+
+		const result = await uninstallEnginePlugin({ claudeDir, installer });
+
+		expect(result).toMatchObject({
+			uninstalled: false,
+			marketplaceRemoved: true,
+			marketplaceStillRegistered: false,
+			error: undefined,
+		});
+		expect(calls).toEqual([["plugin", "marketplace", "remove", "claudekit"]]);
+		expect(JSON.parse(await readFile(registryPath(), "utf-8"))).toEqual({
+			community: unrelated,
+		});
+	});
+
+	test("nested marketplace-only registry shape is removed and verified", async () => {
+		await writeRegistry({
+			marketplaces: {
+				claudekit: { installLocation: "/tmp/claudekit" },
+				community: { installLocation: "/tmp/community" },
+			},
+		});
+		const { installer } = recordingInstaller(async (args) => {
+			if (args.join(" ") === "plugin marketplace remove claudekit") {
+				await writeRegistry({
+					marketplaces: { community: { installLocation: "/tmp/community" } },
+				});
+			}
+			return undefined;
+		});
+
+		const result = await uninstallEnginePlugin({ claudeDir, installer });
+
+		expect(result.marketplaceRemoved).toBe(true);
+		expect(result.marketplaceStillRegistered).toBe(false);
+		expect(result.error).toBeUndefined();
+	});
+
+	test("successful command with a remaining marketplace blocks cleanup success", async () => {
+		await writeRegistry({ claudekit: { installLocation: "/tmp/claudekit" } });
+		const { installer } = recordingInstaller();
+
+		const result = await uninstallEnginePlugin({ claudeDir, installer });
+
+		expect(result.marketplaceRemoved).toBe(true);
+		expect(result.marketplaceStillRegistered).toBe(true);
+		expect(result.error).toContain("marketplace remains registered");
+	});
+
+	test("failed marketplace removal with a registry remnant blocks cleanup success", async () => {
+		await writeRegistry({ claudekit: { installLocation: "/tmp/claudekit" } });
+		const { installer } = recordingInstaller((args) => {
+			if (args.join(" ") === "plugin marketplace remove claudekit") {
+				return { ok: false, stdout: "", stderr: "registry locked", code: 1 };
+			}
+			return undefined;
+		});
+
+		const result = await uninstallEnginePlugin({ claudeDir, installer });
+
+		expect(result.marketplaceRemoved).toBe(false);
+		expect(result.marketplaceStillRegistered).toBe(true);
+		expect(result.error).toContain("marketplace remove failed: registry locked");
+		expect(result.error).toContain("marketplace remains registered");
+	});
+
+	test("malformed marketplace registry cannot falsely verify cleanup", async () => {
+		await mkdir(join(claudeDir, "plugins"), { recursive: true });
+		await writeFile(registryPath(), "{not-json", "utf-8");
+		const { installer, calls } = recordingInstaller();
+
+		const result = await uninstallEnginePlugin({ claudeDir, installer });
+
+		expect(calls).toEqual([["plugin", "marketplace", "remove", "claudekit"]]);
+		expect(result.marketplaceStillRegistered).toBe(true);
+		expect(result.error).toContain("marketplace absence cannot be verified");
+	});
+
+	test("already-absent marketplace is an idempotent no-op", async () => {
+		await writeRegistry({ community: { installLocation: "/tmp/community" } });
+		const { installer, calls } = recordingInstaller();
+
+		const first = await uninstallEnginePlugin({ claudeDir, installer });
+		const second = await uninstallEnginePlugin({ claudeDir, installer });
+
+		expect(first).toMatchObject({
+			marketplaceRemoved: false,
+			marketplaceStillRegistered: false,
+			error: undefined,
+		});
+		expect(second).toMatchObject(first);
+		expect(calls).toHaveLength(0);
+	});
+
+	test("unrelated ck plugin and cache are preserved without provider calls", async () => {
+		const settings = { enabledPlugins: { "ck@community": true } };
+		const registry = { community: { installLocation: "/tmp/community" } };
+		const communityCache = join(claudeDir, "plugins", "cache", "community", "ck", "9.9.9");
+		await writeFile(join(claudeDir, "settings.json"), JSON.stringify(settings), "utf-8");
+		await mkdir(communityCache, { recursive: true });
+		await writeRegistry(registry);
+		const { installer, calls } = recordingInstaller();
+
+		const result = await uninstallEnginePlugin({ claudeDir, installer });
+
+		expect(result).toEqual({
+			uninstalled: false,
+			staleCacheRemoved: false,
+			marketplaceRemoved: false,
+			pluginStillInstalled: false,
+			marketplaceStillRegistered: false,
+			error: undefined,
+		});
+		expect(calls).toHaveLength(0);
+		expect(JSON.parse(await readFile(join(claudeDir, "settings.json"), "utf-8"))).toEqual(settings);
+		expect(JSON.parse(await readFile(registryPath(), "utf-8"))).toEqual(registry);
+		expect(existsSync(communityCache)).toBe(true);
 	});
 });

--- a/src/domains/installation/plugin/claude-plugin-health.ts
+++ b/src/domains/installation/plugin/claude-plugin-health.ts
@@ -23,12 +23,22 @@ export interface ClaudePluginHealth {
 	source: string | null;
 }
 
+export type ClaudeMarketplaceRegistrationStatus = "present" | "absent" | "unverifiable";
+
+export interface ClaudeMarketplaceRegistration {
+	status: ClaudeMarketplaceRegistrationStatus;
+	source: string | null;
+}
+
 export function detectClaudePluginHealth(
 	claudeDir: string,
 	options: ClaudePluginHealthOptions = {},
 ): ClaudePluginHealth {
 	const state = detectPluginState(claudeDir);
-	const source = readMarketplaceSource(claudeDir, state.marketplace ?? "claudekit");
+	const source = inspectClaudeMarketplaceRegistration(
+		claudeDir,
+		state.marketplace ?? "claudekit",
+	).source;
 	const base = { installedVersion: state.version, source };
 
 	if (!state.installed) {
@@ -51,23 +61,48 @@ export function detectClaudePluginHealth(
 	return { ...base, status: "installed-current", shouldRefresh: false };
 }
 
-function readMarketplaceSource(claudeDir: string, marketplace: string): string | null {
+/**
+ * Inspect Claude's persisted marketplace registry without invoking the provider.
+ * Both registry layouts observed in released Claude versions are supported.
+ * Invalid bytes or an invalid nested container are explicitly unverifiable so
+ * cleanup cannot report success from an unreadable registry.
+ */
+export function inspectClaudeMarketplaceRegistration(
+	claudeDir: string,
+	marketplace = "claudekit",
+): ClaudeMarketplaceRegistration {
+	const registryPath = join(claudeDir, "plugins", "known_marketplaces.json");
+	if (!existsSync(registryPath)) return { status: "absent", source: null };
+
 	try {
-		const parsed = JSON.parse(
-			readFileSync(join(claudeDir, "plugins", "known_marketplaces.json"), "utf-8"),
-		);
-		if (!isRecord(parsed)) return null;
-		const entry = isRecord(parsed[marketplace])
-			? parsed[marketplace]
-			: isRecord(parsed.marketplaces) && isRecord(parsed.marketplaces[marketplace])
-				? parsed.marketplaces[marketplace]
-				: null;
-		if (!entry) return null;
-		if (typeof entry.installLocation === "string") return entry.installLocation;
-		if (isRecord(entry.source) && typeof entry.source.path === "string") return entry.source.path;
-		return null;
+		const parsed: unknown = JSON.parse(readFileSync(registryPath, "utf-8"));
+		if (!isRecord(parsed)) return { status: "unverifiable", source: null };
+
+		let rawEntry: unknown;
+		if (Object.hasOwn(parsed, marketplace)) {
+			rawEntry = parsed[marketplace];
+		} else if (Object.hasOwn(parsed, "marketplaces")) {
+			if (!isRecord(parsed.marketplaces)) {
+				return { status: "unverifiable", source: null };
+			}
+			if (!Object.hasOwn(parsed.marketplaces, marketplace)) {
+				return { status: "absent", source: null };
+			}
+			rawEntry = parsed.marketplaces[marketplace];
+		} else {
+			return { status: "absent", source: null };
+		}
+
+		if (!isRecord(rawEntry)) return { status: "present", source: null };
+		if (typeof rawEntry.installLocation === "string") {
+			return { status: "present", source: rawEntry.installLocation };
+		}
+		if (isRecord(rawEntry.source) && typeof rawEntry.source.path === "string") {
+			return { status: "present", source: rawEntry.source.path };
+		}
+		return { status: "present", source: null };
 	} catch {
-		return null;
+		return { status: "unverifiable", source: null };
 	}
 }
 

--- a/src/domains/installation/plugin/engineer-provider-cleanup.ts
+++ b/src/domains/installation/plugin/engineer-provider-cleanup.ts
@@ -1,4 +1,5 @@
 import { PathResolver } from "@/shared/path-resolver.js";
+import { inspectClaudeMarketplaceRegistration } from "./claude-plugin-health.js";
 import {
 	type CodexPluginState,
 	detectCodexPluginState,
@@ -54,7 +55,8 @@ export async function cleanupEngineerProviderPlugins(
 		deps.verifyClaudePluginAbsent ??
 		(() => {
 			const state = detectPluginState(PathResolver.getGlobalKitDir());
-			return !state.installed && !state.staleCache;
+			const marketplace = inspectClaudeMarketplaceRegistration(PathResolver.getGlobalKitDir());
+			return !state.installed && !state.staleCache && marketplace.status === "absent";
 		});
 	const readCodexState = deps.readCodexPluginState ?? (() => detectCodexPluginState());
 
@@ -68,9 +70,18 @@ export async function cleanupEngineerProviderPlugins(
 
 	if (claudeAttempt.status === "rejected") {
 		errors.push(`Claude plugin cleanup failed: ${String(claudeAttempt.reason)}`);
-	} else if (claudeAttempt.value.error || claudeAttempt.value.pluginStillInstalled) {
+	} else if (
+		claudeAttempt.value.error ||
+		claudeAttempt.value.pluginStillInstalled ||
+		claudeAttempt.value.marketplaceStillRegistered
+	) {
 		errors.push(
-			`Claude plugin cleanup failed: ${claudeAttempt.value.error ?? "plugin is still installed"}`,
+			`Claude plugin cleanup failed: ${
+				claudeAttempt.value.error ??
+				(claudeAttempt.value.pluginStillInstalled
+					? "plugin is still installed"
+					: "marketplace is still registered")
+			}`,
 		);
 	}
 
@@ -108,6 +119,7 @@ export async function cleanupEngineerProviderPlugins(
 		changed: Boolean(
 			claude?.uninstalled ||
 				claude?.staleCacheRemoved ||
+				claude?.marketplaceRemoved ||
 				codex?.removed ||
 				codex?.marketplaceRemoved,
 		),

--- a/src/domains/installation/plugin/historical-metadata-files.ts
+++ b/src/domains/installation/plugin/historical-metadata-files.ts
@@ -24,14 +24,21 @@ export function collectEngineerHistoricalFiles(metadata: unknown): HistoricalTra
 	if (!isRecord(metadata)) return [];
 
 	const tracked: HistoricalTrackedFile[] = [];
+	const seen = new Set<string>();
 	const push = (files: unknown) => {
 		if (!Array.isArray(files)) return;
 		for (const file of files) {
 			if (typeof file === "string") {
+				const key = normalizeHistoricalPath(file);
+				if (seen.has(key)) continue;
+				seen.add(key);
 				tracked.push({ path: file, ownership: "unknown" });
 				continue;
 			}
 			if (!isRecord(file) || typeof file.path !== "string") continue;
+			const key = normalizeHistoricalPath(file.path);
+			if (seen.has(key)) continue;
+			seen.add(key);
 			tracked.push({
 				path: file.path,
 				ownership: normalizeOwnership(file.ownership),
@@ -40,16 +47,28 @@ export function collectEngineerHistoricalFiles(metadata: unknown): HistoricalTra
 		}
 	};
 
+	let includeTransitionalRoot = true;
 	if (isRecord(metadata.kits)) {
 		const engineer = metadata.kits.engineer;
-		if (isRecord(engineer)) {
-			push(engineer.files);
-			push(engineer.installedFiles);
-		}
-		return tracked;
+		if (!isRecord(engineer)) return [];
+		push(engineer.files);
+		push(engineer.installedFiles);
+		includeTransitionalRoot = Object.keys(metadata.kits).length === 1;
 	}
 
-	push(metadata.files);
-	push(metadata.installedFiles);
+	// metadata-migration preserved root records beside the sole nested kit. Once
+	// multiple kits exist, root records are ambiguous and must not be attributed
+	// to Engineer; nested Engineer metadata is the only deletion authority.
+	if (includeTransitionalRoot) {
+		push(metadata.files);
+		push(metadata.installedFiles);
+	}
 	return tracked;
+}
+
+function normalizeHistoricalPath(pathValue: string): string {
+	return pathValue
+		.replace(/\\/g, "/")
+		.replace(/^\.\/+/, "")
+		.replace(/^\.claude\//, "");
 }

--- a/src/domains/installation/plugin/install-mode-detector.ts
+++ b/src/domains/installation/plugin/install-mode-detector.ts
@@ -65,13 +65,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Detect Claude Code plugin install state for the `ck` plugin.
+ * Detect Claude Code plugin install state for the official `ck@claudekit` plugin.
  *
  * `installed` is authoritative from settings.json `enabledPlugins` (this is what
  * `claude plugin list` reflects). The plugin cache directory
- * `plugins/cache/<marketplace>/ck/<version>/` resolves the version, and when it
+ * `plugins/cache/claudekit/ck/<version>/` resolves the version, and when it
  * exists WITHOUT a registration it is reported as an orphaned `staleCache`
  * (uninstall removes the registration but leaves the cached payload on disk).
+ * Plugins or caches named `ck` under other marketplaces are unrelated and are
+ * deliberately ignored.
  */
 export function detectPluginState(claudeDir: string): PluginState {
 	const state: PluginState = {
@@ -82,41 +84,26 @@ export function detectPluginState(claudeDir: string): PluginState {
 		staleCache: false,
 	};
 
-	// Authoritative signal: settings.json enabledPlugins (key = "<plugin>@<marketplace>")
+	// Authoritative signal: the exact CK-owned settings registration.
 	const settings = readJsonSafe(join(claudeDir, "settings.json"));
 	if (isRecord(settings) && isRecord(settings.enabledPlugins)) {
-		for (const [key, value] of Object.entries(settings.enabledPlugins)) {
-			const [name, marketplace] = key.split("@");
-			if (name === CK_PLUGIN_NAME) {
-				state.installed = true;
-				state.marketplace = marketplace ?? null;
-				if (value === true) state.enabled = true;
-				break;
-			}
+		const registration = `${CK_PLUGIN_NAME}@${CK_MARKETPLACE_NAME}`;
+		if (Object.hasOwn(settings.enabledPlugins, registration)) {
+			state.installed = true;
+			state.marketplace = CK_MARKETPLACE_NAME;
+			if (settings.enabledPlugins[registration] === true) state.enabled = true;
 		}
 	}
 
-	// Cache payload: resolves version; flags an orphaned cache when not registered.
-	const cacheRoot = join(claudeDir, "plugins", "cache");
-	if (existsSync(cacheRoot)) {
-		// Prefer the marketplace recorded in settings (the registered one) over readdir
-		// order, so version resolution does not pick a stale cache under another marketplace.
-		const all = safeReaddir(cacheRoot);
-		const marketplaces = state.marketplace
-			? [state.marketplace, ...all.filter((m) => m !== state.marketplace)]
-			: all;
-		for (const marketplace of marketplaces) {
-			const ckDir = join(cacheRoot, marketplace, CK_PLUGIN_NAME);
-			if (existsSync(ckDir) && isDir(ckDir)) {
-				state.marketplace = state.marketplace ?? marketplace;
-				const versions = safeReaddir(ckDir).filter((v) => isDir(join(ckDir, v)));
-				if (versions.length > 0 && state.version === null) {
-					state.version = selectPluginCacheVersion(versions, ckDir);
-				}
-				if (!state.installed) state.staleCache = true;
-				break;
-			}
+	// Only the CK-owned marketplace cache participates in ClaudeKit lifecycle state.
+	const ckDir = join(claudeDir, "plugins", "cache", CK_MARKETPLACE_NAME, CK_PLUGIN_NAME);
+	if (existsSync(ckDir) && isDir(ckDir)) {
+		state.marketplace = CK_MARKETPLACE_NAME;
+		const versions = safeReaddir(ckDir).filter((version) => isDir(join(ckDir, version)));
+		if (versions.length > 0) {
+			state.version = selectPluginCacheVersion(versions, ckDir);
 		}
+		if (!state.installed) state.staleCache = true;
 	}
 
 	return state;

--- a/src/domains/installation/plugin/migrate-legacy-to-plugin.ts
+++ b/src/domains/installation/plugin/migrate-legacy-to-plugin.ts
@@ -1,10 +1,12 @@
 import { createHash } from "node:crypto";
 import {
-	cpSync,
+	copyFileSync,
 	existsSync,
+	lstatSync,
 	mkdirSync,
 	readFileSync,
 	readdirSync,
+	realpathSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
@@ -52,7 +54,11 @@ export interface MigrateResult {
 }
 
 /** Removes legacy ck-owned files; returns removed relative paths. Injectable for tests. */
-export type LegacyRemover = (claudeDir: string, backupDir: string) => string[];
+export type LegacyRemover = (
+	claudeDir: string,
+	backupDir: string,
+	pluginSourceDir?: string,
+) => string[];
 
 export interface MigrateOptions {
 	/** Staged kit dir containing .claude-plugin/marketplace.json (the local marketplace source). */
@@ -114,10 +120,10 @@ export async function migrateLegacyToPlugin(opts: MigrateOptions): Promise<Migra
 	}
 	const verified = await installer.verifyInstalled();
 	if (!verified) {
-		prepared.rollback?.();
+		const rollbackFailures = prepared.rollback?.() ?? [];
 		return {
 			...base("install-failed", before.mode, false),
-			error: "plugin did not verify after install",
+			error: appendRollbackFailures("plugin did not verify after install", rollbackFailures),
 		};
 	}
 
@@ -134,8 +140,8 @@ export async function migrateLegacyToPlugin(opts: MigrateOptions): Promise<Migra
 	try {
 		if (before.legacy.installed) {
 			backupDir = join(claudeDir, "backups", `ck-legacy-${ts.replace(/[:.]/g, "-")}`);
-			mkdirSync(backupDir, { recursive: true });
-			removedPaths = removeLegacy(claudeDir, backupDir);
+			createSafeBackupDirectory(claudeDir, backupDir);
+			removedPaths = removeLegacy(claudeDir, backupDir, opts.pluginSourceDir);
 			prunePluginSuppliedLegacyFilesFromMetadata(claudeDir, removedPaths);
 		}
 
@@ -150,13 +156,33 @@ export async function migrateLegacyToPlugin(opts: MigrateOptions): Promise<Migra
 			timestamp: ts,
 		});
 	} catch (error) {
-		if (backupDir) restoreLegacyBackup(claudeDir, backupDir, removedPaths);
-		restoreFile(metadataPath, metadataSnapshot);
-		restoreFile(receiptFile, receiptSnapshot);
-		prepared.rollback?.();
+		const rollbackFailures =
+			backupDir && removedPaths.length > 0
+				? restoreLegacyBackup(claudeDir, backupDir, removedPaths)
+				: [];
+		const metadataFailure = restoreFileSafely(
+			claudeDir,
+			metadataPath,
+			metadataSnapshot,
+			"metadata.json",
+		);
+		if (metadataFailure) rollbackFailures.push(metadataFailure);
+		const receiptFailure = restoreFileSafely(
+			claudeDir,
+			receiptFile,
+			receiptSnapshot,
+			".ck-migration-log.json",
+		);
+		if (receiptFailure) rollbackFailures.push(receiptFailure);
+		rollbackFailures.push(...(prepared.rollback?.() ?? []));
+		const rollbackDetail =
+			rollbackFailures.length > 0
+				? `; rollback incomplete: ${rollbackFailures.join(", ")}${backupDir ? `; backup retained at ${backupDir}` : ""}`
+				: "";
 		return {
 			...base("install-failed", before.mode, false),
-			error: `plugin migration transaction failed: ${(error as Error).message}`,
+			...(rollbackFailures.length > 0 ? { backupDir, removedPaths } : {}),
+			error: `plugin migration transaction failed: ${(error as Error).message}${rollbackDetail}`,
 		};
 	}
 
@@ -198,7 +224,11 @@ const LEGACY_SENTINEL_FILENAMES = new Set([".gitignore"]);
  * are now supplied by the Claude Code plugin, preserving user-owned files and
  * legacy runtime surfaces that the plugin format does not yet provide.
  */
-export function defaultLegacyRemover(claudeDir: string, backupDir: string): string[] {
+export function defaultLegacyRemover(
+	claudeDir: string,
+	backupDir: string,
+	pluginSourceDir?: string,
+): string[] {
 	const meta = readJsonSafe(join(claudeDir, "metadata.json"));
 	const files = collectEngineerHistoricalFiles(meta);
 	const removed: string[] = [];
@@ -206,36 +236,95 @@ export function defaultLegacyRemover(claudeDir: string, backupDir: string): stri
 		const legacyPath = resolveSafePluginSuppliedLegacyPath(claudeDir, file.path);
 		if (!legacyPath) continue;
 		if (!existsSync(legacyPath.absolutePath)) continue;
-		if (!isSafeToRemovePluginSuppliedLegacyFile(file, legacyPath.absolutePath)) continue;
+		if (
+			!isSafeToRemovePluginSuppliedLegacyFile(
+				file,
+				claudeDir,
+				legacyPath.absolutePath,
+				legacyPath.relativePath,
+				pluginSourceDir,
+			)
+		)
+			continue;
 		// Back up before removing.
-		if (!backupAndRemove(backupDir, legacyPath.relativePath, legacyPath.absolutePath)) continue;
+		if (!backupAndRemove(claudeDir, backupDir, legacyPath.relativePath, legacyPath.absolutePath))
+			continue;
 		removed.push(legacyPath.relativePath);
 	}
 	removed.push(...removeOrphanLegacySentinels(claudeDir, backupDir, removed));
 	return removed;
 }
 
-function backupAndRemove(backupDir: string, relativePath: string, abs: string): boolean {
+function backupAndRemove(
+	sourceBaseDir: string,
+	backupDir: string,
+	relativePath: string,
+	abs: string,
+): boolean {
 	const backupTarget = resolveSafeChildPath(backupDir, relativePath);
-	if (!backupTarget) return false;
+	if (
+		!backupTarget ||
+		!isSafeDirectoryWithin(sourceBaseDir, backupDir) ||
+		!isSafeRegularFileWithin(sourceBaseDir, abs)
+	)
+		return false;
 	try {
+		if (pathHasSymlinkComponent(backupDir, dirname(backupTarget))) return false;
 		mkdirSync(dirname(backupTarget), { recursive: true });
-		cpSync(abs, backupTarget, { recursive: true });
-		rmSync(abs, { recursive: true, force: true });
+		if (pathHasSymlinkComponent(backupDir, backupTarget)) return false;
+		copyFileSync(abs, backupTarget);
+		rmSync(abs, { force: true });
 		return true;
 	} catch {
 		return false;
 	}
 }
 
-function restoreLegacyBackup(claudeDir: string, backupDir: string, removedPaths: string[]): void {
+function restoreLegacyBackup(
+	claudeDir: string,
+	backupDir: string,
+	removedPaths: string[],
+): string[] {
+	const failures: string[] = [];
+	if (!isSafeDirectoryWithin(claudeDir, backupDir)) {
+		return removedPaths.map((pathValue) => `${pathValue}: unsafe backup directory`);
+	}
+
 	for (const pathValue of removedPaths) {
 		const source = resolveSafeChildPath(backupDir, pathValue);
 		const target = resolveSafeChildPath(claudeDir, pathValue);
-		if (!source || !target || !existsSync(source)) continue;
-		mkdirSync(dirname(target), { recursive: true });
-		cpSync(source, target, { recursive: true });
+		if (!source || !target || !isSafeRegularFileWithin(backupDir, source)) {
+			failures.push(`${pathValue}: unsafe or missing backup file`);
+			continue;
+		}
+		if (pathHasSymlinkComponent(claudeDir, target) || existsSync(target)) {
+			failures.push(`${pathValue}: unsafe rollback destination`);
+			continue;
+		}
+
+		try {
+			const targetParent = dirname(target);
+			if (pathHasSymlinkComponent(claudeDir, targetParent)) {
+				failures.push(`${pathValue}: unsafe rollback destination`);
+				continue;
+			}
+			mkdirSync(targetParent, { recursive: true });
+			if (
+				!isSafeDirectoryWithin(claudeDir, targetParent) ||
+				pathHasSymlinkComponent(claudeDir, target)
+			) {
+				failures.push(`${pathValue}: unsafe rollback destination`);
+				continue;
+			}
+			copyFileSync(source, target);
+			if (!isSafeRegularFileWithin(claudeDir, target)) {
+				failures.push(`${pathValue}: restored file failed safety verification`);
+			}
+		} catch (error) {
+			failures.push(`${pathValue}: ${(error as Error).message}`);
+		}
 	}
+	return failures;
 }
 
 function removeOrphanLegacySentinels(
@@ -261,8 +350,9 @@ function removeOrphanLegacySentinels(
 		);
 		for (const sentinelAbs of sentinels) {
 			const sentinelPath = normalizeLegacyPath(relative(claudeDir, sentinelAbs));
-			if (!isSafeToRemoveLegacySentinel(sentinelPath, sentinelAbs, normalizedRemoved)) continue;
-			if (!backupAndRemove(backupDir, sentinelPath, sentinelAbs)) continue;
+			if (!isSafeToRemoveLegacySentinel(claudeDir, sentinelPath, sentinelAbs, normalizedRemoved))
+				continue;
+			if (!backupAndRemove(claudeDir, backupDir, sentinelPath, sentinelAbs)) continue;
 			removed.push(sentinelPath);
 		}
 	}
@@ -290,12 +380,14 @@ function findLegacySentinels(dir: string): string[] {
 }
 
 function isSafeToRemoveLegacySentinel(
+	claudeDir: string,
 	sentinelPath: string,
 	sentinelAbs: string,
 	removedTrackedPaths: string[],
 ): boolean {
 	if (!isPluginSuppliedLegacyPath(sentinelPath)) return false;
 	if (!LEGACY_SENTINEL_FILENAMES.has(sentinelPath.split("/").pop() ?? "")) return false;
+	if (!isSafeRegularFileWithin(claudeDir, sentinelAbs)) return false;
 
 	const sentinelDir = dirname(sentinelPath).replace(/\\/g, "/");
 	if (!removedTrackedPaths.some((removedPath) => removedPath.startsWith(`${sentinelDir}/`))) {
@@ -324,8 +416,18 @@ function directoryContainsOnlySentinels(dir: string): boolean {
 	return true;
 }
 
-function isSafeToRemovePluginSuppliedLegacyFile(file: HistoricalTrackedFile, abs: string): boolean {
+function isSafeToRemovePluginSuppliedLegacyFile(
+	file: HistoricalTrackedFile,
+	claudeDir: string,
+	abs: string,
+	relativePath: string,
+	pluginSourceDir?: string,
+): boolean {
+	if (!isSafeRegularFileWithin(claudeDir, abs)) return false;
 	if (file.ownership === "ck") return true;
+	if (file.ownership === "unknown") {
+		return stagedPluginPayloadMatches(pluginSourceDir, relativePath, abs);
+	}
 	if (file.ownership !== "user") return false;
 
 	// Offline/local kit installs can lack release-manifest.json, so files are
@@ -333,6 +435,106 @@ function isSafeToRemovePluginSuppliedLegacyFile(file: HistoricalTrackedFile, abs
 	// only when the tracked checksum still matches disk; edited or untracked
 	// user files stay protected.
 	return checksumMatches(abs, file.checksum);
+}
+
+function stagedPluginPayloadMatches(
+	pluginSourceDir: string | undefined,
+	relativePath: string,
+	legacyPath: string,
+): boolean {
+	if (!pluginSourceDir) return false;
+	const stagedPath = resolveSafePluginSuppliedLegacyPath(
+		join(pluginSourceDir, ".claude"),
+		relativePath,
+	);
+	if (!stagedPath || !existsSync(stagedPath.absolutePath)) return false;
+
+	try {
+		if (!isSafeRegularFileWithin(join(pluginSourceDir, ".claude"), stagedPath.absolutePath))
+			return false;
+		return readFileSync(legacyPath).equals(readFileSync(stagedPath.absolutePath));
+	} catch {
+		return false;
+	}
+}
+
+function isSafeRegularFileWithin(baseDir: string, filePath: string): boolean {
+	const resolvedBase = resolve(baseDir);
+	const resolvedFile = resolve(filePath);
+	const relativePath = normalizeLegacyPath(relative(resolvedBase, resolvedFile));
+	if (!relativePath || relativePath === ".." || relativePath.startsWith("../")) return false;
+	if (pathHasSymlinkComponent(resolvedBase, resolvedFile)) return false;
+
+	try {
+		if (!lstatSync(resolvedFile).isFile()) return false;
+		const realBase = realpathSync(resolvedBase);
+		const realFile = realpathSync(resolvedFile);
+		const realRelative = normalizeLegacyPath(relative(realBase, realFile));
+		return Boolean(realRelative && realRelative !== ".." && !realRelative.startsWith("../"));
+	} catch {
+		return false;
+	}
+}
+
+function createSafeBackupDirectory(claudeDir: string, backupDir: string): void {
+	if (pathHasSymlinkComponent(claudeDir, backupDir)) {
+		throw new Error("unsafe backup directory: symlink or path escape detected");
+	}
+	mkdirSync(backupDir, { recursive: true });
+	if (!isSafeDirectoryWithin(claudeDir, backupDir)) {
+		throw new Error("unsafe backup directory: path is outside Claude config");
+	}
+}
+
+function isSafeDirectoryWithin(baseDir: string, directoryPath: string): boolean {
+	const resolvedBase = resolve(baseDir);
+	const resolvedDirectory = resolve(directoryPath);
+	const relativePath = normalizeLegacyPath(relative(resolvedBase, resolvedDirectory));
+	if (!relativePath || relativePath === ".." || relativePath.startsWith("../")) return false;
+	if (pathHasSymlinkComponent(resolvedBase, resolvedDirectory)) return false;
+
+	try {
+		if (!lstatSync(resolvedDirectory).isDirectory()) return false;
+		const realBase = realpathSync(resolvedBase);
+		const realDirectory = realpathSync(resolvedDirectory);
+		const realRelative = normalizeLegacyPath(relative(realBase, realDirectory));
+		return Boolean(realRelative && realRelative !== ".." && !realRelative.startsWith("../"));
+	} catch {
+		return false;
+	}
+}
+
+function isSafeDirectoryAtOrWithin(baseDir: string, directoryPath: string): boolean {
+	const resolvedBase = resolve(baseDir);
+	const resolvedDirectory = resolve(directoryPath);
+	if (resolvedBase === resolvedDirectory) {
+		try {
+			return realpathSync(resolvedBase) === realpathSync(resolvedDirectory);
+		} catch {
+			return false;
+		}
+	}
+	return isSafeDirectoryWithin(resolvedBase, resolvedDirectory);
+}
+
+function pathHasSymlinkComponent(baseDir: string, targetPath: string): boolean {
+	const resolvedBase = resolve(baseDir);
+	const relativePath = normalizeLegacyPath(relative(resolvedBase, resolve(targetPath)));
+	if (!relativePath || relativePath === ".." || relativePath.startsWith("../")) return true;
+
+	let current = resolvedBase;
+	for (const segment of relativePath.split("/")) {
+		current = join(current, segment);
+		try {
+			if (lstatSync(current).isSymbolicLink()) return true;
+		} catch (error) {
+			// A not-yet-created destination component is safe; source callers apply
+			// an existence/realpath check immediately after this walk.
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+			return true;
+		}
+	}
+	return false;
 }
 
 function checksumMatches(filePath: string, expected?: string): boolean {
@@ -416,31 +618,34 @@ function prunePluginSuppliedLegacyFilesFromMetadata(
 		const pruned = files.filter((file) => {
 			if (typeof file === "string") {
 				const normalizedPath = normalizeComparableLegacyPath(file);
-				return !(
-					isPluginSuppliedLegacyPath(normalizedPath) &&
-					resolveSafePluginSuppliedLegacyPath(claudeDir, normalizedPath) !== null
-				);
+				const resolvedPath = resolveSafePluginSuppliedLegacyPath(claudeDir, normalizedPath);
+				const shouldPrune =
+					(removed?.has(normalizedPath) ?? false) ||
+					(resolvedPath !== null && !existsSync(resolvedPath.absolutePath));
+				return !shouldPrune;
 			}
 			if (!isRecord(file) || typeof file.path !== "string") return true;
 			const normalizedPath = normalizeComparableLegacyPath(file.path);
 			const resolvedPath = resolveSafePluginSuppliedLegacyPath(claudeDir, normalizedPath);
-			const shouldPrune = removed
-				? removed.has(normalizedPath) ||
-					(resolvedPath !== null && !existsSync(resolvedPath.absolutePath))
-				: isPluginSuppliedLegacyPath(normalizedPath);
+			const shouldPrune =
+				(removed?.has(normalizedPath) ?? false) ||
+				(resolvedPath !== null && !existsSync(resolvedPath.absolutePath));
 			return !shouldPrune;
 		});
 		if (pruned.length !== files.length) changed = true;
 		return pruned;
 	};
 
+	let pruneTransitionalRoot = true;
 	if (isRecord(meta.kits)) {
 		const engineer = (meta.kits as Record<string, unknown>)[ENGINEER_KIT_KEY];
 		if (isRecord(engineer)) {
 			engineer.files = pruneFiles(engineer.files);
 			engineer.installedFiles = pruneFiles(engineer.installedFiles);
 		}
-	} else {
+		pruneTransitionalRoot = isRecord(engineer) && Object.keys(meta.kits).length === 1;
+	}
+	if (pruneTransitionalRoot) {
 		meta.files = pruneFiles(meta.files);
 		meta.installedFiles = pruneFiles(meta.installedFiles);
 	}
@@ -487,19 +692,59 @@ function snapshotFile(filePath: string): Buffer | null {
 	return existsSync(filePath) ? readFileSync(filePath) : null;
 }
 
-function restoreFile(filePath: string, content: Buffer | null): void {
-	if (content === null) {
-		rmSync(filePath, { force: true });
-		return;
+function restoreFileSafely(
+	rootDir: string,
+	filePath: string,
+	content: Buffer | null,
+	label: string,
+): string | null {
+	const resolvedRoot = resolve(rootDir);
+	const resolvedFile = resolve(filePath);
+	const relativePath = normalizeLegacyPath(relative(resolvedRoot, resolvedFile));
+	if (!relativePath || relativePath === ".." || relativePath.startsWith("../")) {
+		return `${label}: restore target escapes owned root`;
 	}
-	mkdirSync(dirname(filePath), { recursive: true });
-	writeFileSync(filePath, content);
+	if (pathHasSymlinkComponent(resolvedRoot, resolvedFile)) {
+		return `${label}: unsafe restore target`;
+	}
+
+	try {
+		if (content === null) {
+			if (!existsSync(resolvedFile)) return null;
+			if (!isSafeRegularFileWithin(resolvedRoot, resolvedFile)) {
+				return `${label}: unsafe restore target`;
+			}
+			rmSync(resolvedFile, { force: true });
+			return null;
+		}
+
+		const parent = dirname(resolvedFile);
+		if (parent !== resolvedRoot && pathHasSymlinkComponent(resolvedRoot, parent)) {
+			return `${label}: unsafe restore parent`;
+		}
+		mkdirSync(parent, { recursive: true });
+		if (
+			!isSafeDirectoryAtOrWithin(resolvedRoot, parent) ||
+			pathHasSymlinkComponent(resolvedRoot, resolvedFile)
+		) {
+			return `${label}: unsafe restore target`;
+		}
+		if (existsSync(resolvedFile) && !isSafeRegularFileWithin(resolvedRoot, resolvedFile)) {
+			return `${label}: unsafe restore target`;
+		}
+		writeFileSync(resolvedFile, content);
+		return isSafeRegularFileWithin(resolvedRoot, resolvedFile)
+			? null
+			: `${label}: restored snapshot failed safety verification`;
+	} catch (error) {
+		return `${label}: ${(error as Error).message}`;
+	}
 }
 
 interface PluginPrepareResult {
 	ok: boolean;
 	error?: string;
-	rollback?: () => void;
+	rollback?: () => string[];
 }
 
 async function installPlugin(
@@ -511,8 +756,14 @@ async function installPlugin(
 	if (!marketplace.ok) return marketplace;
 	const installed = await installer.install("user");
 	if (!installed.ok) {
-		marketplace.rollback?.();
-		return { ok: false, error: `plugin install failed: ${installed.stderr.trim()}` };
+		const rollbackFailures = marketplace.rollback?.() ?? [];
+		return {
+			ok: false,
+			error: appendRollbackFailures(
+				`plugin install failed: ${installed.stderr.trim()}`,
+				rollbackFailures,
+			),
+		};
 	}
 	return { ok: true, rollback: marketplace.rollback };
 }
@@ -535,20 +786,33 @@ async function refreshExistingPlugin(
 	if (!enabled) {
 		const enabledResult = await installer.enable();
 		if (!enabledResult.ok) {
-			marketplace.rollback?.();
-			return { ok: false, error: `plugin enable failed: ${enabledResult.stderr.trim()}` };
+			const rollbackFailures = marketplace.rollback?.() ?? [];
+			return {
+				ok: false,
+				error: appendRollbackFailures(
+					`plugin enable failed: ${enabledResult.stderr.trim()}`,
+					rollbackFailures,
+				),
+			};
 		}
 	}
 
 	const updated = await installer.update();
 	if (!updated.ok) {
-		marketplace.rollback?.();
-		return { ok: false, error: `plugin update failed: ${updated.stderr.trim()}` };
+		const rollbackFailures = marketplace.rollback?.() ?? [];
+		return {
+			ok: false,
+			error: appendRollbackFailures(
+				`plugin update failed: ${updated.stderr.trim()}`,
+				rollbackFailures,
+			),
+		};
 	}
 	return { ok: true, rollback: marketplace.rollback };
 }
 
 interface ClaudeRegistrationSnapshot {
+	claudeDir: string;
 	files: Array<{ path: string; content: Buffer | null }>;
 }
 
@@ -563,18 +827,24 @@ async function prepareClaudeMarketplace(
 	if (forceReplacement) {
 		const removed = await installer.marketplaceRemove();
 		if (!removed.ok) {
-			rollback();
+			const rollbackFailures = rollback();
 			return {
 				ok: false,
-				error: `marketplace replacement failed: ${removed.stderr.trim()}`,
+				error: appendRollbackFailures(
+					`marketplace replacement failed: ${removed.stderr.trim()}`,
+					rollbackFailures,
+				),
 			};
 		}
 		const replaced = await installer.marketplaceAdd(pluginSourceDir);
 		if (replaced.ok) return { ok: true, rollback };
-		rollback();
+		const rollbackFailures = rollback();
 		return {
 			ok: false,
-			error: `marketplace replacement failed: ${replaced.stderr.trim()}; restored previous registration`,
+			error: describeRegistrationRollback(
+				`marketplace replacement failed: ${replaced.stderr.trim()}`,
+				rollbackFailures,
+			),
 		};
 	}
 	const added = await installer.marketplaceAdd(pluginSourceDir);
@@ -585,24 +855,31 @@ async function prepareClaudeMarketplace(
 
 	const removed = await installer.marketplaceRemove();
 	if (!removed.ok) {
-		rollback();
+		const rollbackFailures = rollback();
 		return {
 			ok: false,
-			error: `marketplace replacement failed: ${removed.stderr.trim() || updated.stderr.trim() || added.stderr.trim()}`,
+			error: appendRollbackFailures(
+				`marketplace replacement failed: ${removed.stderr.trim() || updated.stderr.trim() || added.stderr.trim()}`,
+				rollbackFailures,
+			),
 		};
 	}
 	const replaced = await installer.marketplaceAdd(pluginSourceDir);
 	if (replaced.ok) return { ok: true, rollback };
 
-	rollback();
+	const rollbackFailures = rollback();
 	return {
 		ok: false,
-		error: `marketplace replacement failed: ${replaced.stderr.trim() || updated.stderr.trim() || added.stderr.trim()}; restored previous registration`,
+		error: describeRegistrationRollback(
+			`marketplace replacement failed: ${replaced.stderr.trim() || updated.stderr.trim() || added.stderr.trim()}`,
+			rollbackFailures,
+		),
 	};
 }
 
 function snapshotClaudeRegistration(claudeDir: string): ClaudeRegistrationSnapshot {
 	return {
+		claudeDir,
 		files: [
 			join(claudeDir, "plugins", "known_marketplaces.json"),
 			join(claudeDir, "settings.json"),
@@ -613,15 +890,28 @@ function snapshotClaudeRegistration(claudeDir: string): ClaudeRegistrationSnapsh
 	};
 }
 
-function restoreClaudeRegistration(snapshot: ClaudeRegistrationSnapshot): void {
+function restoreClaudeRegistration(snapshot: ClaudeRegistrationSnapshot): string[] {
+	const failures: string[] = [];
 	for (const file of snapshot.files) {
-		if (file.content === null) {
-			rmSync(file.path, { force: true });
-			continue;
-		}
-		mkdirSync(dirname(file.path), { recursive: true });
-		writeFileSync(file.path, file.content);
+		const failure = restoreFileSafely(
+			snapshot.claudeDir,
+			file.path,
+			file.content,
+			normalizeLegacyPath(relative(snapshot.claudeDir, file.path)),
+		);
+		if (failure) failures.push(failure);
 	}
+	return failures;
+}
+
+function appendRollbackFailures(message: string, failures: string[]): string {
+	return failures.length > 0 ? `${message}; rollback incomplete: ${failures.join(", ")}` : message;
+}
+
+function describeRegistrationRollback(message: string, failures: string[]): string {
+	return failures.length > 0
+		? appendRollbackFailures(message, failures)
+		: `${message}; restored previous registration`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/domains/installation/plugin/uninstall-plugin.ts
+++ b/src/domains/installation/plugin/uninstall-plugin.ts
@@ -7,11 +7,14 @@ import {
 } from "@/domains/installation/plugin/install-mode-detector.js";
 import { PluginInstaller } from "@/domains/installation/plugin/plugin-installer.js";
 import { PathResolver } from "@/shared/path-resolver.js";
+import { inspectClaudeMarketplaceRegistration } from "./claude-plugin-health.js";
 
 export interface UninstallPluginResult {
 	uninstalled: boolean;
 	staleCacheRemoved: boolean;
+	marketplaceRemoved?: boolean;
 	pluginStillInstalled: boolean;
+	marketplaceStillRegistered?: boolean;
 	error?: string;
 }
 
@@ -21,10 +24,9 @@ export interface UninstallPluginOptions {
 }
 
 /**
- * Remove the engineer `ck` plugin: deregister via `claude plugin uninstall` +
- * `marketplace remove`, then purge any leftover cache payload. Used by
- * `ck uninstall` (#691). Non-fatal / idempotent: a no-op when no plugin/cache
- * is present.
+ * Remove the Engineer `ck` plugin, its CK-owned marketplace registration, and
+ * any leftover cache payload. Marketplace state is handled independently from
+ * plugin/cache state so interrupted installs converge on repeated cleanup.
  */
 export async function uninstallEnginePlugin(
 	opts: UninstallPluginOptions = {},
@@ -34,6 +36,7 @@ export async function uninstallEnginePlugin(
 	const state = detectPluginState(claudeDir);
 
 	let uninstalled = false;
+	let marketplaceRemoved = false;
 	const errors: string[] = [];
 	if (state.installed) {
 		const removed = await installer.uninstall();
@@ -42,34 +45,52 @@ export async function uninstallEnginePlugin(
 		} else {
 			errors.push(`plugin uninstall failed: ${removed.stderr.trim() || "unknown error"}`);
 		}
-		const marketplaceRemoved = await installer.marketplaceRemove(
-			state.marketplace ?? CK_MARKETPLACE_NAME,
-		);
-		if (!marketplaceRemoved.ok) {
-			errors.push(
-				`marketplace remove failed: ${marketplaceRemoved.stderr.trim() || "unknown error"}`,
-			);
+	}
+
+	const marketplaceBefore = inspectClaudeMarketplaceRegistration(claudeDir, CK_MARKETPLACE_NAME);
+	let marketplaceRemovalError: string | null = null;
+	if (marketplaceBefore.status !== "absent") {
+		const removed = await installer.marketplaceRemove(CK_MARKETPLACE_NAME);
+		marketplaceRemoved = removed.ok;
+		if (!removed.ok) {
+			marketplaceRemovalError = removed.stderr.trim() || "unknown error";
 		}
 	}
 
 	// Purge cache payload (covers both a registered uninstall and an orphaned stale cache).
 	let staleCacheRemoved = false;
-	const marketplace = state.marketplace ?? CK_MARKETPLACE_NAME;
-	const cacheDir = join(claudeDir, "plugins", "cache", marketplace, CK_PLUGIN_NAME);
+	const cacheDir = join(claudeDir, "plugins", "cache", CK_MARKETPLACE_NAME, CK_PLUGIN_NAME);
 	if (existsSync(cacheDir)) {
 		rmSync(cacheDir, { recursive: true, force: true });
 		staleCacheRemoved = true;
 	}
 
-	const pluginStillInstalled = state.installed ? detectPluginState(claudeDir).installed : false;
+	const pluginStillInstalled = detectPluginState(claudeDir).installed;
 	if (pluginStillInstalled) {
 		errors.push("plugin remains registered after cleanup");
+	}
+
+	const marketplaceAfter = inspectClaudeMarketplaceRegistration(claudeDir, CK_MARKETPLACE_NAME);
+	const marketplaceStillRegistered = marketplaceAfter.status !== "absent";
+	if (marketplaceRemovalError && !isAlreadyAbsentError(marketplaceRemovalError)) {
+		errors.push(`marketplace remove failed: ${marketplaceRemovalError}`);
+	}
+	if (marketplaceAfter.status === "present") {
+		errors.push("marketplace remains registered after cleanup");
+	} else if (marketplaceAfter.status === "unverifiable") {
+		errors.push("marketplace absence cannot be verified after cleanup");
 	}
 
 	return {
 		uninstalled,
 		staleCacheRemoved,
+		marketplaceRemoved,
 		pluginStillInstalled,
+		marketplaceStillRegistered,
 		error: errors.length > 0 ? errors.join("; ") : undefined,
 	};
+}
+
+function isAlreadyAbsentError(message: string): boolean {
+	return /(?:not found|does not exist|is not installed|already (?:absent|removed))/i.test(message);
 }


### PR DESCRIPTION
## Summary
- remove and verify marketplace-only Claude plugin state while preserving unrelated plugins, caches, and marketplace entries
- converge deprecated Engineer metadata only with exact staged-byte ownership proof and correct multi-kit boundaries
- harden migration backup and rollback paths against symlink escapes, directory deletion, and unsafe snapshot restoration

## Validation
- 5,296 tests passed; 65 expected skips; 0 failures
- 153 UI tests passed
- typecheck, Biome, CLI/UI builds, help parity, npm tarball, and fresh packed install passed
- real Claude/Codex provider canary: 7 passed; host state hash unchanged
- independent lifecycle and rollback containment review: no findings

## Docs impact
None. Existing installation documentation already describes the normal-default and explicit plugin opt-in contract; this PR corrects lifecycle enforcement without changing commands or choices.

Closes #914
Closes #917